### PR TITLE
Phase 2: Mcp35.Server — stdio server SDK + dispatch runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,13 @@ jobs:
         run: |
           dotnet restore GxPT.Tests/GxPT.Tests.csproj
           dotnet restore tests/Mcp35.Core.Tests/Mcp35.Core.Tests.csproj
+          dotnet restore tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
 
       - name: Test (Mcp35.Core)
         run: dotnet test tests/Mcp35.Core.Tests/Mcp35.Core.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (Mcp35.Server)
+        run: dotnet test tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -7,6 +7,8 @@ Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "GxPT.Setup", "GxPT.Setup\Gx
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Core", "src\Mcp35.Core\Mcp35.Core.csproj", "{667AC466-F30B-4CDB-BEC9-7A139A709AA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Server", "src\Mcp35.Server\Mcp35.Server.csproj", "{DCA697A6-1B4C-430C-BC45-134CB5F90072}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{667AC466-F30B-4CDB-BEC9-7A139A709AA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{667AC466-F30B-4CDB-BEC9-7A139A709AA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{667AC466-F30B-4CDB-BEC9-7A139A709AA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Mcp35.Server/Mcp35.Server.csproj
+++ b/src/Mcp35.Server/Mcp35.Server.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mcp35.Server</RootNamespace>
+    <AssemblyName>Mcp35.Server</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="McpServer.cs" />
+    <Compile Include="ToolRegistration.cs" />
+    <Compile Include="ToolResults.cs" />
+    <Compile Include="SchemaBuilder.cs" />
+    <Compile Include="StdErrLogSink.cs" />
+    <Compile Include="Process\ProcessRunner.cs" />
+    <Compile Include="Process\ProcessRequest.cs" />
+    <Compile Include="Process\ProcessResult.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Mcp35.Server/McpServer.cs
+++ b/src/Mcp35.Server/McpServer.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Mcp35.Core.Transport;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server
+{
+    /// <summary>
+    /// The stdio MCP server runtime: register tools, then <see cref="Run()"/> the
+    /// newline-delimited JSON dispatch loop until stdin EOF. Single-threaded and serial
+    /// (one request fully handled before the next). See mcp35-server-spec.md §2,§4.
+    /// </summary>
+    public sealed class McpServer
+    {
+        private readonly Implementation _serverInfo;
+        private readonly ILogSink _log;
+        private readonly Dictionary<string, RegisteredTool> _tools =
+            new Dictionary<string, RegisteredTool>(StringComparer.Ordinal);
+        private readonly List<string> _toolOrder = new List<string>();
+        private readonly List<Action> _shutdownHooks = new List<Action>();
+
+        private bool _started;   // latches true on first Run(); registration is frozen thereafter
+        private bool _initialized;
+
+        public McpServer(Implementation serverInfo, ILogSink log)
+        {
+            if (serverInfo == null) throw new ArgumentNullException("serverInfo");
+            _serverInfo = serverInfo;
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        // ---- registration ----
+
+        public void AddTool(string name, string description, JObject inputSchema, ToolHandler handler)
+        {
+            if (string.IsNullOrEmpty(name)) throw new ArgumentException("Tool name is required.", "name");
+            if (handler == null) throw new ArgumentNullException("handler");
+            if (_started) throw new InvalidOperationException("Cannot add tools after Run() has started.");
+            if (_tools.ContainsKey(name)) throw new ArgumentException("Duplicate tool name: " + name, "name");
+
+            Tool descriptor = new Tool();
+            descriptor.Name = name;
+            descriptor.Description = description;
+            descriptor.InputSchema = inputSchema ?? EmptyObjectSchema();
+
+            _tools[name] = new RegisteredTool(descriptor, handler);
+            _toolOrder.Add(name);
+        }
+
+        public void OnShutdown(Action cleanup)
+        {
+            if (cleanup != null) _shutdownHooks.Add(cleanup);
+        }
+
+        // ---- run loop ----
+
+        public void Run()
+        {
+            Stream stdin = Console.OpenStandardInput();
+            Stream stdout = Console.OpenStandardOutput();
+            Run(stdin, stdout);
+        }
+
+        public void Run(Stream stdin, Stream stdout)
+        {
+            if (stdin == null) throw new ArgumentNullException("stdin");
+            if (stdout == null) throw new ArgumentNullException("stdout");
+            _started = true;
+
+            StreamReader reader = StdioFraming.CreateReader(stdin);
+            try
+            {
+                string line;
+                while ((line = StdioFraming.ReadMessage(reader)) != null)
+                {
+                    DispatchLine(line, stdout);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Unrecoverable transport fault: log, then fall through to the same clean shutdown.
+                _log.Log("mcp", "Dispatch loop fault: " + ex.Message);
+            }
+            finally
+            {
+                RunShutdown(stdout);
+            }
+        }
+
+        private void DispatchLine(string line, Stream stdout)
+        {
+            JObject msg;
+            try
+            {
+                JToken tok = McpJson.Parse(line);
+                msg = tok as JObject;
+            }
+            catch (Exception ex)
+            {
+                _log.Log("mcp", "Parse error: " + ex.Message);
+                WriteError(stdout, RequestId.Null, JsonRpcErrorCodes.ParseError, "Parse error");
+                return;
+            }
+
+            if (msg == null)
+            {
+                WriteError(stdout, RequestId.Null, JsonRpcErrorCodes.InvalidRequest, "Expected a JSON-RPC object");
+                return;
+            }
+
+            string method = (string)msg["method"];
+
+            // Notification (no id).
+            if (msg.Property("id") == null)
+            {
+                HandleNotification(method);
+                return;
+            }
+
+            RequestId id = ParseId(msg["id"]);
+            JObject prms = msg["params"] as JObject;
+
+            switch (method)
+            {
+                case McpMethods.Initialize:
+                    WriteResult(stdout, id, BuildInitializeResult(prms));
+                    break;
+                case McpMethods.ToolsList:
+                    WriteResult(stdout, id, BuildToolsList());
+                    break;
+                case McpMethods.ToolsCall:
+                    HandleToolsCall(stdout, id, prms);
+                    break;
+                case McpMethods.Ping:
+                    WriteResult(stdout, id, new JObject());
+                    break;
+                default:
+                    WriteError(stdout, id, JsonRpcErrorCodes.MethodNotFound, "method not found: " + method);
+                    break;
+            }
+        }
+
+        private void HandleNotification(string method)
+        {
+            switch (method)
+            {
+                case McpMethods.Initialized:
+                    _initialized = true;
+                    _log.Log("mcp", "Client initialized.");
+                    break;
+                // notifications/cancelled and anything else: ignored (serial dispatch, §7).
+            }
+        }
+
+        // ---- method handlers ----
+
+        private JObject BuildInitializeResult(JObject prms)
+        {
+            string clientVersion = prms == null ? null : (string)prms["protocolVersion"];
+            string negotiated = NegotiateVersion(clientVersion);
+
+            JObject toolsCap = new JObject();
+            toolsCap["listChanged"] = false; // static tool sets (§7)
+            JObject capabilities = new JObject();
+            capabilities["tools"] = toolsCap;
+
+            InitializeResult result = new InitializeResult();
+            result.ProtocolVersion = negotiated;
+            result.Capabilities = capabilities;
+            result.ServerInfo = _serverInfo;
+
+            return JObject.FromObject(result, Serializer());
+        }
+
+        private static string NegotiateVersion(string clientVersion)
+        {
+            // Echo the client's version if it's one we recognize at or above the HTTP floor;
+            // otherwise advertise our default. (Stdio framing is identical across revisions.)
+            if (!string.IsNullOrEmpty(clientVersion))
+            {
+                if (string.CompareOrdinal(clientVersion, ProtocolVersions.HttpFloor) >= 0)
+                    return clientVersion;
+            }
+            return ProtocolVersions.Default;
+        }
+
+        private JObject BuildToolsList()
+        {
+            ListToolsResult list = new ListToolsResult();
+            list.Tools = new List<Tool>();
+            for (int i = 0; i < _toolOrder.Count; i++)
+                list.Tools.Add(_tools[_toolOrder[i]].Descriptor);
+            list.NextCursor = null; // no paging — small static sets
+            return JObject.FromObject(list, Serializer());
+        }
+
+        private void HandleToolsCall(Stream stdout, RequestId id, JObject prms)
+        {
+            string name = prms == null ? null : (string)prms["name"];
+            if (string.IsNullOrEmpty(name))
+            {
+                WriteError(stdout, id, JsonRpcErrorCodes.InvalidParams, "missing tool name");
+                return;
+            }
+
+            RegisteredTool tool;
+            if (!_tools.TryGetValue(name, out tool))
+            {
+                WriteError(stdout, id, JsonRpcErrorCodes.InvalidParams, "unknown tool: " + name);
+                return;
+            }
+
+            JObject args = prms["arguments"] as JObject;
+            ToolCallContext ctx = new ToolCallContext(name, args, _log);
+
+            CallToolResult result;
+            try
+            {
+                result = tool.Handler(ctx);
+                if (result == null) result = ToolResults.Error("tool returned no result");
+            }
+            catch (Exception ex)
+            {
+                // A tool bug must never crash the server: contain it as an isError result.
+                _log.Log("mcp", "Tool '" + name + "' threw: " + ex.Message);
+                result = ToolResults.Error("tool execution failed: " + ex.Message);
+            }
+
+            WriteResult(stdout, id, JObject.FromObject(result, Serializer()));
+        }
+
+        // ---- shutdown ----
+
+        private void RunShutdown(Stream stdout)
+        {
+            for (int i = 0; i < _shutdownHooks.Count; i++)
+            {
+                try { _shutdownHooks[i](); }
+                catch (Exception ex) { _log.Log("mcp", "Shutdown hook threw: " + ex.Message); }
+            }
+            try { stdout.Flush(); }
+            catch { }
+            try { Console.Error.Flush(); }
+            catch { }
+            _log.Log("mcp", "Server shut down cleanly.");
+        }
+
+        // ---- wire helpers ----
+
+        private void WriteResult(Stream stdout, RequestId id, JToken result)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = IdToToken(id);
+            o["result"] = result ?? JValue.CreateNull();
+            StdioFraming.WriteMessage(stdout, o.ToString(Formatting.None));
+        }
+
+        private void WriteError(Stream stdout, RequestId id, int code, string message)
+        {
+            JObject err = new JObject();
+            err["code"] = code;
+            err["message"] = message;
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = IdToToken(id);
+            o["error"] = err;
+            StdioFraming.WriteMessage(stdout, o.ToString(Formatting.None));
+        }
+
+        private static JsonSerializer Serializer()
+        {
+            return JsonSerializer.Create(McpJson.Settings);
+        }
+
+        private static JObject EmptyObjectSchema()
+        {
+            JObject s = new JObject();
+            s["type"] = "object";
+            return s;
+        }
+
+        private static JToken IdToToken(RequestId id)
+        {
+            if (id.IsNull) return JValue.CreateNull();
+            if (id.IsString) return new JValue(id.AsString);
+            return new JValue(id.AsLong);
+        }
+
+        private static RequestId ParseId(JToken t)
+        {
+            if (t == null || t.Type == JTokenType.Null) return RequestId.Null;
+            if (t.Type == JTokenType.Integer) return RequestId.FromLong(t.Value<long>());
+            if (t.Type == JTokenType.String) return RequestId.FromString(t.Value<string>());
+            return RequestId.FromString(t.ToString());
+        }
+    }
+}

--- a/src/Mcp35.Server/Process/ProcessRequest.cs
+++ b/src/Mcp35.Server/Process/ProcessRequest.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Mcp35.Server.Process
+{
+    /// <summary>
+    /// One external-process invocation. Argument escaping/quoting is the <b>caller's</b>
+    /// responsibility — <see cref="ProcessRunner"/> does not build command lines (§6).
+    /// </summary>
+    public sealed class ProcessRequest
+    {
+        /// <summary>Resolved executable path (injected or found on PATH by the caller).</summary>
+        public string FileName;
+
+        /// <summary>Pre-escaped command-line arguments.</summary>
+        public string Arguments;
+
+        public string WorkingDirectory;
+
+        /// <summary>Extra environment variables to set for the child (added to the inherited block).</summary>
+        public IDictionary<string, string> Environment;
+
+        /// <summary>Optional text to write to the child's stdin (then stdin is closed).</summary>
+        public string StdinText;
+
+        /// <summary>Kill the process if it runs longer than this. 0 or less = no timeout.</summary>
+        public int TimeoutMs;
+    }
+}

--- a/src/Mcp35.Server/Process/ProcessResult.cs
+++ b/src/Mcp35.Server/Process/ProcessResult.cs
@@ -1,0 +1,11 @@
+namespace Mcp35.Server.Process
+{
+    /// <summary>The outcome of a <see cref="ProcessRunner"/> invocation.</summary>
+    public sealed class ProcessResult
+    {
+        public int ExitCode;
+        public string StdOut;   // UTF-8 decoded
+        public string StdErr;   // UTF-8 decoded
+        public bool TimedOut;
+    }
+}

--- a/src/Mcp35.Server/Process/ProcessRunner.cs
+++ b/src/Mcp35.Server/Process/ProcessRunner.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Mcp35.Core.Diagnostics;
+
+namespace Mcp35.Server.Process
+{
+    /// <summary>
+    /// Runs an external process and captures its output. Pure BCL; mirrors the ProcessStartInfo
+    /// pattern in OpenRouterClient. stdout/stderr are drained on separate threads to avoid pipe
+    /// deadlock on large output. See mcp35-server-spec.md §6.
+    /// </summary>
+    public sealed class ProcessRunner
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+        private readonly ILogSink _log;
+
+        public ProcessRunner(ILogSink log)
+        {
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        public ProcessResult Run(ProcessRequest req)
+        {
+            if (req == null) throw new ArgumentNullException("req");
+            if (string.IsNullOrEmpty(req.FileName)) throw new ArgumentException("FileName is required.", "req");
+
+            ProcessStartInfo psi = new ProcessStartInfo();
+            psi.FileName = req.FileName;
+            psi.Arguments = req.Arguments ?? string.Empty;
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            psi.RedirectStandardOutput = true;
+            psi.RedirectStandardError = true;
+            psi.RedirectStandardInput = true;
+            psi.StandardOutputEncoding = Utf8;
+            psi.StandardErrorEncoding = Utf8;
+            if (!string.IsNullOrEmpty(req.WorkingDirectory)) psi.WorkingDirectory = req.WorkingDirectory;
+
+            if (req.Environment != null)
+            {
+                foreach (System.Collections.Generic.KeyValuePair<string, string> kv in req.Environment)
+                    psi.EnvironmentVariables[kv.Key] = kv.Value;
+            }
+
+            ProcessResult result = new ProcessResult();
+            StringBuilder outBuf = new StringBuilder();
+            StringBuilder errBuf = new StringBuilder();
+
+            System.Diagnostics.Process proc = new System.Diagnostics.Process();
+            proc.StartInfo = psi;
+
+            // Drain each pipe on its own thread so a large stream on one can't block the other.
+            Thread outThread = null;
+            Thread errThread = null;
+
+            try
+            {
+                proc.Start();
+
+                outThread = StartDrain(proc.StandardOutput, outBuf);
+                errThread = StartDrain(proc.StandardError, errBuf);
+
+                if (req.StdinText != null)
+                {
+                    try
+                    {
+                        proc.StandardInput.Write(req.StdinText);
+                    }
+                    finally
+                    {
+                        proc.StandardInput.Close();
+                    }
+                }
+                else
+                {
+                    proc.StandardInput.Close();
+                }
+
+                bool exited;
+                if (req.TimeoutMs > 0)
+                {
+                    exited = proc.WaitForExit(req.TimeoutMs);
+                    if (!exited)
+                    {
+                        result.TimedOut = true;
+                        KillTree(proc);
+                        proc.WaitForExit(); // reap after kill
+                    }
+                }
+                else
+                {
+                    proc.WaitForExit();
+                    exited = true;
+                }
+
+                // Let the drain threads finish flushing the pipes.
+                JoinDrain(outThread);
+                JoinDrain(errThread);
+
+                result.ExitCode = SafeExitCode(proc);
+                result.StdOut = outBuf.ToString();
+                result.StdErr = errBuf.ToString();
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _log.Log("process", "Run failed for '" + req.FileName + "': " + ex.Message);
+                throw;
+            }
+            finally
+            {
+                try { proc.Close(); }
+                catch { }
+            }
+        }
+
+        private Thread StartDrain(System.IO.StreamReader reader, StringBuilder sink)
+        {
+            Thread t = new Thread(delegate ()
+            {
+                try
+                {
+                    char[] buf = new char[4096];
+                    int n;
+                    while ((n = reader.Read(buf, 0, buf.Length)) > 0)
+                    {
+                        lock (sink) { sink.Append(buf, 0, n); }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _log.Log("process", "Drain error: " + ex.Message);
+                }
+            });
+            t.IsBackground = true;
+            t.Start();
+            return t;
+        }
+
+        private static void JoinDrain(Thread t)
+        {
+            if (t != null) t.Join(2000);
+        }
+
+        private void KillTree(System.Diagnostics.Process proc)
+        {
+            try
+            {
+                if (!proc.HasExited) proc.Kill();
+            }
+            catch (Exception ex)
+            {
+                _log.Log("process", "Kill failed: " + ex.Message);
+            }
+        }
+
+        private static int SafeExitCode(System.Diagnostics.Process proc)
+        {
+            try { return proc.ExitCode; }
+            catch { return -1; }
+        }
+    }
+}

--- a/src/Mcp35.Server/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Mcp35.Server")]
+[assembly: AssemblyDescription("Ergonomic SDK for building Model Context Protocol servers over stdio on .NET 3.5.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("dca697a6-1b4c-430c-bc45-134cb5f90072")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/src/Mcp35.Server/SchemaBuilder.cs
+++ b/src/Mcp35.Server/SchemaBuilder.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server
+{
+    /// <summary>
+    /// A minimal fluent builder for the common case — an object schema with typed properties and
+    /// a required list. Anything more complex can be passed as a raw <see cref="JObject"/> / JSON
+    /// string to <see cref="McpServer.AddTool"/>; this is convenience, not a full JSON-Schema DSL.
+    ///
+    /// Uses explicit overloads rather than C# 4 optional parameters so the SDK compiles under the
+    /// C# 3 (VS2008) toolchain, matching the rest of the net35 codebase.
+    /// </summary>
+    public sealed class SchemaBuilder
+    {
+        private readonly JObject _props = new JObject();
+        private readonly List<string> _required = new List<string>();
+
+        public static SchemaBuilder Object()
+        {
+            return new SchemaBuilder();
+        }
+
+        // ---- string ----
+        public SchemaBuilder Str(string name) { return Prop(name, "string", false, null); }
+        public SchemaBuilder Str(string name, bool required) { return Prop(name, "string", required, null); }
+        public SchemaBuilder Str(string name, bool required, string description) { return Prop(name, "string", required, description); }
+
+        // ---- integer ----
+        public SchemaBuilder Int(string name) { return Prop(name, "integer", false, null); }
+        public SchemaBuilder Int(string name, bool required) { return Prop(name, "integer", required, null); }
+        public SchemaBuilder Int(string name, bool required, string description) { return Prop(name, "integer", required, description); }
+
+        // ---- number ----
+        public SchemaBuilder Num(string name) { return Prop(name, "number", false, null); }
+        public SchemaBuilder Num(string name, bool required) { return Prop(name, "number", required, null); }
+        public SchemaBuilder Num(string name, bool required, string description) { return Prop(name, "number", required, description); }
+
+        // ---- boolean ----
+        public SchemaBuilder Bool(string name) { return Prop(name, "boolean", false, null); }
+        public SchemaBuilder Bool(string name, bool required) { return Prop(name, "boolean", required, null); }
+        public SchemaBuilder Bool(string name, bool required, string description) { return Prop(name, "boolean", required, description); }
+
+        // ---- array of a primitive item type ----
+        public SchemaBuilder Arr(string name, string itemType) { return Arr(name, itemType, false, null); }
+        public SchemaBuilder Arr(string name, string itemType, bool required) { return Arr(name, itemType, required, null); }
+        public SchemaBuilder Arr(string name, string itemType, bool required, string description)
+        {
+            JObject p = new JObject();
+            p["type"] = "array";
+            JObject items = new JObject();
+            items["type"] = itemType;
+            p["items"] = items;
+            if (description != null) p["description"] = description;
+            _props[name] = p;
+            if (required) _required.Add(name);
+            return this;
+        }
+
+        // ---- raw schema fragment (nested objects, enums, …) ----
+        public SchemaBuilder Raw(string name, JObject schema) { return Raw(name, schema, false); }
+        public SchemaBuilder Raw(string name, JObject schema, bool required)
+        {
+            _props[name] = schema;
+            if (required) _required.Add(name);
+            return this;
+        }
+
+        private SchemaBuilder Prop(string name, string type, bool required, string description)
+        {
+            JObject p = new JObject();
+            p["type"] = type;
+            if (description != null) p["description"] = description;
+            _props[name] = p;
+            if (required) _required.Add(name);
+            return this;
+        }
+
+        public JObject Build()
+        {
+            JObject schema = new JObject();
+            schema["type"] = "object";
+            schema["properties"] = _props;
+            if (_required.Count > 0)
+            {
+                JArray req = new JArray();
+                for (int i = 0; i < _required.Count; i++) req.Add(_required[i]);
+                schema["required"] = req;
+            }
+            return schema;
+        }
+    }
+}

--- a/src/Mcp35.Server/StdErrLogSink.cs
+++ b/src/Mcp35.Server/StdErrLogSink.cs
@@ -1,0 +1,24 @@
+using System;
+using Mcp35.Core.Diagnostics;
+
+namespace Mcp35.Server
+{
+    /// <summary>
+    /// Routes all diagnostics to <c>stderr</c>. Critical: a server's <c>stdout</c> carries the
+    /// JSON-RPC stream and nothing else (§5), so logging must never touch it.
+    /// </summary>
+    public sealed class StdErrLogSink : ILogSink
+    {
+        public void Log(string category, string message)
+        {
+            try
+            {
+                Console.Error.WriteLine("[" + (category ?? "mcp") + "] " + message);
+            }
+            catch
+            {
+                // Never let logging failures propagate into the dispatch loop.
+            }
+        }
+    }
+}

--- a/src/Mcp35.Server/ToolRegistration.cs
+++ b/src/Mcp35.Server/ToolRegistration.cs
@@ -1,0 +1,43 @@
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Protocol;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server
+{
+    /// <summary>A tool implementation: receives the call context, returns a result (failures are values).</summary>
+    public delegate CallToolResult ToolHandler(ToolCallContext ctx);
+
+    /// <summary>Everything a handler needs for one <c>tools/call</c> invocation.</summary>
+    public sealed class ToolCallContext
+    {
+        private readonly string _toolName;
+        private readonly JObject _arguments;
+        private readonly ILogSink _log;
+
+        public ToolCallContext(string toolName, JObject arguments, ILogSink log)
+        {
+            _toolName = toolName;
+            // MCP allows arguments to be omitted; normalize null to an empty object so handlers
+            // never have to null-check ctx.Arguments.
+            _arguments = arguments ?? new JObject();
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        public string ToolName { get { return _toolName; } }
+        public JObject Arguments { get { return _arguments; } }
+        public ILogSink Log { get { return _log; } }
+    }
+
+    /// <summary>A registered tool: its public MCP descriptor plus the handler to invoke.</summary>
+    internal sealed class RegisteredTool
+    {
+        public readonly Tool Descriptor;
+        public readonly ToolHandler Handler;
+
+        public RegisteredTool(Tool descriptor, ToolHandler handler)
+        {
+            Descriptor = descriptor;
+            Handler = handler;
+        }
+    }
+}

--- a/src/Mcp35.Server/ToolResults.cs
+++ b/src/Mcp35.Server/ToolResults.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server
+{
+    /// <summary>
+    /// Helpers that keep tool handlers terse. A tool <em>failure</em> is a value
+    /// (<see cref="Error"/> → isError = true), never an exception.
+    /// </summary>
+    public static class ToolResults
+    {
+        /// <summary>A single text content block, success.</summary>
+        public static CallToolResult Text(string text)
+        {
+            CallToolResult r = new CallToolResult();
+            r.Content = new List<ContentBlock>();
+            r.Content.Add(ContentBlock.FromText(text ?? string.Empty));
+            r.IsError = false;
+            return r;
+        }
+
+        /// <summary>
+        /// Structured output: sets <c>structuredContent</c> and also serializes a text mirror so
+        /// hosts/models that only read text still see the data.
+        /// </summary>
+        public static CallToolResult Json(object structured)
+        {
+            JObject obj = structured == null ? new JObject() : JObject.FromObject(structured, McpJsonSerializer());
+
+            CallToolResult r = new CallToolResult();
+            r.Content = new List<ContentBlock>();
+            r.Content.Add(ContentBlock.FromText(obj.ToString(Newtonsoft.Json.Formatting.None)));
+            r.StructuredContent = obj;
+            r.IsError = false;
+            return r;
+        }
+
+        /// <summary>A tool-level failure the host relays to the model (isError = true).</summary>
+        public static CallToolResult Error(string message)
+        {
+            CallToolResult r = new CallToolResult();
+            r.Content = new List<ContentBlock>();
+            r.Content.Add(ContentBlock.FromText(message ?? "error"));
+            r.IsError = true;
+            return r;
+        }
+
+        private static Newtonsoft.Json.JsonSerializer McpJsonSerializer()
+        {
+            return Newtonsoft.Json.JsonSerializer.Create(McpJson.Settings);
+        }
+    }
+}

--- a/tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
+++ b/tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    JSON spike + unit tests for Mcp35.Server (phase 2).
+
+    Like the other test projects, this links the production source files under test (both
+    Mcp35.Server and the Mcp35.Core it builds on) and compiles them into the test assembly,
+    rather than building the VS2008-era net35 projects. Targets net48, runs via 'dotnet test'.
+    Newtonsoft resolves via a version-pinned PackageReference (13.0.3), matching the vendored
+    net35 DLL (D12).
+
+    NOTE: intentionally NOT added to GxPT.sln (VS2008 cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Mcp35.Server.Tests</AssemblyName>
+    <RootNamespace>Mcp35.Server.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Mcp35.Server.Tests/McpServerTests.cs
+++ b/tests/Mcp35.Server.Tests/McpServerTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Mcp35.Server.Tests
+{
+    public class McpServerTests
+    {
+        private static McpServer NewServer()
+        {
+            return new McpServer(new Implementation { Name = "test", Version = "1.0" }, null);
+        }
+
+        private static JObject EchoSchema()
+        {
+            return SchemaBuilder.Object().Str("text", true).Build();
+        }
+
+        // ---- Criterion 1: handshake ----
+
+        [Fact]
+        public void Initialize_returns_negotiated_version_and_static_tools_capability()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.Initialize(1, "2025-06-18"));
+
+            Assert.Single(msgs);
+            JObject result = (JObject)msgs[0]["result"];
+            Assert.Equal("2025-06-18", (string)result["protocolVersion"]);          // echoed (>= floor)
+            Assert.False((bool)result["capabilities"]["tools"]["listChanged"]);     // static set
+            Assert.Equal("test", (string)result["serverInfo"]["name"]);
+        }
+
+        [Fact]
+        public void Initialize_below_floor_falls_back_to_default_version()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.Initialize(1, "2024-11-05"));
+
+            JObject result = (JObject)msgs[0]["result"];
+            Assert.Equal(ProtocolVersions.Default, (string)result["protocolVersion"]);
+        }
+
+        [Fact]
+        public void Initialized_notification_produces_no_reply()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.InitializedNotification());
+            Assert.Empty(msgs);
+        }
+
+        // ---- Criterion 2: listing ----
+
+        [Fact]
+        public void ToolsList_returns_registered_tools_with_schema()
+        {
+            var server = NewServer();
+            server.AddTool("echo", "Echoes text.", EchoSchema(),
+                ctx => ToolResults.Text(ctx.Arguments.Value<string>("text")));
+
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsList(2));
+
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            Assert.Single(tools);
+            Assert.Equal("echo", (string)tools[0]["name"]);
+            Assert.Equal("Echoes text.", (string)tools[0]["description"]);
+            // inputSchema preserved intact
+            Assert.Equal("object", (string)tools[0]["inputSchema"]["type"]);
+            Assert.Equal("string", (string)tools[0]["inputSchema"]["properties"]["text"]["type"]);
+            Assert.Null(msgs[0]["result"]["nextCursor"]); // no paging
+        }
+
+        [Fact]
+        public void ToolsList_preserves_registration_order()
+        {
+            var server = NewServer();
+            server.AddTool("a", "", null, ctx => ToolResults.Text("a"));
+            server.AddTool("b", "", null, ctx => ToolResults.Text("b"));
+            server.AddTool("c", "", null, ctx => ToolResults.Text("c"));
+
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsList(1));
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            Assert.Equal("a", (string)tools[0]["name"]);
+            Assert.Equal("b", (string)tools[1]["name"]);
+            Assert.Equal("c", (string)tools[2]["name"]);
+        }
+
+        // ---- Criterion 3: calling ----
+
+        [Fact]
+        public void ToolsCall_routes_to_handler_and_passes_arguments()
+        {
+            var server = NewServer();
+            server.AddTool("echo", "Echoes text.", EchoSchema(),
+                ctx => ToolResults.Text("you said: " + ctx.Arguments.Value<string>("text")));
+
+            JObject args = new JObject();
+            args["text"] = "hello";
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsCall(3, "echo", args));
+
+            JObject result = (JObject)msgs[0]["result"];
+            Assert.False(result.Value<bool>("isError"));
+            Assert.Equal("you said: hello", (string)result["content"][0]["text"]);
+        }
+
+        [Fact]
+        public void ToolsCall_with_null_arguments_gives_handler_empty_object()
+        {
+            var server = NewServer();
+            bool argsWereNull = true;
+            server.AddTool("noargs", "", null, ctx =>
+            {
+                argsWereNull = ctx.Arguments == null;
+                return ToolResults.Text("ok");
+            });
+
+            ServerHarness.Exchange(server, ServerHarness.ToolsCall(1, "noargs", null));
+            Assert.False(argsWereNull); // normalized to {}
+        }
+
+        [Fact]
+        public void ToolResults_Json_sets_structuredContent_and_text_mirror()
+        {
+            var server = NewServer();
+            server.AddTool("data", "", null, ctx => ToolResults.Json(new Dictionary<string, object> {
+                { "count", 3 }, { "ok", true }
+            }));
+
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsCall(1, "data", null));
+            JObject result = (JObject)msgs[0]["result"];
+            Assert.Equal(3, (int)result["structuredContent"]["count"]);
+            Assert.True((bool)result["structuredContent"]["ok"]);
+            Assert.NotNull(result["content"][0]["text"]); // text mirror present
+        }
+
+        // ---- Criterion 4: errors ----
+
+        [Fact]
+        public void Unknown_tool_is_invalid_params()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsCall(4, "nope", null));
+            Assert.Equal(-32602, (int)msgs[0]["error"]["code"]);
+        }
+
+        [Fact]
+        public void Unknown_method_is_method_not_found()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.Request(5, "resources/list", null));
+            Assert.Equal(-32601, (int)msgs[0]["error"]["code"]);
+        }
+
+        [Fact]
+        public void Handler_that_throws_yields_isError_and_server_survives()
+        {
+            var server = NewServer();
+            server.AddTool("boom", "", null, ctx => { throw new InvalidOperationException("kaboom"); });
+
+            // A second request after the throwing one must still be served (process stays alive).
+            var msgs = ServerHarness.Exchange(server,
+                ServerHarness.ToolsCall(1, "boom", null),
+                ServerHarness.Request(2, "ping", null));
+
+            Assert.Equal(2, msgs.Count);
+            JObject callResult = (JObject)msgs[0]["result"];
+            Assert.True(callResult.Value<bool>("isError"));
+            Assert.Contains("kaboom", (string)callResult["content"][0]["text"]);
+            // ping after the throw still answered:
+            Assert.NotNull(msgs[1]["result"]);
+        }
+
+        [Fact]
+        public void Ping_is_answered_with_empty_result()
+        {
+            var server = NewServer();
+            var msgs = ServerHarness.Exchange(server, ServerHarness.Request(7, "ping", null));
+            Assert.Equal(JTokenType.Object, msgs[0]["result"].Type);
+            Assert.Empty(((JObject)msgs[0]["result"]).Properties());
+        }
+
+        [Fact]
+        public void Duplicate_tool_name_throws()
+        {
+            var server = NewServer();
+            server.AddTool("dup", "", null, ctx => ToolResults.Text("1"));
+            Assert.Throws<ArgumentException>(() => server.AddTool("dup", "", null, ctx => ToolResults.Text("2")));
+        }
+
+        // ---- Criterion 5: framing / stdout hygiene ----
+
+        [Fact]
+        public void Each_response_is_exactly_one_line_on_stdout()
+        {
+            var server = NewServer();
+            server.AddTool("echo", "", EchoSchema(),
+                ctx => ToolResults.Text(ctx.Arguments.Value<string>("text")));
+
+            JObject args = new JObject();
+            args["text"] = "multi\nline\nvalue"; // newlines in payload must not break framing
+
+            byte[] raw;
+            var msgs = ServerHarness.Exchange(server, out raw,
+                ServerHarness.Initialize(1, "2025-06-18"),
+                ServerHarness.ToolsCall(2, "echo", args));
+
+            string text = new UTF8Encoding(false, false).GetString(raw);
+            // Exactly 2 responses => exactly 2 newline terminators, none embedded.
+            int newlines = 0;
+            foreach (char c in text) if (c == '\n') newlines++;
+            Assert.Equal(2, newlines);
+            Assert.Equal(2, msgs.Count);
+            // and the value round-tripped despite its embedded newlines
+            Assert.Equal("multi\nline\nvalue", (string)msgs[1]["result"]["content"][0]["text"]);
+        }
+
+        [Fact]
+        public void OnShutdown_hooks_run_on_eof()
+        {
+            var server = NewServer();
+            bool cleaned = false;
+            server.OnShutdown(() => cleaned = true);
+
+            ServerHarness.Exchange(server, ServerHarness.Request(1, "ping", null));
+            Assert.True(cleaned); // EOF after the scripted input triggered shutdown
+        }
+
+        [Fact]
+        public void Cannot_add_tool_after_run()
+        {
+            var server = NewServer();
+            ServerHarness.Exchange(server, ServerHarness.Request(1, "ping", null));
+            Assert.Throws<InvalidOperationException>(
+                () => server.AddTool("late", "", null, ctx => ToolResults.Text("x")));
+        }
+    }
+}

