### PR TITLE
Fix FilesMcpServer VS2008 build (add Mcp35.Core ProjectReference)

### DIFF
--- a/servers/FilesMcpServer/FilesMcpServer.csproj
+++ b/servers/FilesMcpServer/FilesMcpServer.csproj
@@ -50,6 +50,10 @@
       <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
       <Name>Mcp35.Server</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
## Problem

`FilesMcpServer` fails to build in VS2008 with `The type or namespace name 'Core'
does not exist in the namespace 'Mcp35'` and missing `ILogSink` / `CallToolResult`
(reported by the maintainer after pulling locally).

## Cause

`FilesMcpServer`'s sources use **`Mcp35.Core` types directly** (`ILogSink`,
`CallToolResult`, `Implementation`, `Tool`), but the `.csproj` referenced only
`Mcp35.Server`. In classic net35 csproj a `ProjectReference` is **not transitive**
for compile-time type resolution — depending on Server does not let you compile
against Core's types. `WebSearchMcpServer` references **both** and builds fine;
`FilesMcpServer` (from the earlier phase-7a PR) was missing the Core reference.

## Fix

Add the direct `Mcp35.Core` `ProjectReference` to `FilesMcpServer.csproj`, matching
`WebSearchMcpServer`. (The Newtonsoft `HintPath` was already present.)

## Why CI didn't catch it

CI builds only the **linked-source net48 test projects**, which compile the
Core + Server sources directly into the test assembly — so the VS2008
`ProjectReference` graph is never exercised. This is a known blind spot of the
linked-source test model; the real net35 project build only happens in VS2008.
I audited both existing servers: WebSearch already had the reference, Files was the
only gap, and I'll make sure the upcoming Git/Command servers include both
references from the start.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_