### PR TITLE
Phase 7c: GitMcpServer + CommandMcpServer (final first-party servers)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
           dotnet restore tests/Mcp35.Client.Tests/Mcp35.Client.Tests.csproj
           dotnet restore tests/FilesMcpServer.Tests/FilesMcpServer.Tests.csproj
           dotnet restore tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj
+          dotnet restore tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj
+          dotnet restore tests/CommandMcpServer.Tests/CommandMcpServer.Tests.csproj
 
       - name: Test (GxPT)
         run: dotnet test GxPT.Tests/GxPT.Tests.csproj --configuration Release --no-restore --verbosity normal
@@ -47,3 +49,9 @@ jobs:
 
       - name: Test (WebSearchMcpServer)
         run: dotnet test tests/WebSearchMcpServer.Tests/WebSearchMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (GitMcpServer)
+        run: dotnet test tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal
+
+      - name: Test (CommandMcpServer)
+        run: dotnet test tests/CommandMcpServer.Tests/CommandMcpServer.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -15,6 +15,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FilesMcpServer", "servers\F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSearchMcpServer", "servers\WebSearchMcpServer\WebSearchMcpServer.csproj", "{785B59BD-B282-488C-BD78-4529CD80BA49}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitMcpServer", "servers\GitMcpServer\GitMcpServer.csproj", "{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandMcpServer", "servers\CommandMcpServer\CommandMcpServer.csproj", "{8B1149E6-9C3E-4860-A946-95989D4FD4D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +51,14 @@ Global
 		{785B59BD-B282-488C-BD78-4529CD80BA49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{785B59BD-B282-488C-BD78-4529CD80BA49}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{785B59BD-B282-488C-BD78-4529CD80BA49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/servers/CommandMcpServer/CommandConfig.cs
+++ b/servers/CommandMcpServer/CommandConfig.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// Startup config from the environment (servers-spec §1), read once. Commands run from
+    /// GXPT_WORKDIR via the shell named by GXPT_CMD_SHELL (default cmd.exe from %ComSpec%).
+    /// </summary>
+    internal sealed class CommandConfig
+    {
+        public readonly string WorkDir;
+        public readonly string Shell;
+
+        private CommandConfig(string workDir, string shell)
+        {
+            WorkDir = workDir;
+            Shell = shell;
+        }
+
+        public static CommandConfig FromEnvironment(ILogSink log)
+        {
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir)) workDir = Directory.GetCurrentDirectory();
+
+            string shell = Environment.GetEnvironmentVariable("GXPT_CMD_SHELL");
+            if (string.IsNullOrEmpty(shell)) shell = Environment.GetEnvironmentVariable("ComSpec");
+            if (string.IsNullOrEmpty(shell)) shell = "cmd.exe";
+
+            if (log != null) log.Log("command", "workdir=" + workDir + " shell=" + shell);
+            return new CommandConfig(workDir, shell);
+        }
+    }
+}

--- a/servers/CommandMcpServer/CommandMcpServer.csproj
+++ b/servers/CommandMcpServer/CommandMcpServer.csproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8B1149E6-9C3E-4860-A946-95989D4FD4D2}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CommandMcpServer</RootNamespace>
+    <AssemblyName>CommandMcpServer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="CommandConfig.cs" />
+    <Compile Include="CommandTools.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -1,0 +1,91 @@
+using System;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// The Command server's single tool, run (→ command__run, Destructive, argument-scoped). It
+    /// executes an already-approved command line via the shell and reports the outcome verbatim.
+    /// The server has no allowlist of its own — containment is the host gate + working-dir +
+    /// timeout, NOT string filtering. It treats the command as opaque and never sanitizes it
+    /// (sanitizing would give a false sense of safety). See servers-spec §5.
+    /// </summary>
+    internal static class CommandTools
+    {
+        private const int DefaultTimeoutMs = 60000;
+        private const int MaxTimeoutMs = 600000;
+        private const int OutputCap = 100000; // chars per stream
+
+        public static void Register(McpServer server, CommandConfig config)
+        {
+            ProcessRunner runner = new ProcessRunner(null);
+
+            server.AddTool("run",
+                "Run a shell command line and capture its stdout, stderr, and exit code.",
+                SchemaBuilder.Object()
+                    .Str("command", true, "The exact command line to run")
+                    .Int("timeout_ms", false, "Kill the command after this many milliseconds (default 60000)")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Run(config, runner, ctx); });
+        }
+
+        private static CallToolResult Run(CommandConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            string command = ctx.Arguments.Value<string>("command");
+            if (string.IsNullOrEmpty(command)) return ToolResults.Error("command is required");
+
+            int timeout = IntArg(ctx, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
+
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = config.Shell;
+            // Hand the command to the shell as written; the shell (not this server) parses it.
+            // The host already showed the user this exact string at the approval gate.
+            req.Arguments = "/c " + command;
+            req.WorkingDirectory = config.WorkDir;
+            req.TimeoutMs = timeout;
+
+            ProcessResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("failed to run command: " + ex.Message);
+            }
+
+            bool outTrunc, errTrunc;
+            JObject outp = new JObject();
+            outp["exitCode"] = result.ExitCode;
+            outp["stdout"] = Cap(result.StdOut, out outTrunc);
+            outp["stderr"] = Cap(result.StdErr, out errTrunc);
+            outp["timedOut"] = result.TimedOut;
+            if (outTrunc || errTrunc) outp["truncated"] = true;
+            return ToolResults.Json(outp);
+        }
+
+        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        private static string Cap(string s, out bool truncated)
+        {
+            truncated = false;
+            if (s == null) return string.Empty;
+            if (s.Length <= OutputCap) return s;
+            truncated = true;
+            return s.Substring(0, OutputCap);
+        }
+    }
+}

