### PR TITLE
Cache ConversationStore.ListAll metadata per file

### DIFF
--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -12,6 +12,30 @@ namespace GxPT
         private const string FolderName = "Conversations";
         private const string FileExt = ".json";
 
+        // Per-file metadata cache for ListAll, so repeated sidebar refreshes don't re-read and
+        // re-parse every conversation file. Entries are keyed by path and validated against the
+        // file's last-write timestamp, so a stale entry is refreshed automatically when the file
+        // changes, and entries for deleted files are pruned.
+        private static readonly object _listCacheGate = new object();
+        private static readonly Dictionary<string, CachedListMeta> _listCache =
+            new Dictionary<string, CachedListMeta>(StringComparer.OrdinalIgnoreCase);
+
+        private sealed class CachedListMeta
+        {
+            public DateTime StampUtc;
+            public ConversationListItem Item;
+        }
+
+        // Lightweight DTO for listing: only the fields the sidebar needs, so we avoid
+        // allocating the (potentially large) message list when reading metadata.
+        private sealed class ConversationMetaDto
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string SelectedModel { get; set; }
+            public DateTime LastUpdated { get; set; }
+        }
+
         private static string GetRoot()
         {
             string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -132,28 +156,77 @@ namespace GxPT
         {
             var list = new List<ConversationListItem>();
             string root = GetRoot();
-            if (!Directory.Exists(root)) return list;
-            foreach (var path in Directory.GetFiles(root, "*" + FileExt))
+            if (!Directory.Exists(root))
             {
-                try
-                {
-                    string json = File.ReadAllText(path);
-                    var dto = new JavaScriptSerializer().Deserialize<ConversationDto>(json);
-                    if (dto == null) continue;
-                    list.Add(new ConversationListItem
-                    {
-                        Id = dto.Id,
-                        Name = string.IsNullOrEmpty(dto.Name) ? "New Conversation" : dto.Name,
-                        SelectedModel = dto.SelectedModel,
-                        LastUpdated = dto.LastUpdated,
-                        Path = path
-                    });
-                }
-                catch { }
+                lock (_listCacheGate) { _listCache.Clear(); }
+                return list;
             }
+
+            string[] files;
+            try { files = Directory.GetFiles(root, "*" + FileExt); }
+            catch { files = new string[0]; }
+
+            lock (_listCacheGate)
+            {
+                var present = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var path in files)
+                {
+                    present.Add(path);
+                    try
+                    {
+                        DateTime stamp;
+                        try { stamp = File.GetLastWriteTimeUtc(path); }
+                        catch { stamp = DateTime.MinValue; }
+
+                        CachedListMeta cached;
+                        if (_listCache.TryGetValue(path, out cached) && cached != null
+                            && cached.Item != null && cached.StampUtc == stamp)
+                        {
+                            // Unchanged since last read: reuse cached metadata, no file I/O.
+                            list.Add(cached.Item);
+                            continue;
+                        }
+
+                        var item = ReadListItem(path);
+                        if (item == null) continue;
+                        _listCache[path] = new CachedListMeta { StampUtc = stamp, Item = item };
+                        list.Add(item);
+                    }
+                    catch { }
+                }
+
+                // Prune cache entries for files that no longer exist.
+                if (_listCache.Count > present.Count)
+                {
+                    var stale = new List<string>();
+                    foreach (var kv in _listCache)
+                        if (!present.Contains(kv.Key)) stale.Add(kv.Key);
+                    for (int i = 0; i < stale.Count; i++) _listCache.Remove(stale[i]);
+                }
+            }
+
             // Order by LastUpdated descending
             list = list.OrderByDescending(i => i.LastUpdated).ToList();
             return list;
+        }
+
+        private static ConversationListItem ReadListItem(string path)
+        {
+            try
+            {
+                string json = File.ReadAllText(path);
+                var dto = new JavaScriptSerializer().Deserialize<ConversationMetaDto>(json);
+                if (dto == null) return null;
+                return new ConversationListItem
+                {
+                    Id = dto.Id,
+                    Name = string.IsNullOrEmpty(dto.Name) ? "New Conversation" : dto.Name,
+                    SelectedModel = dto.SelectedModel,
+                    LastUpdated = dto.LastUpdated,
+                    Path = path
+                };
+            }
+            catch { return null; }
         }
 
         public static void DeleteById(string id)


### PR DESCRIPTION
## Summary

`RefreshSidebarList()` runs after every send, model change, import, rename, and delete, and each call had `ConversationStore.ListAll()` read and fully deserialize **every** conversation file just to extract `Id`/`Name`/`SelectedModel`/`LastUpdated`. That's O(total history size) per refresh and scales badly as the conversation corpus grows.

This adds a per-file metadata cache so unchanged files are no longer re-read on every refresh.

## Changes

- **Per-file metadata cache** keyed by path and validated against the file's last-write timestamp:
  - Unchanged files are served from cache with **no I/O**.
  - A changed file (e.g. the conversation you just saved) is re-read and the cache entry refreshed.
  - Entries for deleted files are pruned on the next `ListAll`.
  - Because validation is timestamp-based (same approach as the AppSettings cache), saves/renames/deletes performed anywhere are picked up automatically — no explicit invalidation to keep in sync, so no drift risk.
- **Metadata-only DTO** (`ConversationMetaDto`) for the read path, so a changed file no longer allocates its full message list just to read four fields.

Ordering (newest first) and the `"New Conversation"` name fallback are unchanged. `ConversationListItem` instances are treated read-only by callers (stored as `ListViewItem.Tag`), so sharing cached instances is safe.

## Testing

Not built/run — authored in a Linux environment without the .NET 3.5 / MSBuild toolchain. Suggested checks on Windows (these exercise the cache-invalidation paths):
- Send a message → that conversation moves to the top of the sidebar (LastUpdated re-read).
- Rename a conversation → new name appears in the sidebar.
- Delete one / delete all → they disappear (pruning).
- Import an archive → imported conversations appear.
- Sidebar still lists everything newest-first; switching conversations stays responsive.

https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp)_