### PR TITLE
Phase 3: Mcp35.Client — stdio transport + McpServerConnection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           dotnet restore GxPT.Tests/GxPT.Tests.csproj
           dotnet restore tests/Mcp35.Core.Tests/Mcp35.Core.Tests.csproj
           dotnet restore tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
+          dotnet restore tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
@@ -35,3 +36,6 @@ jobs:
 
       - name: Test (Mcp35.Server)
         run: dotnet test tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (Mcp35.Client)
+        run: dotnet test tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Core", "src\Mcp35.Cor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Server", "src\Mcp35.Server\Mcp35.Server.csproj", "{DCA697A6-1B4C-430C-BC45-134CB5F90072}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Client", "src\Mcp35.Client\Mcp35.Client.csproj", "{A043F034-FFF5-44CE-9605-B40FF0016262}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DCA697A6-1B4C-430C-BC45-134CB5F90072}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A043F034-FFF5-44CE-9605-B40FF0016262}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A043F034-FFF5-44CE-9605-B40FF0016262}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A043F034-FFF5-44CE-9605-B40FF0016262}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A043F034-FFF5-44CE-9605-B40FF0016262}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Mcp35.Client/ConnectionState.cs
+++ b/src/Mcp35.Client/ConnectionState.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Mcp35.Client
+{
+    /// <summary>Lifecycle states of an <see cref="McpServerConnection"/>.</summary>
+    public enum ConnectionState
+    {
+        Created,
+        Starting,
+        Initializing,
+        Ready,
+        Faulted,
+        Closed
+    }
+
+    public sealed class ConnectionStateEventArgs : EventArgs
+    {
+        public readonly ConnectionState OldState;
+        public readonly ConnectionState NewState;
+
+        /// <summary>Populated when transitioning to <see cref="ConnectionState.Faulted"/>.</summary>
+        public readonly string FaultMessage;
+
+        public ConnectionStateEventArgs(ConnectionState oldState, ConnectionState newState, string faultMessage)
+        {
+            OldState = oldState;
+            NewState = newState;
+            FaultMessage = faultMessage;
+        }
+    }
+}

