### PR TITLE
Phase 7b: SerperMcpServer (web search over curl)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
           dotnet restore tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
           dotnet restore tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
           dotnet restore tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
+          dotnet restore tests/SerperMcpServer.Tests/SerperMcpServer.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
@@ -43,3 +44,6 @@ jobs:
 
       - name: Test (FilesMcpServer)
         run: dotnet test tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (SerperMcpServer)
+        run: dotnet test tests/SerperMcpServer.Tests/SerperMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Client", "src\Mcp35.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilesMcpServer", "servers\FilesMcpServer\FilesMcpServer.csproj", "{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerperMcpServer", "servers\SerperMcpServer\SerperMcpServer.csproj", "{1135067C-205D-43C7-B689-0DF5CDEA61C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1135067C-205D-43C7-B689-0DF5CDEA61C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1135067C-205D-43C7-B689-0DF5CDEA61C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1135067C-205D-43C7-B689-0DF5CDEA61C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1135067C-205D-43C7-B689-0DF5CDEA61C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/servers/SerperMcpServer/Program.cs
+++ b/servers/SerperMcpServer/Program.cs
@@ -1,0 +1,26 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace SerperMcpServer
+{
+    /// <summary>
+    /// First-party Serper MCP server: one web-search tool over curl. The standard five lines
+    /// around the Serper tool set (servers-spec §1).
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "serper";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            SerperTools.Register(server, SerperConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/SerperMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/SerperMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SerperMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: web search via google.serper.dev over curl (TLS 1.2).")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("1135067c-205d-43c7-b689-0df5cdea61c7")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/servers/SerperMcpServer/SerperConfig.cs
+++ b/servers/SerperMcpServer/SerperConfig.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace SerperMcpServer
+{
+    /// <summary>
+    /// Startup config from the environment (servers-spec §1), read once. The API key and curl
+    /// path are required; when absent the search tool degrades to a clear Error rather than the
+    /// server crashing. Secrets are never logged.
+    /// </summary>
+    internal sealed class SerperConfig
+    {
+        public readonly string ApiKey;     // GXPT_SERPER_KEY (required)
+        public readonly string CurlPath;   // GXPT_CURL_PATH (required; net35 can't TLS 1.2)
+        public readonly string CaBundle;   // GXPT_CA_BUNDLE (optional)
+        public readonly string WorkDir;    // GXPT_WORKDIR (unused by Serper but part of the contract)
+
+        private SerperConfig(string apiKey, string curlPath, string caBundle, string workDir)
+        {
+            ApiKey = apiKey;
+            CurlPath = curlPath;
+            CaBundle = caBundle;
+            WorkDir = workDir;
+        }
+
+        public bool HasKey { get { return !string.IsNullOrEmpty(ApiKey); } }
+        public bool HasCurl { get { return !string.IsNullOrEmpty(CurlPath); } }
+
+        public static SerperConfig FromEnvironment(ILogSink log)
+        {
+            string apiKey = Environment.GetEnvironmentVariable("GXPT_SERPER_KEY");
+            string curlPath = Environment.GetEnvironmentVariable("GXPT_CURL_PATH");
+            string caBundle = Environment.GetEnvironmentVariable("GXPT_CA_BUNDLE");
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir)) workDir = Directory.GetCurrentDirectory();
+
+            if (log != null)
+            {
+                // Never log the key itself — only whether it is present.
+                log.Log("serper", "key=" + (string.IsNullOrEmpty(apiKey) ? "absent" : "present")
+                    + " curl=" + (string.IsNullOrEmpty(curlPath) ? "absent" : "present"));
+            }
+            return new SerperConfig(apiKey, curlPath, caBundle, workDir);
+        }
+    }
+}

--- a/servers/SerperMcpServer/SerperMcpServer.csproj
+++ b/servers/SerperMcpServer/SerperMcpServer.csproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{1135067C-205D-43C7-B689-0DF5CDEA61C7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SerperMcpServer</RootNamespace>
+    <AssemblyName>SerperMcpServer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="SerperConfig.cs" />
+    <Compile Include="SerperTools.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/servers/SerperMcpServer/SerperTools.cs
+++ b/servers/SerperMcpServer/SerperTools.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Transport;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace SerperMcpServer
+{
+    /// <summary>
+    /// The Serper server's single tool, <c>search</c> (ReadOnly). Web search via
+    /// google.serper.dev over curl (net35 can't negotiate TLS 1.2 natively), reusing
+    /// Mcp35.Core's CurlRunner. Results condense to organic[] + answer/knowledge boxes.
+    /// Every failure mode returns an Error value; the API key never appears in output.
+    /// See servers-spec §3.
+    /// </summary>
+    internal static class SerperTools
+    {
+        private const string Endpoint = "https://google.serper.dev/search";
+        private const int DefaultNum = 10;
+        private const int MaxNum = 20;
+        private const int RequestTimeoutMs = 20000;
+
+        public static void Register(McpServer server, SerperConfig config)
+        {
+            server.AddTool("search",
+                "Search the web and return condensed results (title, link, snippet) plus answer/knowledge boxes.",
+                SchemaBuilder.Object()
+                    .Str("query", true, "The search query")
+                    .Int("num", false, "Number of results (default 10, max 20)")
+                    .Str("gl", false, "Country code, e.g. 'us'")
+                    .Str("hl", false, "UI language, e.g. 'en'")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Search(config, ctx); });
+        }
+
+        private static CallToolResult Search(SerperConfig config, ToolCallContext ctx)
+        {
+            if (!config.HasKey) return ToolResults.Error("Serper API key not configured.");
+            if (!config.HasCurl) return ToolResults.Error("curl path not configured.");
+
+            string query = ctx.Arguments.Value<string>("query");
+            if (string.IsNullOrEmpty(query)) return ToolResults.Error("query is required");
+
+            // Build request body.
+            JObject body = new JObject();
+            body["q"] = query;
+            body["num"] = ClampNum(ctx);
+            string gl = ctx.Arguments.Value<string>("gl");
+            string hl = ctx.Arguments.Value<string>("hl");
+            if (!string.IsNullOrEmpty(gl)) body["gl"] = gl;
+            if (!string.IsNullOrEmpty(hl)) body["hl"] = hl;
+
+            CurlRequest req = new CurlRequest();
+            req.Url = Endpoint;
+            req.Method = "POST";
+            req.BodyJson = body.ToString(Newtonsoft.Json.Formatting.None);
+            req.TimeoutMs = RequestTimeoutMs;
+            req.Headers = new Dictionary<string, string>();
+            req.Headers["Content-Type"] = "application/json";
+            req.Headers["X-API-KEY"] = config.ApiKey; // → -K config file, never the command line
+
+            CurlRunner runner = new CurlRunner(config.CurlPath, config.CaBundle, ctx.Log);
+
+            CurlResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("search request failed: " + ex.Message);
+            }
+
+            if (result.HttpStatus != 0 && (result.HttpStatus < 200 || result.HttpStatus >= 300))
+                return ToolResults.Error("search failed with HTTP status " + result.HttpStatus);
+
+            if (string.IsNullOrEmpty(result.Body))
+                return ToolResults.Error("empty response from search provider");
+
+            JObject parsed;
+            try
+            {
+                parsed = JObject.Parse(result.Body);
+            }
+            catch (Exception)
+            {
+                return ToolResults.Error("could not parse search response");
+            }
+
+            return ToolResults.Json(Condense(parsed));
+        }
+
+        private static int ClampNum(ToolCallContext ctx)
+        {
+            JToken t = ctx.Arguments["num"];
+            if (t == null || t.Type == JTokenType.Null) return DefaultNum;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return DefaultNum; }
+            if (n < 1) return 1;
+            if (n > MaxNum) return MaxNum;
+            return n;
+        }
+
+        /// <summary>
+        /// Project the raw Serper JSON into a compact, model-friendly shape: organic results as
+        /// {title, link, snippet}, plus answerBox / knowledgeGraph when present. Pure function —
+        /// unit-tested directly.
+        /// </summary>
+        public static JObject Condense(JObject raw)
+        {
+            JObject outp = new JObject();
+
+            JArray organicOut = new JArray();
+            JToken organic = raw["organic"];
+            if (organic != null && organic.Type == JTokenType.Array)
+            {
+                foreach (JToken item in (JArray)organic)
+                {
+                    JObject o = item as JObject;
+                    if (o == null) continue;
+                    JObject r = new JObject();
+                    r["title"] = StringOf(o["title"]);
+                    r["link"] = StringOf(o["link"]);
+                    r["snippet"] = StringOf(o["snippet"]);
+                    organicOut.Add(r);
+                }
+            }
+            outp["organic"] = organicOut;
+
+            JToken answerBox = raw["answerBox"];
+            if (answerBox != null && answerBox.Type == JTokenType.Object)
+            {
+                JObject ab = (JObject)answerBox;
+                JObject abOut = new JObject();
+                if (ab["answer"] != null) abOut["answer"] = StringOf(ab["answer"]);
+                if (ab["snippet"] != null) abOut["snippet"] = StringOf(ab["snippet"]);
+                if (ab["title"] != null) abOut["title"] = StringOf(ab["title"]);
+                if (ab["link"] != null) abOut["link"] = StringOf(ab["link"]);
+                outp["answerBox"] = abOut;
+            }
+
+            JToken kg = raw["knowledgeGraph"];
+            if (kg != null && kg.Type == JTokenType.Object)
+            {
+                JObject k = (JObject)kg;
+                JObject kgOut = new JObject();
+                if (k["title"] != null) kgOut["title"] = StringOf(k["title"]);
+                if (k["type"] != null) kgOut["type"] = StringOf(k["type"]);
+                if (k["description"] != null) kgOut["description"] = StringOf(k["description"]);
+                outp["knowledgeGraph"] = kgOut;
+            }
+
+            return outp;
+        }
+
+        private static string StringOf(JToken t)
+        {
+            if (t == null || t.Type == JTokenType.Null) return null;
+            return t.Type == JTokenType.String ? (string)t : t.ToString();
+        }
+    }
+}

