### PR TITLE
Phase 7a: CurlRunner (Core) + FilesMcpServer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
           dotnet restore tests/Mcp35.Core.Tests/Mcp35.Core.Tests.csproj
           dotnet restore tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
           dotnet restore tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
+          dotnet restore tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
@@ -39,3 +40,6 @@ jobs:
 
       - name: Test (Mcp35.Client)
         run: dotnet test tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (FilesMcpServer)
+        run: dotnet test tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Server", "src\Mcp35.S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Client", "src\Mcp35.Client\Mcp35.Client.csproj", "{A043F034-FFF5-44CE-9605-B40FF0016262}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilesMcpServer", "servers\FilesMcpServer\FilesMcpServer.csproj", "{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{A043F034-FFF5-44CE-9605-B40FF0016262}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A043F034-FFF5-44CE-9605-B40FF0016262}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A043F034-FFF5-44CE-9605-B40FF0016262}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/servers/FilesMcpServer/FilesConfig.cs
+++ b/servers/FilesMcpServer/FilesConfig.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace FilesMcpServer
+{
+    /// <summary>
+    /// Startup config, read once from the environment (servers-spec §1). The Files server's only
+    /// input is its sandbox root, <c>GXPT_WORKDIR</c> (default: the process current directory).
+    /// </summary>
+    internal sealed class FilesConfig
+    {
+        public readonly string WorkDir;
+
+        private FilesConfig(string workDir)
+        {
+            WorkDir = workDir;
+        }
+
+        public static FilesConfig FromEnvironment(ILogSink log)
+        {
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir))
+                workDir = Directory.GetCurrentDirectory();
+
+            if (log != null) log.Log("files", "workdir=" + workDir);
+            return new FilesConfig(workDir);
+        }
+    }
+}

