### PR TITLE
Phase 8: HttpTransport (Streamable HTTP over curl)

### DIFF
--- a/docs/mcp35-client-spec.md
+++ b/docs/mcp35-client-spec.md
@@ -101,12 +101,14 @@ pending calls and `StdioTransport` reports `IsConnected == false`;
 
 ---
 
-## 3. `HttpTransport` (phase 8 — placeholder)
+## 3. `HttpTransport` (implemented — phase 8)
 
-Lives here for symmetry but is specified in the phase-8 work: `IRpcTransport`
-implemented directly over Core's `CurlRunner` + `SseParser` (one POST = one
-correlated response; no `JsonRpcPeer` needed). In phase 3 it is an unimplemented
-stub so `McpServerConnection` can be written transport-agnostically.
+`IRpcTransport` implemented directly over Core's `CurlRunner` + `SseParser` (one
+POST = one correlated response; no `JsonRpcPeer` needed). It was an unimplemented
+stub in phase 3 so `McpServerConnection` could be written transport-agnostically;
+phase 8 fills it in. See `mcp35-http-spec.md` for the full contract (session +
+version headers, `Content-Type` branching, `DELETE` teardown, the HTTP version
+floor enforced via `McpServerConnection.MinProtocolVersion`).
 
 ---
 

--- a/src/Mcp35.Client/McpServerConnection.cs
+++ b/src/Mcp35.Client/McpServerConnection.cs
@@ -30,6 +30,14 @@ namespace Mcp35.Client
         private List<Tool> _toolsCache;
         private bool _toolsDirty = true;
 
+        /// <summary>
+        /// Optional minimum acceptable negotiated protocol version (inclusive). null = accept any
+        /// (stdio default; framing is identical across revisions). The host sets this to
+        /// <c>ProtocolVersions.HttpFloor</c> for HTTP connections, where older dual-endpoint
+        /// transports are unsupported (mcp35-http-spec.md §3).
+        /// </summary>
+        public string MinProtocolVersion;
+
         public event EventHandler<ConnectionStateEventArgs> StateChanged;
         public event EventHandler ToolsChanged;
 
@@ -225,9 +233,13 @@ namespace Mcp35.Client
 
         private bool IsAcceptableVersion(string negotiated)
         {
-            // Stdio accepts any returned version (framing is identical across revisions).
-            // HTTP's >= HttpFloor gate is enforced by HttpTransport/host in phase 8.
-            return !string.IsNullOrEmpty(negotiated);
+            if (string.IsNullOrEmpty(negotiated)) return false;
+            // Stdio accepts any returned version (framing is identical across revisions). HTTP sets
+            // MinProtocolVersion = HttpFloor; the date-shaped version strings sort lexicographically,
+            // so an ordinal compare is a correct >= test.
+            if (!string.IsNullOrEmpty(MinProtocolVersion))
+                return string.CompareOrdinal(negotiated, MinProtocolVersion) >= 0;
+            return true;
         }
 
         private static JsonSerializer Serializer()

--- a/src/Mcp35.Client/Transport/HttpTransport.cs
+++ b/src/Mcp35.Client/Transport/HttpTransport.cs
@@ -1,38 +1,303 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Errors;
+using Mcp35.Core.Json;
+using Mcp35.Core.Protocol;
 using Mcp35.Core.Rpc;
