### PR TITLE
Add unit tests for MarkdownParser and ZipSafe with Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      # Only the test project is built. It links the production source files under test
+      # (MarkdownParser, ZipSafe), so the .NET Framework 3.5 app itself is not built here.
+      - name: Restore
+        run: dotnet restore GxPT.Tests/GxPT.Tests.csproj
+
+      - name: Test
+        run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.Tests/ConversationStoreTests.cs
+++ b/GxPT.Tests/ConversationStoreTests.cs
@@ -1,0 +1,72 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Exercises the pure JSON-to-model path. A null client is fine here: LoadFromJson adds
+    // messages directly to History and never triggers naming or network calls.
+    public class ConversationStoreTests
+    {
+        [Fact]
+        public void LoadFromJson_NullOrEmpty_ReturnsNull()
+        {
+            Assert.Null(ConversationStore.LoadFromJson(null, null));
+            Assert.Null(ConversationStore.LoadFromJson(null, ""));
+        }
+
+        [Fact]
+        public void LoadFromJson_ParsesNameModelAndMessages()
+        {
+            string json =
+                "{\"Id\":\"abc123\",\"Name\":\"My Chat\",\"SelectedModel\":\"openai/gpt-4o\"," +
+                "\"Messages\":[" +
+                "{\"Role\":\"user\",\"Content\":\"hello\"}," +
+                "{\"Role\":\"assistant\",\"Content\":\"hi there\"}]}";
+
+            var convo = ConversationStore.LoadFromJson(null, json);
+
+            Assert.NotNull(convo);
+            Assert.Equal("abc123", convo.Id);
+            Assert.Equal("My Chat", convo.Name);
+            Assert.Equal("openai/gpt-4o", convo.SelectedModel);
+            Assert.Equal(2, convo.History.Count);
+            Assert.Equal("user", convo.History[0].Role);
+            Assert.Equal("hello", convo.History[0].Content);
+            Assert.Equal("assistant", convo.History[1].Role);
+            Assert.Equal("hi there", convo.History[1].Content);
+        }
+
+        [Fact]
+        public void LoadFromJson_MissingName_DefaultsToNewConversation()
+        {
+            string json = "{\"Messages\":[{\"Role\":\"user\",\"Content\":\"x\"}]}";
+            var convo = ConversationStore.LoadFromJson(null, json);
+            Assert.NotNull(convo);
+            Assert.Equal("New Conversation", convo.Name);
+        }
+
+        [Fact]
+        public void LoadFromJson_ExtractsLegacyAttachmentMarkers()
+        {
+            // Older saves embedded attachments inline in the message content using markers.
+            // LoadFromJson should split them back out into Attachments when no Attachments field exists.
+            string content =
+                "Here is my question" +
+                "\\n--- Attached File: foo.txt ---" +
+                "\\nhello world" +
+                "\\n--- End Attached File: foo.txt ---";
+            string json = "{\"Name\":\"Chat\",\"Messages\":[{\"Role\":\"user\",\"Content\":\"" + content + "\"}]}";
+
+            var convo = ConversationStore.LoadFromJson(null, json);
+
+            Assert.NotNull(convo);
+            Assert.Single(convo.History);
+            var msg = convo.History[0];
+            Assert.Equal("Here is my question", msg.Content);
+            Assert.NotNull(msg.Attachments);
+            Assert.Single(msg.Attachments);
+            Assert.Equal("foo.txt", msg.Attachments[0].FileName);
+            Assert.Contains("hello world", msg.Attachments[0].Content);
+        }
+    }
+}