--- a/servers/FilesMcpServer/FilesMcpServer.csproj
+++ b/servers/FilesMcpServer/FilesMcpServer.csproj
@@ -5,11 +5,11 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <ProjectGuid>{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Mcp35.Core</RootNamespace>
-    <AssemblyName>Mcp35.Core</AssemblyName>
+    <RootNamespace>FilesMcpServer</RootNamespace>
+    <AssemblyName>FilesMcpServer</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -33,33 +33,23 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>lib\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Json\McpJson.cs" />
-    <Compile Include="Json\RequestIdConverter.cs" />
-    <Compile Include="Rpc\RequestId.cs" />
-    <Compile Include="Rpc\JsonRpcRequest.cs" />
-    <Compile Include="Rpc\JsonRpcNotification.cs" />
-    <Compile Include="Rpc\JsonRpcResponse.cs" />
-    <Compile Include="Rpc\JsonRpcError.cs" />
-    <Compile Include="Rpc\JsonRpcErrorCodes.cs" />
-    <Compile Include="Rpc\IRpcTransport.cs" />
-    <Compile Include="Rpc\JsonRpcPeer.cs" />
-    <Compile Include="Transport\StdioFraming.cs" />
-    <Compile Include="Transport\SseParser.cs" />
-    <Compile Include="Transport\CurlRunner.cs" />
-    <Compile Include="Protocol\McpMethods.cs" />
-    <Compile Include="Protocol\ProtocolVersions.cs" />
-    <Compile Include="Protocol\Initialize.cs" />
-    <Compile Include="Protocol\Tools.cs" />
-    <Compile Include="Protocol\ContentBlock.cs" />
-    <Compile Include="Diagnostics\ILogSink.cs" />
-    <Compile Include="Errors\McpException.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="FilesConfig.cs" />
+    <Compile Include="FilesTools.cs" />
+    <Compile Include="PathSandbox.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace FilesMcpServer
+{
+    /// <summary>
+    /// The Files server's four tools, all confined to the sandbox root. read/list are ReadOnly,
+    /// write is Write(path-scoped), delete is Destructive(path-scoped) — host-gated; the server's
+    /// job is safe construction (servers-spec §2).
+    /// </summary>
+    internal static class FilesTools
+    {
+        // Caps (servers-spec §2).
+        private const long MaxReadBytes = 1024 * 1024;       // 1 MiB
+        private const int MaxListEntries = 1000;
+        private const int MaxRecursiveDepth = 16;
+        private const int BinarySniffBytes = 8000;
+
+        public static void Register(McpServer server, FilesConfig config)
+        {
+            PathSandbox sandbox = new PathSandbox(config.WorkDir);
+
+            server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root.",
+                SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
+                delegate(ToolCallContext ctx) { return Read(sandbox, ctx); });
+
+            server.AddTool("list", "List entries of a directory under the workspace root.",
+                SchemaBuilder.Object()
+                    .Str("path", true, "Directory path relative to the workspace root")
+                    .Bool("recursive", false, "Recurse into subdirectories (bounded depth)")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return List(sandbox, ctx); });
+
+            server.AddTool("write", "Create or overwrite a text file under the workspace root.",
+                SchemaBuilder.Object()
+                    .Str("path", true, "Path relative to the workspace root")
+                    .Str("content", true, "UTF-8 text content to write")
+                    .Bool("create_dirs", false, "Create missing parent directories")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Write(sandbox, ctx); });
+
+            server.AddTool("delete", "Delete a file or an empty directory under the workspace root.",
+                SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
+                delegate(ToolCallContext ctx) { return Delete(sandbox, ctx); });
+        }
+
+        // ---- read ----
+
+        private static CallToolResult Read(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string full;
+            CallToolResult err = ResolvePath(sandbox, ctx, out full);
+            if (err != null) return err;
+
+            if (!File.Exists(full)) return ToolResults.Error("file not found");
+
+            FileInfo fi = new FileInfo(full);
+            if (fi.Length > MaxReadBytes)
+                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes + ")");
+
+            byte[] bytes = File.ReadAllBytes(full);
+            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
+
+            return ToolResults.Text(DecodeUtf8(bytes));
+        }
+
+        // ---- list ----
+
+        private static CallToolResult List(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string full;
+            CallToolResult err = ResolvePath(sandbox, ctx, out full);
+            if (err != null) return err;
+
+            if (!Directory.Exists(full)) return ToolResults.Error("directory not found");
+
+            bool recursive = BoolArg(ctx, "recursive", false);
+
+            List<JObject> entries = new List<JObject>();
+            bool truncated = Collect(sandbox, full, recursive, recursive ? MaxRecursiveDepth : 0, entries);
+
+            JObject result = new JObject();
+            JArray arr = new JArray();
+            foreach (JObject e in entries) arr.Add(e);
+            result["entries"] = arr;
+            result["count"] = entries.Count;
+            result["truncated"] = truncated;
+            return ToolResults.Json(result);
+        }
+
+        private static bool Collect(PathSandbox sandbox, string dir, bool recursive, int depthLeft, List<JObject> entries)
+        {
+            string[] dirs = Directory.GetDirectories(dir);
+            string[] files = Directory.GetFiles(dir);
+
+            foreach (string d in dirs)
+            {
+                if (entries.Count >= MaxListEntries) return true;
+                entries.Add(Entry(sandbox, d, "dir", 0));
+                if (recursive && depthLeft > 0)
+                {
+                    if (Collect(sandbox, d, true, depthLeft - 1, entries)) return true;
+                }
+            }
+            foreach (string f in files)
+            {
+                if (entries.Count >= MaxListEntries) return true;
+                long size = 0;
+                try { size = new FileInfo(f).Length; }
+                catch { }
+                entries.Add(Entry(sandbox, f, "file", size));
+            }
+            return false;
+        }
+
+        private static JObject Entry(PathSandbox sandbox, string full, string type, long size)
+        {
+            JObject o = new JObject();
+            o["name"] = sandbox.ToRelative(full);
+            o["type"] = type;
+            o["size"] = size;
+            return o;
+        }
+
+        // ---- write ----
+
+        private static CallToolResult Write(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string full;
+            CallToolResult err = ResolvePath(sandbox, ctx, out full);
+            if (err != null) return err;
+
+            if (Directory.Exists(full)) return ToolResults.Error("path is a directory");
+
+            string content = ctx.Arguments.Value<string>("content");
+            if (content == null) return ToolResults.Error("content is required");
+
+            bool createDirs = BoolArg(ctx, "create_dirs", false);
+            string parent = Path.GetDirectoryName(full);
+            if (!Directory.Exists(parent))
+            {
+                if (!createDirs) return ToolResults.Error("parent directory does not exist (set create_dirs to create it)");
+                Directory.CreateDirectory(parent);
+            }
+
+            // Atomic-ish write: temp file in the same dir, then replace (mirrors AppSettings).
+            string tmp = Path.Combine(parent, "." + Guid.NewGuid().ToString("N") + ".tmp");
+            UTF8Encoding utf8NoBom = new UTF8Encoding(false);
+            try
+            {
+                File.WriteAllText(tmp, content, utf8NoBom);
+                if (File.Exists(full)) File.Delete(full);
+                File.Move(tmp, full);
+            }
+            finally
+            {
+                try { if (File.Exists(tmp)) File.Delete(tmp); }
+                catch { }
+            }
+
+            JObject result = new JObject();
+            result["path"] = sandbox.ToRelative(full);
+            result["bytesWritten"] = utf8NoBom.GetByteCount(content);
+            return ToolResults.Json(result);
+        }
+
+        // ---- delete ----
+
+        private static CallToolResult Delete(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string full;
+            CallToolResult err = ResolvePath(sandbox, ctx, out full);
+            if (err != null) return err;
+
+            if (Directory.Exists(full))
+            {
+                // Empty directories only — never recursive (bounded blast radius, §2).
+                if (Directory.GetFileSystemEntries(full).Length > 0)
+                    return ToolResults.Error("directory is not empty");
+                Directory.Delete(full, false);
+            }
+            else if (File.Exists(full))
+            {
+                File.Delete(full);
+            }
+            else
+            {
+                return ToolResults.Error("path not found");
+            }
+
+            JObject result = new JObject();
+            result["deleted"] = sandbox.ToRelative(full);
+            return ToolResults.Json(result);
+        }
+
+        // ---- helpers ----
+
+        private static CallToolResult ResolvePath(PathSandbox sandbox, ToolCallContext ctx, out string full)
+        {
+            full = null;
+            string rel = ctx.Arguments.Value<string>("path");
+            try
+            {
+                full = sandbox.Resolve(rel);
+                return null;
+            }
+            catch (SandboxException ex)
+            {
+                return ToolResults.Error(ex.Message);
+            }
+        }
+
+        private static bool BoolArg(ToolCallContext ctx, string name, bool fallback)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            try { return t.Value<bool>(); }
+            catch { return fallback; }
+        }
+
+        private static bool LooksBinary(byte[] bytes)
+        {
+            int n = Math.Min(bytes.Length, BinarySniffBytes);
+            for (int i = 0; i < n; i++)
+                if (bytes[i] == 0) return true; // NUL byte → treat as binary
+            return false;
+        }
+
+        private static string DecodeUtf8(byte[] bytes)
+        {
+            // BOM-aware: strip a leading UTF-8 BOM if present.
+            int start = 0;
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+                start = 3;
+            UTF8Encoding utf8 = new UTF8Encoding(false, false);
+            return utf8.GetString(bytes, start, bytes.Length - start);
+        }
+    }
+}