--- a/src/Mcp35.Client/Mcp35.Client.csproj
+++ b/src/Mcp35.Client/Mcp35.Client.csproj
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A043F034-FFF5-44CE-9605-B40FF0016262}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mcp35.Client</RootNamespace>
+    <AssemblyName>Mcp35.Client</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="McpServerConnection.cs" />
+    <Compile Include="ConnectionState.cs" />
+    <Compile Include="Transport\StdioTransport.cs" />
+    <Compile Include="Transport\StdioChannel.cs" />
+    <Compile Include="Transport\StdioLaunch.cs" />
+    <Compile Include="Transport\HttpTransport.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Mcp35.Client/McpServerConnection.cs
+++ b/src/Mcp35.Client/McpServerConnection.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Errors;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Client
+{
+    /// <summary>
+    /// One connected MCP server: drives the handshake, caches <c>tools/list</c>, and routes
+    /// <c>tools/call</c>. Transport-agnostic (any <see cref="IRpcTransport"/>), single-connection
+    /// by design — the host owns the collection. See mcp35-client-spec.md §4.
+    /// </summary>
+    public sealed class McpServerConnection : IDisposable
+    {
+        private readonly string _name;
+        private readonly IRpcTransport _transport;
+        private readonly Implementation _clientInfo;
+        private readonly ILogSink _log;
+        private readonly object _gate = new object();
+
+        private ConnectionState _state = ConnectionState.Created;
+        private InitializeResult _serverInfo;
+        private bool _supportsTools;
+
+        private List<Tool> _toolsCache;
+        private bool _toolsDirty = true;
+
+        public event EventHandler<ConnectionStateEventArgs> StateChanged;
+        public event EventHandler ToolsChanged;
+
+        public McpServerConnection(string name, IRpcTransport transport, Implementation clientInfo, ILogSink log)
+        {
+            if (transport == null) throw new ArgumentNullException("transport");
+            _name = name ?? "mcp";
+            _transport = transport;
+            _clientInfo = clientInfo ?? DefaultClientInfo();
+            _log = log ?? NullLogSink.Instance;
+            _transport.Inbound += OnInbound;
+        }
+
+        public string Name { get { return _name; } }
+        public ConnectionState State { get { lock (_gate) { return _state; } } }
+        public InitializeResult ServerInfo { get { return _serverInfo; } }
+        public bool SupportsTools { get { return _supportsTools; } }
+
+        // ---- handshake ----
+
+        public void Open(int initializeTimeoutMs)
+        {
+            try
+            {
+                SetState(ConnectionState.Starting, null);
+                _transport.Start();
+
+                SetState(ConnectionState.Initializing, null);
+
+                InitializeParams ip = new InitializeParams();
+                ip.ProtocolVersion = ProtocolVersions.Default;
+                ip.Capabilities = new JObject();   // empty client capabilities (phase 3)
+                ip.ClientInfo = _clientInfo;
+
+                JsonRpcResponse resp = _transport.SendRequest(
+                    McpMethods.Initialize, JObject.FromObject(ip, Serializer()), initializeTimeoutMs);
+
+                if (resp.IsError)
+                {
+                    Fault("initialize failed: " + (resp.Error == null ? "unknown error" : resp.Error.Message));
+                    throw new McpException(resp.Error);
+                }
+
+                InitializeResult result = ((JObject)resp.Result).ToObject<InitializeResult>(Serializer());
+                if (!IsAcceptableVersion(result.ProtocolVersion))
+                {
+                    string msg = "unacceptable protocol version: " + result.ProtocolVersion;
+                    Fault(msg);
+                    throw new McpException(msg);
+                }
+
+                _serverInfo = result;
+                _supportsTools = result.Capabilities != null && result.Capabilities["tools"] != null;
+
+                _transport.SendNotification(McpMethods.Initialized, null);
+
+                // Prefetch tools so the host can list immediately.
+                RefreshTools();
+
+                SetState(ConnectionState.Ready, null);
+            }
+            catch (McpException)
+            {
+                throw; // already faulted above
+            }
+            catch (Exception ex)
+            {
+                Fault("open failed: " + ex.Message);
+                throw new McpTransportException("Failed to open connection '" + _name + "': " + ex.Message, ex);
+            }
+        }
+
+        // ---- tools ----
+
+        public IList<Tool> ListTools(bool refresh)
+        {
+            if (!_supportsTools) return new List<Tool>();
+
+            lock (_gate)
+            {
+                if (!refresh && !_toolsDirty && _toolsCache != null)
+                    return new List<Tool>(_toolsCache);
+            }
+
+            return RefreshTools();
+        }
+
+        private IList<Tool> RefreshTools()
+        {
+            if (!_supportsTools)
+            {
+                lock (_gate) { _toolsCache = new List<Tool>(); _toolsDirty = false; }
+                return new List<Tool>();
+            }
+
+            List<Tool> all = new List<Tool>();
+            string cursor = null;
+            do
+            {
+                ListToolsParams p = new ListToolsParams();
+                p.Cursor = cursor;
+                JToken paramsTok = cursor == null ? null : (JToken)JObject.FromObject(p, Serializer());
+
+                JsonRpcResponse resp = _transport.SendRequest(McpMethods.ToolsList, paramsTok, DefaultCallTimeoutMs);
+                if (resp.IsError) throw new McpException(resp.Error);
+
+                ListToolsResult page = ((JObject)resp.Result).ToObject<ListToolsResult>(Serializer());
+                if (page.Tools != null) all.AddRange(page.Tools);
+                cursor = string.IsNullOrEmpty(page.NextCursor) ? null : page.NextCursor;
+            }
+            while (cursor != null);
+
+            lock (_gate)
+            {
+                _toolsCache = all;
+                _toolsDirty = false;
+            }
+            return new List<Tool>(all);
+        }
+
+        // ---- calling ----
+
+        public CallToolResult CallTool(string name, JObject args, int timeoutMs)
+        {
+            if (State != ConnectionState.Ready)
+                throw new InvalidOperationException("Connection '" + _name + "' is not Ready (state=" + State + ").");
+            if (!_supportsTools)
+                throw new InvalidOperationException("Server '" + _name + "' does not support tools.");
+
+            CallToolParams cp = new CallToolParams();
+            cp.Name = name;
+            cp.Arguments = args;
+
+            JsonRpcResponse resp = _transport.SendRequest(
+                McpMethods.ToolsCall, JObject.FromObject(cp, Serializer()), timeoutMs);
+
+            // A JSON-RPC error (e.g. unknown tool -32602) is a protocol failure → throw.
+            if (resp.IsError) throw new McpException(resp.Error);
+
+            // Otherwise the CallToolResult (including isError tool failures) passes through verbatim.
+            return ((JObject)resp.Result).ToObject<CallToolResult>(Serializer());
+        }
+
+        // ---- inbound notifications (reader thread) ----
+
+        private void OnInbound(object sender, JsonRpcInboundEventArgs e)
+        {
+            if (e.IsRequest) return; // server->client requests handled/declined by the peer
+
+            if (e.Method == McpMethods.ToolsListChanged)
+            {
+                lock (_gate) { _toolsDirty = true; }
+                EventHandler h = ToolsChanged;
+                if (h != null) h(this, EventArgs.Empty);
+            }
+            else
+            {
+                _log.Log("mcp", "Notification ignored: " + e.Method);
+            }
+        }
+
+        // ---- lifecycle ----
+
+        public void Close()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            try { _transport.Inbound -= OnInbound; }
+            catch { }
+            try { _transport.Dispose(); }
+            catch (Exception ex) { _log.Log("mcp", "Transport dispose threw: " + ex.Message); }
+            SetState(ConnectionState.Closed, null);
+        }
+
+        // ---- helpers ----
+
+        private void Fault(string message)
+        {
+            _log.Log("mcp", "Connection '" + _name + "' faulted: " + message);
+            SetState(ConnectionState.Faulted, message);
+        }
+
+        private void SetState(ConnectionState next, string faultMessage)
+        {
+            ConnectionState prev;
+            lock (_gate)
+            {
+                if (_state == next) return;
+                // Closed is terminal.
+                if (_state == ConnectionState.Closed) return;
+                prev = _state;
+                _state = next;
+            }
+            EventHandler<ConnectionStateEventArgs> h = StateChanged;
+            if (h != null) h(this, new ConnectionStateEventArgs(prev, next, faultMessage));
+        }
+
+        private bool IsAcceptableVersion(string negotiated)
+        {
+            // Stdio accepts any returned version (framing is identical across revisions).
+            // HTTP's >= HttpFloor gate is enforced by HttpTransport/host in phase 8.
+            return !string.IsNullOrEmpty(negotiated);
+        }
+
+        private static JsonSerializer Serializer()
+        {
+            return JsonSerializer.Create(McpJson.Settings);
+        }
+
+        private static Implementation DefaultClientInfo()
+        {
+            Implementation impl = new Implementation();
+            impl.Name = "Mcp35.Client";
+            impl.Version = "0.1.0";
+            return impl;
+        }
+
+        /// <summary>Default per-call timeout (ms); the host can pass its own to <see cref="CallTool"/>.</summary>
+        public const int DefaultCallTimeoutMs = 60000;
+
+        /// <summary>Default handshake timeout (ms): generous for stdio cold start.</summary>
+        public const int DefaultInitializeTimeoutMs = 10000;
+    }
+}