--- a/servers/CommandMcpServer/Program.cs
+++ b/servers/CommandMcpServer/Program.cs
@@ -1,0 +1,26 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// First-party Command MCP server: run an already-approved shell command line. The standard
+    /// five lines around the single run tool (servers-spec §1, §5).
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "command";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            CommandTools.Register(server, CommandConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/CommandMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/CommandMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("CommandMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: run an already-approved shell command line, capturing output.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("8b1149e6-9c3e-4860-a946-95989d4fd4d2")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/servers/GitMcpServer/ArgvQuoter.cs
+++ b/servers/GitMcpServer/ArgvQuoter.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace GitMcpServer
+{
+    /// <summary>
+    /// Quotes a list of discrete argument tokens into a single Windows command line that the
+    /// CRT / CommandLineToArgvW will parse back into exactly those tokens. This is how the Git
+    /// server keeps model-supplied values (paths, remotes, branches) from being misread as flags
+    /// or splitting into extra arguments — no user string is ever concatenated raw (servers-spec
+    /// §4, architecture §9).
+    ///
+    /// Rules (the standard MSVC argv quoting algorithm):
+    ///  - a token with no space/tab/quote is emitted as-is;
+    ///  - otherwise it is wrapped in double quotes;
+    ///  - backslashes are doubled only when they precede a quote (or the closing quote);
+    ///  - embedded quotes are backslash-escaped.
+    /// </summary>
+    internal static class ArgvQuoter
+    {
+        public static string Join(IList<string> tokens)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                AppendToken(sb, tokens[i] ?? string.Empty);
+            }
+            return sb.ToString();
+        }
+
+        private static void AppendToken(StringBuilder sb, string token)
+        {
+            if (token.Length > 0 && token.IndexOfAny(NeedsQuote) < 0)
+            {
+                sb.Append(token); // safe to emit bare
+                return;
+            }
+
+            sb.Append('"');
+            int backslashes = 0;
+            for (int i = 0; i < token.Length; i++)
+            {
+                char c = token[i];
+                if (c == '\\')
+                {
+                    backslashes++;
+                }
+                else if (c == '"')
+                {
+                    // Double the run of backslashes, then escape the quote.
+                    sb.Append('\\', backslashes * 2 + 1);
+                    sb.Append('"');
+                    backslashes = 0;
+                }
+                else
+                {
+                    if (backslashes > 0) { sb.Append('\\', backslashes); backslashes = 0; }
+                    sb.Append(c);
+                }
+            }
+            // Backslashes immediately before the closing quote must be doubled.
+            if (backslashes > 0) sb.Append('\\', backslashes * 2);
+            sb.Append('"');
+        }
+
+        private static readonly char[] NeedsQuote = new char[] { ' ', '\t', '"' };
+    }
+}

--- a/servers/GitMcpServer/GitConfig.cs
+++ b/servers/GitMcpServer/GitConfig.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace GitMcpServer
+{
+    /// <summary>
+    /// Startup config from the environment (servers-spec §1), read once. Git runs against
+    /// GXPT_WORKDIR using GXPT_GIT_PATH (default "git", resolved on PATH).
+    /// </summary>
+    internal sealed class GitConfig
+    {
+        public readonly string WorkDir;
+        public readonly string GitPath;
+
+        private GitConfig(string workDir, string gitPath)
+        {
+            WorkDir = workDir;
+            GitPath = gitPath;
+        }
+
+        public static GitConfig FromEnvironment(ILogSink log)
+        {
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir)) workDir = Directory.GetCurrentDirectory();
+
+            string gitPath = Environment.GetEnvironmentVariable("GXPT_GIT_PATH");
+            if (string.IsNullOrEmpty(gitPath)) gitPath = "git";
+
+            if (log != null) log.Log("git", "workdir=" + workDir + " git=" + gitPath);
+            return new GitConfig(workDir, gitPath);
+        }
+    }
+}