+using Mcp35.Core.Transport;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Mcp35.Client.Transport
 {
     /// <summary>
-    /// Streamable-HTTP transport for remote servers (GitHub). Specified and implemented in
-    /// phase 8 (directly over Core's CurlRunner + SseParser — one POST = one correlated response,
-    /// no JsonRpcPeer). Present here only so <see cref="Mcp35.Client.McpServerConnection"/> can be
-    /// written transport-agnostically; every member throws until phase 8.
+    /// Streamable-HTTP transport (MCP) implemented directly over Core's <see cref="CurlRunner"/> +
+    /// <see cref="SseParser"/>. Unlike stdio, HTTP is one POST = one correlated response, so there
+    /// is no JsonRpcPeer: each <see cref="SendRequest"/> is its own curl invocation that blocks the
+    /// calling worker thread and gets its own reply. Session id + negotiated protocol version are
+    /// captured at handshake and replayed on every later request. See mcp35-http-spec.md.
     /// </summary>
     public sealed class HttpTransport : IRpcTransport
     {
-        public HttpTransport(string endpointUrl, string curlPath, string caBundlePath, ILogSink log)
+        private readonly string _url;
+        private readonly IDictionary<string, string> _baseHeaders; // e.g. Authorization (secrets)
+        private readonly ICurlRunner _curl;
+        private readonly ILogSink _log;
+
+        private long _idCounter;
+        private string _sessionId;          // from Mcp-Session-Id, replayed after initialize
+        private string _protocolVersion;    // negotiated, sent as MCP-Protocol-Version after initialize
+        private bool _connected;
+        private bool _disposed;
+
+        public event EventHandler<JsonRpcInboundEventArgs> Inbound;
+
+        public HttpTransport(string url, IDictionary<string, string> headers, ICurlRunner curl, ILogSink log)
         {
-            // Retained for the phase-8 implementation; intentionally not wired yet.
+            if (string.IsNullOrEmpty(url)) throw new ArgumentException("url is required", "url");
+            if (curl == null) throw new ArgumentNullException("curl");
+            _url = url;
+            _baseHeaders = headers ?? new Dictionary<string, string>();
+            _curl = curl;
+            _log = log ?? NullLogSink.Instance;
         }
 
-        private static Exception NotYet()
+        /// <summary>No-op: HTTP is connectionless until the first POST. The session is a protocol state.</summary>
+        public void Start() { }
+
+        public bool IsConnected
         {
-            return new NotImplementedException("HttpTransport is implemented in phase 8.");
+            get { return _connected && !_disposed; }
         }
 
-        public event EventHandler<JsonRpcInboundEventArgs> Inbound
+        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs)
         {
-            add { throw NotYet(); }
-            remove { throw NotYet(); }
+            if (_disposed) throw new McpTransportException("Transport disposed.");
+
+            RequestId id = RequestId.FromLong(Interlocked.Increment(ref _idCounter));
+
+            JsonRpcRequest req = new JsonRpcRequest();
+            req.Id = id;
+            req.Method = method;
+            req.Params = @params;
+
+            CurlRequest cr = new CurlRequest();
+            cr.Url = _url;
+            cr.Method = "POST";
+            cr.BodyJson = McpJson.Serialize(req);
+            cr.Headers = BuildHeaders(true);
+            cr.TimeoutMs = timeoutMs;
+
+            CurlResult res;
+            try
+            {
+                res = _curl.Run(cr);
+            }
+            catch (Exception ex)
+            {
+                throw new McpTransportException("HTTP request '" + method + "' failed: " + ex.Message, ex);
+            }
+
+            // Auth failures fault the connection (host may surface "check your PAT").
+            if (res.HttpStatus == 401 || res.HttpStatus == 403)
+            {
+                _connected = false;
+                throw new McpTransportException("HTTP " + res.HttpStatus + " (authorization failed) for '" + method + "'.");
+            }
+            // A post-init 404 most likely means the session expired. We fault, never auto-reinit.
+            if (res.HttpStatus == 404 && _sessionId != null)
+            {
+                _connected = false;
+                throw new McpTransportException("HTTP 404 (session expired?) for '" + method + "'.");
+            }
+
+            // Capture the session id from the initialize response (only set once).
+            if (_sessionId == null)
+            {
+                string sid = res.GetHeader("Mcp-Session-Id");
+                if (!string.IsNullOrEmpty(sid)) _sessionId = sid;
+            }
+
+            JsonRpcResponse response = ExtractResponse(res, id, method);
+
+            // initialize success establishes the session/connection (version stamped by caller below).
+            if (method == McpMethods.Initialize && !response.IsError)
+            {
+                _connected = true;
+                CaptureNegotiatedVersion(response);
+            }
+            return response;
         }
 
-        public void Start() { throw NotYet(); }
-        public bool IsConnected { get { return false; } }
-        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs) { throw NotYet(); }
-        public void SendNotification(string method, JToken @params) { throw NotYet(); }
-        public void Dispose() { }
+        public void SendNotification(string method, JToken @params)
+        {
+            if (_disposed) return;
+
+            JsonRpcNotification n = new JsonRpcNotification();
+            n.Method = method;
+            n.Params = @params;
+
+            CurlRequest cr = new CurlRequest();
+            cr.Url = _url;
+            cr.Method = "POST";
+            cr.BodyJson = McpJson.Serialize(n);
+            cr.Headers = BuildHeaders(true);
+            cr.TimeoutMs = 30000;
+
+            try
+            {
+                CurlResult res = _curl.Run(cr);
+                // Notifications expect 202 Accepted with no body; any 2xx is fine, non-2xx is logged.
+                if (res.HttpStatus != 0 && (res.HttpStatus < 200 || res.HttpStatus >= 300))
+                    _log.Log("mcp-http", "notification '" + method + "' got HTTP " + res.HttpStatus + " (ignored)");
+            }
+            catch (Exception ex)
+            {
+                // A dropped notification must not fault the session.
+                _log.Log("mcp-http", "notification '" + method + "' failed: " + ex.Message);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            // Best-effort session teardown: DELETE with the session header. Failure is swallowed.
+            if (_sessionId != null)
+            {
+                try
+                {
+                    CurlRequest cr = new CurlRequest();
+                    cr.Url = _url;
+                    cr.Method = "DELETE";
+                    cr.Headers = BuildHeaders(false);
+                    cr.TimeoutMs = 10000;
+                    _curl.Run(cr);
+                }
+                catch (Exception ex)
+                {
+                    _log.Log("mcp-http", "session DELETE failed (ignored): " + ex.Message);
+                }
+            }
+            _connected = false;
+        }
+
+        // ---- response extraction ----
+
+        /// <summary>
+        /// Read the reply: a single application/json message, or a text/event-stream whose events
+        /// each carry one JSON-RPC message. Inbound notifications/requests on the SSE are surfaced;
+        /// the message whose id matches ours is returned.
+        /// </summary>
+        private JsonRpcResponse ExtractResponse(CurlResult res, RequestId expectedId, string method)
+        {
+            string contentType = res.GetHeader("Content-Type");
+            bool isSse = contentType != null &&
+                contentType.IndexOf("text/event-stream", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            if (string.IsNullOrEmpty(res.Body))
+                throw new McpTransportException("empty HTTP response for '" + method + "'.");
+
+            if (!isSse)
+            {
+                JObject single = ParseObject(res.Body, method);
+                return MatchOrFault(single, expectedId, method);
+            }
+
+            // SSE: feed lines through the parser; each event's Data is a JSON-RPC message.
+            SseParser parser = new SseParser();
+            JsonRpcResponse matched = null;
+
+            string[] lines = res.Body.Replace("\r\n", "\n").Split('\n');
+            List<SseEvent> events = new List<SseEvent>();
+            for (int i = 0; i < lines.Length; i++)
+                foreach (SseEvent ev in parser.PushLine(lines[i])) events.Add(ev);
+            SseEvent tail = parser.Flush();
+            if (tail != null) events.Add(tail);
+
+            for (int i = 0; i < events.Count; i++)
+            {
+                string data = events[i].Data;
+                if (string.IsNullOrEmpty(data)) continue;
+
+                JObject obj;
+                try { obj = (JObject)McpJson.Parse(data); }
+                catch (Exception ex) { _log.Log("mcp-http", "bad SSE message (ignored): " + ex.Message); continue; }
+
+                if (obj["method"] != null)
+                {
+                    // server -> client notification or request seen on this POST's stream
+                    RaiseInbound(obj);
+                    continue;
+                }
+                // a response: is it ours?
+                JsonRpcResponse r = JsonRpcResponse.Parse(obj);
+                if (r.Id.Equals(expectedId)) matched = r;
+            }
+
+            if (matched == null)
+                throw new McpTransportException("no matching response for '" + method + "' in SSE stream.");
+            return matched;
+        }
+
+        private JsonRpcResponse MatchOrFault(JObject obj, RequestId expectedId, string method)
+        {
+            if (obj["method"] != null)
+            {
+                // The server answered a request with a notification/request — surface and fault.
+                RaiseInbound(obj);
+                throw new McpTransportException("expected a response to '" + method + "', got a request/notification.");
+            }
+            JsonRpcResponse r = JsonRpcResponse.Parse(obj);
+            if (!r.Id.Equals(expectedId))
+                throw new McpTransportException("response id mismatch for '" + method + "'.");
+            return r;
+        }
+
+        // ---- helpers ----
+
+        private IDictionary<string, string> BuildHeaders(bool isPost)
+        {
+            Dictionary<string, string> h = new Dictionary<string, string>(StringComparer.Ordinal);
+            // Caller-supplied headers first (Authorization, etc.).
+            foreach (KeyValuePair<string, string> kv in _baseHeaders) h[kv.Key] = kv.Value;
+
+            h["Accept"] = "application/json, text/event-stream";
+            if (isPost) h["Content-Type"] = "application/json";
+            if (_protocolVersion != null) h["MCP-Protocol-Version"] = _protocolVersion;
+            if (_sessionId != null) h["Mcp-Session-Id"] = _sessionId;
+            return h;
+        }
+
+        private void CaptureNegotiatedVersion(JsonRpcResponse initResult)
+        {
+            try
+            {
+                if (initResult.Result != null && initResult.Result.Type == JTokenType.Object)
+                {
+                    JToken v = initResult.Result["protocolVersion"];
+                    if (v != null && v.Type == JTokenType.String) _protocolVersion = (string)v;
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Log("mcp-http", "could not read negotiated protocolVersion: " + ex.Message);
+            }
+        }
+
+        private JObject ParseObject(string body, string method)
+        {
+            try
+            {
+                return (JObject)McpJson.Parse(body);
+            }
+            catch (Exception ex)
+            {
+                throw new McpTransportException("unparseable HTTP response for '" + method + "': " + ex.Message, ex);
+            }
+        }
+
+        private void RaiseInbound(JObject obj)
+        {
+            EventHandler<JsonRpcInboundEventArgs> handler = Inbound;
+            if (handler == null) return;
+
+            JsonRpcInboundEventArgs args = new JsonRpcInboundEventArgs();
+            args.Method = (string)obj["method"];
+            args.Params = obj["params"];
+            args.Raw = obj;
+            args.IsRequest = obj.Property("id") != null;
+            if (args.IsRequest)
+            {
+                JToken idTok = obj["id"];
+                if (idTok != null && idTok.Type == JTokenType.Integer) args.Id = RequestId.FromLong(idTok.Value<long>());
+                else if (idTok != null && idTok.Type == JTokenType.String) args.Id = RequestId.FromString(idTok.Value<string>());
+            }
+            try { handler(this, args); }
+            catch (Exception ex) { _log.Log("mcp-http", "inbound handler threw: " + ex.Message); }
+        }
     }
 }

--- a/src/Mcp35.Core/Mcp35.Core.csproj
+++ b/src/Mcp35.Core/Mcp35.Core.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Transport\StdioFraming.cs" />
     <Compile Include="Transport\SseParser.cs" />
     <Compile Include="Transport\CurlRunner.cs" />
+    <Compile Include="Transport\ICurlRunner.cs" />
     <Compile Include="Protocol\McpMethods.cs" />
     <Compile Include="Protocol\ProtocolVersions.cs" />
     <Compile Include="Protocol\Initialize.cs" />

--- a/src/Mcp35.Core/Transport/CurlRunner.cs
+++ b/src/Mcp35.Core/Transport/CurlRunner.cs
@@ -16,7 +16,7 @@ namespace Mcp35.Core.Transport
     /// in Core without a native build dependency. Shared by the client's HttpTransport (phase 8)
     /// and WebSearchMcpServer (phase 7). See mcp35-core-spec.md §6.
     /// </summary>
-    public sealed class CurlRunner
+    public sealed class CurlRunner : ICurlRunner
     {
         // No BOM; the request body / config must be plain UTF-8 for curl.
         private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false);
@@ -42,7 +42,12 @@ namespace Mcp35.Core.Transport
             List<string> tempFiles = new List<string>();
             try
             {
-                string args = BuildArgs(req, false, tempFiles);
+                // Capture response headers to a temp file via -D so callers can read Content-Type,
+                // Mcp-Session-Id, etc. (needed by HttpTransport).
+                string headerPath = WriteTempFile("gxpt_curlhdr_", ".txt", string.Empty);
+                if (headerPath != null) tempFiles.Add(headerPath);
+
+                string args = BuildArgs(req, false, tempFiles, headerPath);
                 ProcessStartInfo psi = NewStartInfo(args);
 
                 using (Process p = Process.Start(psi))
@@ -63,6 +68,7 @@ namespace Mcp35.Core.Transport
                     result.Body = body;
                     result.Stderr = stderr;
                     result.HttpStatus = status;
+                    result.Headers = ReadHeaders(headerPath);
                     return result;
                 }
             }