--- a/src/Mcp35.Client/McpServerConnection.cs
+++ b/src/Mcp35.Client/McpServerConnection.cs
@@ -68,18 +68,11 @@ namespace Mcp35.Client
                     McpMethods.Initialize, JObject.FromObject(ip, Serializer()), initializeTimeoutMs);
 
                 if (resp.IsError)
-                {
-                    Fault("initialize failed: " + (resp.Error == null ? "unknown error" : resp.Error.Message));
                     throw new McpException(resp.Error);
-                }
 
                 InitializeResult result = ((JObject)resp.Result).ToObject<InitializeResult>(Serializer());
                 if (!IsAcceptableVersion(result.ProtocolVersion))
-                {
-                    string msg = "unacceptable protocol version: " + result.ProtocolVersion;
-                    Fault(msg);
-                    throw new McpException(msg);
-                }
+                    throw new McpException("unacceptable protocol version: " + result.ProtocolVersion);
 
                 _serverInfo = result;
                 _supportsTools = result.Capabilities != null && result.Capabilities["tools"] != null;
@@ -91,14 +84,14 @@ namespace Mcp35.Client
 
                 SetState(ConnectionState.Ready, null);
             }
-            catch (McpException)
-            {
-                throw; // already faulted above
-            }
             catch (Exception ex)
             {
+                // Any failure during the handshake faults the connection. Re-throw the original
+                // exception so callers can distinguish timeout / protocol error / transport fault
+                // (McpTimeoutException and McpTransportException both extend McpException, so a
+                // type-based catch here would otherwise mask them).
                 Fault("open failed: " + ex.Message);
-                throw new McpTransportException("Failed to open connection '" + _name + "': " + ex.Message, ex);
+                throw;
             }
         }
 