--- a/GxPT.Tests/FileSafeTests.cs
+++ b/GxPT.Tests/FileSafeTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Text;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class FileSafeTests : IDisposable
+    {
+        private readonly string _root;
+
+        public FileSafeTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_filesafetests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void WriteAllTextAtomic_CreatesFileWithContent()
+        {
+            string path = Path.Combine(_root, "new.txt");
+            FileSafe.WriteAllTextAtomic(path, "hello", new UTF8Encoding(false));
+            Assert.True(File.Exists(path));
+            Assert.Equal("hello", File.ReadAllText(path));
+        }
+
+        [Fact]
+        public void WriteAllTextAtomic_OverwritesExistingFile()
+        {
+            string path = Path.Combine(_root, "over.txt");
+            FileSafe.WriteAllTextAtomic(path, "first", new UTF8Encoding(false));
+            FileSafe.WriteAllTextAtomic(path, "second", new UTF8Encoding(false));
+            Assert.Equal("second", File.ReadAllText(path));
+        }
+
+        [Fact]
+        public void WriteAllTextAtomic_CreatesMissingDirectory()
+        {
+            string path = Path.Combine(_root, "sub", "deep", "file.txt");
+            FileSafe.WriteAllTextAtomic(path, "content", new UTF8Encoding(false));
+            Assert.True(File.Exists(path));
+            Assert.Equal("content", File.ReadAllText(path));
+        }
+
+        [Fact]
+        public void WriteAllTextAtomic_LeavesNoTempFiles()
+        {
+            string path = Path.Combine(_root, "clean.txt");
+            FileSafe.WriteAllTextAtomic(path, "data", new UTF8Encoding(false));
+            // The temp file is named "<path>.tmp-<guid>" and must be gone after a successful write.
+            string[] leftovers = Directory.GetFiles(_root, "clean.txt.tmp-*");
+            Assert.Empty(leftovers);
+        }
+
+        [Fact]
+        public void WriteAllTextAtomic_WritesUtf8WithoutBom()
+        {
+            string path = Path.Combine(_root, "nobom.txt");
+            FileSafe.WriteAllTextAtomic(path, "abc", new UTF8Encoding(false));
+            byte[] bytes = File.ReadAllBytes(path);
+            // No UTF-8 BOM (EF BB BF) at the start.
+            Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+            Assert.Equal(new byte[] { 0x61, 0x62, 0x63 }, bytes);
+        }
+    }
+}

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Unit tests for the pure-logic parts of GxPT.
+
+    The main app targets .NET Framework 3.5 (VS2008-era, classic csproj) and can't be
+    built by a modern SDK on a stock CI runner. Rather than build that project, this test
+    project links the specific source files under test and compiles them into the test
+    assembly. That also makes the 'internal' ZipSafe accessible without InternalsVisibleTo.
+
+    Targets net48 so it can reference the vendored .NET Framework DotNetZip.dll directly
+    (the real dependency the app ships). Runs via 'dotnet test' on a Windows runner.
+
+    NOTE: intentionally NOT added to GxPT.sln, which VS2008 must still be able to open
+    (it cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>GxPT.Tests</AssemblyName>
+    <RootNamespace>GxPT.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <!-- Production source under test, compiled directly into the test assembly -->
+  <ItemGroup>
+    <Compile Include="..\GxPT\Services\MarkdownParser.cs" Link="Linked\MarkdownParser.cs" />
+    <Compile Include="..\GxPT\Utilities\ZipSafe.cs" Link="Linked\ZipSafe.cs" />
+  </ItemGroup>
+
+  <!-- The same vendored DotNetZip the app ships with -->
+  <ItemGroup>
+    <Reference Include="DotNetZip">
+      <HintPath>..\GxPT\lib\DotNetZip.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- Provides net48 reference assemblies so the build doesn't depend on an installed targeting pack -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -23,18 +23,32 @@
     <RootNamespace>GxPT.Tests</RootNamespace>
   </PropertyGroup>
 
-  <!-- Production source under test, compiled directly into the test assembly -->
+  <!--
+    Production source under test, compiled directly into the test assembly.
+    ConversationStore.LoadFromJson pulls in its dependency chain (Conversation ->
+    OpenRouterClient -> Logger -> AppSettings -> FileSafe, plus the model types), so those
+    files are linked too. None of them reference WinForms, so they compile on net48.
+  -->
   <ItemGroup>
     <Compile Include="..\GxPT\Services\MarkdownParser.cs" Link="Linked\MarkdownParser.cs" />
     <Compile Include="..\GxPT\Utilities\ZipSafe.cs" Link="Linked\ZipSafe.cs" />
+    <Compile Include="..\GxPT\Utilities\FileSafe.cs" Link="Linked\FileSafe.cs" />
+    <Compile Include="..\GxPT\Data\ConversationStore.cs" Link="Linked\ConversationStore.cs" />
+    <Compile Include="..\GxPT\Models\Conversation.cs" Link="Linked\Conversation.cs" />
+    <Compile Include="..\GxPT\Models\ChatModels.cs" Link="Linked\ChatModels.cs" />
+    <Compile Include="..\GxPT\Services\OpenRouterClient.cs" Link="Linked\OpenRouterClient.cs" />
+    <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
+    <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
   </ItemGroup>
 
-  <!-- The same vendored DotNetZip the app ships with -->
+  <!-- The vendored DotNetZip the app ships with, plus the framework assembly that
+       provides System.Web.Script.Serialization.JavaScriptSerializer. -->
   <ItemGroup>
     <Reference Include="DotNetZip">
       <HintPath>..\GxPT\lib\DotNetZip.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GxPT.Tests/MarkdownParserTests.cs
+++ b/GxPT.Tests/MarkdownParserTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Text;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public class MarkdownParserTests
+    {
+        private static string InlineText(IEnumerable<InlineRun> runs)
+        {
+            var sb = new StringBuilder();
+            if (runs != null)
+                foreach (var r in runs)
+                    if (r != null && r.Text != null) sb.Append(r.Text);
+            return sb.ToString();
+        }
+
+        private static T FirstBlock<T>(List<Block> blocks) where T : Block
+        {
+            foreach (var b in blocks)
+            {
+                var t = b as T;
+                if (t != null) return t;
+            }
+            return null;
+        }
+
+        [Fact]
+        public void EmptyInput_ReturnsSingleEmptyParagraph()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("");
+            Assert.Single(blocks);
+            var p = Assert.IsType<ParagraphBlock>(blocks[0]);
+            Assert.Empty(p.Inlines);
+        }
+
+        [Fact]
+        public void Heading_ParsesLevelAndText()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("## Title Here");
+            var h = FirstBlock<HeadingBlock>(blocks);
+            Assert.NotNull(h);
+            Assert.Equal(2, h.Level);
+            Assert.Equal("Title Here", InlineText(h.Inlines));
+        }
+
+        [Fact]
+        public void FencedCodeBlock_CapturesLanguageAndText()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("```csharp\nint x = 1;\n```");
+            var code = FirstBlock<CodeBlock>(blocks);
+            Assert.NotNull(code);
+            Assert.Equal("csharp", code.Language);
+            Assert.Equal("int x = 1;", code.Text);
+        }
+
+        [Fact]
+        public void BulletList_CollectsItems()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("- one\n- two");
+            var list = FirstBlock<BulletListBlock>(blocks);
+            Assert.NotNull(list);
+            Assert.Equal(2, list.Items.Count);
+            Assert.Equal("one", InlineText(list.Items[0].Content));
+            Assert.Equal("two", InlineText(list.Items[1].Content));
+        }
+
+        [Fact]
+        public void NestedBullet_HasIndentLevel()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("- a\n  - b");
+            var list = FirstBlock<BulletListBlock>(blocks);
+            Assert.NotNull(list);
+            Assert.Equal(2, list.Items.Count);
+            Assert.Equal(0, list.Items[0].IndentLevel);
+            Assert.Equal(1, list.Items[1].IndentLevel);
+        }
+
+        [Fact]
+        public void NumberedList_PreservesNumbers()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("1. first\n2. second");
+            var list = FirstBlock<NumberedListBlock>(blocks);
+            Assert.NotNull(list);
+            Assert.Equal(2, list.Items.Count);
+            Assert.Equal(1, list.Items[0].Number);
+            Assert.Equal(2, list.Items[1].Number);
+        }
+
+        [Fact]
+        public void Table_ParsesHeaderAndRow()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |");
+            var table = FirstBlock<TableBlock>(blocks);
+            Assert.NotNull(table);
+            Assert.Equal(2, table.Header.Count);
+            Assert.Equal("A", InlineText(table.Header[0]));
+            Assert.Equal("B", InlineText(table.Header[1]));
+            Assert.Single(table.Rows);
+            Assert.Equal(2, table.Rows[0].Count);
+            Assert.Equal("1", InlineText(table.Rows[0][0]));
+            Assert.Equal("2", InlineText(table.Rows[0][1]));
+        }
+
+        [Fact]
+        public void Inline_Bold_SetsBoldStyle()
+        {
+            var runs = MarkdownParser.ParseInlines("**bold**");
+            Assert.Contains(runs, r => r.Text == "bold" && (r.Style & RunStyle.Bold) != 0);
+        }
+
+        [Fact]
+        public void Inline_Italic_SetsItalicStyle()
+        {
+            var runs = MarkdownParser.ParseInlines("*italic*");
+            Assert.Contains(runs, r => r.Text == "italic" && (r.Style & RunStyle.Italic) != 0);
+        }
+
+        [Fact]
+        public void Inline_Code_SetsCodeStyle()
+        {
+            var runs = MarkdownParser.ParseInlines("`x = 1`");
+            Assert.Contains(runs, r => r.Text == "x = 1" && (r.Style & RunStyle.Code) != 0);
+        }
+
+        [Fact]
+        public void Inline_Link_SetsLinkUrl()
+        {
+            var runs = MarkdownParser.ParseInlines("[Google](https://google.com)");
+            Assert.Contains(runs, r => r.Text == "Google"
+                && (r.Style & RunStyle.Link) != 0
+                && r.LinkUrl == "https://google.com");
+        }
+
+        [Fact]
+        public void Inline_BareUrl_BecomesLink()
+        {
+            var runs = MarkdownParser.ParseInlines("see https://example.com now");
+            Assert.Contains(runs, r => r.LinkUrl == "https://example.com" && (r.Style & RunStyle.Link) != 0);
+        }
+    }
+}