@@ -84,7 +90,7 @@ namespace Mcp35.Core.Transport
             List<string> tempFiles = new List<string>();
             try
             {
-                string args = BuildArgs(req, true, tempFiles);
+                string args = BuildArgs(req, true, tempFiles, null);
                 ProcessStartInfo psi = NewStartInfo(args);
 
                 using (Process p = Process.Start(psi))
@@ -137,7 +143,7 @@ namespace Mcp35.Core.Transport
 
         // ---- argument construction ----
 
-        private string BuildArgs(CurlRequest req, bool streaming, List<string> tempFiles)
+        private string BuildArgs(CurlRequest req, bool streaming, List<string> tempFiles, string headerDumpPath)
         {
             StringBuilder sb = new StringBuilder();
             // -sS: silent but still show errors; --fail-with-body: fail on HTTP errors but keep body.
@@ -147,6 +153,10 @@ namespace Mcp35.Core.Transport
             // off afterwards. Skip it when streaming so it can't be mistaken for an SSE line.
             if (!streaming)
                 sb.Append("-w \"").Append(StatusMarker).Append("%{http_code}\" ");
+
+            // -D dumps response headers to a file so the caller can read them (Content-Type, etc.).
+            if (!string.IsNullOrEmpty(headerDumpPath))
+                sb.Append("-D \"").Append(headerDumpPath).Append("\" ");
 
             if (!string.IsNullOrEmpty(_caBundlePath))
                 sb.Append("--cacert \"").Append(_caBundlePath).Append("\" ");
@@ -302,6 +312,43 @@ namespace Mcp35.Core.Transport
                 catch (Exception ex) { _log.Log("curl", "temp cleanup: " + ex.Message); }
             }
         }