--- a/src/Mcp35.Client/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Mcp35.Client")]
+[assembly: AssemblyDescription("Client-side Model Context Protocol library for .NET 3.5: transports and per-server connection.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("a043f034-fff5-44ce-9605-b40ff0016262")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/src/Mcp35.Client/Transport/HttpTransport.cs
+++ b/src/Mcp35.Client/Transport/HttpTransport.cs
@@ -1,0 +1,38 @@
+using System;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Client.Transport
+{
+    /// <summary>
+    /// Streamable-HTTP transport for remote servers (GitHub). Specified and implemented in
+    /// phase 8 (directly over Core's CurlRunner + SseParser — one POST = one correlated response,
+    /// no JsonRpcPeer). Present here only so <see cref="Mcp35.Client.McpServerConnection"/> can be
+    /// written transport-agnostically; every member throws until phase 8.
+    /// </summary>
+    public sealed class HttpTransport : IRpcTransport
+    {
+        public HttpTransport(string endpointUrl, string curlPath, string caBundlePath, ILogSink log)
+        {
+            // Retained for the phase-8 implementation; intentionally not wired yet.
+        }
+
+        private static Exception NotYet()
+        {
+            return new NotImplementedException("HttpTransport is implemented in phase 8.");
+        }
+
+        public event EventHandler<JsonRpcInboundEventArgs> Inbound
+        {
+            add { throw NotYet(); }
+            remove { throw NotYet(); }
+        }
+
+        public void Start() { throw NotYet(); }
+        public bool IsConnected { get { return false; } }
+        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs) { throw NotYet(); }
+        public void SendNotification(string method, JToken @params) { throw NotYet(); }
+        public void Dispose() { }
+    }
+}

--- a/src/Mcp35.Client/Transport/StdioChannel.cs
+++ b/src/Mcp35.Client/Transport/StdioChannel.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Rpc;
+using Mcp35.Core.Transport;
+
+namespace Mcp35.Client.Transport
+{
+    /// <summary>
+    /// An <see cref="IDuplexMessageChannel"/> backed by a child process: spawns it, reads framed
+    /// messages off stdout on a reader thread, drains stderr to the log, and writes framed
+    /// messages to stdin under a write lock. See mcp35-client-spec.md §2.
+    /// </summary>
+    internal sealed class StdioChannel : IDuplexMessageChannel
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        private readonly StdioLaunch _launch;
+        private readonly ILogSink _log;
+        private readonly object _writeLock = new object();
+
+        private System.Diagnostics.Process _proc;
+        private StreamReader _stdoutReader;
+        private Thread _readerThread;
+        private Thread _stderrThread;
+
+        private volatile bool _started;
+        private volatile bool _stopping;
+        private int _faultRaised; // 0/1 guard so Faulted fires at most once
+
+        public event Action<string> MessageReceived;
+        public event Action<Exception> Faulted;
+
+        public StdioChannel(StdioLaunch launch, ILogSink log)
+        {
+            if (launch == null) throw new ArgumentNullException("launch");
+            if (string.IsNullOrEmpty(launch.Command)) throw new ArgumentException("Command is required.", "launch");
+            _launch = launch;
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        public bool IsAlive
+        {
+            get
+            {
+                if (!_started || _proc == null) return false;
+                try { return !_proc.HasExited; }
+                catch { return false; }
+            }
+        }
+
+        public void Start()
+        {
+            if (_started) return;
+
+            ProcessStartInfo psi = new ProcessStartInfo();
+            psi.FileName = _launch.Command;
+            psi.Arguments = _launch.Arguments ?? string.Empty;
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            psi.RedirectStandardInput = true;
+            psi.RedirectStandardOutput = true;
+            psi.RedirectStandardError = true;
+            psi.StandardOutputEncoding = Utf8;
+            psi.StandardErrorEncoding = Utf8;
+            if (!string.IsNullOrEmpty(_launch.WorkingDirectory)) psi.WorkingDirectory = _launch.WorkingDirectory;
+            if (_launch.Environment != null)
+            {
+                foreach (System.Collections.Generic.KeyValuePair<string, string> kv in _launch.Environment)
+                    psi.EnvironmentVariables[kv.Key] = kv.Value;
+            }
+
+            _proc = new System.Diagnostics.Process();
+            _proc.StartInfo = psi;
+            _proc.Start();
+            _started = true;
+
+            _stdoutReader = _proc.StandardOutput;
+
+            _readerThread = new Thread(ReaderLoop);
+            _readerThread.IsBackground = true;
+            _readerThread.Name = "mcp-stdio-reader";
+            _readerThread.Start();
+
+            _stderrThread = new Thread(StderrLoop);
+            _stderrThread.IsBackground = true;
+            _stderrThread.Name = "mcp-stdio-stderr";
+            _stderrThread.Start();
+        }
+
+        public void Send(string json)
+        {
+            if (!_started) throw new InvalidOperationException("Channel not started.");
+            lock (_writeLock)
+            {
+                Stream stdin = _proc.StandardInput.BaseStream;
+                StdioFraming.WriteMessage(stdin, json);
+            }
+        }
+
+        private void ReaderLoop()
+        {
+            try
+            {
+                string line;
+                while ((line = StdioFraming.ReadMessage(_stdoutReader)) != null)
+                {
+                    Action<string> h = MessageReceived;
+                    if (h != null) h(line);
+                }
+                // null => EOF: the process closed stdout (normal on shutdown, or it died).
+                if (!_stopping) RaiseFault(new EndOfStreamException("Server stdout closed (process exited)."));
+            }
+            catch (Exception ex)
+            {
+                if (!_stopping) RaiseFault(ex);
+            }
+        }
+
+        private void StderrLoop()
+        {
+            try
+            {
+                StreamReader err = _proc.StandardError;
+                string line;
+                while ((line = err.ReadLine()) != null)
+                {
+                    _log.Log("mcp-server", line);
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Log("mcp", "stderr drain ended: " + ex.Message);
+            }
+        }
+
+        private void RaiseFault(Exception ex)
+        {
+            if (Interlocked.CompareExchange(ref _faultRaised, 1, 0) != 0) return;
+            Action<Exception> h = Faulted;
+            if (h != null) h(ex);
+        }
+
+        public void Dispose()
+        {
+            _stopping = true;
+
+            // 1. Close stdin → server sees EOF → graceful shutdown.
+            try
+            {
+                if (_proc != null) _proc.StandardInput.Close();
+            }
+            catch (Exception ex) { _log.Log("mcp", "Closing stdin threw: " + ex.Message); }
+
+            // 2. Wait for graceful exit, else kill.
+            try
+            {
+                if (_proc != null)
+                {
+                    if (!_proc.WaitForExit(_launch.ShutdownGraceMs))
+                    {
+                        try { if (!_proc.HasExited) _proc.Kill(); }
+                        catch (Exception ex) { _log.Log("mcp", "Kill threw: " + ex.Message); }
+                    }
+                }
+            }
+            catch (Exception ex) { _log.Log("mcp", "WaitForExit threw: " + ex.Message); }
+
+            // 3. Join threads.
+            JoinThread(_readerThread);
+            JoinThread(_stderrThread);
+
+            try { if (_proc != null) _proc.Close(); }
+            catch { }
+        }
+
+        private static void JoinThread(Thread t)
+        {
+            if (t != null && t.IsAlive) t.Join(2000);
+        }
+    }
+}

--- a/src/Mcp35.Client/Transport/StdioLaunch.cs
+++ b/src/Mcp35.Client/Transport/StdioLaunch.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Mcp35.Client.Transport
+{
+    /// <summary>How to launch a stdio MCP server child process.</summary>
+    public sealed class StdioLaunch
+    {
+        /// <summary>Resolved executable path (the host resolves built-ins / PATH).</summary>
+        public string Command;
+
+        public string Arguments;
+        public string WorkingDirectory;
+
+        /// <summary>Extra environment variables for the child (added to the inherited block).</summary>
+        public IDictionary<string, string> Environment;
+
+        /// <summary>Grace period after stdin EOF before the child is force-killed on Dispose.</summary>
+        public int ShutdownGraceMs = 2000;
+    }
+}

--- a/src/Mcp35.Client/Transport/StdioTransport.cs
+++ b/src/Mcp35.Client/Transport/StdioTransport.cs
@@ -1,0 +1,60 @@
+using System;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Client.Transport
+{
+    /// <summary>
+    /// An <see cref="IRpcTransport"/> over a child process: composes a <see cref="StdioChannel"/>
+    /// (process + framing) with a Core <see cref="JsonRpcPeer"/> (id-correlation + dispatch). The
+    /// transport owns process lifecycle; the peer owns RPC semantics. See mcp35-client-spec.md §2.
+    /// </summary>
+    public sealed class StdioTransport : IRpcTransport
+    {
+        private readonly StdioChannel _channel;
+        private readonly JsonRpcPeer _peer;
+
+        public StdioTransport(StdioLaunch launch, ILogSink log)
+        {
+            ILogSink sink = log ?? NullLogSink.Instance;
+            _channel = new StdioChannel(launch, sink);
+            _peer = new JsonRpcPeer(_channel, sink);
+        }
+
+        public event EventHandler<JsonRpcInboundEventArgs> Inbound
+        {
+            add { _peer.Inbound += value; }
+            remove { _peer.Inbound -= value; }
+        }
+
+        public void Start()
+        {
+            // JsonRpcPeer.Start() calls channel.Start() (spawns the process).
+            _peer.Start();
+        }
+
+        public bool IsConnected
+        {
+            get { return _peer.IsConnected && _channel.IsAlive; }
+        }
+
+        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs)
+        {
+            return _peer.SendRequest(method, @params, timeoutMs);
+        }
+
+        public void SendNotification(string method, JToken @params)
+        {
+            _peer.SendNotification(method, @params);
+        }
+
+        public void Dispose()
+        {
+            // Dispose the peer first (faults pending calls so no caller hangs), then the channel
+            // performs graceful stdin-EOF shutdown. JsonRpcPeer.Dispose disposes its channel too,
+            // so guard against a double dispose in StdioChannel (idempotent via _stopping).
+            _peer.Dispose();
+        }
+    }
+}

--- a/tests/EchoMcpServer/EchoMcpServer.csproj
+++ b/tests/EchoMcpServer/EchoMcpServer.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A minimal Mcp35.Server-based echo server used by Mcp35.Client.Tests for the end-to-end
+    StdioTransport integration test (phase-3 criterion 5). It links the Core + Server sources
+    (same pattern as the test projects) and produces a console exe the test launches as a child
+    process. Targets net48 so it runs on the CI runner via the .NET SDK.
+
+    NOTE: intentionally NOT in GxPT.sln. The shipping first-party servers (phase 7) are separate
+    net35 projects; this is a test fixture only.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>EchoMcpServer</AssemblyName>
+    <RootNamespace>EchoMcpServer</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <!-- Keep the exe self-contained next to the test assembly for easy launch. -->
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EchoMcpServer/Program.cs
+++ b/tests/EchoMcpServer/Program.cs
@@ -1,0 +1,39 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace EchoMcpServer
+{
+    /// <summary>
+    /// A minimal MCP server over stdio: one "echo" tool that returns its <c>text</c> argument,
+    /// and one "boom" tool that throws (to exercise contained-exception handling). Used by
+    /// Mcp35.Client.Tests' end-to-end StdioTransport test.
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            Implementation info = new Implementation();
+            info.Name = "echo";
+            info.Version = "1.0.0";
+
+            McpServer server = new McpServer(info, new StdErrLogSink());
+
+            server.AddTool("echo", "Echoes the provided text back.",
+                SchemaBuilder.Object().Str("text", true, "Text to echo").Build(),
+                delegate(ToolCallContext ctx)
+                {
+                    string text = ctx.Arguments.Value<string>("text");
+                    return ToolResults.Text(text == null ? "" : text);
+                });
+
+            server.AddTool("boom", "Always throws (for error-path testing).", null,
+                delegate(ToolCallContext ctx)
+                {
+                    throw new System.InvalidOperationException("intentional failure");
+                });
+
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/tests/Mcp35.Client.Tests/FakeTransport.cs
+++ b/tests/Mcp35.Client.Tests/FakeTransport.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Client.Tests
+{
+    /// <summary>
+    /// An in-memory <see cref="IRpcTransport"/> (no process) for driving
+    /// <see cref="Mcp35.Client.McpServerConnection"/> in unit tests. Lets a test script per-method
+    /// responses, record sent messages, simulate faults/timeouts, and push inbound notifications.
+    /// </summary>
+    internal sealed class FakeTransport : IRpcTransport
+    {
+        public readonly List<string> SentMethods = new List<string>();
+        public readonly List<string> Notifications = new List<string>();
+
+        /// <summary>method =&gt; produce a response for a request to that method.</summary>
+        public readonly Dictionary<string, Func<JToken, JsonRpcResponse>> Handlers =
+            new Dictionary<string, Func<JToken, JsonRpcResponse>>(StringComparer.Ordinal);
+
+        public bool ThrowOnSend;            // simulate a mid-call transport fault
+        public bool TimeoutEverything;      // simulate no response (throw timeout)
+        public bool Started;
+        private bool _connected = true;
+
+        public event EventHandler<JsonRpcInboundEventArgs> Inbound;
+
+        public void Start() { Started = true; }
+        public bool IsConnected { get { return _connected; } }
+
+        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs)
+        {
+            SentMethods.Add(method);
+
+            if (ThrowOnSend)
+            {
+                _connected = false;
+                throw new Mcp35.Core.Errors.McpTransportException("simulated transport fault");
+            }
+            if (TimeoutEverything)
+                throw new Mcp35.Core.Errors.McpTimeoutException("simulated timeout");
+
+            Func<JToken, JsonRpcResponse> h;
+            if (Handlers.TryGetValue(method, out h)) return h(@params);
+
+            // Default: empty object result.
+            return Result(new JObject());
+        }
+
+        public void SendNotification(string method, JToken @params)
+        {
+            Notifications.Add(method);
+        }
+
+        public void Dispose() { _connected = false; }
+
+        public void RaiseInbound(string method)
+        {
+            EventHandler<JsonRpcInboundEventArgs> h = Inbound;
+            if (h == null) return;
+            JsonRpcInboundEventArgs e = new JsonRpcInboundEventArgs();
+            e.Method = method;
+            e.IsRequest = false;
+            h(this, e);
+        }
+
+        // ---- response builders ----
+
+        public static JsonRpcResponse Result(JToken result)
+        {
+            JsonRpcResponse r = new JsonRpcResponse();
+            r.Id = RequestId.FromLong(1);
+            r.IsError = false;
+            r.Result = result;
+            return r;
+        }
+
+        public static JsonRpcResponse Error(int code, string message)
+        {
+            JsonRpcResponse r = new JsonRpcResponse();
+            r.Id = RequestId.FromLong(1);
+            r.IsError = true;
+            r.Error = new JsonRpcError(code, message);
+            return r;
+        }
+
+        public static JObject InitializeResult(string version, bool withTools)
+        {
+            JObject caps = new JObject();
+            if (withTools) caps["tools"] = new JObject();
+
+            JObject serverInfo = new JObject();
+            serverInfo["name"] = "fake";
+            serverInfo["version"] = "1.0";
+
+            JObject result = new JObject();
+            result["protocolVersion"] = version;
+            result["capabilities"] = caps;
+            result["serverInfo"] = serverInfo;
+            return result;
+        }
+
+        public static JObject ToolsListResult(string nextCursor, params string[] names)
+        {
+            JArray tools = new JArray();
+            foreach (string n in names)
+            {
+                JObject t = new JObject();
+                t["name"] = n;
+                JObject schema = new JObject();
+                schema["type"] = "object";
+                t["inputSchema"] = schema;
+                tools.Add(t);
+            }
+            JObject result = new JObject();
+            result["tools"] = tools;
+            if (nextCursor != null) result["nextCursor"] = nextCursor;
+            return result;
+        }
+    }
+}

--- a/tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
+++ b/tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for Mcp35.Client (phase 3). Links the Core + Client production sources (same
+    linked-source pattern as the other test projects) and compiles them into the test assembly.
+    Targets net48; Newtonsoft via pinned PackageReference (13.0.3) matching the vendored net35 DLL.
+
+    The end-to-end test (criterion 5) launches the EchoMcpServer exe as a child process; we
+    reference that project (ReferenceOutputAssembly=false) purely to force a build ordering and
+    to locate its output path.
+
+    NOTE: intentionally NOT added to GxPT.sln (VS2008 cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>Mcp35.Client.Tests</AssemblyName>
+    <RootNamespace>Mcp35.Client.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Client\**\*.cs"
+             Exclude="..\..\src\Mcp35.Client\Properties\**\*.cs;..\..\src\Mcp35.Client\obj\**\*.cs;..\..\src\Mcp35.Client\bin\**\*.cs"
+             Link="Linked\Client\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Build the echo server first; the e2e test discovers its exe via EchoServerPath. -->
+    <ProjectReference Include="..\EchoMcpServer\EchoMcpServer.csproj"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+    Copy the (already-built, via ProjectReference) EchoMcpServer output into a known subfolder of
+    this test's output dir so the e2e test can launch it via AppContext.BaseDirectory/echo-server.
+  -->
+  <Target Name="CopyEchoServer" AfterTargets="Build">
+    <ItemGroup>
+      <EchoServerFiles Include="..\EchoMcpServer\bin\$(Configuration)\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(EchoServerFiles)"
+          DestinationFiles="@(EchoServerFiles->'$(OutDir)echo-server\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/tests/Mcp35.Client.Tests/McpServerConnectionTests.cs
+++ b/tests/Mcp35.Client.Tests/McpServerConnectionTests.cs
@@ -203,7 +203,8 @@ namespace Mcp35.Client.Tests
 
             using (var conn = NewConnection(t))
             {
-                Assert.Throws<McpTransportException>(delegate { conn.Open(500); });
+                // The timeout surfaces as its own type (not masked), and the connection faults.
+                Assert.Throws<McpTimeoutException>(delegate { conn.Open(500); });
                 Assert.Equal(ConnectionState.Faulted, conn.State);
             }
         }

--- a/tests/Mcp35.Client.Tests/McpServerConnectionTests.cs
+++ b/tests/Mcp35.Client.Tests/McpServerConnectionTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Client;
+using Mcp35.Core.Errors;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Mcp35.Client.Tests
+{
+    public class McpServerConnectionTests
+    {
+        private static McpServerConnection NewConnection(FakeTransport t)
+        {
+            Implementation client = new Implementation();
+            client.Name = "test-client";
+            client.Version = "1.0";
+            return new McpServerConnection("fake", t, client, null);
+        }
+
+        private static FakeTransport ReadyTransport(string version, bool withTools, params string[] tools)
+        {
+            var t = new FakeTransport();
+            t.Handlers[McpMethods.Initialize] = delegate (JToken p)
+            {
+                return FakeTransport.Result(FakeTransport.InitializeResult(version, withTools));
+            };
+            t.Handlers[McpMethods.ToolsList] = delegate (JToken p)
+            {
+                return FakeTransport.Result(FakeTransport.ToolsListResult(null, tools));
+            };
+            return t;
+        }
+
+        // ---- Criterion 1: connection / handshake ----
+
+        [Fact]
+        public void Open_drives_initialize_then_initialized_and_reaches_ready()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            var states = new List<ConnectionState>();
+
+            using (var conn = NewConnection(t))
+            {
+                conn.StateChanged += delegate (object s, ConnectionStateEventArgs e) { states.Add(e.NewState); };
+                conn.Open(5000);
+
+                Assert.Equal(ConnectionState.Ready, conn.State);
+                Assert.True(conn.SupportsTools);
+                Assert.Equal("fake", conn.ServerInfo.ServerInfo.Name);
+
+                // initialize was sent and initialized notification followed.
+                Assert.Contains(McpMethods.Initialize, t.SentMethods);
+                Assert.Contains(McpMethods.Initialized, t.Notifications);
+
+                // state progression
+                Assert.Equal(ConnectionState.Starting, states[0]);
+                Assert.Equal(ConnectionState.Initializing, states[1]);
+                Assert.Equal(ConnectionState.Ready, states[states.Count - 1]);
+            }
+        }
+
+        [Fact]
+        public void Server_without_tools_capability_has_no_tools()
+        {
+            var t = ReadyTransport("2025-06-18", false);
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                Assert.False(conn.SupportsTools);
+                Assert.Empty(conn.ListTools(false));
+            }
+        }
+
+        // ---- Criterion 2: tools cache + paging ----
+
+        [Fact]
+        public void ListTools_follows_next_cursor_across_pages()
+        {
+            var t = new FakeTransport();
+            t.Handlers[McpMethods.Initialize] = delegate (JToken p)
+            {
+                return FakeTransport.Result(FakeTransport.InitializeResult("2025-06-18", true));
+            };
+            int call = 0;
+            t.Handlers[McpMethods.ToolsList] = delegate (JToken p)
+            {
+                call++;
+                if (call == 1) return FakeTransport.Result(FakeTransport.ToolsListResult("page2", "a", "b"));
+                return FakeTransport.Result(FakeTransport.ToolsListResult(null, "c"));
+            };
+
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000); // prefetch does page 1 + 2 already
+                IList<Tool> tools = conn.ListTools(false);
+                Assert.Equal(3, tools.Count);
+                Assert.Equal("a", tools[0].Name);
+                Assert.Equal("c", tools[2].Name);
+            }
+        }
+
+        [Fact]
+        public void ListTools_is_cached_until_refresh()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                int afterOpen = CountCalls(t, McpMethods.ToolsList);
+
+                conn.ListTools(false); // served from cache — no new call
+                Assert.Equal(afterOpen, CountCalls(t, McpMethods.ToolsList));
+
+                conn.ListTools(true);  // forced refresh — one more call
+                Assert.Equal(afterOpen + 1, CountCalls(t, McpMethods.ToolsList));
+            }
+        }
+
+        [Fact]
+        public void ToolsListChanged_invalidates_cache_and_raises_event()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                bool raised = false;
+                conn.ToolsChanged += delegate (object s, EventArgs e) { raised = true; };
+
+                int before = CountCalls(t, McpMethods.ToolsList);
+                t.RaiseInbound(McpMethods.ToolsListChanged);
+                Assert.True(raised);
+
+                conn.ListTools(false); // cache was invalidated → re-fetches
+                Assert.Equal(before + 1, CountCalls(t, McpMethods.ToolsList));
+            }
+        }
+
+        // ---- Criterion 3: CallTool routing ----
+
+        [Fact]
+        public void CallTool_passes_through_isError_result()
+        {
+            var t = ReadyTransport("2025-06-18", true, "boom");
+            t.Handlers[McpMethods.ToolsCall] = delegate (JToken p)
+            {
+                JObject result = new JObject();
+                JArray content = new JArray();
+                JObject block = new JObject();
+                block["type"] = "text";
+                block["text"] = "it failed";
+                content.Add(block);
+                result["content"] = content;
+                result["isError"] = true;
+                return FakeTransport.Result(result);
+            };
+
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                CallToolResult r = conn.CallTool("boom", new JObject(), 5000);
+                Assert.True(r.IsError);
+                Assert.Equal("it failed", r.Content[0].Text);
+            }
+        }
+
+        [Fact]
+        public void CallTool_throws_on_jsonrpc_error_response()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            t.Handlers[McpMethods.ToolsCall] = delegate (JToken p)
+            {
+                return FakeTransport.Error(JsonRpcErrorCodes.InvalidParams, "unknown tool");
+            };
+
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                McpException ex = Assert.Throws<McpException>(delegate { conn.CallTool("nope", new JObject(), 5000); });
+                Assert.Equal(JsonRpcErrorCodes.InvalidParams, ex.Error.Code);
+            }
+        }
+
+        [Fact]
+        public void CallTool_before_ready_throws()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            using (var conn = NewConnection(t))
+            {
+                // not opened
+                Assert.Throws<InvalidOperationException>(delegate { conn.CallTool("echo", new JObject(), 5000); });
+            }
+        }
+
+        // ---- Criterion 4: fault paths ----
+
+        [Fact]
+        public void Handshake_timeout_faults_the_connection()
+        {
+            var t = new FakeTransport();
+            t.TimeoutEverything = true;
+
+            using (var conn = NewConnection(t))
+            {
+                Assert.Throws<McpTransportException>(delegate { conn.Open(500); });
+                Assert.Equal(ConnectionState.Faulted, conn.State);
+            }
+        }
+
+        [Fact]
+        public void Mid_call_transport_fault_propagates_and_faults()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            using (var conn = NewConnection(t))
+            {
+                conn.Open(5000);
+                t.ThrowOnSend = true;
+                Assert.Throws<McpTransportException>(delegate { conn.CallTool("echo", new JObject(), 5000); });
+            }
+        }
+
+        [Fact]
+        public void Dispose_transitions_to_closed()
+        {
+            var t = ReadyTransport("2025-06-18", true, "echo");
+            var conn = NewConnection(t);
+            conn.Open(5000);
+            conn.Dispose();
+            Assert.Equal(ConnectionState.Closed, conn.State);
+        }
+
+        private static int CountCalls(FakeTransport t, string method)
+        {
+            int n = 0;
+            foreach (string m in t.SentMethods) if (m == method) n++;
+            return n;
+        }
+    }
+}