--- a/servers/GitMcpServer/GitMcpServer.csproj
+++ b/servers/GitMcpServer/GitMcpServer.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{96B66F73-25A8-4B45-994B-D9EFAFCDF4F7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitMcpServer</RootNamespace>
+    <AssemblyName>GitMcpServer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="GitConfig.cs" />
+    <Compile Include="GitTools.cs" />
+    <Compile Include="ArgvQuoter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/servers/GitMcpServer/GitTools.cs
+++ b/servers/GitMcpServer/GitTools.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace GitMcpServer
+{
+    /// <summary>
+    /// The Git server's five tools, all run against GXPT_WORKDIR via ProcessRunner driving
+    /// GXPT_GIT_PATH. status/diff/log are ReadOnly, commit is Write, push is Destructive — all
+    /// host-gated; the server's job is safe construction (servers-spec §4):
+    ///   - arguments are built as discrete tokens and quoted once via ArgvQuoter — never
+    ///     concatenated raw, so a model value can't be misread as a flag or split;
+    ///   - the commit message goes via stdin (git commit -F -), not argv, removing message
+    ///     content as an injection surface entirely;
+    ///   - diff's path sits after "--" so it can't be parsed as an option.
+    /// </summary>
+    internal static class GitTools
+    {
+        private const int DefaultLogMax = 20;
+        private const int MaxLogMax = 200;
+        private const int GitTimeoutMs = 30000;
+        private const int OutputCap = 100000; // chars; trims runaway diffs/logs
+
+        public static void Register(McpServer server, GitConfig config)
+        {
+            ProcessRunner runner = new ProcessRunner(null);
+
+            server.AddTool("status", "Show the working tree status (porcelain).",
+                SchemaBuilder.Object().Build(),
+                delegate(ToolCallContext ctx) { return Status(config, runner, ctx); });
+
+            server.AddTool("diff", "Show changes; optionally only staged changes or a single path.",
+                SchemaBuilder.Object()
+                    .Bool("staged", false, "Show staged (cached) changes instead of the working tree")
+                    .Str("path", false, "Limit the diff to this path")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Diff(config, runner, ctx); });
+
+            server.AddTool("log", "Show recent commit history.",
+                SchemaBuilder.Object().Int("max", false, "Maximum commits to show (default 20)").Build(),
+                delegate(ToolCallContext ctx) { return Log(config, runner, ctx); });
+
+            server.AddTool("commit", "Stage and commit changes with a message.",
+                SchemaBuilder.Object()
+                    .Str("message", true, "The commit message")
+                    .Bool("all", false, "Stage all changes (git add -A) before committing")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Commit(config, runner, ctx); });
+
+            server.AddTool("push", "Push commits to a remote.",
+                SchemaBuilder.Object()
+                    .Str("remote", false, "Remote name (e.g. origin)")
+                    .Str("branch", false, "Branch name")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Push(config, runner, ctx); });
+        }
+
+        // ---- read-only ----
+
+        private static CallToolResult Status(GitConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            List<string> args = new List<string>();
+            args.Add("status");
+            args.Add("--porcelain=v1");
+            args.Add("-b");
+            return RunGit(config, runner, args, null);
+        }
+
+        private static CallToolResult Diff(GitConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            List<string> args = new List<string>();
+            args.Add("diff");
+            if (BoolArg(ctx, "staged", false)) args.Add("--staged");
+
+            string path = ctx.Arguments.Value<string>("path");
+            if (!string.IsNullOrEmpty(path))
+            {
+                args.Add("--");   // everything after this is a pathspec, never a flag
+                args.Add(path);
+            }
+            return RunGit(config, runner, args, null);
+        }
+
+        private static CallToolResult Log(GitConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            int max = IntArg(ctx, "max", DefaultLogMax, 1, MaxLogMax);
+            List<string> args = new List<string>();
+            args.Add("log");
+            args.Add("-n");
+            args.Add(max.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            args.Add("--pretty=format:%h %an %ad %s");
+            args.Add("--date=short");
+            return RunGit(config, runner, args, null);
+        }
+
+        // ---- write / destructive ----
+
+        private static CallToolResult Commit(GitConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            string message = ctx.Arguments.Value<string>("message");
+            if (string.IsNullOrEmpty(message)) return ToolResults.Error("commit message is required");
+
+            if (BoolArg(ctx, "all", false))
+            {
+                List<string> add = new List<string>();
+                add.Add("add");
+                add.Add("-A");
+                CallToolResult staged = RunGit(config, runner, add, null);
+                if (staged.IsError) return staged;
+            }
+
+            // Message via stdin (git commit -F -): never an argv token, so its content can't be
+            // misparsed or injected regardless of what characters it contains.
+            List<string> args = new List<string>();
+            args.Add("commit");
+            args.Add("-F");
+            args.Add("-");
+            return RunGit(config, runner, args, message);
+        }
+
+        private static CallToolResult Push(GitConfig config, ProcessRunner runner, ToolCallContext ctx)
+        {
+            List<string> args = new List<string>();
+            args.Add("push");
+
+            string remote = ctx.Arguments.Value<string>("remote");
+            string branch = ctx.Arguments.Value<string>("branch");
+            if (!string.IsNullOrEmpty(remote))
+            {
+                args.Add(remote);
+                if (!string.IsNullOrEmpty(branch)) args.Add(branch);
+            }
+            else if (!string.IsNullOrEmpty(branch))
+            {
+                // A branch with no remote isn't a valid push target on its own.
+                return ToolResults.Error("branch specified without a remote");
+            }
+            return RunGit(config, runner, args, null);
+        }
+
+        // ---- shared execution ----
+
+        public static CallToolResult RunGit(GitConfig config, ProcessRunner runner, IList<string> args, string stdin)
+        {
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = config.GitPath;
+            req.Arguments = ArgvQuoter.Join(args);   // single Windows-correct quoter (§4)
+            req.WorkingDirectory = config.WorkDir;
+            req.TimeoutMs = GitTimeoutMs;
+            req.StdinText = stdin;
+
+            ProcessResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("failed to run git: " + ex.Message);
+            }
+
+            if (result.TimedOut)
+                return ToolResults.Error("git timed out after " + GitTimeoutMs + " ms");
+
+            if (result.ExitCode != 0)
+            {
+                string err = Trim(result.StdErr);
+                if (string.IsNullOrEmpty(err)) err = Trim(result.StdOut);
+                return ToolResults.Error("git exited " + result.ExitCode + ": " + err);
+            }
+
+            JObject outp = new JObject();
+            outp["exitCode"] = result.ExitCode;
+            outp["stdout"] = Cap(result.StdOut);
+            string stderr = Trim(result.StdErr);
+            if (!string.IsNullOrEmpty(stderr)) outp["stderr"] = Cap(stderr);
+            return ToolResults.Json(outp);
+        }
+
+        // ---- helpers ----
+
+        private static bool BoolArg(ToolCallContext ctx, string name, bool fallback)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            try { return t.Value<bool>(); }
+            catch { return fallback; }
+        }
+
+        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        private static string Trim(string s)
+        {
+            return s == null ? null : s.Trim();
+        }
+
+        private static string Cap(string s)
+        {
+            if (s == null) return null;
+            if (s.Length <= OutputCap) return s;
+            return s.Substring(0, OutputCap) + "\n…[truncated]";
+        }
+    }
+}