+
+        /// <summary>
+        /// Parse curl's -D header dump into a case-insensitive map. On a redirect or multiple
+        /// response blocks, later "Name: value" lines win (the final response's headers). The
+        /// HTTP status line(s) are ignored.
+        /// </summary>
+        private Dictionary<string, string> ReadHeaders(string headerPath)
+        {
+            Dictionary<string, string> headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(headerPath)) return headers;
+
+            string text;
+            try
+            {
+                if (!File.Exists(headerPath)) return headers;
+                text = File.ReadAllText(headerPath, Utf8Decode);
+            }
+            catch (Exception ex)
+            {
+                _log.Log("curl", "header read failed: " + ex.Message);
+                return headers;
+            }
+
+            string[] lines = text.Replace("\r\n", "\n").Split('\n');
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                if (line.Length == 0) continue;
+                if (line.StartsWith("HTTP/", StringComparison.OrdinalIgnoreCase)) continue; // status line
+                int colon = line.IndexOf(':');
+                if (colon <= 0) continue;
+                string name = line.Substring(0, colon).Trim();
+                string value = line.Substring(colon + 1).Trim();
+                if (name.Length > 0) headers[name] = value; // last wins across redirect blocks
+            }
+            return headers;
+        }
     }
 
     /// <summary>A curl request: URL + method + optional JSON body and headers.</summary>
@@ -327,5 +374,16 @@ namespace Mcp35.Core.Transport
         public int HttpStatus;
         public string Body;
         public string Stderr;
