### PR TITLE
Remove duplicated tab/transcript/width logic

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -669,52 +669,15 @@ namespace GxPT
             // Apply transcript/message width settings to existing transcripts
             try
             {
-                int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
-                if (tw <= 0) tw = 1000; if (tw < 300) tw = 300; if (tw > 1900) tw = 1900;
-
-                // Read message_max_width which now stores a percent (50-100). If outside that range,
-                // interpret it as legacy pixels, convert to percent of transcript width, clamp, and persist.
-                int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
-                int mp = rawMp;
-                if (mp < 50 || mp > 100)
-                {
-                    int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
-                    if (computed < 50) computed = 50; if (computed > 100) computed = 100;
-                    mp = computed;
-                    try { AppSettings.SetInt("message_max_width", mp); }
-                    catch { }
-                }
-                // Final safety clamp
-                if (mp < 50) mp = 50; if (mp > 100) mp = 100;
+                var widths = TranscriptWidthSettings.Resolve();
                 // Primary designer transcript
-                try
-                {
-                    if (this.chatTranscript != null)
-                    {
-                        this.chatTranscript.MaxContentWidth = tw;
-                        // Set percent-based bubble width
-                        try { this.chatTranscript.BubbleWidthPercent = mp; }
-                        catch { }
-                    }
-                }
-                catch { }
+                widths.ApplyTo(this.chatTranscript);
                 // All tab transcripts
-                try
+                if (_tabManager != null)
                 {
-                    if (_tabManager != null)
-                    {
-                        foreach (var kv in _tabManager.TabContexts)
-                        {
-                            var t = kv.Value != null ? kv.Value.Transcript : null;
-                            if (t == null) continue;
-                            try { t.MaxContentWidth = tw; }
-                            catch { }
-                            try { t.BubbleWidthPercent = mp; }
-                            catch { }
-                        }
-                    }
+                    foreach (var kv in _tabManager.TabContexts)
+                        widths.ApplyTo(kv.Value != null ? kv.Value.Transcript : null);
                 }
-                catch { }
             }
             catch { }
         }
@@ -770,36 +733,12 @@ namespace GxPT
                 // Re-apply transcript/message widths in case they changed
                 try
                 {
-                    int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
-                    if (tw <= 0) tw = 1000; if (tw < 300) tw = 300; if (tw > 1900) tw = 1900;
-                    int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
-                    int mp = rawMp;
-                    if (mp < 50 || mp > 100)
-                    {
-                        int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
-                        if (computed < 50) computed = 50; if (computed > 100) computed = 100;
-                        mp = computed;
-                        try { AppSettings.SetInt("message_max_width", mp); }
-                        catch { }
-                    }
-                    if (mp < 50) mp = 50; if (mp > 100) mp = 100;
-                    if (this.chatTranscript != null)
-                    {
-                        this.chatTranscript.MaxContentWidth = tw;
-                        try { this.chatTranscript.BubbleWidthPercent = mp; }
-                        catch { }
-                    }
+                    var widths = TranscriptWidthSettings.Resolve();
+                    widths.ApplyTo(this.chatTranscript);
                     if (_tabManager != null)
                     {
                         foreach (var kv in _tabManager.TabContexts)
-                        {
-                            var t = kv.Value != null ? kv.Value.Transcript : null;
-                            if (t == null) continue;
-                            try { t.MaxContentWidth = tw; }
-                            catch { }
-                            try { t.BubbleWidthPercent = mp; }
-                            catch { }
-                        }
+                            widths.ApplyTo(kv.Value != null ? kv.Value.Transcript : null);
                     }
                 }
                 catch { }
@@ -1804,22 +1743,13 @@ namespace GxPT
             catch { }
         }
 