--- a/tests/Mcp35.Server.Tests/ProcessRunnerTests.cs
+++ b/tests/Mcp35.Server.Tests/ProcessRunnerTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Text;
+using Mcp35.Server.Process;
+using Xunit;
+
+namespace Mcp35.Server.Tests
+{
+    /// <summary>
+    /// Exercises ProcessRunner against real OS commands. CI runs on windows-latest; the helpers
+    /// pick cmd.exe vs /bin/sh so the suite is robust if run on either platform.
+    /// </summary>
+    public class ProcessRunnerTests
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        private static ProcessRequest Shell(string command, int timeoutMs)
+        {
+            ProcessRequest req = new ProcessRequest();
+            req.TimeoutMs = timeoutMs;
+            if (IsWindows)
+            {
+                req.FileName = "cmd.exe";
+                req.Arguments = "/c " + command;
+            }
+            else
+            {
+                req.FileName = "/bin/sh";
+                req.Arguments = "-c \"" + command.Replace("\"", "\\\"") + "\"";
+            }
+            return req;
+        }
+
+        [Fact]
+        public void Captures_stdout_and_zero_exit()
+        {
+            var runner = new ProcessRunner(null);
+            var result = runner.Run(Shell("echo hello", 10000));
+
+            Assert.False(result.TimedOut);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("hello", result.StdOut);
+        }
+
+        [Fact]
+        public void Captures_nonzero_exit_code()
+        {
+            var runner = new ProcessRunner(null);
+            // 'exit 3' on both shells.
+            var result = runner.Run(Shell("exit 3", 10000));
+            Assert.Equal(3, result.ExitCode);
+        }
+
+        [Fact]
+        public void Captures_stderr_separately()
+        {
+            var runner = new ProcessRunner(null);
+            string cmd = IsWindows ? "echo oops 1>&2" : "echo oops 1>&2";
+            var result = runner.Run(Shell(cmd, 10000));
+            Assert.Contains("oops", result.StdErr);
+        }
+
+        [Fact]
+        public void Timeout_kills_and_flags()
+        {
+            var runner = new ProcessRunner(null);
+            // Sleep well past the timeout: ping -n is a portable Windows delay; sleep on unix.
+            string cmd = IsWindows ? "ping -n 10 127.0.0.1 >NUL" : "sleep 10";
+            var result = runner.Run(Shell(cmd, 500));
+            Assert.True(result.TimedOut);
+        }
+
+        [Fact]
+        public void Large_output_does_not_deadlock()
+        {
+            var runner = new ProcessRunner(null);
+            // Emit a lot of stdout; the separate drain thread must keep the pipe from blocking.
+            string cmd;
+            if (IsWindows)
+                cmd = "for /L %i in (1,1,5000) do @echo line-%i";
+            else
+                cmd = "for i in $(seq 1 5000); do echo line-$i; done";
+
+            var result = runner.Run(Shell(cmd, 30000));
+            Assert.False(result.TimedOut);
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("line-5000", result.StdOut);
+            Assert.True(result.StdOut.Length > 10000);
+        }
+
+        [Fact]
+        public void Stdin_text_is_passed_through()
+        {
+            var runner = new ProcessRunner(null);
+            // 'sort' reads stdin on both platforms.
+            ProcessRequest req = new ProcessRequest();
+            req.TimeoutMs = 10000;
+            req.StdinText = "banana\napple\ncherry\n";
+            if (IsWindows) { req.FileName = "sort.exe"; req.Arguments = ""; }
+            else { req.FileName = "/usr/bin/sort"; req.Arguments = ""; }
+
+            var result = runner.Run(req);
+            // apple should sort first regardless of platform line endings.
+            Assert.StartsWith("apple", result.StdOut.TrimStart());
+        }
+    }
+}