--- a/tests/Mcp35.Client.Tests/StdioEndToEndTests.cs
+++ b/tests/Mcp35.Client.Tests/StdioEndToEndTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using Mcp35.Client;
+using Mcp35.Client.Transport;
+using Mcp35.Core.Protocol;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Mcp35.Client.Tests
+{
+    /// <summary>
+    /// The first Core + Server + Client integration test: launches the real EchoMcpServer exe as a
+    /// child process and runs initialize + tools/list + tools/call over StdioTransport, then
+    /// verifies graceful shutdown on Dispose (stdin EOF → exit). Phase-3 criterion 5.
+    /// </summary>
+    public class StdioEndToEndTests
+    {
+        private static string EchoServerExe()
+        {
+            // The csproj CopyEchoServer target stages the server under <output>/echo-server/.
+            string dir = Path.Combine(AppContext.BaseDirectory, "echo-server");
+            string exe = Path.Combine(dir, "EchoMcpServer.exe");
+            string dll = Path.Combine(dir, "EchoMcpServer.dll");
+
+            if (File.Exists(exe)) return exe;
+            // On the CI runner the apphost exe should exist; fall back to the dll via dotnet if not.
+            if (File.Exists(dll)) return dll;
+            throw new FileNotFoundException("EchoMcpServer not found in " + dir +
+                " (looked for EchoMcpServer.exe/.dll).");
+        }
+
+        private static StdioLaunch BuildLaunch()
+        {
+            string target = EchoServerExe();
+            StdioLaunch launch = new StdioLaunch();
+            launch.ShutdownGraceMs = 3000;
+
+            if (target.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                launch.Command = "dotnet";
+                launch.Arguments = "\"" + target + "\"";
+            }
+            else
+            {
+                launch.Command = target;
+                launch.Arguments = "";
+            }
+            return launch;
+        }
+
+        private static McpServerConnection Connect()
+        {
+            StdioTransport transport = new StdioTransport(BuildLaunch(), null);
+            Implementation client = new Implementation();
+            client.Name = "e2e-test";
+            client.Version = "1.0";
+            return new McpServerConnection("echo", transport, client, null);
+        }
+
+        [Fact]
+        public void Full_handshake_list_and_call_over_real_process()
+        {
+            using (McpServerConnection conn = Connect())
+            {
+                conn.Open(McpServerConnection.DefaultInitializeTimeoutMs);
+                Assert.Equal(ConnectionState.Ready, conn.State);
+                Assert.True(conn.SupportsTools);
+                Assert.Equal("echo", conn.ServerInfo.ServerInfo.Name);
+
+                var tools = conn.ListTools(false);
+                Assert.Contains(tools, delegate (Tool t) { return t.Name == "echo"; });
+                Assert.Contains(tools, delegate (Tool t) { return t.Name == "boom"; });
+
+                JObject args = new JObject();
+                args["text"] = "hello over stdio";
+                CallToolResult result = conn.CallTool("echo", args, 10000);
+
+                Assert.False(result.IsError);
+                Assert.Equal("hello over stdio", result.Content[0].Text);
+            }
+            // Dispose (end of using) closed stdin → the server exited gracefully; no hang/throw.
+        }
+
+        [Fact]
+        public void Handler_exception_in_real_server_comes_back_as_isError()
+        {
+            using (McpServerConnection conn = Connect())
+            {
+                conn.Open(McpServerConnection.DefaultInitializeTimeoutMs);
+                CallToolResult result = conn.CallTool("boom", new JObject(), 10000);
+                Assert.True(result.IsError); // server contained the throw, stayed alive
+            }
+        }
+
+        [Fact]
+        public void Unknown_tool_on_real_server_throws_mcp_exception()
+        {
+            using (McpServerConnection conn = Connect())
+            {
+                conn.Open(McpServerConnection.DefaultInitializeTimeoutMs);
+                Assert.Throws<Mcp35.Core.Errors.McpException>(
+                    delegate { conn.CallTool("does_not_exist", new JObject(), 10000); });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 3** of the MCP roadmap: `Mcp35.Client`, the client-side half — the
transport implementations and a per-server connection. Built on phase-1
`Mcp35.Core` (ProjectRef, strict one-way dep, no `GxPT.*`). Draft — CI on the
Windows runner builds the net48 linked-source test project and runs the phase-3
exit criteria, **including the first real Core + Server + Client integration test**
(launches an actual child-process server).

## What's here

**`src/Mcp35.Client/`** (net35, `ProjectRef → Mcp35.Core`):
- **`StdioChannel`** (`IDuplexMessageChannel`) — spawns the server child process;
  a reader thread pumps framed stdout messages, stderr drains to the log, writes
  are serialized under a lock; EOF/exit raises `Faulted` once. Graceful `Dispose`
  closes stdin → waits `ShutdownGraceMs` → `Kill`.
- **`StdioTransport`** (`IRpcTransport`) — composes `StdioChannel` + Core's
  `JsonRpcPeer` (process lifecycle vs. RPC semantics).
- **`HttpTransport`** — phase-8 placeholder stub so `McpServerConnection` is
  written transport-agnostically.
- **`McpServerConnection`** — drives `initialize` → validate version →
  `initialized` → prefetch `tools/list`; caches tools (cursor paging); routes
  `tools/call` (`isError` passes through verbatim, a JSON-RPC error throws
  `McpException`); invalidates cache + raises `ToolsChanged` on
  `notifications/tools/list_changed`; `Created…Ready/Faulted/Closed` state machine.

**`tests/`** (net48 linked-source, Newtonsoft 13.0.3):
- `McpServerConnectionTests` over a `FakeTransport` (no process): handshake +
  state transitions, tools cache + paging + `list_changed` invalidation, CallTool
  routing (isError vs `-32602` throw), fault paths (handshake timeout, mid-call
  fault, dispose→closed).
- `StdioEndToEndTests` — launches the real **`EchoMcpServer`** child exe and runs
  `initialize` + `tools/list` + `tools/call` over `StdioTransport`, plus
  contained-throw and unknown-tool paths, then graceful EOF shutdown.
- `EchoMcpServer` — minimal `Mcp35.Server`-based fixture exe (echo + boom tools).

## Scope note — host integration deferred

Spec §7 (the GxPT-side `mcp.json` loader, `BuiltInServers`, `McpHost`, and the MCP
settings tab) is **not** in this PR: it touches WinForms / `AppSettings` and isn't
exercised by the linked-source CI model. It lands as a focused follow-up that
completes the phase-3 milestone (host enumerates the union of tools). This PR is
the full, CI-verifiable **library** with the end-to-end integration test that
proves Core + Server + Client wire together over a real pipe.

## Review focus

- **Process/thread lifecycle** in `StdioChannel` — the reader/stderr threads,
  the once-only `Faulted`, and the close-stdin→wait→kill `Dispose` path. This is
  the first code that spawns real processes; the e2e test is where CI flakiness,
  if any, would show.
- The `StdioTransport.Dispose` → `JsonRpcPeer.Dispose` → `StdioChannel.Dispose`
  ordering (peer faults pending calls first; channel dispose is idempotent).
- `IsAcceptableVersion`: stdio accepts any non-empty negotiated version; the HTTP
  `≥ HttpFloor` gate is deferred to phase 8.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_