-        private void OpenConversationInNewTab(Conversation convo)
+        // Rebuild a tab's transcript from a conversation's history without blocking the UI:
+        // Markdown is parsed on a background thread and the resulting blocks are appended to the
+        // transcript in small batches on a UI timer. System messages are skipped; help templates
+        // (NoSaveUntilUserSend) are scrolled to the top, otherwise the view sticks to the bottom.
+        private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)
         {
-            if (this.tabControl1 == null || convo == null) return;
-            var ctx = _tabManager != null ? _tabManager.CreateConversationTab() : null;
-            if (ctx == null) return;
-
-            // Replace the conversation and refresh transcript UI
-            ctx.Conversation = convo;
-            ctx.SelectedModel = string.IsNullOrEmpty(convo.SelectedModel) ? GetSelectedModel() : convo.SelectedModel;
-            try { this.cmbModel.Text = ctx.SelectedModel; }
-            catch { }
-            ConversationStore.EnsureConversationId(ctx.Conversation);
-            if (_sidebarManager != null && ctx.Conversation != null)
-                _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
-
-            // Rebuild transcript UI using background parsing and chunked appends to avoid UI freezes
+            if (ctx == null || ctx.Transcript == null || convo == null) return;
             try
             {
                 ctx.Transcript.ClearMessages();
@@ -1838,12 +1768,11 @@ namespace GxPT
 
                 // Producer-consumer: parse off-UI, consume on UI timer in small chunks
                 var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));
-                int produced = 0; // number of parsed items ready in 'parsed'
-                int consumed = 0; // number consumed/appended to transcript
+                int produced = 0; // parsed items ready in 'parsed'
+                int consumed = 0; // items appended to transcript
                 bool parsingDone = false;
                 object gate = new object();
 
-                // Start background parsing
                 System.Threading.ThreadPool.QueueUserWorkItem(delegate
                 {
                     try
@@ -1872,10 +1801,7 @@ namespace GxPT
                         }
                     }
                     catch { }
-                    finally
-                    {
-                        parsingDone = true;
-                    }
+                    finally { parsingDone = true; }
                 });
 
                 // UI timer consumes progressively
@@ -1887,41 +1813,32 @@ namespace GxPT
                     lock (gate) { avail = produced - consumed; }
                     if (avail <= 0)
                     {
-                        if (parsingDone)
-                        {
-                            // Nothing left and parsing finished
-                            timer.Stop();
-                            timer.Dispose();
-                        }
+                        if (parsingDone) { timer.Stop(); timer.Dispose(); }
                         return;
                     }
 