--- a/servers/FilesMcpServer/PathSandbox.cs
+++ b/servers/FilesMcpServer/PathSandbox.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+
+namespace FilesMcpServer
+{
+    /// <summary>Thrown when a requested path would escape the sandbox root.</summary>
+    internal sealed class SandboxException : Exception
+    {
+        public SandboxException(string message) : base(message) { }
+    }
+
+    /// <summary>
+    /// Confines every file path to a single root. The one rule that matters (servers-spec §2):
+    /// resolve the relative path against the root, canonicalize <c>.</c>/<c>..</c>, and verify the
+    /// result is inside the root using a <b>directory-boundary</b> check — so "/root" does not
+    /// match "/root-evil". Absolute inputs are rejected outright.
+    /// </summary>
+    internal sealed class PathSandbox
+    {
+        private readonly string _root;          // canonical, no trailing separator
+        private readonly string _rootWithSep;   // canonical + separator, for boundary checks
+
+        public PathSandbox(string root)
+        {
+            if (string.IsNullOrEmpty(root)) throw new ArgumentException("root is required", "root");
+            // Canonicalize the root itself and strip any trailing separator for a stable boundary.
+            string full = Path.GetFullPath(root);
+            _root = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            _rootWithSep = _root + Path.DirectorySeparatorChar;
+        }
+
+        public string Root { get { return _root; } }
+
+        /// <summary>Resolve a caller-supplied relative path to a full path guaranteed inside the root.</summary>
+        public string Resolve(string rel)
+        {
+            if (rel == null) throw new SandboxException("path is required");
+            if (rel.Length == 0) throw new SandboxException("path is required");
+            if (Path.IsPathRooted(rel)) throw new SandboxException("absolute paths are not allowed");
+
+            // Reject explicit drive-relative or UNC-ish forms early (defense in depth).
+            if (rel.IndexOf(':') >= 0) throw new SandboxException("invalid path");
+
+            string combined = Path.Combine(_root, rel);
+            string full = Path.GetFullPath(combined); // collapses . and ..
+
+            if (!IsWithin(full)) throw new SandboxException("path escapes the workspace root");
+            return full;
+        }
+
+        /// <summary>True if <paramref name="full"/> is the root itself or a descendant of it.</summary>
+        public bool IsWithin(string full)
+        {
+            if (string.IsNullOrEmpty(full)) return false;
+            string trimmed = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            // Equal to root, or under root + separator. Windows paths are case-insensitive.
+            if (string.Equals(trimmed, _root, StringComparison.OrdinalIgnoreCase)) return true;
+            return full.StartsWith(_rootWithSep, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Path relative to the root (for display in listings); falls back to the full path.</summary>
+        public string ToRelative(string full)
+        {
+            if (full.StartsWith(_rootWithSep, StringComparison.OrdinalIgnoreCase))
+                return full.Substring(_rootWithSep.Length);
+            if (string.Equals(full, _root, StringComparison.OrdinalIgnoreCase))
+                return string.Empty;
+            return full;
+        }
+    }
+}

--- a/servers/FilesMcpServer/Program.cs
+++ b/servers/FilesMcpServer/Program.cs
@@ -1,0 +1,26 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace FilesMcpServer
+{
+    /// <summary>
+    /// First-party Files MCP server: read/list/write/delete confined to GXPT_WORKDIR. The same
+    /// five lines as every first-party server (servers-spec §1), around the Files tool set.
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "files";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            FilesTools.Register(server, FilesConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/FilesMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/FilesMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("FilesMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: sandboxed file read/list/write/delete under a workspace root.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("fde32af9-71c6-4b14-8521-285bd2b36ab9")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/src/Mcp35.Core/Transport/CurlRunner.cs
+++ b/src/Mcp35.Core/Transport/CurlRunner.cs
@@ -54,10 +54,15 @@ namespace Mcp35.Core.Transport
                         stderr = e.ReadToEnd();
                     WaitWithTimeout(p, req.TimeoutMs);
 
+                    // curl's -w status marker is written to stdout after the body; split it off
+                    // so it neither pollutes Body nor is mistaken for response content.
+                    int status;
+                    body = SplitStatusMarker(body, out status);
+
                     CurlResult result = new CurlResult();
                     result.Body = body;
                     result.Stderr = stderr;
-                    result.HttpStatus = ParseHttpStatus(stderr);
+                    result.HttpStatus = status;
                     return result;
                 }
             }
@@ -138,8 +143,10 @@ namespace Mcp35.Core.Transport
             // -sS: silent but still show errors; --fail-with-body: fail on HTTP errors but keep body.
             sb.Append("-sS --fail-with-body ");
 
-            // Surface the HTTP status on stderr in a parseable form (kept off the body).
-            sb.Append("-w \"\\nHTTP_STATUS:%{http_code}\" ");
+            // For buffered requests, append the HTTP status as a trailing stdout marker we split
+            // off afterwards. Skip it when streaming so it can't be mistaken for an SSE line.
+            if (!streaming)
+                sb.Append("-w \"").Append(StatusMarker).Append("%{http_code}\" ");
 
             if (!string.IsNullOrEmpty(_caBundlePath))
                 sb.Append("--cacert \"").Append(_caBundlePath).Append("\" ");
@@ -229,18 +236,40 @@ namespace Mcp35.Core.Transport
             }
         }
 
-        private static int ParseHttpStatus(string stderr)
+        /// <summary>
+        /// The trailing stdout marker our <c>-w</c> appends; e.g. "__GXPT_HTTP_STATUS__200".
+        /// Deliberately alphanumeric+underscore (no shell metacharacters) so it survives being
+        /// emitted by any shell/echo and is vanishingly unlikely to collide with real body content.
+        /// </summary>
+        private const string StatusMarker = "__GXPT_HTTP_STATUS__";
+
+        /// <summary>
+        /// Find the trailing status marker in curl's stdout, parse the code, and return the body
+        /// with the marker removed. If the marker is absent (e.g. curl never ran), returns the
+        /// input unchanged with status 0.
+        /// </summary>
+        private static string SplitStatusMarker(string stdout, out int status)
         {
-            if (string.IsNullOrEmpty(stderr)) return 0;
-            const string marker = "HTTP_STATUS:";
-            int i = stderr.LastIndexOf(marker, StringComparison.Ordinal);
-            if (i < 0) return 0;
-            int start = i + marker.Length;
+            status = 0;
+            if (string.IsNullOrEmpty(stdout)) return stdout;
+
+            int i = stdout.LastIndexOf(StatusMarker, StringComparison.Ordinal);
+            if (i < 0) return stdout;
+
+            int start = i + StatusMarker.Length;
             int end = start;
-            while (end < stderr.Length && char.IsDigit(stderr[end])) end++;
-            if (end == start) return 0;
-            int code;
-            return int.TryParse(stderr.Substring(start, end - start), out code) ? code : 0;
+            while (end < stdout.Length && char.IsDigit(stdout[end])) end++;
+            if (end > start)
+            {
+                int code;
+                if (int.TryParse(stdout.Substring(start, end - start), out code)) status = code;
+            }
+
+            // Strip the marker (and a single preceding newline, if present) from the body.
+            int cut = i;
+            if (cut > 0 && stdout[cut - 1] == '\n') cut--;
+            if (cut > 0 && stdout[cut - 1] == '\r') cut--;
+            return stdout.Substring(0, cut);
         }
 
         private string WriteTempFile(string prefix, string ext, string content)

--- a/src/Mcp35.Core/Transport/CurlRunner.cs
+++ b/src/Mcp35.Core/Transport/CurlRunner.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Mcp35.Core.Diagnostics;
+
+namespace Mcp35.Core.Transport
+{
+    /// <summary>
+    /// A reusable curl wrapper distilled from GxPT's OpenRouterClient (D9). HTTP plumbing for
+    /// .NET 3.5, which can't reliably negotiate TLS 1.2 natively — so anything hitting a modern
+    /// HTTPS endpoint (GitHub, Serper) shells out to curl. Pure BCL + injected paths, so it lives
+    /// in Core without a native build dependency. Shared by the client's HttpTransport (phase 8)
+    /// and SerperMcpServer (phase 7). See mcp35-core-spec.md §6.
+    /// </summary>
+    public sealed class CurlRunner
+    {
+        // No BOM; the request body / config must be plain UTF-8 for curl.
+        private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false);
+        // Decode responses tolerantly (no throw on invalid bytes).
+        private static readonly UTF8Encoding Utf8Decode = new UTF8Encoding(false, false);
+
+        private readonly string _curlPath;
+        private readonly string _caBundlePath;
+        private readonly ILogSink _log;
+
+        public CurlRunner(string curlPath, string caBundlePath, ILogSink log)
+        {
+            _curlPath = curlPath;
+            _caBundlePath = caBundlePath;
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        /// <summary>Run a buffered request; the full response body is read into <see cref="CurlResult.Body"/>.</summary>
+        public CurlResult Run(CurlRequest req)
+        {
+            if (req == null) throw new ArgumentNullException("req");
+
+            List<string> tempFiles = new List<string>();
+            try
+            {
+                string args = BuildArgs(req, false, tempFiles);
+                ProcessStartInfo psi = NewStartInfo(args);
+
+                using (Process p = Process.Start(psi))
+                {
+                    string body, stderr;
+                    using (StreamReader r = new StreamReader(p.StandardOutput.BaseStream, Utf8Decode, false))
+                        body = r.ReadToEnd();
+                    using (StreamReader e = new StreamReader(p.StandardError.BaseStream, Utf8Decode, false))
+                        stderr = e.ReadToEnd();
+                    WaitWithTimeout(p, req.TimeoutMs);
+
+                    CurlResult result = new CurlResult();
+                    result.Body = body;
+                    result.Stderr = stderr;
+                    result.HttpStatus = ParseHttpStatus(stderr);
+                    return result;
+                }
+            }
+            finally
+            {
+                CleanupTempFiles(tempFiles);
+            }
+        }
+
+        /// <summary>
+        /// Run a streaming request (adds <c>-N</c>); each stdout line is delivered to
+        /// <paramref name="onLine"/> as it arrives (SSE). Calls <paramref name="onDone"/> at EOF,
+        /// or <paramref name="onError"/> with curl's stderr on failure.
+        /// </summary>
+        public void RunStreaming(CurlRequest req, Action<string> onLine, Action onDone, Action<string> onError)
+        {
+            if (req == null) throw new ArgumentNullException("req");
+
+            List<string> tempFiles = new List<string>();
+            try
+            {
+                string args = BuildArgs(req, true, tempFiles);
+                ProcessStartInfo psi = NewStartInfo(args);
+
+                using (Process p = Process.Start(psi))
+                {
+                    // Drain stderr on a worker thread so it can't block the stdout pump.
+                    string capturedErr = null;
+                    Thread errThread = new Thread(delegate ()
+                    {
+                        try
+                        {
+                            using (StreamReader e = new StreamReader(p.StandardError.BaseStream, Utf8Decode, false))
+                                capturedErr = e.ReadToEnd();
+                        }
+                        catch (Exception ex) { _log.Log("curl", "stderr drain: " + ex.Message); }
+                    });
+                    errThread.IsBackground = true;
+                    errThread.Start();
+
+                    bool sawAnyLine = false;
+                    using (StreamReader r = new StreamReader(p.StandardOutput.BaseStream, Utf8Decode, false))
+                    {
+                        string line;
+                        while ((line = r.ReadLine()) != null)
+                        {
+                            sawAnyLine = true;
+                            if (onLine != null) onLine(line);
+                        }
+                    }
+
+                    WaitWithTimeout(p, req.TimeoutMs);
+                    errThread.Join(2000);
+
+                    if (!sawAnyLine && !string.IsNullOrEmpty(capturedErr))
+                    {
+                        if (onError != null) onError(capturedErr);
+                        return;
+                    }
+                    if (onDone != null) onDone();
+                }
+            }
+            catch (Exception ex)
+            {
+                if (onError != null) onError(ex.Message);
+            }
+            finally
+            {
+                CleanupTempFiles(tempFiles);
+            }
+        }
+
+        // ---- argument construction ----
+
+        private string BuildArgs(CurlRequest req, bool streaming, List<string> tempFiles)
+        {
+            StringBuilder sb = new StringBuilder();
+            // -sS: silent but still show errors; --fail-with-body: fail on HTTP errors but keep body.
+            sb.Append("-sS --fail-with-body ");
+
+            // Surface the HTTP status on stderr in a parseable form (kept off the body).
+            sb.Append("-w \"\\nHTTP_STATUS:%{http_code}\" ");
+
+            if (!string.IsNullOrEmpty(_caBundlePath))
+                sb.Append("--cacert \"").Append(_caBundlePath).Append("\" ");
+
+            string method = string.IsNullOrEmpty(req.Method) ? "POST" : req.Method;
+            sb.Append("-X ").Append(method).Append(" ");
+
+            if (streaming) sb.Append("-N ");
+
+            if (req.TimeoutMs > 0)
+            {
+                // curl wants whole seconds; round up so a sub-second cap still allows one second.
+                int secs = (req.TimeoutMs + 999) / 1000;
+                sb.Append("--max-time ").Append(secs.ToString(CultureInfo.InvariantCulture)).Append(" ");
+            }
+
+            // Headers go into a -K config file so secrets never touch the command line.
+            if (req.Headers != null && req.Headers.Count > 0)
+            {
+                string cfgPath = WriteTempFile("gxpt_curlcfg_", ".txt", BuildHeaderConfig(req.Headers));
+                if (cfgPath != null)
+                {
+                    tempFiles.Add(cfgPath);
+                    sb.Append("-K \"").Append(cfgPath).Append("\" ");
+                }
+            }
+
+            // Body → temp file, passed via --data-binary @file (avoids cmd-line length/quoting).
+            if (req.BodyJson != null)
+            {
+                string bodyPath = WriteTempFile("gxpt_curlbody_", ".json", req.BodyJson);
+                if (bodyPath != null)
+                {
+                    tempFiles.Add(bodyPath);
+                    sb.Append("--data-binary @\"").Append(bodyPath).Append("\" ");
+                }
+            }
+
+            sb.Append("\"").Append(req.Url).Append("\"");
+            return sb.ToString();
+        }
+
+        private static string BuildHeaderConfig(IDictionary<string, string> headers)
+        {
+            StringBuilder cfg = new StringBuilder();
+            foreach (KeyValuePair<string, string> h in headers)
+            {
+                // curl config: header = "Name: value"  (within quotes curl honors \\ and \")
+                cfg.Append("header = \"")
+                   .Append(EscapeForCurlConfig(h.Key))
+                   .Append(": ")
+                   .Append(EscapeForCurlConfig(h.Value))
+                   .Append("\"\n");
+            }
+            return cfg.ToString();
+        }
+
+        // ---- helpers ----
+
+        private ProcessStartInfo NewStartInfo(string args)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+            psi.FileName = _curlPath;
+            psi.Arguments = args;
+            psi.UseShellExecute = false;
+            psi.CreateNoWindow = true;
+            psi.RedirectStandardOutput = true;
+            psi.RedirectStandardError = true;
+            return psi;
+        }
+
+        private void WaitWithTimeout(Process p, int timeoutMs)
+        {
+            // curl's own --max-time bounds the request; this is a backstop so we never block forever.
+            int wait = timeoutMs > 0 ? timeoutMs + 5000 : 0;
+            if (wait > 0)
+            {
+                if (!p.WaitForExit(wait))
+                {
+                    try { if (!p.HasExited) p.Kill(); }
+                    catch (Exception ex) { _log.Log("curl", "kill: " + ex.Message); }
+                }
+            }
+            else
+            {
+                p.WaitForExit();
+            }
+        }
+
+        private static int ParseHttpStatus(string stderr)
+        {
+            if (string.IsNullOrEmpty(stderr)) return 0;
+            const string marker = "HTTP_STATUS:";
+            int i = stderr.LastIndexOf(marker, StringComparison.Ordinal);
+            if (i < 0) return 0;
+            int start = i + marker.Length;
+            int end = start;
+            while (end < stderr.Length && char.IsDigit(stderr[end])) end++;
+            if (end == start) return 0;
+            int code;
+            return int.TryParse(stderr.Substring(start, end - start), out code) ? code : 0;
+        }
+
+        private string WriteTempFile(string prefix, string ext, string content)
+        {
+            try
+            {
+                string path = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N") + ext);
+                File.WriteAllText(path, content ?? string.Empty, Utf8NoBom);
+                return path;
+            }
+            catch (Exception ex)
+            {
+                _log.Log("curl", "temp write failed: " + ex.Message);
+                return null;
+            }
+        }
+
+        private static string EscapeForCurlConfig(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+            return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        }
+
+        private void CleanupTempFiles(IEnumerable<string> paths)
+        {
+            if (paths == null) return;
+            foreach (string p in paths)
+            {
+                try { if (!string.IsNullOrEmpty(p) && File.Exists(p)) File.Delete(p); }
+                catch (Exception ex) { _log.Log("curl", "temp cleanup: " + ex.Message); }
+            }
+        }
+    }
+
+    /// <summary>A curl request: URL + method + optional JSON body and headers.</summary>
+    public sealed class CurlRequest
+    {
+        public string Url;
+        public string Method = "POST";
+
+        /// <summary>JSON body; written to a temp file and passed via <c>--data-binary @file</c>.</summary>
+        public string BodyJson;
+
+        /// <summary>Headers (incl. secrets); written to a <c>-K</c> config file, never the command line.</summary>
+        public IDictionary<string, string> Headers;
+
+        /// <summary>Adds <c>-N</c> when used with <see cref="CurlRunner.RunStreaming"/>.</summary>
+        public bool Stream;
+
+        public int TimeoutMs;
+    }
+
+    public sealed class CurlResult
+    {
+        public int HttpStatus;
+        public string Body;
+        public string Stderr;
+    }
+}

