### PR TITLE
Phase 7b: WebSearchMcpServer (Tavily search + extract)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
           dotnet restore tests/Mcp35.Server.Tests/Mcp35.Server.Tests.csproj
           dotnet restore tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
           dotnet restore tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
+          dotnet restore tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
@@ -43,3 +44,6 @@ jobs:
 
       - name: Test (FilesMcpServer)
         run: dotnet test tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (WebSearchMcpServer)
+        run: dotnet test tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mcp35.Client", "src\Mcp35.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilesMcpServer", "servers\FilesMcpServer\FilesMcpServer.csproj", "{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSearchMcpServer", "servers\WebSearchMcpServer\WebSearchMcpServer.csproj", "{785B59BD-B282-488C-BD78-4529CD80BA49}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDE32AF9-71C6-4B14-8521-285BD2B36AB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{785B59BD-B282-488C-BD78-4529CD80BA49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{785B59BD-B282-488C-BD78-4529CD80BA49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{785B59BD-B282-488C-BD78-4529CD80BA49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{785B59BD-B282-488C-BD78-4529CD80BA49}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -20,7 +20,7 @@ decision-oriented rather than code.
 - Ship a small, reusable, role-neutral MCP library (**Mcp35**) targeting **.NET
   Framework 3.5**, usable outside GxPT later — for *both* writing clients/hosts
   and writing servers.
-- Provide a handful of useful **stdio servers** (serper, file ops, git,
+- Provide a handful of useful **stdio servers** (web search, file ops, git,
   command-line) and connect to **GitHub's hosted MCP** over HTTP.
 - Keep token cost bounded as the tool catalog grows (progressive disclosure /
   progressive disclosure via a name manifest + define-on-demand).
@@ -45,13 +45,13 @@ decision-oriented rather than code.
 | D6 | Approval = **three tiers** (ReadOnly/Write remember-eligible per-tool; **Destructive always confirms**), with **argument-scoped rules** (exact / base+subcommand / directory — no regex) for arbitrary-exec & file tools | Read/write stay low-friction; cmd/code/file tools get *granular* allowlisting, never a blanket "allow this tool" → §9, `mcp35-approval-spec.md` |
 | D7 | **Dependencies are injected, never embedded** in the library | Keeps Core binary-pure and the future split cheap |
 | D8 | **`Mcp35.Client` is a real, separate project now** (transports + **single-connection** lifecycle); GxPT depends on it **one-way** | A compile-time project boundary prevents client logic from intertwining with GxPT — stronger than "extract later" |
-| D9 | **curl-exec helper lives in `Mcp35.Core`** | Shared by Client `HttpTransport` and the Serper server; avoids duplication |
+| D9 | **curl-exec helper lives in `Mcp35.Core`** | Shared by Client `HttpTransport` and the web search server; avoids duplication |
 | D10 | **Each server is its own independent `.csproj`** depending on mcp35; extractable to its own repo. Not part of the mcp35 library package | Maximum modularity — servers can each peel off as standalone projects/repos |
 | D11 | **Multi-server aggregation, collision-naming, ranking & reveal all live in the GxPT host registry**; `Mcp35.Client` stays strictly single-connection | Keeps Client minimal; host owns all multi-server policy |
 | D12 | **net48 test projects resolve Newtonsoft via version-pinned `PackageReference`** | Consistent with `GxPT.Tests`; pin matches the vendored net35 dll to avoid drift |
-| D13 | **Concrete servers get neutral names** (`SerperMcpServer`, `FilesMcpServer`, `GitMcpServer`, `CommandMcpServer`) — *not* `Mcp35.Servers.*` | They're independent consumers (D10), not a collection inside the `Mcp35.Server` SDK |
+| D13 | **Concrete servers get neutral names** (`WebSearchMcpServer`, `FilesMcpServer`, `GitMcpServer`, `CommandMcpServer`) — *not* `Mcp35.Servers.*` | They're independent consumers (D10), not a collection inside the `Mcp35.Server` SDK |
 | D14 | **MCP servers are configured only in a dedicated MCP settings tab**; custom servers live in `%AppData%/GxPT/mcp.json` (Cursor-style schema, **snake_case** `mcp_servers`, transport inferred from `url`/`command`) | One clear home for MCP config, separate from `settings.json`; familiar Cursor-like format |
-| D15 | **Only first-party servers are obscured** (hardcoded, out of `mcp.json`, managed via toggles + a Serper key field in `settings.json`). **GitHub lives in `mcp.json`** like any HTTP server, PAT in its `Authorization` header; a malformed PAT disables that server | Keeps internal wiring safe while giving GitHub the standard, Cursor-familiar config path |
+| D15 | **Only first-party servers are obscured** (hardcoded, out of `mcp.json`, managed via toggles + a web search key field in `settings.json`). **GitHub lives in `mcp.json`** like any HTTP server, PAT in its `Authorization` header; a malformed PAT disables that server | Keeps internal wiring safe while giving GitHub the standard, Cursor-familiar config path |
 | D16 | **Host adopts Newtonsoft.Json**, migrated **scoped + incrementally** from JavaScriptSerializer: OpenRouter wire path + MCP/host glue + `mcp.json` now; `ConversationStore` with tool-message persistence; **`AppSettings` deferred** | One JSON library across host+library removes the `JObject`/`Dictionary` seam in the tool loop, kills the `MaxJsonLength` cap, and reuses the already-shipping Newtonsoft DLL (one HintPath, no new vendored binary) |
 
 ---
@@ -77,7 +77,7 @@ decision-oriented rather than code.
    deps: Newtonsoft.Json only · NO GxPT refs                      ▲
                                                                   │ builds on
                                                        MCP server exes (independent consumers)
-                                                       SerperMcpServer · FilesMcpServer ·
+                                                       WebSearchMcpServer · FilesMcpServer ·
                                                        GitMcpServer · CommandMcpServer
 ```
 
@@ -95,7 +95,7 @@ Server — servers are independent executables.
   in).
 - **Shared curl-exec helper** (`CurlRunner` — pure BCL process spawn + temp
   files, curl path **injected**). Used by both Client's `HttpTransport` and the
-  Serper server, so it lives here rather than being duplicated.
+  web search server, so it lives here rather than being duplicated.
 - JSON strategy: **typed DTOs** for stable envelopes; **`JObject`/`JToken`** at
   the open-ended boundaries (tool input-schemas, tool results).
 - **Only** managed dependency is `Newtonsoft.Json`. No reference to `GxPT.*`.
@@ -122,7 +122,7 @@ Server — servers are independent executables.
 - The stdio dispatch loop (read framed requests on stdin, write responses on
   stdout).
 - A **process-exec** helper (for git/cmd-style servers). curl-exec is *not*
-  here — it lives in Core (D9), since `SerperMcpServer` and the client's
+  here — it lives in Core (D9), since `WebSearchMcpServer` and the client's
   `HttpTransport` both need it.
 - The four servers are its first consumers and its dogfooding.
 
@@ -131,7 +131,7 @@ Everything here is GxPT-specific orchestration, deliberately kept *out* of the
 library:
 - `McpHost` — owns the **collection** of `Mcp35.Client.McpServerConnection`
   instances and their lifecycle, assembled from **enabled Tier-1 first-party
-  servers** (Serper key injected) plus every valid **Tier-2 `mcp.json` entry**
+  servers** (web search key injected) plus every valid **Tier-2 `mcp.json` entry**
   (incl. GitHub, subject to its PAT gate) — see §8.
 - `McpToolRegistry` — **catalog aggregation** across connections,
   **server-qualified collision naming**, **manifest assembly** (qualified names
@@ -147,7 +147,7 @@ library:
 ### MCP server executables (independent consumers, net35 console exes)
 Each is its own project/repo (D10) consuming the `Mcp35.Server` SDK; neutrally
 named because they are *not* part of the library (D13).
-- `SerperMcpServer` — web search (Serper API; needs curl for TLS 1.2).
+- `WebSearchMcpServer` — web search + page extraction (Tavily API; needs curl for TLS 1.2).
 - `FilesMcpServer` — file read/list/write.
 - `GitMcpServer` — git status/diff/commit (uses `git.exe`).
 - `CommandMcpServer` — arbitrary command execution (sharpest security edge;
@@ -220,7 +220,7 @@ GxPT.sln                         (VS2008 format)
 ├─ src/Mcp35.Client/            net35 lib   (ProjectRef → Mcp35.Core)
 ├─ src/Mcp35.Server/            net35 lib   (ProjectRef → Mcp35.Core)  ← server SDK
 └─ servers/                     independent consumer exes (own projects/repos)
-   ├─ SerperMcpServer/          net35 Exe   (ProjectRef → Mcp35.Server)
+   ├─ WebSearchMcpServer/       net35 Exe   (ProjectRef → Mcp35.Server)
    ├─ FilesMcpServer/           net35 Exe
    ├─ GitMcpServer/             net35 Exe
    └─ CommandMcpServer/         net35 Exe
@@ -259,7 +259,7 @@ always supplied by whoever runs the process:
 | Artifact | Native need | Source of the binary |
 |----------|-------------|----------------------|
 | GxPT host (Client `HttpTransport` → GitHub) | curl | **already vendored** in `GxPT/lib/`; host injects the path into the transport |
-| `SerperMcpServer` | curl (TLS 1.2 to Serper API) | own `lib/curl.exe` next to the exe |
+| `WebSearchMcpServer` | curl (TLS 1.2 to Tavily API) | own `lib/curl.exe` next to the exe |
 | `GitMcpServer` | `git.exe` | injected path → PATH |
 | `FilesMcpServer` / `CommandMcpServer` | none | BCL only |
 | `Mcp35.Core` / `.Client` / `.Server` (DLLs) | none | pure managed |
@@ -269,7 +269,7 @@ Path resolution everywhere: injected explicit path → app-relative
 
 > Note on TLS: .NET 3.5's `HttpWebRequest` can't reliably negotiate TLS 1.2,
 > which is why curl is vendored. Anything hitting a modern HTTPS endpoint
-> (GitHub, Serper) needs curl — `WebClient` is not a substitute.
+> (GitHub, Tavily) needs curl — `WebClient` is not a substitute.
 
 ### Why Newtonsoft (and not JavaScriptSerializer / SimpleJson)
 - **JSON-RPC field presence is semantic**: a notification is a request with
@@ -347,15 +347,15 @@ dedicated **MCP tab** in `SettingsForm` — never via the Visual or JSON
 (settings.json) tabs (D14).
 
 ### Tier 1 — first-party servers (obscured)
-The bundled first-party servers (`SerperMcpServer`, `FilesMcpServer`,
+The bundled first-party servers (`WebSearchMcpServer`, `FilesMcpServer`,
 `GitMcpServer`, `CommandMcpServer`) are *built in*: their stdio launch commands
 are **hardcoded in GxPT and never appear in `mcp.json`** (D15). Users manage
 them with:
 - a per-server **enable toggle**, persisted in `settings.json` via `AppSettings`
-  (e.g. `AppSettings.SetBool("mcp.builtin.serper.enabled", …)`);
-- a **Serper API Key** field, stored like the existing OpenRouter key
+  (e.g. `AppSettings.SetBool("mcp.builtin.web.enabled", …)`);
+- a **Web Search API Key** field, stored like the existing OpenRouter key
   (`AppSettings.SetString`, in `settings.json`) and injected into
-  `SerperMcpServer`'s `env` at runtime — never written to `mcp.json`.
+  `WebSearchMcpServer`'s `env` at runtime — never written to `mcp.json`.
 
 (GitHub is **not** in this tier — it lives in `mcp.json` like any HTTP server;
 see Tier 2.)
@@ -394,7 +394,7 @@ error spam.
 
 ### Assembly
 `McpHost` builds its connection collection (D11) from **enabled Tier-1
-first-party servers** (Serper key injected) **plus every valid Tier-2 entry** in
+first-party servers** (web search key injected) **plus every valid Tier-2 entry** in
 `mcp.json` (the GitHub entry only if its PAT passes the shape gate). The host
 parses `mcp.json` with **Newtonsoft** (`JObject`), consistent with the host's
 adoption of Newtonsoft for the OpenRouter/MCP path (D16); snake_case maps
@@ -406,14 +406,14 @@ vendored binary.
 A new `TabPage` in `SettingsForm`, modeled on the existing JSON tab (`tabJson` /
 the Consolas `rtbJson` RichTextBox):
 - **Top:** per-server **enable toggles** (`CheckBox` per first-party server) and
-  the **Serper API Key** `TextBox` (plaintext, matching the existing
+  the **Web Search API Key** `TextBox` (plaintext, matching the existing
   `txtApiKey`; masking is a possible later enhancement).
 - **Below:** a Consolas RichTextBox editing **`mcp.json`** — custom servers
   **and** the GitHub entry (the PAT is pasted into its `Authorization` header
   here).
 - Shares the form's **Save**: validates the editor JSON, writes `mcp.json`
   crash-safe (as `AppSettings` does for `settings.json`), and persists the
-  first-party toggles + Serper key to `settings.json`. Invalid JSON blocks the
+  first-party toggles + web search key to `settings.json`. Invalid JSON blocks the
   save with an error.
 
 ---
@@ -433,7 +433,7 @@ the Consolas `rtbJson` RichTextBox):
 - `CommandMcpServer` is the sharpest edge: always-confirm (no blanket remember) +
   process isolation; treat all server/tool output as untrusted input at the parse
   boundary (the gate is also the prompt-injection backstop).
-- **Secrets**: the Serper key lives in `settings.json` (like the OpenRouter
+- **Secrets**: the web search key lives in `settings.json` (like the OpenRouter
   key); the **GitHub PAT lives in `mcp.json`** (in the `Authorization` header,
   Cursor-style), so **`mcp.json` is sensitive** — not freely shareable. All HTTP
   `headers` reach curl via `-K`, never the command line. A malformed GitHub PAT
@@ -504,7 +504,7 @@ the Consolas `rtbJson` RichTextBox):
    → *Split `Mcp35.*` into its own repo here once the API is stable.*
 6. **Approval tiers** (gate Command / git writes). → **Detailed in
    [`mcp35-approval-spec.md`](mcp35-approval-spec.md).**
-7. **Four servers**, riskiest last: Files → Serper → Git → Command. → **Detailed
+7. **Four servers**, riskiest last: Files → Web → Git → Command. → **Detailed
    in [`mcp35-servers-spec.md`](mcp35-servers-spec.md).**
 8. **`Mcp35.Client` HttpTransport + GitHub MCP** via its `mcp.json` entry + PAT
    shape gate (the names manifest + `reveal_tools` now tame its large tool
@@ -533,7 +533,7 @@ the Consolas `rtbJson` RichTextBox):
 - ~~Newtonsoft net48 build in tests~~ → version-pinned PackageReference (D12).
 
 - ~~Server project naming~~ → `Mcp35.Server` is the singular SDK; concrete
-  servers get neutral names (`SerperMcpServer`, …), not `Mcp35.Servers.*` (D13).
+  servers get neutral names (`WebSearchMcpServer`, …), not `Mcp35.Servers.*` (D13).
 - ~~Tool discovery mechanism~~ → names-only manifest with define-on-demand via
   batch `reveal_tools` (multi-reveal for ambiguity); no free-text search tool —
   deferred until/if the catalog grows huge (D4).

--- a/docs/mcp35-approval-spec.md
+++ b/docs/mcp35-approval-spec.md
@@ -91,7 +91,8 @@ public interface IToolClassifier {
    | `git__commit` | Write | Tool |
    | `git__push` | Destructive | None |
    | `command__run` | Destructive | **Argument(`command`)** |
-   | `serper__search` | ReadOnly | Tool |
+   | `web__search` | ReadOnly | Tool |
+   | `web__extract` | Write | Tool |
 3. **Third-party → annotations** (advisory): `destructiveHint:true` →
    Destructive/None; `readOnlyHint:true` → ReadOnly/Tool; otherwise → Write/Tool.
    We can't infer a third-party server's argument semantics, so third-party
@@ -236,7 +237,7 @@ cap does).
 
 ## 9. Secrets (recap, already decided)
 
-Serper key in `settings.json`; GitHub PAT in `mcp.json`'s `Authorization` header;
+web search key in `settings.json`; GitHub PAT in `mcp.json`'s `Authorization` header;
 both reach curl via `-K`, never the command line; a malformed PAT disables the
 GitHub server (architecture §8/§9, D15). No change here — listed so the security
 picture is complete in one place.

--- a/docs/mcp35-client-spec.md
+++ b/docs/mcp35-client-spec.md
@@ -213,13 +213,13 @@ This is the GxPT side that consumes the Client and lands the config plumbing
   D16) → a list of server defs; infers transport (`url`→HTTP,
   `command`→stdio); applies the **GitHub PAT shape gate** (disable on malformed).
 - **`BuiltInServers`** — hardcoded first-party launch defs (resolve
-  `SerperMcpServer`/etc. under an app-relative `servers/` dir; inject the Serper
+  `WebSearchMcpServer`/etc. under an app-relative `servers/` dir; inject the web search
   key into `env`), each gated by its `AppSettings` enable toggle.
 - **`McpHost`** — assembles `McpServerConnection`s from **enabled built-ins** +
   **valid mcp.json entries**, builds the matching `StdioTransport`
   (`HttpTransport` in phase 8), `Open`s them, and exposes the connections to
   `McpToolRegistry`.
-- **MCP settings tab** + toggles + Serper key field land here too (architecture
+- **MCP settings tab** + toggles + web search key field land here too (architecture
   §8 UI).
 
 **Phase-3 milestone:** the host can enumerate the **union of tools** across

--- a/docs/mcp35-core-spec.md
+++ b/docs/mcp35-core-spec.md
@@ -247,7 +247,7 @@ public sealed class JsonRpcPeer : IDisposable   // implements the IRpcTransport 
 ## 6. `CurlRunner` (`Mcp35.Core.Transport`)
 
 A reusable curl wrapper distilled from `OpenRouterClient` (D9 — used by both
-`HttpTransport` and `SerperMcpServer`). HTTP plumbing, but pure BCL + injected
+`HttpTransport` and `WebSearchMcpServer`). HTTP plumbing, but pure BCL + injected
 paths, so it stays in Core without a native build dependency.
 
 ```csharp

--- a/docs/mcp35-server-spec.md
+++ b/docs/mcp35-server-spec.md
@@ -6,7 +6,7 @@ and `mcp35-core-spec.md`; realizes **phase 2** of the roadmap.
 
 `Mcp35.Server` is the ergonomic SDK for **building** MCP servers over stdio. It
 turns "register some tools + `Run()`" into a working server, so each concrete
-server (`SerperMcpServer`, `FilesMcpServer`, …) stays tiny. It builds on
+server (`WebSearchMcpServer`, `FilesMcpServer`, …) stays tiny. It builds on
 `Mcp35.Core` and adds no new managed dependencies.
 
 ---
@@ -78,7 +78,7 @@ A concrete server is then just:
 ```csharp
 static void Main()
 {
-    var s = new McpServer(new Implementation { name = "serper", version = "1.0" },
+    var s = new McpServer(new Implementation { name = "web", version = "1.0" },
                           new StdErrLogSink());
     s.AddTool("web_search", "Search the web.",
               SchemaBuilder.Object().Str("query", required: true).Build(),

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -5,7 +5,7 @@
 Realizes **phase 7** of the roadmap.
 **Branch:** `claude/mcp-server-architecture-cJ088` · PR #22
 
-The four bundled servers — **Files → Serper → Git → Command** (built in that
+The four bundled servers — **Files → Web → Git → Command** (built in that
 order, *riskiest last*). Each is an independent net35 console exe consuming the
 `Mcp35.Server` SDK (D10/D13); none references `GxPT.*`. They are the SDK's first
 real consumers and its dogfooding.
@@ -52,15 +52,15 @@ contract — keep it small and namespaced `GXPT_*`:
 |--------|---------|-------------------|
 | *all* | `GXPT_WORKDIR` | sandbox / working root; default = process `CurrentDirectory` |
 | Files | (uses `GXPT_WORKDIR` as its root) | — |
-| Serper | `GXPT_SERPER_KEY` | **required**; absent → tool returns `Error` |
-| Serper | `GXPT_CURL_PATH` | curl exe (TLS 1.2); **required** (net35 can't TLS-1.2 natively) |
+| Web | `GXPT_WEB_SEARCH_KEY` | **required** (Tavily bearer token); absent → tool returns `Error` |
+| Web | `GXPT_CURL_PATH` | curl exe (TLS 1.2); **required** (net35 can't TLS-1.2 natively) |
 | Git | `GXPT_GIT_PATH` | `git` exe; default `"git"` (resolved on `PATH`) |
 | Command | `GXPT_CMD_SHELL` | shell for `/c`; default `cmd.exe` (from `%ComSpec%`) |
 
 Rules for the contract:
-- A **missing required** secret (Serper key/curl) doesn't crash the server — the
-  affected tool returns `ToolResults.Error("Serper API key not configured.")`.
-  (The host normally won't even enable Serper without a key, §8 architecture, but
+- A **missing required** secret (web key/curl) doesn't crash the server — the
+  affected tool returns `ToolResults.Error("Web search API key not configured.")`.
+  (The host normally won't even enable the web server without a key, §8 architecture, but
   the server stays defensive.)
 - Config is read **once at startup** (`Config.FromEnvironment`), not per call.
 - Secrets are never echoed into results, logs, or error text.
@@ -106,28 +106,35 @@ string Resolve(string root, string rel) {
 - Symlink/junction escapes: on net35/Windows, resolve via `GetFullPath` and the
   boundary check; do **not** follow a path that resolves outside root.
 
-## 3. SerperMcpServer (server name `serper`)
+## 3. WebSearchMcpServer (server name `web`)
 
-One tool, `search` (→ `serper__search`, ReadOnly). Web search via
-`google.serper.dev`, over **curl** because net35's `WebRequest`/`ServicePointManager`
-can't reliably negotiate TLS 1.2. Reuses **`Mcp35.Core`'s `CurlRunner`** (the
-shared curl-exec helper lives in Core precisely so the Serper server and the
-client's `HttpTransport` share it — D9, architecture §3).
+Two tools backed by the **Tavily API**, over **curl** because net35's
+`WebRequest`/`ServicePointManager` can't reliably negotiate TLS 1.2. Reuses
+**`Mcp35.Core`'s `CurlRunner`** (the shared curl-exec helper lives in Core
+precisely so this server and the client's `HttpTransport` share it — D9,
+architecture §3).
 
-| Tool | Schema | Behavior |
-|------|--------|----------|
-| `search` | `query*`, `num?` (default 10, cap ~20), `gl?`, `hl?` | POST search; return condensed organic results. |
+| Tool | Approval | Schema (required *) | Behavior |
+|------|----------|---------------------|----------|
+| `search` (→ `web__search`) | ReadOnly | `query*`, `max_results?` (default 5, cap 20), `topic?`, `search_depth?`, `chunks_per_source?`, `include_answer?`, `include_raw_content?`, `time_range?`, `start_date?`, `end_date?`, `country?`, `include_domains?`, `exclude_domains?` | `POST /search`; condensed results + optional answer. |
+| `extract` (→ `web__extract`) | **Write (confirm each call)** | `urls*` (string or array), `extract_depth?`, `format?`, `include_images?` | `POST /extract`; fetch and return full page content for the given URLs. |
 
-- Request: `POST https://google.serper.dev/search`, header `X-API-KEY:
-  <GXPT_SERPER_KEY>` (passed to curl via **`-K` config file**, never the command
-  line — same discipline as `HttpTransport`/architecture §8), JSON body
-  `{ "q": query, "num": n, "gl": …, "hl": … }`.
-- Response: parse with Newtonsoft; project `organic[]` → `{title, link, snippet}`
-  plus `answerBox`/`knowledgeGraph` if present. Return via
-  `ToolResults.Json(structured)` (structuredContent + a readable text rendering),
-  so the model gets both a clean list and prose.
-- Failure modes → `Error` (never throw): missing key, curl non-zero/timeout,
-  non-200 status, unparseable JSON. The raw API key never appears in any message.
+`extract` is gated as **Write** (not ReadOnly): it fetches arbitrary external
+pages — more network/token cost, and it pulls in whatever content the page
+serves — so each call is confirmed (`mcp35-approval-spec.md`).
+
+- Auth: `Authorization: Bearer <GXPT_WEB_SEARCH_KEY>`, passed to curl via a
+  **`-K` config file**, never the command line (same discipline as
+  `HttpTransport`/architecture §8). Content type `application/json`.
+- Endpoints: `https://api.tavily.com/search` and `https://api.tavily.com/extract`.
+- `search` response: parse with Newtonsoft; project `results[]` →
+  `{title, url, content, score?, raw_content?}` plus the synthesized `answer`
+  when `include_answer` was set. `extract` response: `results[] {url,
+  raw_content, images?}` plus any `failed_results`. Both return via
+  `ToolResults.Json(structured)` (structuredContent + a readable text rendering).
+- Failure modes → `Error` (never throw): missing key/curl, curl non-zero/timeout,
+  non-2xx status, empty/unparseable JSON, empty query / no URLs. The raw API key
+  never appears in any message.
 
 ## 4. GitMcpServer (server name `git`)
 
@@ -198,7 +205,7 @@ observably**.
   host drains it into `GxPT.Logger` (SDK §5).
 - **Graceful shutdown** — stdin EOF → `OnShutdown` hooks → flush → exit 0. Git
   and Command register cleanup hooks if they hold any transient state
-  (temp files); Files/Serper are stateless.
+  (temp files); Files/Web are stateless.
 - **First-party classification is hardcoded host-side** — these servers do **not**
   emit MCP annotations expecting to be trusted; the host's approval table is
   authoritative for them (`mcp35-approval-spec.md` §2). Annotations, if present,
@@ -211,7 +218,7 @@ observably**.
 ```
 servers/
 ├─ FilesMcpServer/      net35 Exe  (ProjectRef → Mcp35.Server)
-├─ SerperMcpServer/     net35 Exe  (also uses Mcp35.Core.CurlRunner)
+├─ WebSearchMcpServer/  net35 Exe  (also uses Mcp35.Core.CurlRunner)
 ├─ GitMcpServer/        net35 Exe
 └─ CommandMcpServer/    net35 Exe
 ```
@@ -229,7 +236,7 @@ Per server, over the scripted-stream harness:
 2. **Files sandbox** — `..`, absolute paths, and `/root` vs `/root-evil` boundary
    tricks are all rejected; in-root read/list/write/delete round-trip; oversize
    and binary reads → `Error`; write is atomic; delete refuses non-empty dirs.
-3. **Serper** — happy path parses `organic[]` into structured+text (curl stubbed
+3. **Web** — happy path parses `results[]` into structured+text (curl stubbed
    via injected `GXPT_CURL_PATH` pointing at a fake); missing key, curl failure,
    non-200, bad JSON → `Error`; key never leaks into output.
 4. **Git** — args built as discrete tokens (assert the `ProcessRequest`);
@@ -259,6 +266,7 @@ feature is end-to-end.
 3. **Read range/paging** — **resolved**: `read` is whole-file with a size cap +
    `Error` over it; `offset`/`limit` are a later enhancement if a real need
    appears.
-4. **Serper result shape** — **resolved**: condense to `organic[] {title, link,
-   snippet}` + answer/knowledge boxes (via `ToolResults.Json`) — keeps context
-   cost down vs. passing raw Serper JSON through.
+4. **Web result shape** — **resolved**: condense to `results[] {title, url,
+   content, score?}` + optional synthesized `answer` (via `ToolResults.Json`) —
+   keeps context cost down vs. passing raw Tavily JSON through. `extract` returns
+   `results[] {url, raw_content}` + `failed_results`.

--- a/servers/WebSearchMcpServer/Program.cs
+++ b/servers/WebSearchMcpServer/Program.cs
@@ -1,0 +1,27 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace WebSearchMcpServer
+{
+    /// <summary>
+    /// First-party web server: search + page extraction via the Tavily API over curl. The standard
+    /// five lines around the web tool set (servers-spec §1). Server name "web" → tools surface to
+    /// the model as web__search and web__extract.
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "web";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            WebSearchTools.Register(server, WebSearchConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/WebSearchMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/WebSearchMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("WebSearchMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: web search and page extraction via the Tavily API over curl (TLS 1.2).")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("785b59bd-b282-488c-bd78-4529cd80ba49")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/servers/WebSearchMcpServer/TavilyClient.cs
+++ b/servers/WebSearchMcpServer/TavilyClient.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Transport;
+using Newtonsoft.Json.Linq;
+
+namespace WebSearchMcpServer
+{
+    /// <summary>The outcome of a Tavily call: either a parsed JSON body or an error message.</summary>
+    internal sealed class TavilyResult
+    {
+        public readonly bool Ok;
+        public readonly JObject Body;       // when Ok
+        public readonly string ErrorMessage; // when !Ok
+
+        private TavilyResult(bool ok, JObject body, string error)
+        {
+            Ok = ok;
+            Body = body;
+            ErrorMessage = error;
+        }
+
+        public static TavilyResult Success(JObject body) { return new TavilyResult(true, body, null); }
+        public static TavilyResult Failure(string message) { return new TavilyResult(false, null, message); }
+    }
+
+    /// <summary>
+    /// Thin wrapper over the Tavily REST API (search + extract) via Mcp35.Core's CurlRunner.
+    /// The bearer token goes into curl's -K config file (never the command line). Every transport
+    /// / HTTP / parse failure is returned as a TavilyResult.Failure — this class never throws and
+    /// never echoes the token. Endpoints are overridable so tests can point at a fake curl.
+    /// </summary>
+    internal sealed class TavilyClient
+    {
+        public const string SearchEndpoint = "https://api.tavily.com/search";
+        public const string ExtractEndpoint = "https://api.tavily.com/extract";
+        private const int RequestTimeoutMs = 30000;
+
+        private readonly WebSearchConfig _config;
+        private readonly ILogSink _log;
+
+        public TavilyClient(WebSearchConfig config, ILogSink log)
+        {
+            _config = config;
+            _log = log ?? NullLogSink.Instance;
+        }
+
+        public TavilyResult Search(JObject requestBody) { return Post(SearchEndpoint, requestBody); }
+        public TavilyResult Extract(JObject requestBody) { return Post(ExtractEndpoint, requestBody); }
+
+        private TavilyResult Post(string url, JObject requestBody)
+        {
+            if (!_config.HasKey) return TavilyResult.Failure("Web search API key not configured.");
+            if (!_config.HasCurl) return TavilyResult.Failure("curl path not configured.");
+
+            CurlRequest req = new CurlRequest();
+            req.Url = url;
+            req.Method = "POST";
+            req.BodyJson = requestBody.ToString(Newtonsoft.Json.Formatting.None);
+            req.TimeoutMs = RequestTimeoutMs;
+            req.Headers = new Dictionary<string, string>();
+            req.Headers["Content-Type"] = "application/json";
+            req.Headers["Authorization"] = "Bearer " + _config.ApiKey; // → -K config file, off the cmd line
+
+            CurlRunner runner = new CurlRunner(_config.CurlPath, _config.CaBundle, _log);
+
+            CurlResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (Exception ex)
+            {
+                return TavilyResult.Failure("request failed: " + ex.Message);
+            }
+
+            if (result.HttpStatus != 0 && (result.HttpStatus < 200 || result.HttpStatus >= 300))
+                return TavilyResult.Failure("request failed with HTTP status " + result.HttpStatus);
+
+            if (string.IsNullOrEmpty(result.Body))
+                return TavilyResult.Failure("empty response from web search provider");
+
+            JObject parsed;
+            try
+            {
+                parsed = JObject.Parse(result.Body);
+            }
+            catch (Exception)
+            {
+                return TavilyResult.Failure("could not parse web search response");
+            }
+
+            return TavilyResult.Success(parsed);
+        }
+    }
+}

--- a/servers/WebSearchMcpServer/WebSearchConfig.cs
+++ b/servers/WebSearchMcpServer/WebSearchConfig.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace WebSearchMcpServer
+{
+    /// <summary>
+    /// Startup config from the environment (servers-spec §1), read once. The Tavily API key and a
+    /// curl path are required (net35 can't negotiate TLS 1.2 natively); when absent the tools
+    /// degrade to a clear Error rather than the server crashing. The key is never logged.
+    /// </summary>
+    internal sealed class WebSearchConfig
+    {
+        public readonly string ApiKey;     // GXPT_WEB_SEARCH_KEY (required) — Tavily bearer token
+        public readonly string CurlPath;   // GXPT_CURL_PATH (required)
+        public readonly string CaBundle;   // GXPT_CA_BUNDLE (optional)
+        public readonly string WorkDir;    // GXPT_WORKDIR (unused here, part of the contract)
+
+        private WebSearchConfig(string apiKey, string curlPath, string caBundle, string workDir)
+        {
+            ApiKey = apiKey;
+            CurlPath = curlPath;
+            CaBundle = caBundle;
+            WorkDir = workDir;
+        }
+
+        public bool HasKey { get { return !string.IsNullOrEmpty(ApiKey); } }
+        public bool HasCurl { get { return !string.IsNullOrEmpty(CurlPath); } }
+
+        public static WebSearchConfig FromEnvironment(ILogSink log)
+        {
+            string apiKey = Environment.GetEnvironmentVariable("GXPT_WEB_SEARCH_KEY");
+            string curlPath = Environment.GetEnvironmentVariable("GXPT_CURL_PATH");
+            string caBundle = Environment.GetEnvironmentVariable("GXPT_CA_BUNDLE");
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir)) workDir = Directory.GetCurrentDirectory();
+
+            if (log != null)
+            {
+                // Never log the key — only whether it's present.
+                log.Log("web", "key=" + (string.IsNullOrEmpty(apiKey) ? "absent" : "present")
+                    + " curl=" + (string.IsNullOrEmpty(curlPath) ? "absent" : "present"));
+            }
+            return new WebSearchConfig(apiKey, curlPath, caBundle, workDir);
+        }
+    }
+}

--- a/servers/WebSearchMcpServer/WebSearchMcpServer.csproj
+++ b/servers/WebSearchMcpServer/WebSearchMcpServer.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{785B59BD-B282-488C-BD78-4529CD80BA49}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebSearchMcpServer</RootNamespace>
+    <AssemblyName>WebSearchMcpServer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="WebSearchConfig.cs" />
+    <Compile Include="TavilyClient.cs" />
+    <Compile Include="WebSearchTools.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/servers/WebSearchMcpServer/WebSearchTools.cs
+++ b/servers/WebSearchMcpServer/WebSearchTools.cs
@@ -1,0 +1,277 @@
+using System;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace WebSearchMcpServer
+{
+    /// <summary>
+    /// The web server's two tools over the Tavily API:
+    ///   web__search  (ReadOnly)    — query the web, condensed results + optional answer.
+    ///   web__extract (Write/confirm) — fetch and return full page content for given URLs.
+    /// Request builders and response condensers are pure functions (unit-tested directly); the
+    /// handlers add the network call. Failures are Error values; the API key never appears in output.
+    /// See servers-spec §3.
+    /// </summary>
+    internal static class WebSearchTools
+    {
+        private const int DefaultMaxResults = 5;
+        private const int MaxMaxResults = 20;
+
+        public static void Register(McpServer server, WebSearchConfig config)
+        {
+            TavilyClient client = new TavilyClient(config, null);
+
+            server.AddTool("search",
+                "Search the web and return relevant results (title, url, content snippet), optionally with a synthesized answer.",
+                BuildSearchSchema(),
+                delegate(ToolCallContext ctx) { return Search(config, client, ctx); });
+
+            server.AddTool("extract",
+                "Fetch and extract the full text content of one or more web pages by URL.",
+                BuildExtractSchema(),
+                delegate(ToolCallContext ctx) { return Extract(config, client, ctx); });
+        }
+
+        // ---- schemas ----
+
+        private static JObject BuildSearchSchema()
+        {
+            // Full Tavily search surface (resolved decision: rich schema).
+            JObject topic = StrEnum("Search topic", new string[] { "general", "news", "finance" });
+            JObject depth = StrEnum("Search depth: 'basic' (faster) or 'advanced' (deeper).", new string[] { "basic", "advanced" });
+
+            return SchemaBuilder.Object()
+                .Str("query", true, "The search query")
+                .Int("max_results", false, "Maximum number of results (default 5, max 20)")
+                .Raw("topic", topic, false)
+                .Raw("search_depth", depth, false)
+                .Int("chunks_per_source", false, "Number of content chunks to retrieve per source (advanced depth)")
+                .Bool("include_answer", false, "Include a synthesized answer to the query")
+                .Bool("include_raw_content", false, "Include the raw page content for each result")
+                .Str("time_range", false, "Relative time filter, e.g. 'day', 'week', 'month', 'year'")
+                .Str("start_date", false, "Earliest result date, YYYY-MM-DD")
+                .Str("end_date", false, "Latest result date, YYYY-MM-DD")
+                .Str("country", false, "Boost results from a country, e.g. 'united states'")
+                .Arr("include_domains", "string", false, "Only include results from these domains")
+                .Arr("exclude_domains", "string", false, "Exclude results from these domains")
+                .Build();
+        }
+
+        private static JObject BuildExtractSchema()
+        {
+            JObject fmt = StrEnum("Output format: 'markdown' (default) or 'text'.", new string[] { "markdown", "text" });
+            JObject depth = StrEnum("Extraction depth: 'basic' (faster) or 'advanced' (more thorough).", new string[] { "basic", "advanced" });
+
+            return SchemaBuilder.Object()
+                .Arr("urls", "string", true, "One or more page URLs to fetch and extract")
+                .Raw("extract_depth", depth, false)
+                .Raw("format", fmt, false)
+                .Bool("include_images", false, "Include image URLs found on the pages")
+                .Build();
+        }
+
+        // ---- search ----
+
+        private static CallToolResult Search(WebSearchConfig config, TavilyClient client, ToolCallContext ctx)
+        {
+            string query = ctx.Arguments.Value<string>("query");
+            if (string.IsNullOrEmpty(query)) return ToolResults.Error("query is required");
+
+            JObject body = BuildSearchRequest(ctx);
+            TavilyResult result = client.Search(body);
+            if (!result.Ok) return ToolResults.Error(result.ErrorMessage);
+
+            return ToolResults.Json(CondenseSearch(result.Body));
+        }
+
+        /// <summary>Map tool arguments onto a Tavily /search request body. Pure.</summary>
+        public static JObject BuildSearchRequest(ToolCallContext ctx)
+        {
+            JObject b = new JObject();
+            b["query"] = ctx.Arguments.Value<string>("query");
+            b["max_results"] = ClampInt(ctx, "max_results", DefaultMaxResults, 1, MaxMaxResults);
+
+            CopyStr(ctx, b, "topic");
+            CopyStr(ctx, b, "search_depth");
+            CopyStr(ctx, b, "time_range");
+            CopyStr(ctx, b, "start_date");
+            CopyStr(ctx, b, "end_date");
+            CopyStr(ctx, b, "country");
+            CopyInt(ctx, b, "chunks_per_source");
+            CopyBool(ctx, b, "include_answer");
+            CopyBool(ctx, b, "include_raw_content");
+            CopyArray(ctx, b, "include_domains");
+            CopyArray(ctx, b, "exclude_domains");
+            return b;
+        }
+
+        /// <summary>Condense a Tavily /search response to results[] + optional answer. Pure.</summary>
+        public static JObject CondenseSearch(JObject raw)
+        {
+            JObject outp = new JObject();
+
+            if (raw["answer"] != null && raw["answer"].Type != JTokenType.Null)
+                outp["answer"] = StringOf(raw["answer"]);
+
+            JArray results = new JArray();
+            JToken arr = raw["results"];
+            if (arr != null && arr.Type == JTokenType.Array)
+            {
+                foreach (JToken item in (JArray)arr)
+                {
+                    JObject o = item as JObject;
+                    if (o == null) continue;
+                    JObject r = new JObject();
+                    r["title"] = StringOf(o["title"]);
+                    r["url"] = StringOf(o["url"]);
+                    r["content"] = StringOf(o["content"]);
+                    if (o["score"] != null && o["score"].Type != JTokenType.Null) r["score"] = o["score"];
+                    if (o["raw_content"] != null && o["raw_content"].Type != JTokenType.Null)
+                        r["raw_content"] = StringOf(o["raw_content"]);
+                    results.Add(r);
+                }
+            }
+            outp["results"] = results;
+            return outp;
+        }
+
+        // ---- extract ----
+
+        private static CallToolResult Extract(WebSearchConfig config, TavilyClient client, ToolCallContext ctx)
+        {
+            JArray urls = NormalizeUrls(ctx.Arguments["urls"]);
+            if (urls.Count == 0) return ToolResults.Error("at least one url is required");
+
+            JObject body = BuildExtractRequest(ctx, urls);
+            TavilyResult result = client.Extract(body);
+            if (!result.Ok) return ToolResults.Error(result.ErrorMessage);
+
+            return ToolResults.Json(CondenseExtract(result.Body));
+        }
+
+        /// <summary>Map tool arguments onto a Tavily /extract request body. Pure.</summary>
+        public static JObject BuildExtractRequest(ToolCallContext ctx, JArray urls)
+        {
+            JObject b = new JObject();
+            b["urls"] = urls;
+            CopyStr(ctx, b, "extract_depth");
+            CopyStr(ctx, b, "format");
+            CopyBool(ctx, b, "include_images");
+            return b;
+        }
+
+        /// <summary>Condense a Tavily /extract response to results[] {url, raw_content, images?} + failures. Pure.</summary>
+        public static JObject CondenseExtract(JObject raw)
+        {
+            JObject outp = new JObject();
+
+            JArray results = new JArray();
+            JToken arr = raw["results"];
+            if (arr != null && arr.Type == JTokenType.Array)
+            {
+                foreach (JToken item in (JArray)arr)
+                {
+                    JObject o = item as JObject;
+                    if (o == null) continue;
+                    JObject r = new JObject();
+                    r["url"] = StringOf(o["url"]);
+                    r["raw_content"] = StringOf(o["raw_content"]);
+                    if (o["images"] != null && o["images"].Type == JTokenType.Array) r["images"] = o["images"];
+                    results.Add(r);
+                }
+            }
+            outp["results"] = results;
+
+            // Surface per-URL failures so the model knows what couldn't be fetched.
+            JToken failed = raw["failed_results"];
+            if (failed != null && failed.Type == JTokenType.Array && ((JArray)failed).Count > 0)
+                outp["failed_results"] = failed;
+
+            return outp;
+        }
+
+        /// <summary>Accept a single URL string or an array; always return a JArray of strings.</summary>
+        public static JArray NormalizeUrls(JToken urls)
+        {
+            JArray result = new JArray();
+            if (urls == null || urls.Type == JTokenType.Null) return result;
+
+            if (urls.Type == JTokenType.String)
+            {
+                string s = (string)urls;
+                if (!string.IsNullOrEmpty(s)) result.Add(s);
+            }
+            else if (urls.Type == JTokenType.Array)
+            {
+                foreach (JToken t in (JArray)urls)
+                {
+                    if (t == null || t.Type == JTokenType.Null) continue;
+                    string s = t.Type == JTokenType.String ? (string)t : t.ToString();
+                    if (!string.IsNullOrEmpty(s)) result.Add(s);
+                }
+            }
+            return result;
+        }
+
+        // ---- helpers ----
+
+        private static JObject StrEnum(string description, string[] values)
+        {
+            JObject o = new JObject();
+            o["type"] = "string";
+            o["description"] = description;
+            JArray e = new JArray();
+            for (int i = 0; i < values.Length; i++) e.Add(values[i]);
+            o["enum"] = e;
+            return o;
+        }
+
+        private static void CopyStr(ToolCallContext ctx, JObject body, string name)
+        {
+            string v = ctx.Arguments.Value<string>(name);
+            if (!string.IsNullOrEmpty(v)) body[name] = v;
+        }
+
+        private static void CopyInt(ToolCallContext ctx, JObject body, string name)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return;
+            try { body[name] = t.Value<int>(); }
+            catch { }
+        }
+
+        private static void CopyBool(ToolCallContext ctx, JObject body, string name)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return;
+            try { body[name] = t.Value<bool>(); }
+            catch { }
+        }
+
+        private static void CopyArray(ToolCallContext ctx, JObject body, string name)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t != null && t.Type == JTokenType.Array && ((JArray)t).Count > 0)
+                body[name] = t;
+        }
+
+        private static int ClampInt(ToolCallContext ctx, string name, int fallback, int min, int max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        private static string StringOf(JToken t)
+        {
+            if (t == null || t.Type == JTokenType.Null) return null;
+            return t.Type == JTokenType.String ? (string)t : t.ToString();
+        }
+    }
+}

--- a/src/Mcp35.Core/Transport/CurlRunner.cs
+++ b/src/Mcp35.Core/Transport/CurlRunner.cs
@@ -12,9 +12,9 @@ namespace Mcp35.Core.Transport
     /// <summary>
     /// A reusable curl wrapper distilled from GxPT's OpenRouterClient (D9). HTTP plumbing for
     /// .NET 3.5, which can't reliably negotiate TLS 1.2 natively — so anything hitting a modern
-    /// HTTPS endpoint (GitHub, Serper) shells out to curl. Pure BCL + injected paths, so it lives
+    /// HTTPS endpoint (GitHub, Tavily) shells out to curl. Pure BCL + injected paths, so it lives
     /// in Core without a native build dependency. Shared by the client's HttpTransport (phase 8)
-    /// and SerperMcpServer (phase 7). See mcp35-core-spec.md §6.
+    /// and WebSearchMcpServer (phase 7). See mcp35-core-spec.md §6.
     /// </summary>
     public sealed class CurlRunner
     {

--- a/tests/WebSearchMcpServer.Tests/Harness.cs
+++ b/tests/WebSearchMcpServer.Tests/Harness.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace WebSearchMcpServer.Tests
+{
+    /// <summary>Scripted-stream harness + web-server construction with env injection.</summary>
+    internal static class Harness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            byte[] rawOut;
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            List<JObject> messages = new List<JObject>();
+            foreach (string line in Utf8.GetString(rawOut).Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        public static string ToolsList(int id) { return Request(id, "tools/list", null); }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static JObject Args(params object[] kv)
+        {
+            JObject o = new JObject();
+            for (int i = 0; i + 1 < kv.Length; i += 2)
+                o[(string)kv[i]] = JToken.FromObject(kv[i + 1]);
+            return o;
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        /// <summary>Build a web server with the given env (null values clear the variable).</summary>
+        public static McpServer NewWebServer(string apiKey, string curlPath)
+        {
+            Environment.SetEnvironmentVariable("GXPT_WEB_SEARCH_KEY", apiKey);
+            Environment.SetEnvironmentVariable("GXPT_CURL_PATH", curlPath);
+            Environment.SetEnvironmentVariable("GXPT_CA_BUNDLE", null);
+
+            Implementation info = new Implementation();
+            info.Name = "web";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            WebSearchTools.Register(server, WebSearchConfig.FromEnvironment(null));
+            return server;
+        }
+
+        // ---- result helpers ----
+
+        public static bool IsError(JObject message)
+        {
+            JObject r = message["result"] as JObject;
+            return r != null && r.Value<bool>("isError");
+        }
+
+        public static string Text(JObject message)
+        {
+            return (string)message["result"]["content"][0]["text"];
+        }
+
+        public static JObject Structured(JObject message)
+        {
+            return (JObject)message["result"]["structuredContent"];
+        }
+    }
+}

--- a/tests/WebSearchMcpServer.Tests/WebSearchLogicTests.cs
+++ b/tests/WebSearchMcpServer.Tests/WebSearchLogicTests.cs
@@ -1,0 +1,147 @@
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+using WebSearchMcpServer;
+using Xunit;
+
+namespace WebSearchMcpServer.Tests
+{
+    /// <summary>Pure-function tests for the request builders, condensers, and URL normalization.</summary>
+    public class WebSearchLogicTests
+    {
+        private static ToolCallContext Ctx(JObject args)
+        {
+            return new ToolCallContext("search", args, null);
+        }
+
+        // ---- search request building ----
+
+        [Fact]
+        public void Search_request_includes_query_and_defaults_max_results()
+        {
+            JObject args = new JObject();
+            args["query"] = "hello world";
+            JObject body = WebSearchTools.BuildSearchRequest(Ctx(args));
+
+            Assert.Equal("hello world", (string)body["query"]);
+            Assert.Equal(5, (int)body["max_results"]); // default
+        }
+
+        [Fact]
+        public void Search_request_clamps_max_results_to_20()
+        {
+            JObject args = new JObject();
+            args["query"] = "x";
+            args["max_results"] = 999;
+            JObject body = WebSearchTools.BuildSearchRequest(Ctx(args));
+            Assert.Equal(20, (int)body["max_results"]);
+        }
+
+        [Fact]
+        public void Search_request_passes_through_optional_params_only_when_present()
+        {
+            JObject args = new JObject();
+            args["query"] = "x";
+            args["topic"] = "news";
+            args["include_answer"] = true;
+            args["include_domains"] = new JArray("a.com", "b.com");
+            JObject body = WebSearchTools.BuildSearchRequest(Ctx(args));
+
+            Assert.Equal("news", (string)body["topic"]);
+            Assert.True((bool)body["include_answer"]);
+            Assert.Equal(2, ((JArray)body["include_domains"]).Count);
+            // absent ones are not emitted
+            Assert.Null(body["country"]);
+            Assert.Null(body["time_range"]);
+            Assert.Null(body["exclude_domains"]); // empty/absent array omitted
+        }
+
+        // ---- search condensing ----
+
+        [Fact]
+        public void CondenseSearch_projects_results_and_answer()
+        {
+            JObject raw = JObject.Parse(
+                "{\"answer\":\"Leo Messi is a footballer.\",\"results\":[" +
+                "{\"title\":\"Messi\",\"url\":\"https://w.test\",\"content\":\"snippet\",\"score\":0.9,\"extra\":\"drop\"}]}");
+
+            JObject c = WebSearchTools.CondenseSearch(raw);
+            Assert.Equal("Leo Messi is a footballer.", (string)c["answer"]);
+            JArray results = (JArray)c["results"];
+            Assert.Single(results);
+            Assert.Equal("Messi", (string)results[0]["title"]);
+            Assert.Equal("https://w.test", (string)results[0]["url"]);
+            Assert.NotNull(results[0]["score"]);
+            Assert.Null(results[0]["extra"]); // unknown field dropped
+        }
+
+        [Fact]
+        public void CondenseSearch_handles_no_answer_and_empty_results()
+        {
+            JObject raw = JObject.Parse("{\"results\":[]}");
+            JObject c = WebSearchTools.CondenseSearch(raw);
+            Assert.Null(c["answer"]);
+            Assert.Empty((JArray)c["results"]);
+        }
+
+        // ---- extract ----
+
+        [Fact]
+        public void NormalizeUrls_accepts_single_string()
+        {
+            JArray urls = WebSearchTools.NormalizeUrls(new JValue("https://a.test"));
+            Assert.Single(urls);
+            Assert.Equal("https://a.test", (string)urls[0]);
+        }
+
+        [Fact]
+        public void NormalizeUrls_accepts_array_and_drops_empties()
+        {
+            JArray input = new JArray("https://a.test", "", "https://b.test");
+            JArray urls = WebSearchTools.NormalizeUrls(input);
+            Assert.Equal(2, urls.Count);
+        }
+
+        [Fact]
+        public void NormalizeUrls_null_is_empty()
+        {
+            Assert.Empty(WebSearchTools.NormalizeUrls(null));
+            Assert.Empty(WebSearchTools.NormalizeUrls(JValue.CreateNull()));
+        }
+
+        [Fact]
+        public void Extract_request_carries_urls_and_optional_params()
+        {
+            JObject args = new JObject();
+            args["extract_depth"] = "advanced";
+            args["format"] = "markdown";
+            JArray urls = new JArray("https://a.test");
+            JObject body = WebSearchTools.BuildExtractRequest(Ctx(args), urls);
+
+            Assert.Equal(1, ((JArray)body["urls"]).Count);
+            Assert.Equal("advanced", (string)body["extract_depth"]);
+            Assert.Equal("markdown", (string)body["format"]);
+        }
+
+        [Fact]
+        public void CondenseExtract_projects_results_and_failures()
+        {
+            JObject raw = JObject.Parse(
+                "{\"results\":[{\"url\":\"https://a.test\",\"raw_content\":\"# Title\\nbody\"}]," +
+                "\"failed_results\":[{\"url\":\"https://bad.test\",\"error\":\"timeout\"}]}");
+
+            JObject c = WebSearchTools.CondenseExtract(raw);
+            Assert.Single((JArray)c["results"]);
+            Assert.Equal("https://a.test", (string)c["results"][0]["url"]);
+            Assert.Contains("Title", (string)c["results"][0]["raw_content"]);
+            Assert.Single((JArray)c["failed_results"]);
+        }
+
+        [Fact]
+        public void CondenseExtract_omits_failures_when_none()
+        {
+            JObject raw = JObject.Parse("{\"results\":[{\"url\":\"https://a.test\",\"raw_content\":\"x\"}]}");
+            JObject c = WebSearchTools.CondenseExtract(raw);
+            Assert.Null(c["failed_results"]);
+        }
+    }
+}

--- a/tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj
+++ b/tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for WebSearchMcpServer (phase 7). Links Core + Server + the WebSearchMcpServer sources
+    and drives Run(stdin, stdout) via the scripted-stream harness. The full search/extract paths
+    are exercised by pointing GXPT_CURL_PATH at a fake-curl script that emits a canned Tavily
+    response plus the status marker CurlRunner expects. Targets net48.
+
+    Program.Main is excluded (second entry point would clash with the test host).
+
+    NOTE: intentionally NOT in GxPT.sln (VS2008 cannot load SDK-style projects).
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>WebSearchMcpServer.Tests</AssemblyName>
+    <RootNamespace>WebSearchMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\WebSearchMcpServer\**\*.cs"
+             Exclude="..\..\servers\WebSearchMcpServer\Program.cs;..\..\servers\WebSearchMcpServer\Properties\**\*.cs;..\..\servers\WebSearchMcpServer\obj\**\*.cs;..\..\servers\WebSearchMcpServer\bin\**\*.cs"
+             Link="Linked\Web\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/WebSearchMcpServer.Tests/WebSearchToolsTests.cs
+++ b/tests/WebSearchMcpServer.Tests/WebSearchToolsTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace WebSearchMcpServer.Tests
+{
+    public class WebSearchToolsTests : IDisposable
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        // Mirrors CurlRunner's status marker (kept in sync intentionally).
+        private const string StatusMarker = "__GXPT_HTTP_STATUS__";
+
+        private readonly string _dir;
+
+        public WebSearchToolsTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "webmcp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        /// <summary>A fake curl that prints a canned JSON body + the status marker on stdout.</summary>
+        private string FakeCurl(string json, int status)
+        {
+            string jsonFile = Path.Combine(_dir, "resp_" + Guid.NewGuid().ToString("N") + ".json");
+            File.WriteAllText(jsonFile, json);
+
+            if (IsWindows)
+            {
+                string path = Path.Combine(_dir, "fakecurl.cmd");
+                string script =
+                    "@echo off\r\n" +
+                    "type \"" + jsonFile + "\"\r\n" +
+                    "echo " + StatusMarker + status + "\r\n";
+                File.WriteAllText(path, script);
+                return path;
+            }
+            else
+            {
+                string path = Path.Combine(_dir, "fakecurl.sh");
+                string script =
+                    "#!/bin/sh\n" +
+                    "cat \"" + jsonFile + "\"\n" +
+                    "printf '%s%d' '" + StatusMarker + "' " + status + "\n";
+                File.WriteAllText(path, script);
+                try { System.Diagnostics.Process.Start("/bin/chmod", "+x \"" + path + "\"").WaitForExit(); } catch { }
+                return path;
+            }
+        }
+
+        private const string SearchResponse =
+            "{\"answer\":\"An answer.\",\"results\":[" +
+            "{\"title\":\"First\",\"url\":\"https://a.test\",\"content\":\"one\",\"score\":0.9}," +
+            "{\"title\":\"Second\",\"url\":\"https://b.test\",\"content\":\"two\",\"score\":0.5}]}";
+
+        private const string ExtractResponse =
+            "{\"results\":[{\"url\":\"https://a.test\",\"raw_content\":\"# Heading\\nFull body text.\"}]," +
+            "\"failed_results\":[]}";
+
+        // ---- listing ----
+
+        [Fact]
+        public void Lists_search_and_extract_tools()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(SearchResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsList(1));
+
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            var names = new System.Collections.Generic.List<string>();
+            foreach (JToken t in tools) names.Add((string)t["name"]);
+            Assert.Contains("search", names);
+            Assert.Contains("extract", names);
+            Assert.Equal(2, names.Count);
+        }
+
+        // ---- search handler ----
+
+        [Fact]
+        public void Search_happy_path_returns_condensed_results()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(SearchResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "hello")));
+
+            Assert.False(Harness.IsError(msgs[0]));
+            JObject s = Harness.Structured(msgs[0]);
+            Assert.Equal("An answer.", (string)s["answer"]);
+            Assert.Equal(2, ((JArray)s["results"]).Count);
+            Assert.Equal("https://a.test", (string)s["results"][0]["url"]);
+        }
+
+        [Fact]
+        public void Search_missing_key_returns_error()
+        {
+            var server = Harness.NewWebServer(null, FakeCurl(SearchResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("API key", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Search_empty_query_returns_error()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(SearchResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "")));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        [Fact]
+        public void Search_non_200_returns_error()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl("{\"detail\":\"unauthorized\"}", 401));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("401", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Search_bad_json_returns_error()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl("not json", 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "x")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("parse", Harness.Text(msgs[0]));
+        }
+
+        // ---- extract handler ----
+
+        [Fact]
+        public void Extract_happy_path_returns_page_content()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(ExtractResponse, 200));
+            JObject args = new JObject();
+            args["urls"] = new JArray("https://a.test");
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "extract", args));
+
+            Assert.False(Harness.IsError(msgs[0]));
+            JObject s = Harness.Structured(msgs[0]);
+            Assert.Single((JArray)s["results"]);
+            Assert.Contains("Full body text", (string)s["results"][0]["raw_content"]);
+        }
+
+        [Fact]
+        public void Extract_accepts_single_url_string()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(ExtractResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "extract", Harness.Args("urls", "https://a.test")));
+            Assert.False(Harness.IsError(msgs[0]));
+        }
+
+        [Fact]
+        public void Extract_no_urls_returns_error()
+        {
+            var server = Harness.NewWebServer("k", FakeCurl(ExtractResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "extract", new JObject()));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        // ---- secret hygiene + lifecycle ----
+
+        [Fact]
+        public void Api_key_never_appears_in_output()
+        {
+            const string secret = "super-secret-tavily-token-xyz";
+            var server = Harness.NewWebServer(secret, FakeCurl(SearchResponse, 200));
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "search", Harness.Args("query", "hello")));
+            Assert.DoesNotContain(secret, msgs[0].ToString());
+        }
+
+        [Fact]
+        public void Server_survives_an_error_and_answers_next_request()
+        {
+            var server = Harness.NewWebServer(null, FakeCurl(SearchResponse, 200)); // no key → error
+            var msgs = Harness.Exchange(server,
+                Harness.ToolsCall(1, "search", Harness.Args("query", "x")),
+                Harness.Request(2, "ping", null));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.NotNull(msgs[1]["result"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the planned **Serper** server with a generically named **`web`** server
backed by the **Tavily API**, adding a **page-extraction** capability alongside
search. Serper was never merged to `main` (it lived only on the now-closed #27
branch), so this is a clean swap — nothing to revert.

## Decisions (confirmed with the maintainer)

- **Server `web`** → tools surface as `web__search` and `web__extract`
- API key env var: **`GXPT_WEB_SEARCH_KEY`** (Tavily bearer token)
- **`extract` gated as Write (confirm each call)**, `search` as ReadOnly — extract
  fetches arbitrary external pages (more cost; pulls in page content)
- **Full** search schema (topic, depth, dates, domains, …)

## What's here

**`servers/WebSearchMcpServer/`** (net35 Exe, `ProjectRef → Mcp35.Server + Mcp35.Core`):
- **`WebSearchConfig`** — `GXPT_WEB_SEARCH_KEY` + `GXPT_CURL_PATH` (required),
  `GXPT_CA_BUNDLE` (optional). Logs key *presence*, never the key.
- **`TavilyClient`** — thin wrapper over `/search` + `/extract` via
  `Mcp35.Core.CurlRunner`; `Authorization: Bearer <key>` in the **`-K` config
  file** (never the command line). Every transport/HTTP/parse failure returned as
  a value, never thrown; key never echoed.
- **`WebSearchTools`** — `search` (full Tavily schema → condensed
  `results[] {title,url,content,score?}` + optional `answer`) and `extract`
  (`urls` string-or-array → `results[] {url,raw_content,images?}` +
  `failed_results`). Request builders, condensers, and URL normalization are
  **pure functions**, unit-tested directly. `max_results` clamped to `[1,20]`.

**Tests** (net48 linked-source): tool listing; pure builders/condensers for both
tools; URL normalization; full handlers over a **fake-curl** (`GXPT_CURL_PATH`)
for happy + failure paths; an assertion the **API key never leaks**; survival
after error.

**Docs** — Serper replaced across the whole spec set: `servers-spec` §3 rewritten
(two tools, Bearer auth, Tavily endpoints), the approval table gains `web__search`
(ReadOnly) + `web__extract` (Write), env var → `GXPT_WEB_SEARCH_KEY`, and the
architecture/client/core/server specs updated. **Zero Serper references remain.**

## Review focus

- **`extract` as Write tier** in the approval table (`mcp35-approval-spec.md` §2) —
  confirm that's the gating you want for arbitrary-URL fetches.
- **Secret hygiene** — bearer token flows only through `CurlRunner`'s `-K` file;
  there's a test asserting it never appears in tool output.

Remaining phase-7 servers: **Git + Command** next.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_