-                    // Consume a small batch to keep UI fluid
+                    // Consume a small batch to keep the UI fluid
                     int take = Math.Min(20, avail);
                     ctx.Transcript.BeginBatchUpdates();
                     try
                     {
                         for (int k = 0; k < take; k++)
                         {
-                            ParsedMessage msg;
-                            lock (gate)
-                            {
-                                msg = parsed[consumed];
-                                consumed++;
-                            }
-                            if (msg != null)
-                                ctx.Transcript.AddParsedMessage(msg.Role, msg.Text, msg.Blocks, msg.Attachments);
+                            ParsedMessage pm;
+                            lock (gate) { pm = parsed[consumed]; consumed++; }
+                            if (pm != null)
+                                ctx.Transcript.AddParsedMessage(pm.Role, pm.Text, pm.Blocks, pm.Attachments);
                         }
                     }
                     finally
                     {
                         bool last = parsingDone && consumed >= items.Count;
-                        bool scrollToBottom = last && !(ctx != null && ctx.NoSaveUntilUserSend);
+                        bool scrollToBottom = last && !ctx.NoSaveUntilUserSend;
                         ctx.Transcript.EndBatchUpdates(scrollToBottom);
                         if (last)
                         {
-                            // For help templates (no-save until user sends), ensure we land at the top
-                            try { if (ctx != null && ctx.NoSaveUntilUserSend && ctx.Transcript != null) ctx.Transcript.ScrollToTop(); }
+                            // Help templates (no-save until user sends) should land at the top
+                            try { if (ctx.NoSaveUntilUserSend && ctx.Transcript != null) ctx.Transcript.ScrollToTop(); }
                             catch { }
                             timer.Stop();
                             timer.Dispose();
@@ -1931,6 +1848,25 @@ namespace GxPT
                 timer.Start();
             }
             catch { }
+        }
+
+        private void OpenConversationInNewTab(Conversation convo)
+        {
+            if (this.tabControl1 == null || convo == null) return;
+            var ctx = _tabManager != null ? _tabManager.CreateConversationTab() : null;
+            if (ctx == null) return;
+
+            // Replace the conversation and refresh transcript UI
+            ctx.Conversation = convo;
+            ctx.SelectedModel = string.IsNullOrEmpty(convo.SelectedModel) ? GetSelectedModel() : convo.SelectedModel;
+            try { this.cmbModel.Text = ctx.SelectedModel; }
+            catch { }
+            ConversationStore.EnsureConversationId(ctx.Conversation);
+            if (_sidebarManager != null && ctx.Conversation != null)
+                _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
+
+            // Rebuild transcript UI off the UI thread to avoid freezes on large histories
+            RebuildTranscriptAsync(ctx, convo);
 
             // Update tab title and window
             try
@@ -1968,93 +1904,8 @@ namespace GxPT
                 if (_sidebarManager != null && ctx.Conversation != null)
                     _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
 
-                // Rebuild transcript UI using background parsing and chunked appends
-                try
-                {
-                    ctx.Transcript.ClearMessages();
-                    if (_themeManager != null) _themeManager.ApplyFontSetting(ctx.Transcript);
-                    try { ctx.Transcript.RefreshTheme(); }
-                    catch { }
-
-                    var items = new List<ChatMessage>();
-                    foreach (var m in convo.History)
-                    {
-                        if (m == null) continue;
-                        if (string.Equals(m.Role, "system", StringComparison.OrdinalIgnoreCase)) continue;
-                        items.Add(m);
-                    }
-
-                    var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));
-                    int produced = 0, consumed = 0; bool parsingDone = false; object gate = new object();
-
-                    System.Threading.ThreadPool.QueueUserWorkItem(delegate
-                    {
-                        try
-                        {
-                            const int parseChunk = 40;
-                            int i = 0;
-                            while (i < items.Count)
-                            {
-                                int count = Math.Min(parseChunk, items.Count - i);
-                                var local = new ParsedMessage[count];
-                                for (int k = 0; k < count; k++)
-                                {
-                                    var m2 = items[i + k];
-                                    var role = string.Equals(m2.Role, "assistant", StringComparison.OrdinalIgnoreCase) ? MessageRole.Assistant : MessageRole.User;
-                                    var text = m2.Content ?? string.Empty;
-                                    var blocks = MarkdownParser.ParseMarkdown(text);
-                                    var att = (m2.Attachments != null && m2.Attachments.Count > 0) ? new List<AttachedFile>(m2.Attachments) : null;
-                                    local[k] = new ParsedMessage { Role = role, Text = text, Blocks = blocks, Attachments = att };
-                                }
-                                lock (gate) { parsed.AddRange(local); produced += count; }
-                                i += count;
-                            }
-                        }
-                        catch { }
-                        finally { parsingDone = true; }
-                    });
-
-                    var timer = new System.Windows.Forms.Timer();
-                    timer.Interval = 15;
-                    timer.Tick += (s2, e2) =>
-                    {
-                        int avail; lock (gate) { avail = produced - consumed; }
-                        if (avail <= 0)
-                        {
-                            if (parsingDone)
-                            {
-                                timer.Stop(); timer.Dispose();
-                            }
-                            return;
-                        }
-                        int take = Math.Min(20, avail);
-                        ctx.Transcript.BeginBatchUpdates();
-                        try
-                        {
-                            for (int k = 0; k < take; k++)
-                            {
-                                ParsedMessage pm; lock (gate) { pm = parsed[consumed]; consumed++; }
-                                if (pm != null) ctx.Transcript.AddParsedMessage(pm.Role, pm.Text, pm.Blocks, pm.Attachments);
-                            }
-                        }
-                        finally
-                        {
-                            bool last = parsingDone && consumed >= items.Count;
-                            bool scrollToBottom = last && !(ctx != null && ctx.NoSaveUntilUserSend);
-                            ctx.Transcript.EndBatchUpdates(scrollToBottom);
-                            if (last)
-                            {
-                                // For help templates (no-save until user sends), ensure we land at the top
-                                try { if (ctx != null && ctx.NoSaveUntilUserSend && ctx.Transcript != null) ctx.Transcript.ScrollToTop(); }
-                                catch { }
-                                timer.Stop();
-                                timer.Dispose();
-                            }
-                        }
-                    };
-                    timer.Start();
-                }
-                catch { }
+                // Rebuild transcript UI off the UI thread to avoid freezes on large histories
+                RebuildTranscriptAsync(ctx, convo);
 
                 // Hook name updates for this conversation
                 try

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -166,6 +166,7 @@
     </Compile>
     <Compile Include="Services\SessionState.cs" />
     <Compile Include="Services\SyntaxHighlightingRenderer.cs" />