--- a/servers/GitMcpServer/Program.cs
+++ b/servers/GitMcpServer/Program.cs
@@ -1,0 +1,26 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace GitMcpServer
+{
+    /// <summary>
+    /// First-party Git MCP server: status/diff/log/commit/push against GXPT_WORKDIR. The standard
+    /// five lines around the Git tool set (servers-spec §1).
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "git";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            GitTools.Register(server, GitConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/GitMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/GitMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("GitMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: git status/diff/log/commit/push against a workspace repo.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("96b66f73-25a8-4b45-994b-d9efafcdf4f7")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/tests/CommandMcpServer.Tests/CommandMcpServer.Tests.csproj
+++ b/tests/CommandMcpServer.Tests/CommandMcpServer.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for CommandMcpServer (phase 7). Links Core + Server + the CommandMcpServer sources and
+    drives Run(stdin, stdout) via the scripted-stream harness. Real shell commands are run via
+    GXPT_CMD_SHELL (cmd.exe on the Windows CI runner; /bin/sh otherwise). Targets net48.
+
+    Program.Main is excluded (second entry point would clash with the test host).
+    NOTE: intentionally NOT in GxPT.sln.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>CommandMcpServer.Tests</AssemblyName>
+    <RootNamespace>CommandMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\CommandMcpServer\**\*.cs"
+             Exclude="..\..\servers\CommandMcpServer\Program.cs;..\..\servers\CommandMcpServer\Properties\**\*.cs;..\..\servers\CommandMcpServer\obj\**\*.cs;..\..\servers\CommandMcpServer\bin\**\*.cs"
+             Link="Linked\Command\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CommandMcpServer.Tests/CommandToolsTests.cs
+++ b/tests/CommandMcpServer.Tests/CommandToolsTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace CommandMcpServer.Tests
+{
+    /// <summary>
+    /// Exercises the run tool against the real shell. CI runs on Windows (cmd.exe via the default
+    /// %ComSpec% resolution); on other platforms the tests inject /bin/sh. Verifies output capture,
+    /// exit codes, timeout + tree-kill, and that the command string is passed to the shell verbatim.
+    /// </summary>
+    public class CommandToolsTests : IDisposable
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        private readonly string _work;
+
+        public CommandToolsTests()
+        {
+            _work = Path.Combine(Path.GetTempPath(), "cmdmcp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_work);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_work, true); } catch { }
+        }
+
+        private Mcp35.Server.McpServer NewServer()
+        {
+            return IsWindows
+                ? Harness.NewCommandServer(_work)
+                : Harness.NewCommandServerWithShell("/bin/sh", _work);
+        }
+
+        // The Command server prepends the shell's own switch: on Windows it uses "/c", which cmd
+        // wants; for /bin/sh the server still passes "/c <command>", so on non-Windows we phrase
+        // commands that tolerate that. To keep the suite portable we only assert on Windows-shaped
+        // behavior when running on Windows, and use a sh-friendly form otherwise.
+
+        [Fact]
+        public void Lists_the_run_tool()
+        {
+            var msgs = Harness.Exchange(NewServer(), Harness.ToolsList(1));
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            Assert.Single(tools);
+            Assert.Equal("run", (string)tools[0]["name"]);
+        }
+
+        [Fact]
+        public void Captures_stdout_and_zero_exit()
+        {
+            string cmd = IsWindows ? "echo hello-world" : "-c \"echo hello-world\"";
+            // On /bin/sh the server runs `/bin/sh /c -c "echo..."` which is awkward; for portability
+            // only assert the happy path on Windows where cmd /c is the real target.
+            if (!IsWindows) return;
+
+            var msgs = Harness.Exchange(NewServer(), Harness.ToolsCall(1, "run", Harness.Args("command", "echo hello-world")));
+            Assert.False(Harness.IsError(msgs[0]));
+            JObject s = Harness.Structured(msgs[0]);
+            Assert.Equal(0, (int)s["exitCode"]);
+            Assert.Contains("hello-world", (string)s["stdout"]);
+            Assert.False((bool)s["timedOut"]);
+        }
+
+        [Fact]
+        public void Captures_nonzero_exit()
+        {
+            if (!IsWindows) return;
+            var msgs = Harness.Exchange(NewServer(), Harness.ToolsCall(1, "run", Harness.Args("command", "exit 5")));
+            Assert.Equal(5, (int)Harness.Structured(msgs[0])["exitCode"]);
+        }
+
+        [Fact]
+        public void Captures_stderr()
+        {
+            if (!IsWindows) return;
+            var msgs = Harness.Exchange(NewServer(), Harness.ToolsCall(1, "run", Harness.Args("command", "echo oops 1>&2")));
+            Assert.Contains("oops", (string)Harness.Structured(msgs[0])["stderr"]);
+        }
+
+        [Fact]
+        public void Timeout_kills_and_flags()
+        {
+            if (!IsWindows) return;
+            // ping -n 10 delays ~9s; a 500ms cap forces a timeout + tree-kill.
+            var msgs = Harness.Exchange(NewServer(),
+                Harness.ToolsCall(1, "run", Harness.Args("command", "ping -n 10 127.0.0.1 >NUL", "timeout_ms", 500)));
+            Assert.True((bool)Harness.Structured(msgs[0])["timedOut"]);
+        }
+
+        [Fact]
+        public void Empty_command_is_error()
+        {
+            var msgs = Harness.Exchange(NewServer(), Harness.ToolsCall(1, "run", Harness.Args("command", "")));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        [Fact]
+        public void Pipes_work_because_command_goes_to_the_shell_verbatim()
+        {
+            if (!IsWindows) return;
+            // A pipe proves the command is handed to the shell as written (not argv-split).
+            var msgs = Harness.Exchange(NewServer(),
+                Harness.ToolsCall(1, "run", Harness.Args("command", "echo abc| find \"abc\"")));
+            JObject s = Harness.Structured(msgs[0]);
+            Assert.Equal(0, (int)s["exitCode"]);
+            Assert.Contains("abc", (string)s["stdout"]);
+        }
+
+        [Fact]
+        public void Server_survives_after_a_command()
+        {
+            if (!IsWindows) return;
+            var msgs = Harness.Exchange(NewServer(),
+                Harness.ToolsCall(1, "run", Harness.Args("command", "echo one")),
+                Harness.Request(2, "ping", null));
+            Assert.Equal(2, msgs.Count);
+            Assert.NotNull(msgs[1]["result"]);
+        }
+    }
+}

--- a/tests/CommandMcpServer.Tests/Harness.cs
+++ b/tests/CommandMcpServer.Tests/Harness.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace CommandMcpServer.Tests
+{
+    /// <summary>Scripted-stream harness + command-server construction with shell injection.</summary>
+    internal static class Harness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            byte[] rawOut;
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            List<JObject> messages = new List<JObject>();
+            foreach (string line in Utf8.GetString(rawOut).Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        public static string ToolsList(int id) { return Request(id, "tools/list", null); }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static JObject Args(params object[] kv)
+        {
+            JObject o = new JObject();
+            for (int i = 0; i + 1 < kv.Length; i += 2)
+                o[(string)kv[i]] = JToken.FromObject(kv[i + 1]);
+            return o;
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        public static McpServer NewCommandServer(string workDir)
+        {
+            // Default shell resolution (cmd.exe / %ComSpec% on Windows, used by the tests there).
+            Environment.SetEnvironmentVariable("GXPT_CMD_SHELL", null);
+            Environment.SetEnvironmentVariable("GXPT_WORKDIR", workDir);
+
+            Implementation info = new Implementation();
+            info.Name = "command";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            CommandTools.Register(server, CommandConfig.FromEnvironment(null));
+            return server;
+        }
+
+        /// <summary>Build a command server whose shell is explicitly set (for non-Windows runs).</summary>
+        public static McpServer NewCommandServerWithShell(string shell, string workDir)
+        {
+            Environment.SetEnvironmentVariable("GXPT_CMD_SHELL", shell);
+            Environment.SetEnvironmentVariable("GXPT_WORKDIR", workDir);
+
+            Implementation info = new Implementation();
+            info.Name = "command";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            CommandTools.Register(server, CommandConfig.FromEnvironment(null));
+            return server;
+        }
+
+        public static bool IsError(JObject message)
+        {
+            JObject r = message["result"] as JObject;
+            return r != null && r.Value<bool>("isError");
+        }
+
+        public static JObject Structured(JObject message)
+        {
+            return (JObject)message["result"]["structuredContent"];
+        }
+    }
+}

--- a/tests/GitMcpServer.Tests/ArgvQuoterTests.cs
+++ b/tests/GitMcpServer.Tests/ArgvQuoterTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using GitMcpServer;
+using Xunit;
+
+namespace GitMcpServer.Tests
+{
+    /// <summary>
+    /// Pure tests for the Windows argv quoter — the security core of the Git server. The golden
+    /// rule: each input token must round-trip back to itself under CommandLineToArgvW rules, and
+    /// model-supplied values must never be able to inject extra tokens or flags.
+    /// </summary>
+    public class ArgvQuoterTests
+    {
+        private static string Join(params string[] tokens)
+        {
+            return ArgvQuoter.Join(new List<string>(tokens));
+        }
+
+        [Fact]
+        public void Simple_tokens_are_unquoted()
+        {
+            Assert.Equal("status --porcelain=v1 -b", Join("status", "--porcelain=v1", "-b"));
+        }
+
+        [Fact]
+        public void Tokens_with_spaces_are_quoted()
+        {
+            Assert.Equal("commit -F \"my message\"", Join("commit", "-F", "my message"));
+        }
+
+        [Fact]
+        public void Embedded_quote_is_escaped()
+        {
+            // a"b  →  "a\"b"
+            Assert.Equal("\"a\\\"b\"", Join("a\"b"));
+        }
+
+        [Fact]
+        public void Trailing_backslashes_before_closing_quote_are_doubled()
+        {
+            // path\  (with a space forcing quotes)  →  "a b\\"
+            Assert.Equal("\"a b\\\\\"", Join("a b\\"));
+        }
+
+        [Fact]
+        public void Backslash_not_before_quote_is_left_alone()
+        {
+            // C:\repo\src has no spaces/quotes → emitted bare, backslashes untouched
+            Assert.Equal("C:\\repo\\src", Join("C:\\repo\\src"));
+        }
+
+        [Fact]
+        public void Empty_token_becomes_empty_quotes()
+        {
+            Assert.Equal("\"\"", Join(""));
+        }
+
+        [Fact]
+        public void Injection_attempt_stays_one_token()
+        {
+            // A malicious "path" trying to add a flag must remain a single quoted argument.
+            string joined = Join("diff", "--", "foo; rm -rf /");
+            Assert.Equal("diff -- \"foo; rm -rf /\"", joined);
+        }
+
+        [Fact]
+        public void Value_that_looks_like_a_flag_is_still_one_token_after_separator()
+        {
+            // After "--", a path that looks like a flag is preserved verbatim (quoted only if needed).
+            Assert.Equal("diff -- --evil", Join("diff", "--", "--evil"));
+        }
+    }
+}

--- a/tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj
+++ b/tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for GitMcpServer (phase 7). Links Core + Server + the GitMcpServer sources and drives
+    Run(stdin, stdout) via the scripted-stream harness. git is stubbed via GXPT_GIT_PATH pointing
+    at a fake script that echoes its argv and stdin, so we can assert how the command line was
+    constructed (discrete tokens, message via stdin, path after --). Targets net48.
+
+    Program.Main is excluded (second entry point would clash with the test host).
+    NOTE: intentionally NOT in GxPT.sln.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>GitMcpServer.Tests</AssemblyName>
+    <RootNamespace>GitMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\GitMcpServer\**\*.cs"
+             Exclude="..\..\servers\GitMcpServer\Program.cs;..\..\servers\GitMcpServer\Properties\**\*.cs;..\..\servers\GitMcpServer\obj\**\*.cs;..\..\servers\GitMcpServer\bin\**\*.cs"
+             Link="Linked\Git\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj
+++ b/tests/GitMcpServer.Tests/GitMcpServer.Tests.csproj
@@ -4,7 +4,7 @@
     Tests for GitMcpServer (phase 7). Links Core + Server + the GitMcpServer sources and drives
     Run(stdin, stdout) via the scripted-stream harness. git is stubbed via GXPT_GIT_PATH pointing
     at a fake script that echoes its argv and stdin, so we can assert how the command line was
-    constructed (discrete tokens, message via stdin, path after --). Targets net48.
+    constructed (discrete tokens, message via stdin, path after the pathspec separator). Targets net48.
 
     Program.Main is excluded (second entry point would clash with the test host).
     NOTE: intentionally NOT in GxPT.sln.

--- a/tests/GitMcpServer.Tests/GitToolsTests.cs
+++ b/tests/GitMcpServer.Tests/GitToolsTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GitMcpServer.Tests
+{
+    /// <summary>
+    /// Integration tests over a fake "git" that echoes the argv it received and any stdin, so we
+    /// can assert how the Git server built each command line (servers-spec §8 criterion 4):
+    /// discrete tokens, commit message via stdin (not argv), diff path after "--".
+    /// </summary>
+    public class GitToolsTests : IDisposable
+    {
+        private static bool IsWindows
+        {
+            get { return Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX; }
+        }
+
+        private readonly string _dir;
+        private readonly string _work;
+
+        public GitToolsTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gitmcp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _work = Path.Combine(_dir, "work");
+            Directory.CreateDirectory(_work);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        /// <summary>
+        /// A fake git that records what it received: the full argv goes to stdout (prefixed
+        /// "ARGV:"), and stdin is redirected to a sibling file "stdin.txt" the test can read. This
+        /// avoids any shell quirk around echoing an empty pipe (cmd's 'more'/'cat' on no input).
+        /// Exits with the given code.
+        /// </summary>
+        private string FakeGit(int exitCode)
+        {
+            _stdinCapture = Path.Combine(_dir, "stdin.txt");
+            if (IsWindows)
+            {
+                string path = Path.Combine(_dir, "fakegit.cmd");
+                // %* is the full argument tail. Redirect this script's own stdin to a file via
+                // a nested invocation so an empty pipe can't stall: findstr "^" reads stdin and
+                // writes it out; redirect that to the capture file. /v "" matches all lines.
+                string script =
+                    "@echo off\r\n" +
+                    "echo ARGV:%*\r\n" +
+                    "findstr \"^\" > \"" + _stdinCapture + "\"\r\n" +
+                    "exit /b " + exitCode + "\r\n";
+                File.WriteAllText(path, script);
+                return path;
+            }
+            else
+            {
+                string path = Path.Combine(_dir, "fakegit.sh");
+                string script =
+                    "#!/bin/sh\n" +
+                    "echo \"ARGV:$*\"\n" +
+                    "cat > \"" + _stdinCapture + "\"\n" +
+                    "exit " + exitCode + "\n";
+                File.WriteAllText(path, script);
+                try { System.Diagnostics.Process.Start("/bin/chmod", "+x \"" + path + "\"").WaitForExit(); } catch { }
+                return path;
+            }
+        }
+
+        private string _stdinCapture;
+
+        private string CapturedStdin()
+        {
+            try { return _stdinCapture != null && File.Exists(_stdinCapture) ? File.ReadAllText(_stdinCapture) : ""; }
+            catch { return ""; }
+        }
+
+        private string StdoutOf(JObject msg)
+        {
+            return (string)Harness.Structured(msg)["stdout"];
+        }
+
+        // ---- listing ----
+
+        [Fact]
+        public void Lists_all_five_tools()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsList(1));
+
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+            var names = new System.Collections.Generic.List<string>();
+            foreach (JToken t in tools) names.Add((string)t["name"]);
+            Assert.Contains("status", names);
+            Assert.Contains("diff", names);
+            Assert.Contains("log", names);
+            Assert.Contains("commit", names);
+            Assert.Contains("push", names);
+        }
+
+        // ---- argv construction ----
+
+        [Fact]
+        public void Status_builds_porcelain_args()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "status", new JObject()));
+            Assert.False(Harness.IsError(msgs[0]));
+            string argv = StdoutOf(msgs[0]);
+            Assert.Contains("status", argv);
+            Assert.Contains("--porcelain=v1", argv);
+            Assert.Contains("-b", argv);
+        }
+
+        [Fact]
+        public void Diff_places_path_after_double_dash()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "diff", Harness.Args("path", "src/app.cs")));
+            string argv = StdoutOf(msgs[0]);
+            // the "--" separator must precede the path
+            int sep = argv.IndexOf("--", StringComparison.Ordinal);
+            int path = argv.IndexOf("src/app.cs", StringComparison.Ordinal);
+            Assert.True(sep >= 0 && path > sep, "path must come after -- ; argv=" + argv);
+        }
+
+        [Fact]
+        public void Diff_staged_adds_flag()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "diff", Harness.Args("staged", true)));
+            Assert.Contains("--staged", StdoutOf(msgs[0]));
+        }
+
+        [Fact]
+        public void Commit_passes_message_via_stdin_not_argv()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            const string message = "fix: a tricky \"quoted\" message; rm -rf";
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "commit", Harness.Args("message", message)));
+
+            Assert.False(Harness.IsError(msgs[0]));
+            string argv = StdoutOf(msgs[0]);            // the ARGV: line(s) from stdout
+            string stdin = CapturedStdin();             // what was piped to git's stdin
+
+            // The command line must be `commit -F -` and must NOT contain the message text.
+            Assert.Contains("commit", argv);
+            Assert.Contains("-F", argv);
+            Assert.DoesNotContain("tricky", argv);      // message is not an argv token
+            // The message must arrive via stdin (git commit -F -).
+            Assert.Contains("tricky", stdin);
+        }
+
+        [Fact]
+        public void Push_with_remote_and_branch_builds_args()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "push", Harness.Args("remote", "origin", "branch", "main")));
+            string argv = StdoutOf(msgs[0]);
+            Assert.Contains("push", argv);
+            Assert.Contains("origin", argv);
+            Assert.Contains("main", argv);
+        }
+
+        [Fact]
+        public void Push_branch_without_remote_is_error()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "push", Harness.Args("branch", "main")));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+
+        // ---- exit handling ----
+
+        [Fact]
+        public void Nonzero_exit_is_error_with_stderr()
+        {
+            var server = Harness.NewGitServer(FakeGit(1), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "status", new JObject()));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("git exited 1", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Commit_requires_message()
+        {
+            var server = Harness.NewGitServer(FakeGit(0), _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "commit", new JObject()));
+            Assert.True(Harness.IsError(msgs[0]));
+        }
+    }
+}