+
+        /// <summary>Response headers (case-insensitive). Populated by the buffered <see cref="CurlRunner.Run"/>.</summary>
+        public IDictionary<string, string> Headers;
+
+        /// <summary>Get a response header value, or null if absent. Case-insensitive.</summary>
+        public string GetHeader(string name)
+        {
+            string v;
+            if (Headers != null && Headers.TryGetValue(name, out v)) return v;
+            return null;
+        }
     }
 }

--- a/src/Mcp35.Core/Transport/ICurlRunner.cs
+++ b/src/Mcp35.Core/Transport/ICurlRunner.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Mcp35.Core.Transport
+{
+    /// <summary>
+    /// The curl-exec seam. <see cref="CurlRunner"/> is the real implementation; consumers that
+    /// want to be testable without a network (e.g. the client's HttpTransport) depend on this
+    /// interface and accept an injected fake. Mirrors <see cref="CurlRunner"/>'s public surface.
+    /// </summary>
+    public interface ICurlRunner
+    {
+        /// <summary>Run a buffered request; the full response body, status, and headers are returned.</summary>
+        CurlResult Run(CurlRequest req);
+
+        /// <summary>Run a streaming request, delivering each stdout line to <paramref name="onLine"/>.</summary>
+        void RunStreaming(CurlRequest req, Action<string> onLine, Action onDone, Action<string> onError);
+    }
+}