+    <Compile Include="Services\TranscriptWidthSettings.cs" />
     <Compile Include="Managers\TabManager.cs" />
     <Compile Include="Managers\ThemeManager.cs" />
     <Compile Include="Services\TextFileAttachmentExtractor.cs" />

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -146,96 +146,15 @@ namespace GxPT
                 };
                 ctx.Conversation.SelectedModel = ctx.SelectedModel;
                 _mainForm.EnsureConversationId(ctx.Conversation);
-                // Wire edit request from transcript to input box
-                try
-                {
-                    if (ctx.Transcript != null)
-                    {
-                        ctx.Transcript.UserMessageEditRequested += delegate(int index, string text)
-                        {
-                            try
-                            {
-                                // Map transcript index (user+assistant only) to conversation history index (skipping system)
-                                int histIndex = MapTranscriptToHistoryIndex(ctx.Conversation, index);
-                                if (histIndex < 0 || histIndex >= ctx.Conversation.History.Count)
-                                    return;
-                                var msg = ctx.Conversation.History[histIndex];
-                                if (msg == null || !string.Equals(msg.Role, "user", StringComparison.OrdinalIgnoreCase))
-                                    return; // only allow editing user messages
-
-                                var im = _mainForm.GetInputManager();
-                                if (im != null) im.SetInputText(msg.Content ?? string.Empty, true);
-                                ctx.PendingEditActive = true;
-                                ctx.PendingEditIndex = histIndex;
-                                // Capture the model at time of entering edit mode
-                                ctx.PendingEditOriginalModel = ctx.SelectedModel;
-                                // Seed pending attachments from the original message being edited
-                                try
-                                {
-                                    var list = new List<AttachedFile>();
-                                    if (msg.Attachments != null)
-                                    {
-                                        for (int i = 0; i < msg.Attachments.Count; i++)
-                                        {
-                                            var af = msg.Attachments[i];
-                                            if (af == null) continue;
-                                            list.Add(new AttachedFile(af.FileName, af.Content));
-                                        }
-                                    }
-                                    ctx.PendingAttachments = list;
-                                    // Refresh attachments banner UI
-                                    try { _mainForm.RefreshAttachmentsBannerUi(); }
-                                    catch { }
-                                }
-                                catch { }
-                                _mainForm.SelectTab(ctx.Page);
-                            }
-                            catch { }
-                        };
-                    }
-                }
-                catch { }
-
-                ctx.Conversation.NameGenerated += delegate(string name)
-                {
-                    try
-                    {
-                        if (_mainForm.IsHandleCreated)
-                        {
-                            _mainForm.BeginInvoke((MethodInvoker)delegate
-                            {
-                                ctx.Page.Text = string.IsNullOrEmpty(name) ? "Conversation" : name;
-                                _mainForm.UpdateWindowTitle();
-                            });
-                        }
-                    }
-                    catch { }
-                };
+                // Wire edit-request and name-generated handlers for this tab
+                HookEditRequest(ctx);
+                HookNameGenerated(ctx);
 
                 try { ctx.Page.Text = "New Conversation"; }
                 catch { }
 
                 // Apply transcript/message width from settings to the initial transcript
-                try
-                {
-                    int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
-                    if (tw <= 0) tw = 1000; if (tw < 300) tw = 300; if (tw > 1900) tw = 1900;
-                    int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
-                    int mp = rawMp;
-                    if (mp < 50 || mp > 100)
-                    {
-                        int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
-                        if (computed < 50) computed = 50; if (computed > 100) computed = 100;
-                        mp = computed;
-                    }
-                    if (mp < 50) mp = 50; if (mp > 100) mp = 100;
-                    if (ctx.Transcript != null)
-                    {
-                        ctx.Transcript.MaxContentWidth = tw;
-                        try { ctx.Transcript.BubbleWidthPercent = mp; }
-                        catch { }
-                    }
-                }
+                try { TranscriptWidthSettings.Resolve().ApplyTo(ctx.Transcript); }
                 catch { }
 
                 _tabContexts[initialTab] = ctx;