--- a/tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
+++ b/tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for FilesMcpServer (phase 7). Links Core + Server + the FilesMcpServer sources and
+    compiles them into the test assembly (same linked-source pattern as the other test projects).
+    Drives the server's Run(stdin, stdout) via the scripted-stream harness. Targets net48.
+
+    The server's Program.Main is excluded (a second entry point would conflict with the test host).
+
+    NOTE: intentionally NOT in GxPT.sln (VS2008 cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>FilesMcpServer.Tests</AssemblyName>
+    <RootNamespace>FilesMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\FilesMcpServer\**\*.cs"
+             Exclude="..\..\servers\FilesMcpServer\Program.cs;..\..\servers\FilesMcpServer\Properties\**\*.cs;..\..\servers\FilesMcpServer\obj\**\*.cs;..\..\servers\FilesMcpServer\bin\**\*.cs"
+             Link="Linked\Files\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Text;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FilesMcpServer.Tests
+{
+    public class FilesToolsTests : IDisposable
+    {
+        private readonly string _root;
+
+        public FilesToolsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "filesmcp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, true); } catch { }
+        }
+
+        private string Abs(string rel) { return Path.Combine(_root, rel); }
+
+        // ---- Criterion 1: listing ----
+
+        [Fact]
+        public void Lists_the_four_documented_tools_with_schema()
+        {
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, Harness.ToolsList(1));
+
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            var names = new System.Collections.Generic.List<string>();
+            foreach (JToken t in tools) names.Add((string)t["name"]);
+
+            Assert.Contains("read", names);
+            Assert.Contains("list", names);
+            Assert.Contains("write", names);
+            Assert.Contains("delete", names);
+            // schema intact
+            foreach (JToken t in tools)
+                Assert.Equal("object", (string)t["inputSchema"]["type"]);
+        }
+
+        // ---- Criterion 2: sandbox ----
+
+        [Theory]
+        [InlineData("../escape.txt")]
+        [InlineData("../../etc/passwd")]
+        [InlineData("subdir/../../outside.txt")]
+        public void Rejects_parent_traversal(string path)
+        {
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "read", Harness.Args("path", path)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("escape", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Rejects_absolute_paths()
+        {
+            var server = Harness.NewFilesServer(_root);
+            string abs = Path.Combine(_root, "x.txt"); // a rooted path
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "read", Harness.Args("path", abs)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("absolute", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Sibling_root_prefix_is_not_within()
+        {
+            // The classic "/root" vs "/root-evil" boundary trick: a sibling dir whose path shares
+            // the root's string prefix must NOT be considered inside the sandbox.
+            string sibling = _root + "-evil";
+            Directory.CreateDirectory(sibling);
+            try
+            {
+                File.WriteAllText(Path.Combine(sibling, "secret.txt"), "nope");
+                var sandbox = new PathSandbox(_root);
+                Assert.False(sandbox.IsWithin(Path.Combine(sibling, "secret.txt")));
+            }
+            finally
+            {
+                try { Directory.Delete(sibling, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void In_root_read_write_list_delete_round_trip()
+        {
+            var server = Harness.NewFilesServer(_root);
+
+            // write
+            var w = Harness.Exchange(server, Harness.ToolsCall(1, "write",
+                Harness.Args("path", "notes/todo.txt", "content", "hello world", "create_dirs", true)));
+            Assert.False(Harness.IsError(w[0]));
+            Assert.True(File.Exists(Abs(Path.Combine("notes", "todo.txt"))));
+
+            // read (fresh server instances are fine; same root)
+            var r = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "notes/todo.txt")));
+            Assert.Equal("hello world", Harness.Text(r[0]));
+
+            // list
+            var l = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "list", Harness.Args("path", "notes")));
+            Assert.False(Harness.IsError(l[0]));
+            Assert.Equal(1, (int)l[0]["result"]["structuredContent"]["count"]);
+
+            // delete
+            var d = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "delete", Harness.Args("path", "notes/todo.txt")));
+            Assert.False(Harness.IsError(d[0]));
+            Assert.False(File.Exists(Abs(Path.Combine("notes", "todo.txt"))));
+        }
+
+        [Fact]
+        public void Oversize_read_is_error()
+        {
+            File.WriteAllText(Abs("big.txt"), new string('a', 2 * 1024 * 1024)); // 2 MiB > 1 MiB cap
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("too large", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Binary_read_is_error()
+        {
+            File.WriteAllBytes(Abs("blob.bin"), new byte[] { 1, 2, 0, 3, 4 }); // NUL byte → binary
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "blob.bin")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("not a text file", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Write_without_create_dirs_into_missing_parent_is_error()
+        {
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "write", Harness.Args("path", "missing/x.txt", "content", "y")));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        [Fact]
+        public void Write_is_atomic_overwrite()
+        {
+            File.WriteAllText(Abs("f.txt"), "old");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "write", Harness.Args("path", "f.txt", "content", "new")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("new", File.ReadAllText(Abs("f.txt")));
+        }
+
+        [Fact]
+        public void Delete_refuses_non_empty_directory()
+        {
+            Directory.CreateDirectory(Abs("full"));
+            File.WriteAllText(Abs(Path.Combine("full", "a.txt")), "x");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "delete", Harness.Args("path", "full")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("not empty", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Delete_removes_empty_directory()
+        {
+            Directory.CreateDirectory(Abs("empty"));
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "delete", Harness.Args("path", "empty")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.False(Directory.Exists(Abs("empty")));
+        }
+
+        [Fact]
+        public void Read_bom_file_strips_bom()
+        {
+            byte[] withBom = new byte[] { 0xEF, 0xBB, 0xBF };
+            byte[] text = Encoding.UTF8.GetBytes("café");
+            byte[] all = new byte[withBom.Length + text.Length];
+            Buffer.BlockCopy(withBom, 0, all, 0, withBom.Length);
+            Buffer.BlockCopy(text, 0, all, withBom.Length, text.Length);
+            File.WriteAllBytes(Abs("bom.txt"), all);
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "bom.txt")));
+            Assert.Equal("café", Harness.Text(msgs[0])); // no leading BOM char
+        }
+
+        // ---- Criterion 6: lifecycle ----
+
+        [Fact]
+        public void Missing_file_read_is_error_and_server_survives()
+        {
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "nope.txt")),
+                Harness.Request(2, "ping", null));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.NotNull(msgs[1]["result"]); // ping still answered
+        }
+    }
+}