--- a/GxPT.Tests/MarkdownParserTests.cs
+++ b/GxPT.Tests/MarkdownParserTests.cs
@@ -139,5 +139,98 @@ namespace GxPT.Tests
             var runs = MarkdownParser.ParseInlines("see https://example.com now");
             Assert.Contains(runs, r => r.LinkUrl == "https://example.com" && (r.Style & RunStyle.Link) != 0);
         }
+
+        [Fact]
+        public void Inline_UnderscoresInsideWord_AreNotItalic()
+        {
+            // snake_case identifiers must not be treated as emphasis
+            var runs = MarkdownParser.ParseInlines("call snake_case_name here");
+            foreach (var r in runs)
+                Assert.True((r.Style & RunStyle.Italic) == 0, "underscores within a word should not be italic");
+        }
+
+        [Fact]
+        public void Inline_UnderscoreEmphasis_IsItalic()
+        {
+            // A proper _word_ delimited by boundaries should be italic
+            var runs = MarkdownParser.ParseInlines("an _emphasized_ word");
+            Assert.Contains(runs, r => r.Text == "emphasized" && (r.Style & RunStyle.Italic) != 0);
+        }
+
+        [Fact]
+        public void Inline_BareUrl_TrailingPeriodExcludedFromUrl()
+        {
+            var runs = MarkdownParser.ParseInlines("visit https://example.com.");
+            // The trailing sentence period must not be part of the captured URL.
+            Assert.Contains(runs, r => r.LinkUrl == "https://example.com");
+            Assert.DoesNotContain(runs, r => r.LinkUrl != null && r.LinkUrl.EndsWith("."));
+        }
+
+        [Fact]
+        public void Table_ParsesColumnAlignments()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("| L | C | R |\n| :-- | :-: | --: |\n| a | b | c |");
+            var table = FirstBlock<TableBlock>(blocks);
+            Assert.NotNull(table);
+            Assert.Equal(3, table.Alignments.Count);
+            Assert.Equal(TableAlign.Left, table.Alignments[0]);
+            Assert.Equal(TableAlign.Center, table.Alignments[1]);
+            Assert.Equal(TableAlign.Right, table.Alignments[2]);
+        }
+
+        [Fact]
+        public void Table_RaggedRow_IsPaddedToColumnCount()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("| A | B |\n| --- | --- |\n| 1 |");
+            var table = FirstBlock<TableBlock>(blocks);
+            Assert.NotNull(table);
+            Assert.Single(table.Rows);
+            Assert.Equal(2, table.Rows[0].Count);
+            Assert.Equal("1", InlineText(table.Rows[0][0]));
+            Assert.Equal("", InlineText(table.Rows[0][1]));
+        }
+
+        [Fact]
+        public void CodeBlock_WithoutLanguage_HasNullLanguage()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("```\nplain text\n```");
+            var code = FirstBlock<CodeBlock>(blocks);
+            Assert.NotNull(code);
+            Assert.Null(code.Language);
+            Assert.Equal("plain text", code.Text);
+        }
+
+        [Fact]
+        public void CodeBlock_UnclosedFenceAtEof_StillCaptured()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("```python\nx = 1");
+            var code = FirstBlock<CodeBlock>(blocks);
+            Assert.NotNull(code);
+            Assert.Equal("python", code.Language);
+            Assert.Equal("x = 1", code.Text);
+        }
+
+        [Fact]
+        public void NumberedList_ParenDelimiter_IsPreserved()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("1) first\n2) second");
+            var list = FirstBlock<NumberedListBlock>(blocks);
+            Assert.NotNull(list);
+            Assert.Equal(2, list.Items.Count);
+            Assert.Equal(1, list.Items[0].Number);
+            Assert.Equal(')', list.Items[0].NumberDelimiter);
+        }
+
+        [Fact]
+        public void Crlf_IsNormalized()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("# Heading\r\n\r\nA paragraph");
+            var h = FirstBlock<HeadingBlock>(blocks);
+            var p = FirstBlock<ParagraphBlock>(blocks);
+            Assert.NotNull(h);
+            Assert.Equal("Heading", InlineText(h.Inlines));
+            Assert.NotNull(p);
+            Assert.Equal("A paragraph", InlineText(p.Inlines));
+        }
     }
 }