@@ -268,70 +187,9 @@ namespace GxPT
             ctx.Conversation.SelectedModel = ctx.SelectedModel;
             _mainForm.EnsureConversationId(ctx.Conversation);
 
-            // Wire edit request from transcript to input box
-            try
-            {
-                if (ctx.Transcript != null)
-                {
-                    ctx.Transcript.UserMessageEditRequested += delegate(int index, string text)
-                    {
-                        try
-                        {
-                            // Map transcript index (user+assistant only) to conversation history index (skipping system)
-                            int histIndex = MapTranscriptToHistoryIndex(ctx.Conversation, index);
-                            if (histIndex < 0 || histIndex >= ctx.Conversation.History.Count)
-                                return;
-                            var msg = ctx.Conversation.History[histIndex];
-                            if (msg == null || !string.Equals(msg.Role, "user", StringComparison.OrdinalIgnoreCase))
-                                return; // only allow editing user messages
-
-                            var im = _mainForm.GetInputManager();
-                            if (im != null) im.SetInputText(msg.Content ?? string.Empty, true);
-                            ctx.PendingEditActive = true;
-                            ctx.PendingEditIndex = histIndex;
-                            // Capture the model at time of entering edit mode
-                            ctx.PendingEditOriginalModel = ctx.SelectedModel;
-                            // Seed pending attachments from the original message being edited
-                            try
-                            {
-                                var list = new List<AttachedFile>();
-                                if (msg.Attachments != null)
-                                {
-                                    for (int i = 0; i < msg.Attachments.Count; i++)
-                                    {
-                                        var af = msg.Attachments[i];
-                                        if (af == null) continue;
-                                        list.Add(new AttachedFile(af.FileName, af.Content));
-                                    }
-                                }
-                                ctx.PendingAttachments = list;
-                                try { _mainForm.RefreshAttachmentsBannerUi(); }
-                                catch { }
-                            }
-                            catch { }
-                            _mainForm.SelectTab(ctx.Page);
-                        }
-                        catch { }
-                    };
-                }
-            }
-            catch { }
-
-            ctx.Conversation.NameGenerated += delegate(string name)
-            {
-                try
-                {
-                    if (_mainForm.IsHandleCreated)
-                    {
-                        _mainForm.BeginInvoke((MethodInvoker)delegate
-                        {
-                            ctx.Page.Text = string.IsNullOrEmpty(name) ? "Conversation" : name;
-                            _mainForm.UpdateWindowTitle();
-                        });
-                    }
-                }
-                catch { }
-            };
+            // Wire edit-request and name-generated handlers for this tab
+            HookEditRequest(ctx);
+            HookNameGenerated(ctx);
 
             _tabContexts[page] = ctx;
 
@@ -340,25 +198,7 @@ namespace GxPT
             catch { }
 
             // Apply transcript/message width from settings for newly created transcript
-            try
-            {
-                int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
-                if (tw <= 0) tw = 1000; if (tw < 300) tw = 300; if (tw > 1900) tw = 1900;
-                int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
-                int mp = rawMp;
-                if (mp < 50 || mp > 100)
-                {
-                    int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
-                    if (computed < 50) computed = 50; if (computed > 100) computed = 100;
-                    mp = computed;
-                }
-                if (mp < 50) mp = 50; if (mp > 100) mp = 100;
-                try { transcript.MaxContentWidth = tw; }
-                catch { }
-                try { transcript.BubbleWidthPercent = mp; }
-                catch { }
-
-            }
+            try { TranscriptWidthSettings.Resolve().ApplyTo(transcript); }
             catch { }
 
             if (TabsChanged != null) TabsChanged();
@@ -417,22 +257,8 @@ namespace GxPT
                             _mainForm.SyncComboModelFromActiveTab();
                         }
                         catch { }