--- a/tests/FilesMcpServer.Tests/Harness.cs
+++ b/tests/FilesMcpServer.Tests/Harness.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace FilesMcpServer.Tests
+{
+    /// <summary>Scripted-stream harness: feed newline-delimited requests, parse framed responses.</summary>
+    internal static class Harness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            byte[] rawOut;
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            List<JObject> messages = new List<JObject>();
+            foreach (string line in Utf8.GetString(rawOut).Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        public static string ToolsList(int id)
+        {
+            return Request(id, "tools/list", null);
+        }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static JObject Args(params object[] kv)
+        {
+            JObject o = new JObject();
+            for (int i = 0; i + 1 < kv.Length; i += 2)
+                o[(string)kv[i]] = JToken.FromObject(kv[i + 1]);
+            return o;
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        /// <summary>Convenience: build a Files server rooted at <paramref name="root"/>.</summary>
+        public static McpServer NewFilesServer(string root)
+        {
+            System.Environment.SetEnvironmentVariable("GXPT_WORKDIR", root);
+            Mcp35.Core.Protocol.Implementation info = new Mcp35.Core.Protocol.Implementation();
+            info.Name = "files";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            FilesTools.Register(server, FilesConfig.FromEnvironment(null));
+            return server;
+        }
+
+        // ---- result helpers ----
+
+        public static JObject Result(JObject message) { return (JObject)message["result"]; }
+
+        public static bool IsError(JObject message)
+        {
+            JObject r = message["result"] as JObject;
+            return r != null && r.Value<bool>("isError");
+        }
+
+        public static string Text(JObject message)
+        {
+            return (string)message["result"]["content"][0]["text"];
+        }
+    }
+}

--- a/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
+++ b/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
@@ -31,18 +31,23 @@ namespace Mcp35.Core.Tests
             try { Directory.Delete(_dir, true); } catch { }
         }
 