--- a/tests/Mcp35.Server.Tests/ServerHarness.cs
+++ b/tests/Mcp35.Server.Tests/ServerHarness.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server.Tests
+{
+    /// <summary>
+    /// Drives <see cref="McpServer.Run(Stream,Stream)"/> with a scripted set of input lines and
+    /// captures the framed stdout. Because the runtime is serial and stdin EOF ends the loop,
+    /// we can feed all input up front and read everything written.
+    /// </summary>
+    internal static class ServerHarness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        /// <summary>Run the server over the given newline-delimited input lines; return parsed stdout messages.</summary>
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawOut;
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            return ParseFramed(rawOut);
+        }
+
+        /// <summary>Run the server, returning both the parsed messages and the raw stdout bytes (for framing checks).</summary>
+        public static List<JObject> Exchange(McpServer server, out byte[] rawStdout, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawStdout = stdout.ToArray();
+            }
+            return ParseFramed(rawStdout);
+        }
+
+        public static List<JObject> ParseFramed(byte[] rawOut)
+        {
+            string text = Utf8.GetString(rawOut);
+            List<JObject> messages = new List<JObject>();
+            string[] lines = text.Split('\n');
+            foreach (string line in lines)
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        // --- request builders ---
+
+        public static string Initialize(int id, string protocolVersion)
+        {
+            JObject p = new JObject();
+            p["protocolVersion"] = protocolVersion;
+            p["capabilities"] = new JObject();
+            return Request(id, "initialize", p);
+        }
+
+        public static string InitializedNotification()
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["method"] = "notifications/initialized";
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        public static string ToolsList(int id)
+        {
+            return Request(id, "tools/list", null);
+        }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the MCP roadmap: `Mcp35.Server`, the ergonomic SDK for *building*
MCP servers over stdio. Built on the phase-1 `Mcp35.Core` (ProjectRef, no new
managed deps). Draft — CI on the Windows runner builds the net48 linked-source
test project and runs the phase-2 exit criteria.

## What's here

**`src/Mcp35.Server/`** (net35, old-format csproj, `ProjectRef → Mcp35.Core`):
- **`McpServer`** — registration API (`AddTool` / `OnShutdown`) + the **serial**
  stdin→stdout dispatch loop. Handles `initialize` (version negotiation +
  `tools.listChanged = false`), `tools/list` (static, no paging), `tools/call`
  (route by name; unknown → `-32602`; **handler exceptions contained as `isError`**
  so a tool bug never crashes the server), `ping`, and `notifications/initialized`.
  stdin EOF → run `OnShutdown` hooks → flush → exit.
- **`ToolResults`** (`Text`/`Json`/`Error`), `ToolCallContext`, `ToolHandler`.
- **`SchemaBuilder`** — minimal fluent object-schema helper, written with explicit
  overloads (no C# 4 optional params) to stay C# 3 / VS2008-compatible.
- **`StdErrLogSink`** — diagnostics to stderr only (stdout is the JSON-RPC stream).
- **`Process/ProcessRunner`** — BCL process exec with separate stdout/stderr drain
  threads (no pipe deadlock) + timeout-kill, for the future git/cmd servers.

**`tests/Mcp35.Server.Tests/`** (net48 linked-source, Newtonsoft 13.0.3):
- `McpServerTests` via an in-memory `ServerHarness` cover all 6 phase-2 criteria:
  handshake, listing (order + schema intact), calling (arg passthrough + `Json`
  structuredContent), errors (`-32602`/`-32601`/contained throw with survival),
  **framing hygiene** (one message per line even with embedded newlines in a
  payload), shutdown hooks, registration-frozen-after-run.
- `ProcessRunnerTests`: exit codes, stdout/stderr capture, timeout kill,
  large-output no-deadlock, stdin passthrough (platform-aware).

## Design discipline note

Caught during a compat scan: `SchemaBuilder` originally used optional parameters +
named-argument call sites — both **C# 4.0** features that the existing net35
codebase never uses and the VS2008 (C# 3) compiler rejects. Refactored to explicit
overloads. CI's Roslyn would have masked this; flagging since the shipping net35
assemblies are built under VS2008/msbuild v3.5.

## Error-mapping contract (worth a look in review)

- **Framework/protocol** problems (bad JSON, unknown method, unknown tool name,
  malformed params) → **JSON-RPC error responses** (`-32700`/`-32601`/`-32602`).
- **Tool execution** problems (incl. handler exceptions) → **`isError` results**,
  never JSON-RPC errors — the model sees them.

Passing this unblocks phase 3 (the `Mcp35.Client` `StdioTransport` consuming a real
server) and phase 7 (the four concrete servers).

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_