-                        // re-hook name event
-                        ctx.Conversation.NameGenerated += delegate(string name)
-                        {
-                            try
-                            {
-                                if (_mainForm.IsHandleCreated)
-                                {
-                                    _mainForm.BeginInvoke((MethodInvoker)delegate
-                                    {
-                                        ctx.Page.Text = string.IsNullOrEmpty(name) ? "Conversation" : name;
-                                        _mainForm.UpdateWindowTitle();
-                                    });
-                                }
-                            }
-                            catch { }
-                        };
+                        // re-hook name event for the fresh conversation on this reused tab
+                        HookNameGenerated(ctx);
                         page.Text = "New Conversation";
                         _mainForm.UpdateWindowTitle();
                     }
@@ -645,27 +471,9 @@ namespace GxPT
         {
             try
             {
-                int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
-                if (tw <= 0) tw = 1000; if (tw < 300) tw = 300; if (tw > 1900) tw = 1900;
-                int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
-                int mp = rawMp;
-                if (mp < 50 || mp > 100)
-                {
-                    int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
-                    if (computed < 50) computed = 50; if (computed > 100) computed = 100;
-                    mp = computed;
-                }
-                if (mp < 50) mp = 50; if (mp > 100) mp = 100;
-
+                var widths = TranscriptWidthSettings.Resolve();
                 foreach (var kv in _tabContexts)
-                {
-                    var t = kv.Value != null ? kv.Value.Transcript : null;
-                    if (t == null) continue;
-                    try { t.MaxContentWidth = tw; }
-                    catch { }
-                    try { t.BubbleWidthPercent = mp; }
-                    catch { }
-                }
+                    widths.ApplyTo(kv.Value != null ? kv.Value.Transcript : null);
             }
             catch { }
         }
@@ -701,6 +509,76 @@ namespace GxPT
                 }
             }
             catch { }
+        }
+
+        // Wire a tab's transcript edit-request to populate the input box and enter edit mode.
+        // Editing is only permitted for prior user messages.
+        private void HookEditRequest(ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Transcript == null) return;
+            ctx.Transcript.UserMessageEditRequested += delegate(int index, string text)
+            {
+                try
+                {
+                    // Map transcript index (user+assistant only) to conversation history index (skipping system)
+                    int histIndex = MapTranscriptToHistoryIndex(ctx.Conversation, index);
+                    if (histIndex < 0 || histIndex >= ctx.Conversation.History.Count)
+                        return;
+                    var msg = ctx.Conversation.History[histIndex];
+                    if (msg == null || !string.Equals(msg.Role, "user", StringComparison.OrdinalIgnoreCase))
+                        return; // only allow editing user messages
+
+                    var im = _mainForm.GetInputManager();
+                    if (im != null) im.SetInputText(msg.Content ?? string.Empty, true);
+                    ctx.PendingEditActive = true;
+                    ctx.PendingEditIndex = histIndex;
+                    // Capture the model at time of entering edit mode
+                    ctx.PendingEditOriginalModel = ctx.SelectedModel;
+                    // Seed pending attachments from the original message being edited
+                    try
+                    {
+                        var list = new List<AttachedFile>();
+                        if (msg.Attachments != null)
+                        {
+                            for (int i = 0; i < msg.Attachments.Count; i++)
+                            {
+                                var af = msg.Attachments[i];
+                                if (af == null) continue;
+                                list.Add(new AttachedFile(af.FileName, af.Content));
+                            }
+                        }
+                        ctx.PendingAttachments = list;
+                        // Refresh attachments banner UI
+                        try { _mainForm.RefreshAttachmentsBannerUi(); }
+                        catch { }
+                    }
+                    catch { }
+                    _mainForm.SelectTab(ctx.Page);
+                }
+                catch { }
+            };
+        }
+
+        // Update the tab title (and window title) on the UI thread when a conversation's
+        // name is generated in the background.
+        private void HookNameGenerated(ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Conversation == null) return;
+            ctx.Conversation.NameGenerated += delegate(string name)
+            {
+                try
+                {
+                    if (_mainForm.IsHandleCreated)
+                    {
+                        _mainForm.BeginInvoke((MethodInvoker)delegate
+                        {
+                            ctx.Page.Text = string.IsNullOrEmpty(name) ? "Conversation" : name;
+                            _mainForm.UpdateWindowTitle();
+                        });
+                    }
+                }
+                catch { }
+            };
         }
 
         // Map a transcript message index (which excludes system messages) to the corresponding