-        /// <summary>Write a fake curl that prints the given body then the HTTP_STATUS marker line.</summary>
+        // Mirrors CurlRunner's internal status marker (kept in sync intentionally).
+        private const string StatusMarker = "__GXPT_HTTP_STATUS__";
+
+        /// <summary>
+        /// Write a fake "curl" that prints the body followed by the status marker — exactly what
+        /// CurlRunner's real <c>-w</c> appends to stdout. The runner then splits the marker off.
+        /// </summary>
         private string FakeCurl(string body, int status)
         {
             if (IsWindows)
             {
                 string path = Path.Combine(_dir, "fakecurl.cmd");
-                // @echo off; print body; then the -w style status line.
+                // echo prints the body + CRLF; the second echo prints the marker line.
                 string script =
                     "@echo off\r\n" +
-                    "<nul set /p=" + body + "\r\n" +
-                    "echo.\r\n" +
-                    "<nul set /p=HTTP_STATUS:" + status + "\r\n";
+                    "echo " + body + "\r\n" +
+                    "echo " + StatusMarker + status + "\r\n";
                 File.WriteAllText(path, script);
                 return path;
             }
@@ -51,7 +56,8 @@ namespace Mcp35.Core.Tests
                 string path = Path.Combine(_dir, "fakecurl.sh");
                 string script =
                     "#!/bin/sh\n" +
-                    "printf '%s\\nHTTP_STATUS:" + status + "' '" + body.Replace("'", "'\\''") + "'\n";
+                    "echo '" + body.Replace("'", "'\\''") + "'\n" +
+                    "printf '%s%d' '" + StatusMarker + "' " + status + "\n";
                 File.WriteAllText(path, script);
                 try { System.Diagnostics.Process.Start("/bin/chmod", "+x \"" + path + "\"").WaitForExit(); } catch { }
                 return path;
@@ -77,6 +83,8 @@ namespace Mcp35.Core.Tests
 
             Assert.Contains("{\"ok\":true}", result.Body);
             Assert.Equal(200, result.HttpStatus);
+            // The status marker must be split off, not left polluting the body.
+            Assert.DoesNotContain(StatusMarker, result.Body);
         }
 
         [Fact]