--- a/GxPT.Tests/ZipSafeTests.cs
+++ b/GxPT.Tests/ZipSafeTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Text;
+using Ionic.Zip;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class ZipSafeTests : IDisposable
+    {
+        private readonly string _root;
+
+        public ZipSafeTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_ziptests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        private string Path2(string name)
+        {
+            return Path.Combine(_root, name);
+        }
+
+        [Fact]
+        public void SafeExtract_ExtractsNestedFilesWithContent()
+        {
+            string zipPath = Path2("ok.zip");
+            using (var zip = new ZipFile())
+            {
+                zip.AddEntry("a.txt", Encoding.UTF8.GetBytes("alpha"));
+                zip.AddEntry("sub/b.txt", Encoding.UTF8.GetBytes("beta"));
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_ok");
+            ZipSafe.SafeExtract(zipPath, dest, true);
+
+            Assert.Equal("alpha", File.ReadAllText(Path.Combine(dest, "a.txt")));
+            Assert.Equal("beta", File.ReadAllText(Path.Combine(dest, "sub", "b.txt")));
+        }
+
+        [Fact]
+        public void SafeExtract_RejectsParentTraversal_AndDoesNotEscapeDestination()
+        {
+            string zipPath = Path2("evil.zip");
+            using (var zip = new ZipFile())
+            {
+                // Set FileName directly so the crafted traversal name is stored verbatim.
+                var e = zip.AddEntry("placeholder.txt", Encoding.UTF8.GetBytes("x"));
+                e.FileName = "../escaped.txt";
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_evil");
+            Assert.Throws<InvalidDataException>(() => ZipSafe.SafeExtract(zipPath, dest, true));
+
+            // The validation pass fails before extraction, so nothing escapes the destination root.
+            Assert.False(File.Exists(Path.Combine(_root, "escaped.txt")));
+        }
+
+        [Fact]
+        public void SafeExtract_RejectsReservedDeviceName()
+        {
+            string zipPath = Path2("dev.zip");
+            using (var zip = new ZipFile())
+            {
+                var e = zip.AddEntry("placeholder.txt", Encoding.UTF8.GetBytes("x"));
+                e.FileName = "CON.txt";
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_dev");
+            Assert.Throws<InvalidDataException>(() => ZipSafe.SafeExtract(zipPath, dest, true));
+        }
+
+        [Fact]
+        public void SafeExtract_CreatesDestinationDirectoryWhenMissing()
+        {
+            string zipPath = Path2("mk.zip");
+            using (var zip = new ZipFile())
+            {
+                zip.AddEntry("only.txt", Encoding.UTF8.GetBytes("hello"));
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2(Path.Combine("nested", "dest"));
+            Assert.False(Directory.Exists(dest));
+
+            ZipSafe.SafeExtract(zipPath, dest, true);
+
+            Assert.True(Directory.Exists(dest));
+            Assert.Equal("hello", File.ReadAllText(Path.Combine(dest, "only.txt")));
+        }
+    }
+}

--- a/GxPT.Tests/ZipSafeTests.cs
+++ b/GxPT.Tests/ZipSafeTests.cs
@@ -98,5 +98,55 @@ namespace GxPT.Tests
             Assert.True(Directory.Exists(dest));
             Assert.Equal("hello", File.ReadAllText(Path.Combine(dest, "only.txt")));
         }
+
+        [Fact]
+        public void SafeExtract_RejectsPercentEncodedTraversal()
+        {
+            string zipPath = Path2("enc.zip");
+            using (var zip = new ZipFile())
+            {
+                var e = zip.AddEntry("placeholder.txt", Encoding.UTF8.GetBytes("x"));
+                e.FileName = "%2e%2e/evil.txt";
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_enc");
+            Assert.Throws<InvalidDataException>(() => ZipSafe.SafeExtract(zipPath, dest, true));
+        }
+
+        [Fact]
+        public void SafeExtract_CreatesDirectoryEntries()
+        {
+            string zipPath = Path2("dir.zip");
+            using (var zip = new ZipFile())
+            {
+                zip.AddDirectoryByName("emptydir");
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_dir");
+            ZipSafe.SafeExtract(zipPath, dest, true);
+
+            Assert.True(Directory.Exists(Path.Combine(dest, "emptydir")));
+        }
+
+        [Fact]
+        public void SafeExtract_WithoutOverwrite_ThrowsWhenFileExists()
+        {
+            string zipPath = Path2("dup.zip");
+            using (var zip = new ZipFile())
+            {
+                zip.AddEntry("dup.txt", Encoding.UTF8.GetBytes("v1"));
+                zip.Save(zipPath);
+            }
+
+            string dest = Path2("out_dup");
+            ZipSafe.SafeExtract(zipPath, dest, true);
+            Assert.Equal("v1", File.ReadAllText(Path.Combine(dest, "dup.txt")));
+
+            // Re-extracting without overwrite must not clobber the existing file.
+            Assert.ThrowsAny<IOException>(() => ZipSafe.SafeExtract(zipPath, dest, false));
+            Assert.Equal("v1", File.ReadAllText(Path.Combine(dest, "dup.txt")));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the first unit-test suite for the pure-logic parts of the app, plus a Windows CI workflow that runs it on PRs and pushes to `main`.

## Approach

`GxPT.Tests` is an SDK-style **net48 xUnit** project that **links the production source files under test** (`MarkdownParser.cs`, `ZipSafe.cs`) and compiles them into the test assembly, rather than building the app:

- The .NET Framework 3.5 app (VS2008-era classic csproj) can't be built by a modern SDK on a stock runner — linking just the files under test side-steps that entirely.
- Compiling `ZipSafe.cs` into the test assembly makes the `internal` class accessible without `InternalsVisibleTo`.
- Targeting **net48** lets the tests reference the **actual vendored `DotNetZip.dll`** the app ships, so `ZipSafe` is exercised against its real dependency.
- The project is **intentionally not added to `GxPT.sln`**, so VS2008 can still open the solution (it can't load SDK-style projects).

## Coverage

- **MarkdownParser** (11 tests): headings (level + text), fenced code blocks (language + body), bullet and nested-bullet lists (indent levels), numbered lists (preserved numbers), GitHub-style pipe tables (header + row), and inline bold/italic/code/link plus bare-URL autolinking. Empty input returns a single empty paragraph.
- **ZipSafe** (4 tests): happy-path nested extraction with content, destination-directory creation, and rejection of parent-directory traversal (zip-slip) and reserved Windows device names.

## CI

`.github/workflows/tests.yml` runs `dotnet test` on **`windows-latest`** for `pull_request` and pushes to `main`, using the .NET 8 SDK to build/run the net48 tests (with `Microsoft.NETFramework.ReferenceAssemblies` so it doesn't depend on a pre-installed targeting pack). Only the test project is built — the app is not.

## Note on verification

These tests were authored from a close read of the sources; there's no .NET runtime in the dev environment, so **this PR's CI run is their first execution**. Two areas I'm watching on that first run:
- The traversal test relies on DotNetZip storing the crafted `../escaped.txt` entry name verbatim (the documented zip-slip behavior `ZipSafe` guards against). If DotNetZip normalizes it on write, that test will need adjusting.
- An absolute-path test was intentionally omitted because DotNetZip strips drive letters on write, making such an entry un-constructable through its API.

If CI comes back red, I'll diagnose and fix.

https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyPcDVSzV1fzD5cQRYP9rp)_