--- a/GxPT/Services/TranscriptWidthSettings.cs
+++ b/GxPT/Services/TranscriptWidthSettings.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace GxPT
+{
+    // Resolves the transcript layout widths from settings in one place:
+    //   - MaxContentWidth: the centered content area width in pixels (clamped 300..1900).
+    //   - BubbleWidthPercent: the message bubble width as a percent of the content area (50..100).
+    // Also performs a one-time migration of the legacy pixel-based "message_max_width" value
+    // to a percentage, persisting the normalized value back to settings.
+    internal struct TranscriptWidthSettings
+    {
+        public int MaxContentWidth;
+        public int BubbleWidthPercent;
+
+        public static TranscriptWidthSettings Resolve()
+        {
+            int tw = (int)AppSettings.GetDouble("transcript_max_width", 1000);
+            if (tw <= 0) tw = 1000;
+            if (tw < 300) tw = 300;
+            if (tw > 1900) tw = 1900;
+
+            int rawMp = (int)AppSettings.GetDouble("message_max_width", 90);
+            int mp = rawMp;
+            if (mp < 50 || mp > 100)
+            {
+                // Legacy value stored as pixels: convert to a percent of the content width.
+                int computed = (rawMp <= 0) ? 90 : (int)Math.Round(100.0 * rawMp / Math.Max(1, tw));
+                if (computed < 50) computed = 50;
+                if (computed > 100) computed = 100;
+                mp = computed;
+                try { AppSettings.SetInt("message_max_width", mp); }
+                catch { }
+            }
+            if (mp < 50) mp = 50;
+            if (mp > 100) mp = 100;
+
+            TranscriptWidthSettings r;
+            r.MaxContentWidth = tw;
+            r.BubbleWidthPercent = mp;
+            return r;
+        }
+
+        // Apply these widths to a transcript control (each setter guarded individually).
+        public void ApplyTo(ChatTranscriptControl transcript)
+        {
+            if (transcript == null) return;
+            try { transcript.MaxContentWidth = MaxContentWidth; }
+            catch { }
+            try { transcript.BubbleWidthPercent = BubbleWidthPercent; }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pure-refactor cleanup of three copy-paste clusters identified in the architecture review. No behavior change; net **−217 lines**.

## Changes

1. **Transcript width logic (5 sites → 1).** The "read `transcript_max_width`/`message_max_width` → clamp (300–1900px / 50–100%) → migrate legacy pixel value to percent" block was duplicated across `MainForm.InitializeClient`, `MainForm.miSettings_Click`, and three spots in `TabManager`. Extracted into a new `TranscriptWidthSettings.Resolve()` / `ApplyTo(transcript)` helper (`GxPT/Services/TranscriptWidthSettings.cs`, registered in `GxPT.csproj`).

2. **TabManager wiring delegates.** The ~45-line transcript edit-request handler (2 copies) and the `NameGenerated` tab-title handler (3 copies) are now `HookEditRequest(ctx)` and `HookNameGenerated(ctx)`.

3. **`OpenConversationInTab` / `OpenConversationInNewTab`.** Each contained a near-identical ~85-line background-parse + chunked-append block to rebuild the transcript without freezing the UI. Extracted into `MainForm.RebuildTranscriptAsync(ctx, convo)`; both methods call it.

## Behavioral note

The width helper now performs the one-time legacy→percent **migration persist** from every resolve site, whereas previously only the two `MainForm` sites persisted. This is still effectively a single migration: `InitializeClient` resolves widths at startup *before* any tab is created, so it performs the migration; every later call finds an in-range value and no-ops. Net effect is identical (and now self-healing from any entry point).

## Testing

Not built/run — authored in a Linux environment without the .NET 3.5 / MSBuild toolchain. Because this is a pure refactor touching tab/transcript flow, a build + click-through on Windows is worthwhile. Suggested checks:
- New tab / close tab / "close others"; tab titles still update on auto-naming.
- Open a conversation from history into both a blank tab and a new tab — transcript renders progressively and scrolls to the bottom.
- Open a Help tab (API Keys / Privacy) — still scrolls to the top.
- Edit a previous user message — loads into the input with its attachments.
- Change transcript/message width in Settings — applies to all open tabs.

https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp)_