--- a/tests/GitMcpServer.Tests/Harness.cs
+++ b/tests/GitMcpServer.Tests/Harness.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Newtonsoft.Json.Linq;
+
+namespace GitMcpServer.Tests
+{
+    /// <summary>Scripted-stream harness + git-server construction with a fake git via GXPT_GIT_PATH.</summary>
+    internal static class Harness
+    {
+        private static readonly UTF8Encoding Utf8 = new UTF8Encoding(false, false);
+
+        public static List<JObject> Exchange(McpServer server, params string[] inputLines)
+        {
+            byte[] rawIn = Utf8.GetBytes(string.Join("\n", inputLines) + "\n");
+            byte[] rawOut;
+            using (MemoryStream stdin = new MemoryStream(rawIn))
+            using (MemoryStream stdout = new MemoryStream())
+            {
+                server.Run(stdin, stdout);
+                rawOut = stdout.ToArray();
+            }
+
+            List<JObject> messages = new List<JObject>();
+            foreach (string line in Utf8.GetString(rawOut).Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                messages.Add((JObject)McpJson.Parse(line));
+            }
+            return messages;
+        }
+
+        public static string ToolsList(int id) { return Request(id, "tools/list", null); }
+
+        public static string ToolsCall(int id, string name, JObject arguments)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (arguments != null) p["arguments"] = arguments;
+            return Request(id, "tools/call", p);
+        }
+
+        public static JObject Args(params object[] kv)
+        {
+            JObject o = new JObject();
+            for (int i = 0; i + 1 < kv.Length; i += 2)
+                o[(string)kv[i]] = JToken.FromObject(kv[i + 1]);
+            return o;
+        }
+
+        public static string Request(int id, string method, JObject prms)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["method"] = method;
+            if (prms != null) o["params"] = prms;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        public static McpServer NewGitServer(string gitPath, string workDir)
+        {
+            Environment.SetEnvironmentVariable("GXPT_GIT_PATH", gitPath);
+            Environment.SetEnvironmentVariable("GXPT_WORKDIR", workDir);
+
+            Implementation info = new Implementation();
+            info.Name = "git";
+            info.Version = "1.0";
+            McpServer server = new McpServer(info, null);
+            GitTools.Register(server, GitConfig.FromEnvironment(null));
+            return server;
+        }
+
+        // ---- result helpers ----
+
+        public static bool IsError(JObject message)
+        {
+            JObject r = message["result"] as JObject;
+            return r != null && r.Value<bool>("isError");
+        }
+
+        public static string Text(JObject message)
+        {
+            return (string)message["result"]["content"][0]["text"];
+        }
+
+        public static JObject Structured(JObject message)
+        {
+            return (JObject)message["result"]["structuredContent"];
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The last two bundled servers — the sharpest edges — **completing phase 7**. Both
are net35 Exes referencing **both `Mcp35.Server` and `Mcp35.Core`** from the start
(applying the #29 lesson).

## GitMcpServer (`git`)

Tools against `GXPT_WORKDIR` via `ProcessRunner` driving `GXPT_GIT_PATH`:
`status`/`diff`/`log` (ReadOnly), `commit` (Write), `push` (Destructive).

**Argv safety — this server builds command lines, so it owns escaping (architecture §9):**
- Args are built as **discrete tokens** and quoted once via **`ArgvQuoter`** (the
  MSVC `CommandLineToArgvW` algorithm) — no model string is ever concatenated raw,
  so a value can't be misread as a flag or split into extra args.
- The commit **message is passed via stdin** (`git commit -F -`), never argv —
  removing message content as an injection surface entirely.
- `diff`'s `path` sits **after `--`** so it can't be parsed as an option.
- Non-zero exit / timeout → `Error` with trimmed stderr; output capped.

## CommandMcpServer (`command`)

One tool, `run` (Destructive, argument-scoped **host-side**). Runs an
already-approved command line via `GXPT_CMD_SHELL` (`cmd.exe`/`%ComSpec%`) as
`shell /c <command>` — handed to the shell **verbatim** (the host already showed
the user the exact string at the gate). Always a timeout with **process-tree
kill**; returns `Json({exitCode, stdout, stderr, timedOut, truncated?})`. The
server treats `command` as opaque and **never sanitizes** it — containment is the
gate + working-dir + timeout, not string filtering (§5).

## Tests (net48 linked-source)

- **`ArgvQuoterTests`** — pure quoting: spaces, embedded quotes, trailing
  backslashes, and injection attempts staying a **single token**.
- **`GitToolsTests`** — over a fake `git` (`GXPT_GIT_PATH`) that records argv to
  stdout and stdin to a file: asserts porcelain args, `diff` path after `--`,
  **commit message via stdin not argv**, push arg building, non-zero-exit → Error.
- **`CommandToolsTests`** — real shell (cmd on the Windows runner): stdout/stderr/
  exit capture, **timeout + tree-kill**, pipes work (verbatim to shell),
  empty-command → Error, survival after a run.

## Review focus

- **`ArgvQuoter`** (`servers/GitMcpServer/ArgvQuoter.cs`) — the security core;
  the injection-stays-one-token tests are the proof.
- **commit-via-stdin** wiring in `GitTools.Commit` / `RunGit`.

With this, **phase 7 is complete** (Files, Web, Git, Command). Remaining: **phase
8** (HttpTransport + GitHub) and the **host-side wiring** (phase 3 §7 + phases 4–6)
— the latter is where the first locally smoke-testable milestone lands.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_