--- a/tests/SerperMcpServer.Tests/Harness.cs
+++ b/tests/SerperMcpServer.Tests/Harness.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace SerperMcpServer.Tests
+{
+    /// <summary>Scripted-stream harness + Serper-server construction with env injection.</summary>
+    internal static class Harness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            byte[] rawOut;
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            List<JObject> messages = new List<JObject>();
+            foreach (string line in Utf8.GetString(rawOut).Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        public static string ToolsList(int id) { return Request(id, "tools/list", null); }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static JObject Args(params object[] kv)
+        {
+            JObject o = new JObject();
+            for (int i = 0; i + 1 < kv.Length; i += 2)
+                o[(string)kv[i]] = JToken.FromObject(kv[i + 1]);
+            return o;
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        /// <summary>Build a Serper server with the given env (null values clear the variable).</summary>
+        public static McpServer NewSerperServer(string apiKey, string curlPath)
+        {
+            Environment.SetEnvironmentVariable("GXPT_SERPER_KEY", apiKey);
+            Environment.SetEnvironmentVariable("GXPT_CURL_PATH", curlPath);
+            Environment.SetEnvironmentVariable("GXPT_CA_BUNDLE", null);
+
+            Implementation info = new Implementation();
+            info.Name = "serper";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            SerperTools.Register(server, SerperConfig.FromEnvironment(null));
+            return server;
+        }
+
+        // ---- result helpers ----
+
+        public static bool IsError(JObject message)
+        {
+            JObject r = message["result"] as JObject;
+            return r != null && r.Value<bool>("isError");
+        }
+
+        public static string Text(JObject message)
+        {
+            return (string)message["result"]["content"][0]["text"];
+        }
+
+        public static JObject Structured(JObject message)
+        {
+            return (JObject)message["result"]["structuredContent"];
+        }
+    }
+}

--- a/tests/SerperMcpServer.Tests/SerperMcpServer.Tests.csproj
+++ b/tests/SerperMcpServer.Tests/SerperMcpServer.Tests.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for SerperMcpServer (phase 7). Links Core + Server + the SerperMcpServer sources and
+    drives Run(stdin, stdout) via the scripted-stream harness. The full search path is exercised
+    by pointing GXPT_CURL_PATH at a fake-curl script that emits a canned Serper response plus the
+    status marker CurlRunner expects. Targets net48.
+
+    Program.Main is excluded (second entry point would clash with the test host).
+
+    NOTE: intentionally NOT in GxPT.sln (VS2008 cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>SerperMcpServer.Tests</AssemblyName>
+    <RootNamespace>SerperMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\SerperMcpServer\**\*.cs"
+             Exclude="..\..\servers\SerperMcpServer\Program.cs;..\..\servers\SerperMcpServer\Properties\**\*.cs;..\..\servers\SerperMcpServer\obj\**\*.cs;..\..\servers\SerperMcpServer\bin\**\*.cs"
+             Link="Linked\Serper\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/SerperMcpServer.Tests/SerperToolsTests.cs
+++ b/tests/SerperMcpServer.Tests/SerperToolsTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using SerperMcpServer;
+using Xunit;
+
+namespace SerperMcpServer.Tests
+{
+    public class SerperToolsTests : IDisposable
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        // Mirrors CurlRunner's status marker (kept in sync intentionally).
+        private const string StatusMarker = "__GXPT_HTTP_STATUS__";
+
+        private readonly string _dir;
+
+        public SerperToolsTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "serpermcp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        /// <summary>A fake curl that prints a canned JSON body + the status marker on stdout.</summary>
+        private string FakeCurl(string json, int status)
+        {
+            if (IsWindows)
+            {
+                string path = Path.Combine(_dir, "fakecurl.cmd");
+                // Write the canned JSON to a sibling file and 'type' it (avoids cmd quoting hell),
+                // then echo the status marker line.
+                string jsonFile = Path.Combine(_dir, "resp.json");
+                File.WriteAllText(jsonFile, json);
+                string script =
+                    "@echo off\r\n" +
+                    "type \"" + jsonFile + "\"\r\n" +
+                    "echo " + StatusMarker + status + "\r\n";
+                File.WriteAllText(path, script);
+                return path;
+            }
+            else
+            {
+                string path = Path.Combine(_dir, "fakecurl.sh");
+                string jsonFile = Path.Combine(_dir, "resp.json");
+                File.WriteAllText(jsonFile, json);
+                string script =
+                    "#!/bin/sh\n" +
+                    "cat \"" + jsonFile + "\"\n" +
+                    "printf '%s%d' '" + StatusMarker + "' " + status + "\n";
+                File.WriteAllText(path, script);
+                try { System.Diagnostics.Process.Start("/bin/chmod", "+x \"" + path + "\"").WaitForExit(); } catch { }
+                return path;
+            }
+        }
+
+        private const string SampleResponse =
+            "{\"organic\":[" +
+            "{\"title\":\"First\",\"link\":\"https://a.test\",\"snippet\":\"one\",\"position\":1}," +
+            "{\"title\":\"Second\",\"link\":\"https://b.test\",\"snippet\":\"two\"}]," +
+            "\"answerBox\":{\"answer\":\"42\",\"snippet\":\"the answer\"}," +
+            "\"knowledgeGraph\":{\"title\":\"Thing\",\"type\":\"Concept\",\"description\":\"desc\"}}";
+
+        // ---- Criterion 1: listing ----
+
+        [Fact]
+        public void Lists_the_search_tool_with_schema()
+        {
+            var server = Harness.NewSerperServer("test-key", FakeCurl(SampleResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsList(1));
+
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            Assert.Single(tools);
+            Assert.Equal("search", (string)tools[0]["name"]);
+            Assert.Equal("string", (string)tools[0]["inputSchema"]["properties"]["query"]["type"]);
+        }
+
+        // ---- Criterion 3: happy path + condense ----
+
+        [Fact]
+        public void Search_happy_path_returns_condensed_structured_results()
+        {
+            var server = Harness.NewSerperServer("test-key", FakeCurl(SampleResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "hello")));
+
+            Assert.False(Harness.IsError(msgs[0]));
+            JObject s = Harness.Structured(msgs[0]);
+            JArray organic = (JArray)s["organic"];
+            Assert.Equal(2, organic.Count);
+            Assert.Equal("First", (string)organic[0]["title"]);
+            Assert.Equal("https://a.test", (string)organic[0]["link"]);
+            // condensed: position dropped, only title/link/snippet retained
+            Assert.Null(organic[0]["position"]);
+            Assert.Equal("42", (string)s["answerBox"]["answer"]);
+            Assert.Equal("Thing", (string)s["knowledgeGraph"]["title"]);
+        }
+
+        [Fact]
+        public void Condense_is_pure_and_projects_only_expected_fields()
+        {
+            JObject raw = JObject.Parse(SampleResponse);
+            JObject c = SerperTools.Condense(raw);
+
+            Assert.Equal(2, ((JArray)c["organic"]).Count);
+            foreach (JToken o in (JArray)c["organic"])
+            {
+                // exactly title/link/snippet
+                Assert.NotNull(o["title"]);
+                Assert.NotNull(o["link"]);
+                Assert.Null(o["position"]);
+            }
+        }
+
+        [Fact]
+        public void Condense_handles_missing_sections()
+        {
+            JObject raw = JObject.Parse("{\"searchParameters\":{\"q\":\"x\"}}"); // no organic/boxes
+            JObject c = SerperTools.Condense(raw);
+            Assert.Empty((JArray)c["organic"]);
+            Assert.Null(c["answerBox"]);
+            Assert.Null(c["knowledgeGraph"]);
+        }
+
+        // ---- Criterion 3: failure modes ----
+
+        [Fact]
+        public void Missing_key_returns_error()
+        {
+            var server = Harness.NewSerperServer(null, FakeCurl(SampleResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("API key", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Missing_curl_returns_error()
+        {
+            var server = Harness.NewSerperServer("test-key", null);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("curl", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Non_200_status_returns_error()
+        {
+            var server = Harness.NewSerperServer("test-key", FakeCurl("{\"message\":\"rate limited\"}", 429));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("429", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Unparseable_response_returns_error()
+        {
+            var server = Harness.NewSerperServer("test-key", FakeCurl("not json at all", 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("parse", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Empty_query_returns_error()
+        {
+            var server = Harness.NewSerperServer("test-key", FakeCurl(SampleResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "")));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        [Fact]
+        public void Api_key_never_appears_in_output()
+        {
+            const string secret = "super-secret-serper-key-12345";
+            var server = Harness.NewSerperServer(secret, FakeCurl(SampleResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "hello")));
+
+            string all = msgs[0].ToString();
+            Assert.DoesNotContain(secret, all);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 7b** — `SerperMcpServer`, the second first-party server: web search via
`google.serper.dev` over **curl**, reusing the `Mcp35.Core.CurlRunner` landed in
7a (net35 can't negotiate TLS 1.2 natively). net35 Exe, `ProjectRef → Mcp35.Server
+ Mcp35.Core`.

## What's here

**`servers/SerperMcpServer/`**:
- **`SerperConfig`** — `GXPT_SERPER_KEY` (required), `GXPT_CURL_PATH` (required),
  `GXPT_CA_BUNDLE` (optional). Read once at startup; logs key *presence*, never
  the key itself.
- **`SerperTools.search`** (ReadOnly) — builds the POST (`q`/`num`/`gl`/`hl`), runs
  it via `CurlRunner` with `X-API-KEY` in the **`-K` config file** (never the
  command line), then condenses `organic[]` → `{title, link, snippet}` plus
  `answerBox`/`knowledgeGraph` via `ToolResults.Json`. Every failure mode
  (missing key/curl, non-2xx, empty/unparseable JSON, empty query) returns an
  **`Error` value**, never throws; `num` clamped to `[1,20]`. `Condense()` is a
  **pure function** for direct unit testing.

**Tests** (net48 linked-source):
- Tool listing; `Condense` projection (incl. missing sections); the **full handler
  over a fake-curl** (`GXPT_CURL_PATH` → a `.cmd`/`.sh` emitting a canned Serper
  response + the status marker) for happy path and each failure mode; and an
  explicit assertion that **the API key never leaks** into the result.

## Review focus

- **Secret hygiene** — `X-API-KEY` flows only through `CurlRunner`'s `-K` config
  file; there's a test asserting the key never appears in tool output.
- **`Condense`** projection shape — this is what the model sees; kept compact
  per the resolved decision (servers-spec §9.4).

Remaining phase-7 servers: **Git + Command** (the sharpest edges — argv escaping
and shell exec) in the next PR.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_