--- a/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
+++ b/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using Mcp35.Core.Transport;
+using Xunit;
+
+namespace Mcp35.Core.Tests
+{
+    /// <summary>
+    /// Exercises CurlRunner against a fake "curl" script that echoes a canned body and appends the
+    /// HTTP_STATUS marker (matching the real curl -w we pass), so we test the runner's argument
+    /// assembly, body/header temp-file plumbing, response read, and status parsing without network.
+    /// CI runs on Windows; the fake is a .cmd there, a shell script otherwise.
+    /// </summary>
+    public class CurlRunnerTests : IDisposable
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        private readonly string _dir;
+
+        public CurlRunnerTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "curlrunner_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        /// <summary>Write a fake curl that prints the given body then the HTTP_STATUS marker line.</summary>
+        private string FakeCurl(string body, int status)
+        {
+            if (IsWindows)
+            {
+                string path = Path.Combine(_dir, "fakecurl.cmd");
+                // @echo off; print body; then the -w style status line.
+                string script =
+                    "@echo off\r\n" +
+                    "<nul set /p=" + body + "\r\n" +
+                    "echo.\r\n" +
+                    "<nul set /p=HTTP_STATUS:" + status + "\r\n";
+                File.WriteAllText(path, script);
+                return path;
+            }
+            else
+            {
+                string path = Path.Combine(_dir, "fakecurl.sh");
+                string script =
+                    "#!/bin/sh\n" +
+                    "printf '%s\\nHTTP_STATUS:" + status + "' '" + body.Replace("'", "'\\''") + "'\n";
+                File.WriteAllText(path, script);
+                try { System.Diagnostics.Process.Start("/bin/chmod", "+x \"" + path + "\"").WaitForExit(); } catch { }
+                return path;
+            }
+        }
+
+        private static CurlRequest Req(string url)
+        {
+            CurlRequest r = new CurlRequest();
+            r.Url = url;
+            r.Method = "POST";
+            r.TimeoutMs = 10000;
+            return r;
+        }
+
+        [Fact]
+        public void Run_reads_body_and_parses_status()
+        {
+            string curl = FakeCurl("{\"ok\":true}", 200);
+            var runner = new CurlRunner(curl, null, null);
+
+            CurlResult result = runner.Run(Req("https://example.test/search"));
+
+            Assert.Contains("{\"ok\":true}", result.Body);
+            Assert.Equal(200, result.HttpStatus);
+        }
+
+        [Fact]
+        public void Run_parses_non_200_status()
+        {
+            string curl = FakeCurl("{\"error\":\"nope\"}", 429);
+            var runner = new CurlRunner(curl, null, null);
+
+            CurlResult result = runner.Run(Req("https://example.test/search"));
+            Assert.Equal(429, result.HttpStatus);
+        }
+
+        [Fact]
+        public void Run_sends_body_and_headers_without_throwing()
+        {
+            // The fake ignores input, but exercising the body/-K config temp-file path proves the
+            // argument assembly + temp write/cleanup don't throw and the body still comes back.
+            string curl = FakeCurl("done", 200);
+            var runner = new CurlRunner(curl, null, null);
+
+            CurlRequest req = Req("https://example.test/x");
+            req.BodyJson = "{\"q\":\"hello\"}";
+            req.Headers = new System.Collections.Generic.Dictionary<string, string>();
+            req.Headers["X-API-KEY"] = "secret-should-go-in-config-file";
+
+            CurlResult result = runner.Run(req);
+            Assert.Contains("done", result.Body);
+            // The secret must never have ended up in the returned body/stderr.
+            Assert.DoesNotContain("secret-should-go-in-config-file", result.Body);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Begins **phase 7** (the four first-party servers, built in the spec's order —
Files → Serper → Git → Command, *riskiest last*). This first slice lands the
deferred **`CurlRunner`** prerequisite plus **`FilesMcpServer`**. Splitting phase 7
across a few CI-verifiable PRs rather than one 4-server mega-PR keeps each
reviewable and debuggable.

## What's here

**`Mcp35.Core.Transport.CurlRunner`** (the phase-1 deferral, D9):
- Reusable curl wrapper distilled from `OpenRouterClient`: buffered `Run` +
  streaming `RunStreaming`; headers via a **`-K` config temp file** (secrets never
  on the command line), body via `--data-binary @tempfile`, `--fail-with-body`,
  UTF-8 decode, HTTP status via a `-w HTTP_STATUS:` marker, `--max-time` +
  `WaitForExit` backstop, and temp-file cleanup. Shared by `SerperMcpServer`
  (next PR) and `HttpTransport` (phase 8).

**`servers/FilesMcpServer/`** (net35 Exe, `ProjectRef → Mcp35.Server`):
- **`PathSandbox`** — the security core: confines every path to `GXPT_WORKDIR` via
  `GetFullPath` canonicalization + a **directory-boundary** check (`root +
  separator`), so `/root` ≠ `/root-evil`; rejects absolute/rooted/`:`-bearing paths.
- **`FilesTools`** — `read` (1 MiB cap, NUL-byte binary sniff, BOM-aware decode),
  `list` (entry cap + bounded recursion, structured output), `write` (atomic
  temp+move, `create_dirs` gate, refuses dir overwrite), `delete` (files + **empty**
  dirs only — bounded blast radius).

**Tests** (net48 linked-source):
- `CurlRunnerTests` drive a fake-curl script (`.cmd`/`.sh`) asserting body read,
  status parse, and that a header secret never lands in the body.
- `FilesToolsTests` cover listing, the sandbox (parent traversal, absolute paths,
  the `/root` vs `/root-evil` sibling-prefix trick), in-root round-trip,
  oversize/binary → `Error`, atomic overwrite, empty-dir-only delete, BOM strip,
  and survival after an error.

## Review focus

- **`PathSandbox.IsWithin`** — the boundary check is the whole ballgame for this
  server; the sibling-prefix test (`/root-evil`) guards the classic `StartsWith`
  bug. Worth a careful look.
- **`CurlRunner`** secret hygiene — headers (incl. API keys) go only into the `-K`
  config file, never `Arguments`.

Remaining phase-7 servers (Serper, then Git + Command) follow in subsequent PRs.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_