--- a/tests/Mcp35.Client.Tests/FakeCurlRunner.cs
+++ b/tests/Mcp35.Client.Tests/FakeCurlRunner.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Core.Transport;
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Client.Tests
+{
+    /// <summary>
+    /// An in-memory <see cref="ICurlRunner"/> for driving <see cref="Mcp35.Client.Transport.HttpTransport"/>
+    /// without a network. A test queues responses (status/headers/body) and the fake records each
+    /// request (method, body, headers) so assertions can check what was sent.
+    /// </summary>
+    internal sealed class FakeCurlRunner : ICurlRunner
+    {
+        public sealed class Sent
+        {
+            public string Method;
+            public string BodyJson;
+            public IDictionary<string, string> Headers;
+        }
+
+        public readonly List<Sent> Requests = new List<Sent>();
+
+        /// <summary>Per-call responder: given the outbound request, produce the canned CurlResult.</summary>
+        public Func<Sent, CurlResult> Responder;
+
+        public bool ThrowNext;
+
+        public CurlResult Run(CurlRequest req)
+        {
+            Sent s = new Sent();
+            s.Method = req.Method;
+            s.BodyJson = req.BodyJson;
+            s.Headers = req.Headers;
+            Requests.Add(s);
+
+            if (ThrowNext)
+            {
+                ThrowNext = false;
+                throw new Exception("simulated curl failure");
+            }
+
+            if (Responder != null) return Responder(s);
+            return Json(200, "{}", null);
+        }
+
+        public void RunStreaming(CurlRequest req, Action<string> onLine, Action onDone, Action<string> onError)
+        {
+            throw new NotImplementedException("HttpTransport uses buffered Run only.");
+        }
+
+        // ---- response builders ----
+
+        public static CurlResult Json(int status, string body, string sessionId)
+        {
+            CurlResult r = new CurlResult();
+            r.HttpStatus = status;
+            r.Body = body;
+            r.Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            r.Headers["Content-Type"] = "application/json";
+            if (sessionId != null) r.Headers["Mcp-Session-Id"] = sessionId;
+            return r;
+        }
+
+        public static CurlResult Sse(int status, string body, string sessionId)
+        {
+            CurlResult r = new CurlResult();
+            r.HttpStatus = status;
+            r.Body = body;
+            r.Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            r.Headers["Content-Type"] = "text/event-stream";
+            if (sessionId != null) r.Headers["Mcp-Session-Id"] = sessionId;
+            return r;
+        }
+
+        // ---- JSON-RPC message builders (the fake echoes the request's id) ----
+
+        public static string InitializeResponse(long id, string protocolVersion, bool withTools)
+        {
+            JObject caps = new JObject();
+            if (withTools) caps["tools"] = new JObject();
+            JObject serverInfo = new JObject();
+            serverInfo["name"] = "github";
+            serverInfo["version"] = "1.0";
+
+            JObject result = new JObject();
+            result["protocolVersion"] = protocolVersion;
+            result["capabilities"] = caps;
+            result["serverInfo"] = serverInfo;
+            return Response(id, result);
+        }
+
+        public static string Response(long id, JToken result)
+        {
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["result"] = result;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        public static string ErrorResponse(long id, int code, string message)
+        {
+            JObject err = new JObject();
+            err["code"] = code;
+            err["message"] = message;
+            JObject o = new JObject();
+            o["jsonrpc"] = "2.0";
+            o["id"] = id;
+            o["error"] = err;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        /// <summary>Read the JSON-RPC id from a recorded request body.</summary>
+        public static long IdOf(Sent s)
+        {
+            JObject o = JObject.Parse(s.BodyJson);
+            return (long)o["id"];
+        }
+    }
+}

--- a/tests/Mcp35.Client.Tests/HttpTransportTests.cs
+++ b/tests/Mcp35.Client.Tests/HttpTransportTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Client;
+using Mcp35.Client.Transport;
+using Mcp35.Core.Errors;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Mcp35.Client.Tests
+{
+    public class HttpTransportTests
+    {
+        private const string Url = "https://api.example.test/mcp/";
+
+        private static HttpTransport NewTransport(FakeCurlRunner curl)
+        {
+            Dictionary<string, string> headers = new Dictionary<string, string>();
+            headers["Authorization"] = "Bearer test-token";
+            return new HttpTransport(Url, headers, curl, null);
+        }
+
+        // ---- handshake / session ----
+
+        [Fact]
+        public void Initialize_returns_result_and_captures_session_id()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(FakeCurlRunner.IdOf(s), "2025-06-18", true), "sess-123");
+            };
+
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.Start(); // no-op
+                JsonRpcResponse resp = t.SendRequest(McpMethods.Initialize, new JObject(), 5000);
+                Assert.False(resp.IsError);
+                Assert.True(t.IsConnected);
+                Assert.Equal("2025-06-18", (string)resp.Result["protocolVersion"]);
+            }
+        }
+
+        [Fact]
+        public void Session_id_and_version_are_replayed_after_initialize()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                long id = FakeCurlRunner.IdOf(s);
+                JObject body = JObject.Parse(s.BodyJson);
+                if ((string)body["method"] == McpMethods.Initialize)
+                    return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(id, "2025-06-18", true), "sess-xyz");
+                return FakeCurlRunner.Json(200, FakeCurlRunner.Response(id, new JObject()), null);
+            };
+
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.SendRequest(McpMethods.Initialize, new JObject(), 5000);
+                t.SendRequest(McpMethods.ToolsList, null, 5000);
+
+                // First request (initialize) carries no session/version header.
+                FakeCurlRunner.Sent first = curl.Requests[0];
+                Assert.False(first.Headers.ContainsKey("Mcp-Session-Id"));
+                Assert.False(first.Headers.ContainsKey("MCP-Protocol-Version"));
+
+                // Second request replays both.
+                FakeCurlRunner.Sent second = curl.Requests[1];
+                Assert.Equal("sess-xyz", second.Headers["Mcp-Session-Id"]);
+                Assert.Equal("2025-06-18", second.Headers["MCP-Protocol-Version"]);
+            }
+        }
+
+        [Fact]
+        public void Every_request_sends_accept_and_auth_headers()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(FakeCurlRunner.IdOf(s), "2025-06-18", true), "s");
+            };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.SendRequest(McpMethods.Initialize, new JObject(), 5000);
+                FakeCurlRunner.Sent first = curl.Requests[0];
+                Assert.Equal("application/json, text/event-stream", first.Headers["Accept"]);
+                Assert.Equal("application/json", first.Headers["Content-Type"]);
+                Assert.Equal("Bearer test-token", first.Headers["Authorization"]);
+            }
+        }
+
+        // ---- Content-Type branching ----
+
+        [Fact]
+        public void Json_reply_yields_response()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                JObject result = new JObject();
+                result["ok"] = true;
+                return FakeCurlRunner.Json(200, FakeCurlRunner.Response(FakeCurlRunner.IdOf(s), result), "s");
+            };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                JsonRpcResponse r = t.SendRequest("tools/list", null, 5000);
+                Assert.False(r.IsError);
+                Assert.True((bool)r.Result["ok"]);
+            }
+        }
+
+        [Fact]
+        public void Sse_reply_yields_matching_response_and_raises_inbound_notifications()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                long id = FakeCurlRunner.IdOf(s);
+                // An intervening notification, then the real response — as two SSE events.
+                JObject prog = new JObject();
+                prog["jsonrpc"] = "2.0";
+                prog["method"] = "notifications/progress";
+                JObject result = new JObject();
+                result["done"] = true;
+
+                string sse =
+                    "event: message\n" +
+                    "data: " + prog.ToString(Newtonsoft.Json.Formatting.None) + "\n" +
+                    "\n" +
+                    "event: message\n" +
+                    "data: " + FakeCurlRunner.Response(id, result) + "\n" +
+                    "\n";
+                return FakeCurlRunner.Sse(200, sse, "s");
+            };
+
+            using (HttpTransport t = NewTransport(curl))
+            {
+                List<string> inbound = new List<string>();
+                t.Inbound += delegate (object sender, JsonRpcInboundEventArgs e) { inbound.Add(e.Method); };
+
+                JsonRpcResponse r = t.SendRequest("tools/call", new JObject(), 5000);
+                Assert.False(r.IsError);
+                Assert.True((bool)r.Result["done"]);
+                Assert.Contains("notifications/progress", inbound);
+            }
+        }
+
+        // ---- correlation / errors ----
+
+        [Fact]
+        public void Response_id_mismatch_faults_the_call()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                // Reply with a deliberately wrong id.
+                return FakeCurlRunner.Json(200, FakeCurlRunner.Response(99999, new JObject()), "s");
+            };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                Assert.Throws<McpTransportException>(delegate { t.SendRequest("tools/list", null, 5000); });
+            }
+        }
+
+        [Fact]
+        public void Error_response_passes_through()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                return FakeCurlRunner.Json(200, FakeCurlRunner.ErrorResponse(FakeCurlRunner.IdOf(s), -32601, "no method"), "s");
+            };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                JsonRpcResponse r = t.SendRequest("bogus", null, 5000);
+                Assert.True(r.IsError);
+                Assert.Equal(-32601, r.Error.Code);
+            }
+        }
+
+        [Fact]
+        public void Auth_failure_faults_connection()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s) { return FakeCurlRunner.Json(401, "{}", null); };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                Assert.Throws<McpTransportException>(delegate { t.SendRequest("tools/list", null, 5000); });
+                Assert.False(t.IsConnected);
+            }
+        }
+
+        [Fact]
+        public void Post_init_404_faults_as_expired_session()
+        {
+            var curl = new FakeCurlRunner();
+            int call = 0;
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                call++;
+                if (call == 1)
+                    return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(FakeCurlRunner.IdOf(s), "2025-06-18", true), "sess");
+                return FakeCurlRunner.Json(404, "{}", null);
+            };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.SendRequest(McpMethods.Initialize, new JObject(), 5000);
+                Assert.Throws<McpTransportException>(delegate { t.SendRequest("tools/list", null, 5000); });
+                Assert.False(t.IsConnected);
+            }
+        }
+
+        [Fact]
+        public void Curl_failure_is_wrapped_as_transport_exception()
+        {
+            var curl = new FakeCurlRunner();
+            curl.ThrowNext = true;
+            using (HttpTransport t = NewTransport(curl))
+            {
+                Assert.Throws<McpTransportException>(delegate { t.SendRequest("tools/list", null, 5000); });
+            }
+        }
+
+        // ---- notifications ----
+
+        [Fact]
+        public void Notification_posts_and_tolerates_202()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s) { return FakeCurlRunner.Json(202, "", null); };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.SendNotification(McpMethods.Initialized, null);
+                Assert.Single(curl.Requests);
+                JObject body = JObject.Parse(curl.Requests[0].BodyJson);
+                Assert.Equal(McpMethods.Initialized, (string)body["method"]);
+                Assert.Null(body["id"]); // notifications have no id
+            }
+        }
+
+        [Fact]
+        public void Notification_nonsuccess_is_not_fatal()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s) { return FakeCurlRunner.Json(500, "boom", null); };
+            using (HttpTransport t = NewTransport(curl))
+            {
+                t.SendNotification("notifications/progress", null); // must not throw
+            }
+        }
+
+        // ---- teardown ----
+
+        [Fact]
+        public void Dispose_sends_delete_with_session_header()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(FakeCurlRunner.IdOf(s), "2025-06-18", true), "sess-del");
+            };
+            HttpTransport t = NewTransport(curl);
+            t.SendRequest(McpMethods.Initialize, new JObject(), 5000);
+            t.Dispose();
+
+            FakeCurlRunner.Sent last = curl.Requests[curl.Requests.Count - 1];
+            Assert.Equal("DELETE", last.Method);
+            Assert.Equal("sess-del", last.Headers["Mcp-Session-Id"]);
+        }
+
+        [Fact]
+        public void Dispose_without_session_sends_no_delete()
+        {
+            var curl = new FakeCurlRunner();
+            HttpTransport t = NewTransport(curl); // never initialized
+            t.Dispose();
+            Assert.Empty(curl.Requests); // nothing sent
+        }
+
+        // ---- via McpServerConnection: the HTTP floor gate ----
+
+        [Fact]
+        public void Connection_faults_when_negotiated_version_below_http_floor()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                // Server returns an old pre-floor version.
+                return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(FakeCurlRunner.IdOf(s), "2024-11-05", true), "s");
+            };
+
+            HttpTransport t = NewTransport(curl);
+            Implementation client = new Implementation();
+            client.Name = "test";
+            client.Version = "1.0";
+            using (McpServerConnection conn = new McpServerConnection("github", t, client, null))
+            {
+                conn.MinProtocolVersion = ProtocolVersions.HttpFloor; // host sets this for HTTP
+                Assert.ThrowsAny<Exception>(delegate { conn.Open(5000); });
+                Assert.Equal(ConnectionState.Faulted, conn.State);
+            }
+        }
+
+        [Fact]
+        public void Connection_opens_when_version_at_or_above_floor()
+        {
+            var curl = new FakeCurlRunner();
+            curl.Responder = delegate (FakeCurlRunner.Sent s)
+            {
+                long id = FakeCurlRunner.IdOf(s);
+                JObject body = JObject.Parse(s.BodyJson);
+                if ((string)body["method"] == McpMethods.Initialize)
+                    return FakeCurlRunner.Json(200, FakeCurlRunner.InitializeResponse(id, "2025-03-26", true), "s");
+                // tools/list prefetch during Open
+                JObject result = new JObject();
+                result["tools"] = new JArray();
+                return FakeCurlRunner.Json(200, FakeCurlRunner.Response(id, result), null);
+            };
+
+            HttpTransport t = NewTransport(curl);
+            Implementation client = new Implementation();
+            client.Name = "test";
+            client.Version = "1.0";
+            using (McpServerConnection conn = new McpServerConnection("github", t, client, null))
+            {
+                conn.MinProtocolVersion = ProtocolVersions.HttpFloor;
+                conn.Open(5000);
+                Assert.Equal(ConnectionState.Ready, conn.State);
+            }
+        }
+    }
+}

