### PR TITLE
Use crash-safe atomic writes for conversations and settings

### DIFF
--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -63,7 +63,9 @@ namespace GxPT
 
             string path = GetPathForId(convo.Id);
             if (string.IsNullOrEmpty(path)) return;
-            File.WriteAllText(path, json);
+            // Crash-safe write so a failure mid-save can't corrupt the conversation file.
+            // UTF-8 without BOM matches the default File.WriteAllText behavior used previously.
+            FileSafe.WriteAllTextAtomic(path, json, new UTF8Encoding(false));
         }
 
         public static Conversation Load(OpenRouterClient client, string path)

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Managers\ThemeManager.cs" />
     <Compile Include="Services\TextFileAttachmentExtractor.cs" />
     <Compile Include="Services\ThemeService.cs" />
+    <Compile Include="Utilities\FileSafe.cs" />
     <Compile Include="Utilities\ZipSafe.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GxPT/Services/AppSettings.cs
+++ b/GxPT/Services/AppSettings.cs
@@ -50,7 +50,8 @@ namespace GxPT
                 if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
                 var ser = new JavaScriptSerializer();
                 string text = ser.Serialize(data);
-                File.WriteAllText(SettingsPath, text, Encoding.UTF8);
+                // Crash-safe write so a failure mid-save can't corrupt settings.json.
+                FileSafe.WriteAllTextAtomic(SettingsPath, text, Encoding.UTF8);
             }
             catch { }
         }

--- a/GxPT/Utilities/FileSafe.cs
+++ b/GxPT/Utilities/FileSafe.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace GxPT
+{
+    // Helpers for crash-safe file writes (write to a temp file, then atomically replace),
+    // so a crash or power loss mid-write cannot leave a truncated/corrupt file in place.
+    // Targets .NET 3.5 / C# 3.0.
+    internal static class FileSafe
+    {
+        // Atomically writes text to 'path' using the given encoding. The content is written
+        // to a sibling temp file first, then swapped into place. Falls back to a best-effort
+        // direct overwrite if the underlying filesystem does not support the atomic replace.
+        public static void WriteAllTextAtomic(string path, string contents, Encoding encoding)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path");
+            if (contents == null) contents = string.Empty;
+            if (encoding == null) encoding = new UTF8Encoding(false);
+
+            string dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            // Temp file lives in the same directory to keep the replace on a single volume.
+            string tmp = path + ".tmp-" + Guid.NewGuid().ToString("N");
+            File.WriteAllText(tmp, contents, encoding);
+
+            try
+            {
+                if (File.Exists(path))
+                {
+                    // Atomic swap; no backup file requested.
+                    File.Replace(tmp, path, null);
+                }
+                else
+                {
+                    File.Move(tmp, path);
+                }
+            }
+            catch
+            {
+                // Some filesystems (e.g. certain network shares) don't support Replace/Move.
+                // Fall back to a best-effort direct overwrite, then remove the temp file.
+                try { File.Copy(tmp, path, true); }
+                finally { TryDelete(tmp); }
+                return;
+            }
+
+            // On success the temp file has been moved/replaced away; clean up just in case.
+            TryDelete(tmp);
+        }
+
+        private static void TryDelete(string path)
+        {
+            try { if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path); }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ConversationStore.Save` and `AppSettings.SaveJson` both wrote with `File.WriteAllText` directly to the destination path. A crash or power loss mid-write leaves a truncated, corrupt JSON file — silently losing the conversation or the app's settings.

This change makes both writes crash-safe: content is written to a sibling temp file and then atomically swapped into place, so you always get either the old complete file or the new complete file.

## Changes

- **New `GxPT/Utilities/FileSafe.cs`** — shared `WriteAllTextAtomic(path, contents, encoding)` helper:
  - Writes to a sibling temp file (`<path>.tmp-<guid>`) in the **same directory** (keeps the swap on a single volume).
  - `File.Replace` for an atomic swap when the target exists; `File.Move` for first-time creation.
  - Falls back to a best-effort direct overwrite if the filesystem doesn't support replace (e.g. some network shares), so it never hard-fails.
  - Registered in the explicit `<Compile>` list in `GxPT.csproj`.
- **`ConversationStore.Save`** and **`AppSettings.SaveJson`** now route through the helper.
- Encodings preserved to match prior behavior: UTF-8 **without** BOM for conversations (matching `File.WriteAllText`'s default), UTF-8 **with** BOM for `settings.json`.

`File.Replace` has existed since .NET 2.0, so this is compatible with the .NET 3.5 target.

## Testing

Not built/run — authored in a Linux environment without the .NET 3.5 / MSBuild toolchain. Worth a quick check on Windows that a normal send still saves the conversation, the Settings dialog still persists changes, and no stray `.tmp-*` files linger in `%AppData%\GxPT\` or its `Conversations\` subfolder.

## Notes

- `SessionState` (`session.json`, open-tab list) was intentionally left on the plain write — it's transient and low-stakes — but it's the same one-line swap if consistency is wanted later.

https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp)_