--- a/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
+++ b/tests/Mcp35.Core.Tests/CurlRunnerTests.cs
@@ -115,5 +115,28 @@ namespace Mcp35.Core.Tests
             // The secret must never have ended up in the returned body/stderr.
             Assert.DoesNotContain("secret-should-go-in-config-file", result.Body);
         }
+
+        [Fact]
+        public void Run_populates_headers_dictionary_even_when_empty()
+        {
+            // The fake curl ignores -D, so no headers are written, but Run must still return a
+            // non-null Headers map so callers can GetHeader without null checks.
+            string curl = FakeCurl("ok", 200);
+            var runner = new CurlRunner(curl, null, null);
+            CurlResult result = runner.Run(Req("https://example.test/x"));
+            Assert.NotNull(result.Headers);
+            Assert.Null(result.GetHeader("Content-Type")); // absent → null, no throw
+        }
+
+        [Fact]
+        public void GetHeader_is_case_insensitive()
+        {
+            CurlResult r = new CurlResult();
+            r.Headers = new System.Collections.Generic.Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
+            r.Headers["Mcp-Session-Id"] = "abc";
+            Assert.Equal("abc", r.GetHeader("mcp-session-id"));
+            Assert.Equal("abc", r.GetHeader("MCP-SESSION-ID"));
+            Assert.Null(r.GetHeader("nope"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements `Mcp35.Client.HttpTransport`, **completing the `Mcp35` library**. HTTP
is one POST = one correlated response, so it implements `IRpcTransport` **directly
over Core's `CurlRunner` + `SseParser`** — no `JsonRpcPeer` needed. This fills in
the phase-3 stub.

## Core changes

- **`CurlRunner` captures response headers** via `-D` into a temp file, exposed on
  `CurlResult.Headers` (+ case-insensitive `GetHeader`). Needed for
  `Mcp-Session-Id` / `Content-Type`. Existing callers (WebSearch/Tavily) unaffected.
- **Extracted `ICurlRunner` seam** (`CurlRunner` implements it) so `HttpTransport`
  is unit-testable with an injected fake — no network.

## HttpTransport

- POST per `SendRequest`, internal monotonic id; verifies reply id matches
  (mismatch → fault). Branches on `Content-Type`: `application/json` (single
  message) vs `text/event-stream` (`SseParser`; intervening notifications raise
  `Inbound`, the matching-id message is the answer).
- **Session/version**: captures `Mcp-Session-Id` from `initialize` and replays it
  + the negotiated `MCP-Protocol-Version` on every later request; first
  `initialize` carries neither. `Accept` + `Authorization` (via `-K`) always.
- `SendNotification` tolerates `202`/any 2xx; non-2xx logged, never fatal.
- **Errors**: `401/403` → fault connection; post-init `404` → fault (expired
  session; no auto-reinit, per §8.1); curl failure / unparseable body →
  `McpTransportException`.
- `Dispose` sends best-effort `DELETE` with the session header; failure swallowed.

## McpServerConnection

- Adds nullable **`MinProtocolVersion`**. `Open()` rejects a negotiated version
  below it; the host sets it to **`ProtocolVersions.HttpFloor` (2025-03-26)** for
  HTTP, while stdio leaves it null (accept any). The HTTP floor gate (§3) lives
  here because the connection drives the handshake transport-agnostically.

## Tests (net48 linked-source, no network)

- **`HttpTransportTests`** via a `FakeCurlRunner` (`ICurlRunner`): handshake +
  session capture/replay, header presence, **json-vs-SSE branching with `Inbound`
  notifications**, id-mismatch fault, error passthrough, `401`/`404` faults,
  curl-failure wrap, notification `202` + non-fatal non-2xx, `DELETE` teardown,
  and the **HTTP floor gate** end-to-end via `McpServerConnection` (below-floor
  faults, at-floor opens).
- `CurlRunnerTests`: `Headers` non-null; `GetHeader` case-insensitive.

## Review focus

- The `ICurlRunner` extraction (small, additive) and the `CurlRunner` `-D`
  header-capture change — confirm it doesn't perturb the WebSearch/Tavily path
  (same `Run` signature; only adds a temp file + populates `Headers`).
- The §5 **GitHub host integration** (seeded `mcp.json` entry, PAT shape gate,
  annotation classification) is intentionally **not** in this PR — it's host-side
  wiring that lands with the `McpHost`/config work (phases 3§7/4/5/6), which is
  also where it first becomes locally runnable. This PR is the transport + its
  CI-verifiable tests.

With this merged, **every `Mcp35` library piece is done** (Core, Server, Client +
both transports, all four servers). What remains is GxPT host wiring.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_