### PR TITLE
Host wiring: config + McpHost + tool-call loop (phases 3§7 / 4 / 5)

### DIFF
--- a/GxPT.Tests/ConversationStoreTests.cs
+++ b/GxPT.Tests/ConversationStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using GxPT;
 using Xunit;
 
@@ -67,6 +68,70 @@ namespace GxPT.Tests
             Assert.Single(msg.Attachments);
             Assert.Equal("foo.txt", msg.Attachments[0].FileName);
             Assert.Contains("hello world", msg.Attachments[0].Content);
+        }
+
+        // ---- Newtonsoft migration (D16): tool-call persistence + backward compatibility ----
+
+        [Fact]
+        public void ToJson_then_Load_roundtrips_tool_calls_and_tool_messages()
+        {
+            var convo = new Conversation(null);
+            convo.Name = "T";
+            convo.History.Add(new ChatMessage("user", "read it"));
+
+            var asst = new ChatMessage("assistant", "");
+            asst.ToolCalls = new List<ToolCall> { new ToolCall("call_1", "files__read", "{\"path\":\"a\"}") };
+            convo.History.Add(asst);
+
+            var tool = new ChatMessage("tool", "file contents");
+            tool.ToolCallId = "call_1";
+            convo.History.Add(tool);
+
+            string json = ConversationStore.ToJson(convo);
+            var reload = ConversationStore.LoadFromJson(null, json);
+
+            Assert.Equal(3, reload.History.Count);
+
+            var a = reload.History[1];
+            Assert.NotNull(a.ToolCalls);
+            Assert.Single(a.ToolCalls);
+            Assert.Equal("call_1", a.ToolCalls[0].Id);
+            Assert.Equal("files__read", a.ToolCalls[0].Name);
+            Assert.Equal("{\"path\":\"a\"}", a.ToolCalls[0].ArgumentsJson);
+
+            var t = reload.History[2];
+            Assert.Equal("tool", t.Role);
+            Assert.Equal("call_1", t.ToolCallId);
+            Assert.Equal("file contents", t.Content);
+        }
+
+        [Fact]
+        public void ToJson_omits_tool_fields_for_plain_messages()
+        {
+            var convo = new Conversation(null);
+            convo.History.Add(new ChatMessage("user", "hi"));
+            string json = ConversationStore.ToJson(convo);
+            Assert.DoesNotContain("ToolCalls", json);
+            Assert.DoesNotContain("ToolCallId", json);
+        }
+
+        [Fact]
+        public void Load_legacy_file_without_tool_fields_has_null_tool_data()
+        {
+            string json = "{\"Name\":\"C\",\"Messages\":[{\"Role\":\"assistant\",\"Content\":\"hi\"}]}";
+            var convo = ConversationStore.LoadFromJson(null, json);
+            Assert.Null(convo.History[0].ToolCalls);
+            Assert.Null(convo.History[0].ToolCallId);
+        }
+
+        [Fact]
+        public void Load_parses_legacy_microsoft_date_format()
+        {
+            // Files written by the old JavaScriptSerializer used "\/Date(ms)\/" timestamps; Newtonsoft
+            // must still parse them so reloading pre-migration conversations preserves LastUpdated.
+            string json = "{\"Name\":\"C\",\"LastUpdated\":\"\\/Date(1700000000000)\\/\",\"Messages\":[]}";
+            var convo = ConversationStore.LoadFromJson(null, json);
+            Assert.Equal(2023, convo.LastUpdated.Year);
         }
     }
 }

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\GxPT\Models\Conversation.cs" Link="Linked\Conversation.cs" />
     <Compile Include="..\GxPT\Models\ChatModels.cs" Link="Linked\ChatModels.cs" />
     <Compile Include="..\GxPT\Services\OpenRouterClient.cs" Link="Linked\OpenRouterClient.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
   </ItemGroup>

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -38,8 +38,22 @@
     <Compile Include="..\GxPT\Models\ChatModels.cs" Link="Linked\ChatModels.cs" />
     <Compile Include="..\GxPT\Services\OpenRouterClient.cs" Link="Linked\OpenRouterClient.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\IToolApprovalPolicy.cs" Link="Linked\Mcp\IToolApprovalPolicy.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\McpToolRegistry.cs" Link="Linked\Mcp\McpToolRegistry.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
+  </ItemGroup>
+
+  <!-- MCP library sources (Core + Client) linked in so the host's Services/Mcp/ code (registry,
+       host, orchestrator) compiles and is testable against real McpServerConnections over a fake
+       transport — same linked-source pattern as tests/Mcp35.Client.Tests. -->
+  <ItemGroup>
+    <Compile Include="..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\src\Mcp35.Core\Properties\**\*.cs;..\src\Mcp35.Core\obj\**\*.cs;..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Mcp35.Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\src\Mcp35.Client\**\*.cs"
+             Exclude="..\src\Mcp35.Client\Properties\**\*.cs;..\src\Mcp35.Client\obj\**\*.cs;..\src\Mcp35.Client\bin\**\*.cs"
+             Link="Linked\Mcp35.Client\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <!-- The vendored DotNetZip the app ships with, plus the framework assembly that
@@ -53,6 +67,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Matches the vendored net35 Newtonsoft.Json.dll the host/library ship with. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -40,6 +40,8 @@
     <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IToolApprovalPolicy.cs" Link="Linked\Mcp\IToolApprovalPolicy.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpToolRegistry.cs" Link="Linked\Mcp\McpToolRegistry.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\IChatStreamer.cs" Link="Linked\Mcp\IChatStreamer.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\McpChatOrchestrator.cs" Link="Linked\Mcp\McpChatOrchestrator.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
   </ItemGroup>

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -42,6 +42,8 @@
     <Compile Include="..\GxPT\Services\Mcp\McpToolRegistry.cs" Link="Linked\Mcp\McpToolRegistry.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IChatStreamer.cs" Link="Linked\Mcp\IChatStreamer.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpChatOrchestrator.cs" Link="Linked\Mcp\McpChatOrchestrator.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\McpServerSpec.cs" Link="Linked\Mcp\McpServerSpec.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\McpConfig.cs" Link="Linked\Mcp\McpConfig.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
   </ItemGroup>

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\GxPT\Services\Mcp\McpChatOrchestrator.cs" Link="Linked\Mcp\McpChatOrchestrator.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpServerSpec.cs" Link="Linked\Mcp\McpServerSpec.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpConfig.cs" Link="Linked\Mcp\McpConfig.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\IServerConnector.cs" Link="Linked\Mcp\IServerConnector.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\McpHost.cs" Link="Linked\Mcp\McpHost.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\DefaultServerConnector.cs" Link="Linked\Mcp\DefaultServerConnector.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
   </ItemGroup>

--- a/GxPT.Tests/Mcp/HostTestSupport.cs
+++ b/GxPT.Tests/Mcp/HostTestSupport.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using GxPT;
+using Mcp35.Client;
+using Mcp35.Core.Protocol;
+
+namespace GxPT.Tests.Mcp
+{
+    // An IServerConnector that returns RegistryFakeTransport-backed connections (Created, not opened)
+    // so McpHost can open them to Ready without spawning processes. Records what it was asked to make.
+    internal sealed class FakeServerConnector : IServerConnector
+    {
+        public readonly List<string> CreatedNames = new List<string>();
+        public readonly List<string> Workdirs = new List<string>();
+        public readonly List<McpServerConnection> Created = new List<McpServerConnection>();
+        public readonly Dictionary<string, ToolDef[]> ToolsByServer = new Dictionary<string, ToolDef[]>();
+
+        public McpServerConnection Create(McpServerSpec spec, string workdir)
+        {
+            CreatedNames.Add(spec.Name);
+            Workdirs.Add(workdir);
+
+            ToolDef[] tools;
+            if (!ToolsByServer.TryGetValue(spec.Name, out tools))
+                tools = new[] { new ToolDef(spec.Name + "_tool") };
+
+            var ft = new RegistryFakeTransport(tools);
+            var ci = new Implementation { Name = "GxPT", Version = "test" };
+            var conn = new McpServerConnection(spec.Name, ft, ci, null);
+            Created.Add(conn);
+            return conn;
+        }
+    }
+
+    internal static class Specs
+    {
+        public static McpServerSpec Eager(string name, bool enabled)
+        {
+            return new McpServerSpec
+            {
+                Name = name,
+                Kind = McpTransportKind.Stdio,
+                Enabled = enabled,
+                WorkdirScoped = false,
+                BuiltIn = true,
+                Command = name + ".exe"
+            };
+        }
+
+        public static McpServerSpec Scoped(string name, bool enabled)
+        {
+            return new McpServerSpec
+            {
+                Name = name,
+                Kind = McpTransportKind.Stdio,
+                Enabled = enabled,
+                WorkdirScoped = true,
+                BuiltIn = true,
+                Command = name + ".exe"
+            };
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -1,0 +1,292 @@
+using System.Collections.Generic;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class McpChatOrchestratorTests
+    {
+        private static McpToolRegistry RegistryWith(out RegistryFakeTransport ft, string server, params ToolDef[] tools)
+        {
+            var conn = FakeConn.Ready(server, out ft, tools);
+            var reg = new McpToolRegistry(8, null);
+            reg.AddConnection(conn);
+            return reg;
+        }
+
+        private static McpChatOrchestrator New(ScriptedStreamer s, McpToolRegistry reg)
+        {
+            return new McpChatOrchestrator(s, reg, null, "test-model", null);
+        }
+
+        [Fact]
+        public void Single_tool_call_then_result_then_final_answer()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("file contents"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("call_1", "files__read", "{\"path\":\"a.txt\"}"));
+            streamer.Turns.Add(Chunks.Text("Here is the file."));
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "read a.txt", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal("Here is the file.", ui.Text.ToString());
+            Assert.Equal(new[] { "files__read" }, ui.ToolCalls.ToArray());
+            Assert.Contains("file contents", ui.ToolResults[0]);
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Equal(2, streamer.Calls);
+
+            // history: user, assistant(+tool_calls), tool(result), assistant(final)
+            Assert.Equal(4, history.Count);
+            Assert.Equal("user", history[0].Role);
+            Assert.Equal("assistant", history[1].Role);
+            Assert.NotNull(history[1].ToolCalls);
+            Assert.Single(history[1].ToolCalls);
+            Assert.Equal("tool", history[2].Role);
+            Assert.Equal("call_1", history[2].ToolCallId);
+            Assert.Contains("file contents", history[2].Content);
+            Assert.Equal("assistant", history[3].Role);
+            Assert.Equal("Here is the file.", history[3].Content);
+        }
+
+        [Fact]
+        public void Passes_manifest_system_message_and_tools_to_streamer()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("hi"));
+
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "hello", new RecordingUi());
+
+            // first request: leading system message is the names manifest, history follows
+            var msgs = streamer.SeenMessages[0];
+            Assert.Equal("system", msgs[0].Role);
+            Assert.Contains("Available MCP tools", msgs[0].Content);
+            Assert.Equal("user", msgs[1].Role);
+            // exposed tools always lead with reveal_tools
+            Assert.Equal("reveal_tools", (string)streamer.SeenTools[0][0]["function"]["name"]);
+        }
+
+        [Fact]
+        public void Multiple_tool_calls_in_one_turn_run_serially()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"), new ToolDef("list"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("r:" + name); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new[]
+            {
+                Chunks.ToolChunk(0, "c1", "files__read", "{}", null),
+                Chunks.ToolChunk(1, "c2", "files__list", "{}", "tool_calls")
+            });
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var history = new List<ChatMessage>();
+            New(streamer, reg).RunTurn(history, "go", new RecordingUi());
+
+            Assert.Equal(new[] { "read", "list" }, ft.CalledTools.ToArray());
+            // user, assistant(2 calls), tool, tool, assistant(final)
+            Assert.Equal(5, history.Count);
+            Assert.Equal(2, history[1].ToolCalls.Count);
+            Assert.Equal("tool", history[2].Role);
+            Assert.Equal("tool", history[3].Role);
+        }
+
+        [Fact]
+        public void Reveal_tools_then_follow_up_call_succeeds_locally()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("content"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("r1", "reveal_tools", "{\"names\":[\"files__read\"]}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("final"));
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "use the read tool", ui);
+
+            Assert.Equal(3, streamer.Calls);
+            Assert.Equal(new[] { "reveal_tools", "files__read" }, ui.ToolCalls.ToArray());
+            // reveal_tools is local — only the real tool hit the transport
+            Assert.Equal(new[] { "read" }, ft.CalledTools.ToArray());
+            // the reveal result lists the requested def
+            Assert.Contains("files__read", ui.ToolResults[0]);
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Equal("final", ui.Text.ToString());
+        }
+
+        [Fact]
+        public void Hitting_iteration_cap_returns_a_note()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Fallback = delegate(int i) { return Chunks.OneToolCall("c" + i, "files__read", "{}"); };
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "m", null, 3, 1000);
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            orch.RunTurn(history, "loop forever", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(3, streamer.Calls);
+            Assert.Equal("[Tool-call limit reached.]", history[history.Count - 1].Content);
+            // user + 3*(assistant+tool) + note
+            Assert.Equal(1 + 6 + 1, history.Count);
+        }
+
+        [Fact]
+        public void Tool_isError_result_is_fed_back_and_loop_continues()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args)
+            {
+                JObject r = RegistryFakeTransport.TextResult("boom");
+                r["isError"] = true;
+                return r;
+            };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("recovered"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("boom", ui.ToolResults[0]);
+            Assert.Equal("recovered", ui.Text.ToString());
+            Assert.True(ui.Completed);
+        }
+
+        [Fact]
+        public void Transport_fault_during_call_surfaces_server_unavailable()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.ThrowTransportOnCall = true;
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("after"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Equal("[Server unavailable.]", ui.ToolResults[0]);
+            Assert.Equal("after", ui.Text.ToString());
+        }
+
+        [Fact]
+        public void Json_rpc_error_during_call_surfaces_tool_error()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.ErrorOnCall = true;
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("after"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.StartsWith("[Tool error:", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Unknown_tool_is_reported_without_hitting_transport()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__nope", "{}"));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("Unknown tool", ui.ToolResults[0]);
+            Assert.Empty(ft.CalledTools);
+        }
+
+        [Fact]
+        public void Malformed_arguments_surface_as_an_error()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{not valid json"));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("Invalid tool arguments", ui.ToolResults[0]);
+            Assert.Empty(ft.CalledTools);
+        }
+
+        [Fact]
+        public void Denied_call_is_not_executed()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var ui = new RecordingUi();
+            var orch = new McpChatOrchestrator(streamer, reg, new DenyAllApprovalPolicy(), "m", null);
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Equal("[Call denied by user.]", ui.ToolResults[0]);
+            Assert.Empty(ft.CalledTools);
+        }
+
+        [Fact]
+        public void Streaming_error_stops_the_turn()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.ErrorMessage = "network down";
+            streamer.ErrorOnCall = 0;
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "go", ui);
+
+            Assert.Equal("network down", ui.Error);
+            Assert.False(ui.Completed);
+            Assert.Single(history); // only the user message was added
+        }
+    }
+
+    internal sealed class DenyAllApprovalPolicy : IToolApprovalPolicy
+    {
+        public ApprovalDecision Check(string functionName, JObject args) { return ApprovalDecision.Deny; }
+    }
+}

--- a/GxPT.Tests/Mcp/McpConfigTests.cs
+++ b/GxPT.Tests/Mcp/McpConfigTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class McpConfigTests
+    {
+        // valid PAT shapes (fake but well-formed)
+        private const string ClassicPat = "ghp_0123456789abcdefghijklmnopqrstuvwxyz";          // ghp_ + 36
+        private const string FineGrainedPat = "github_pat_11AABBCCDD11AABBCCDD11AABBCCDD11AABB"; // long
+
+        // ---- Tier 2: mcp.json parsing ----
+
+        [Fact]
+        public void Parses_http_server_with_headers()
+        {
+            string json = "{\"mcp_servers\":{\"acme\":{\"url\":\"https://x/mcp/\",\"headers\":{\"Authorization\":\"Bearer abc\"}}}}";
+            var specs = McpConfig.ParseUserServers(json, null);
+            var s = specs.Single();
+            Assert.Equal("acme", s.Name);
+            Assert.Equal(McpTransportKind.Http, s.Kind);
+            Assert.Equal("https://x/mcp/", s.Url);
+            Assert.Equal("Bearer abc", s.Headers["Authorization"]);
+            Assert.True(s.Enabled);
+            Assert.False(s.BuiltIn);
+        }
+
+        [Fact]
+        public void Parses_stdio_server_with_args_and_env()
+        {
+            string json = "{\"mcp_servers\":{\"local\":{\"command\":\"C:\\\\srv.exe\",\"args\":[\"--flag\",\"x\"],\"env\":{\"K\":\"V\"}}}}";
+            var s = McpConfig.ParseUserServers(json, null).Single();
+            Assert.Equal(McpTransportKind.Stdio, s.Kind);
+            Assert.Equal("C:\\srv.exe", s.Command);
+            Assert.Equal(new[] { "--flag", "x" }, s.Args);
+            Assert.Equal("V", s.Env["K"]);
+        }
+
+        [Fact]
+        public void Github_with_placeholder_pat_is_disabled()
+        {
+            var s = McpConfig.ParseUserServers(McpConfig.SeedJson, null).Single();
+            Assert.Equal("github", s.Name);
+            Assert.False(s.Enabled); // unedited "Bearer YOUR_GITHUB_PAT"
+        }
+
+        [Theory]
+        [InlineData(ClassicPat)]
+        [InlineData(FineGrainedPat)]
+        public void Github_with_valid_pat_is_enabled(string pat)
+        {
+            string json = "{\"mcp_servers\":{\"github\":{\"url\":\"https://api.githubcopilot.com/mcp/\",\"headers\":{\"Authorization\":\"Bearer " + pat + "\"}}}}";
+            var s = McpConfig.ParseUserServers(json, null).Single();
+            Assert.True(s.Enabled);
+        }
+
+        [Fact]
+        public void Invalid_json_yields_no_servers_without_throwing()
+        {
+            Assert.Empty(McpConfig.ParseUserServers("{ not json", null));
+            Assert.Empty(McpConfig.ParseUserServers("", null));
+            Assert.Empty(McpConfig.ParseUserServers("{\"mcp_servers\":{}}", null));
+        }
+
+        [Fact]
+        public void Entry_without_url_or_command_is_skipped()
+        {
+            string json = "{\"mcp_servers\":{\"bad\":{\"note\":\"nothing useful\"},\"good\":{\"url\":\"https://y\"}}}";
+            var specs = McpConfig.ParseUserServers(json, null);
+            Assert.Single(specs);
+            Assert.Equal("good", specs[0].Name);
+        }
+
+        // ---- PAT shape / bearer extraction ----
+
+        [Theory]
+        [InlineData(ClassicPat, true)]
+        [InlineData(FineGrainedPat, true)]
+        [InlineData("YOUR_GITHUB_PAT", false)]
+        [InlineData("ghp_short", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void Validates_github_pat_shape(string token, bool expected)
+        {
+            Assert.Equal(expected, McpConfig.IsValidGitHubPat(token));
+        }
+
+        [Fact]
+        public void Extracts_bearer_token_case_insensitively()
+        {
+            var headers = new Dictionary<string, string> { { "authorization", "Bearer xyz" } };
+            Assert.Equal("xyz", McpConfig.BearerFromHeaders(headers));
+        }
+
+        // ---- Tier 1: built-in specs ----
+
+        [Fact]
+        public void Builtins_cover_the_four_servers_with_toggles_and_env()
+        {
+            var o = new McpConfig.BuiltInOptions
+            {
+                WebEnabled = true,
+                FilesEnabled = true,
+                GitEnabled = false,
+                CommandEnabled = true,
+                WebSearchKey = "tav_key",
+                CurlPath = "C:\\curl.exe",
+                GitPath = "git",
+                CmdShell = "cmd.exe",
+                ServerDir = "C:\\app\\servers"
+            };
+            var specs = McpConfig.BuiltInSpecs(o);
+            var byName = specs.ToDictionary(s => s.Name);
+
+            Assert.Equal(4, specs.Count);
+            Assert.True(specs.All(s => s.BuiltIn && s.Kind == McpTransportKind.Stdio));
+
+            var web = byName["web"];
+            Assert.True(web.Enabled);
+            Assert.False(web.WorkdirScoped); // workdir-independent
+            Assert.Equal(Path.Combine("C:\\app\\servers", "WebSearchMcpServer.exe"), web.Command);
+            Assert.Equal("tav_key", web.Env[McpConfig.EnvWebSearchKey]);
+            Assert.Equal("C:\\curl.exe", web.Env[McpConfig.EnvCurlPath]);
+
+            var files = byName["files"];
+            Assert.True(files.WorkdirScoped);
+            Assert.Empty(files.Env); // GXPT_WORKDIR injected at launch, not baked in
+
+            Assert.False(byName["git"].Enabled); // toggle off
+            Assert.Equal("git", byName["git"].Env[McpConfig.EnvGitPath]);
+
+            Assert.Equal("cmd.exe", byName["command"].Env[McpConfig.EnvCmdShell]);
+            Assert.True(byName["command"].WorkdirScoped);
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/McpHostTests.cs
+++ b/GxPT.Tests/Mcp/McpHostTests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using GxPT;
+using Mcp35.Client;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class McpHostTests
+    {
+        private static List<string> Manifest(McpToolRegistry reg)
+        {
+            var names = new List<string>();
+            foreach (var line in reg.NamesManifestSystemMessage().Split('\n'))
+                if (line.StartsWith("- ")) names.Add(line.Substring(2));
+            return names;
+        }
+
+        private static McpHost NewHost(out FakeServerConnector connector, out McpToolRegistry reg)
+        {
+            connector = new FakeServerConnector();
+            reg = new McpToolRegistry(24, null);
+            return new McpHost(connector, reg, null, 2000);
+        }
+
+        [Fact]
+        public void Start_opens_workdir_independent_servers_and_defers_scoped()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+
+            host.Start(new[] { Specs.Eager("web", true), Specs.Eager("github", true), Specs.Scoped("files", true) });
+
+            Assert.Equal(new[] { "web", "github" }, c.CreatedNames.ToArray()); // files deferred
+            var m = Manifest(reg);
+            Assert.Contains("web__web_tool", m);
+            Assert.Contains("github__github_tool", m);
+            Assert.DoesNotContain("files__files_tool", m);
+        }
+
+        [Fact]
+        public void Start_skips_disabled_servers()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+
+            host.Start(new[] { Specs.Eager("web", false), Specs.Eager("github", true) });
+
+            Assert.Equal(new[] { "github" }, c.CreatedNames.ToArray());
+            Assert.DoesNotContain("web__web_tool", Manifest(reg));
+        }
+
+        [Fact]
+        public void SetActiveWorkingDir_opens_scoped_servers_with_the_workdir()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true), Specs.Scoped("git", true) });
+            Assert.Empty(c.CreatedNames); // nothing opened until a workdir is active
+
+            host.SetActiveWorkingDir("C:\\proj");
+
+            Assert.Equal(new[] { "files", "git" }, c.CreatedNames.ToArray());
+            Assert.True(c.Workdirs.All(w => w == "C:\\proj"));
+            var m = Manifest(reg);
+            Assert.Contains("files__files_tool", m);
+            Assert.Contains("git__git_tool", m);
+            Assert.Equal("C:\\proj", host.ActiveWorkingDir);
+        }
+
+        [Fact]
+        public void Switching_workdir_tears_down_old_scoped_and_opens_new()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true) });
+
+            host.SetActiveWorkingDir("C:\\a");
+            var firstConn = c.Created.Last();
+            host.SetActiveWorkingDir("C:\\b");
+
+            Assert.Equal(new[] { "files", "files" }, c.CreatedNames.ToArray());
+            Assert.Equal(new[] { "C:\\a", "C:\\b" }, c.Workdirs.ToArray());
+            Assert.Equal(ConnectionState.Closed, firstConn.State); // old one disposed
+            Assert.Contains("files__files_tool", Manifest(reg)); // new one present
+        }
+
+        [Fact]
+        public void SetActiveWorkingDir_null_tears_down_scoped()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true) });
+
+            host.SetActiveWorkingDir("C:\\a");
+            Assert.Contains("files__files_tool", Manifest(reg));
+
+            host.SetActiveWorkingDir(null);
+            Assert.Empty(Manifest(reg));
+            Assert.Null(host.ActiveWorkingDir);
+        }
+
+        [Fact]
+        public void Disabled_scoped_spec_is_not_opened()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", false) });
+
+            host.SetActiveWorkingDir("C:\\a");
+
+            Assert.Empty(c.CreatedNames);
+            Assert.Empty(Manifest(reg));
+        }
+
+        [Fact]
+        public void A_connection_closing_removes_its_tools_from_the_registry()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Eager("web", true) });
+            Assert.Contains("web__web_tool", Manifest(reg));
+
+            c.Created[0].Dispose(); // simulates a fault/close → StateChanged(Closed)
+
+            Assert.DoesNotContain("web__web_tool", Manifest(reg));
+        }
+
+        [Fact]
+        public void Dispose_closes_all_connections()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Eager("web", true), Specs.Scoped("files", true) });
+            host.SetActiveWorkingDir("C:\\a");
+            Assert.Equal(2, Manifest(reg).Count);
+
+            host.Dispose();
+
+            Assert.Empty(Manifest(reg));
+            Assert.True(c.Created.All(conn => conn.State == ConnectionState.Closed));
+        }
+    }
+
+    // Compile-coverage + smoke for the live connector against the real Mcp35.Client transports.
+    public class DefaultServerConnectorTests
+    {
+        [Fact]
+        public void Creates_http_connection_in_created_state_without_opening()
+        {
+            var ci = new Mcp35.Core.Protocol.Implementation { Name = "GxPT", Version = "test" };
+            var connector = new DefaultServerConnector(ci, "curl", null, null);
+
+            var spec = new McpServerSpec
+            {
+                Name = "github",
+                Kind = McpTransportKind.Http,
+                Url = "https://api.githubcopilot.com/mcp/",
+                Enabled = true
+            };
+            spec.Headers["Authorization"] = "Bearer ghp_x";
+
+            var conn = connector.Create(spec, null);
+            Assert.NotNull(conn);
+            Assert.Equal("github", conn.Name);
+            Assert.Equal(ConnectionState.Created, conn.State); // not opened → no network
+            conn.Dispose();
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -1,0 +1,261 @@
+using System.Collections.Generic;
+using GxPT;
+using Mcp35.Client;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class McpToolRegistryTests
+    {
+        private static McpToolRegistry NewRegistry(int cap)
+        {
+            return new McpToolRegistry(cap, null);
+        }
+
+        private static List<string> ManifestNames(McpToolRegistry reg)
+        {
+            string msg = reg.NamesManifestSystemMessage();
+            var names = new List<string>();
+            foreach (var line in msg.Split('\n'))
+                if (line.StartsWith("- ")) names.Add(line.Substring(2));
+            return names;
+        }
+
+        private static List<string> ExposedNames(McpToolRegistry reg)
+        {
+            var names = new List<string>();
+            foreach (JObject def in reg.ExposedFunctionDefs())
+                names.Add((string)def["function"]["name"]);
+            return names;
+        }
+
+        // ---- munging / bijection ----
+
+        [Fact]
+        public void Munges_qualified_name_and_resolves_back()
+        {
+            var reg = NewRegistry(8);
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            reg.AddConnection(conn);
+
+            Assert.Contains("files__read", ManifestNames(reg));
+
+            McpServerConnection resolved;
+            string toolName;
+            Assert.True(reg.TryResolve("files__read", out resolved, out toolName));
+            Assert.Same(conn, resolved);
+            Assert.Equal("read", toolName);
+        }
+
+        [Fact]
+        public void Sanitizes_illegal_characters()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("git", new ToolDef("weird/name")));
+            Assert.Contains("git__weird_name", ManifestNames(reg));
+        }
+
+        [Fact]
+        public void Disambiguates_collisions_with_hash_suffix()
+        {
+            // "x/y" and "x_y" under server "s" both sanitize to base "s__x_y".
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("s", new ToolDef("x/y"), new ToolDef("x_y")));
+
+            var names = ManifestNames(reg);
+            Assert.Equal(2, names.Count);
+            Assert.Contains("s__x_y", names);                 // first claimant keeps the base
+            // the other is base truncated/suffixed: starts with "s__x_y_" + 6 hex, length <= 64
+            string other = names[0] == "s__x_y" ? names[1] : names[0];
+            Assert.StartsWith("s__x_y_", other);
+            Assert.True(other.Length <= 64);
+
+            // both still resolve to their distinct original tools
+            McpServerConnection c; string t1, t2;
+            Assert.True(reg.TryResolve("s__x_y", out c, out t1));
+            Assert.True(reg.TryResolve(other, out c, out t2));
+            Assert.NotEqual(t1, t2);
+        }
+
+        [Fact]
+        public void Over_long_names_truncate_to_64_with_hash()
+        {
+            var reg = NewRegistry(8);
+            string longTool = new string('a', 90);
+            reg.AddConnection(FakeConn.Ready("srv", new ToolDef(longTool)));
+            var names = ManifestNames(reg);
+            Assert.Single(names);
+            Assert.True(names[0].Length <= 64);
+            Assert.Equal('_', names[0][64 - 7]); // "_" + 6 hex tail
+        }
+
+        [Fact]
+        public void Munging_is_deterministic_across_remove_and_readd()
+        {
+            var reg = NewRegistry(8);
+            var conn = FakeConn.Ready("s", new ToolDef("x/y"), new ToolDef("x_y"));
+            reg.AddConnection(conn);
+            var first = ManifestNames(reg);
+            first.Sort();
+
+            reg.RemoveConnection(conn);
+            reg.AddConnection(conn);
+            var second = ManifestNames(reg);
+            second.Sort();
+
+            Assert.Equal(first, second);
+        }
+
+        // ---- manifest ----
+
+        [Fact]
+        public void Manifest_is_names_only_sorted_and_reflects_mutations()
+        {
+            var reg = NewRegistry(8);
+            var files = FakeConn.Ready("files", new ToolDef("write"), new ToolDef("read"));
+            var git = FakeConn.Ready("git", new ToolDef("status"));
+            reg.AddConnection(files);
+            reg.AddConnection(git);
+
+            Assert.Equal(new[] { "files__read", "files__write", "git__status" }, ManifestNames(reg).ToArray());
+
+            reg.RemoveConnection(git);
+            Assert.Equal(new[] { "files__read", "files__write" }, ManifestNames(reg).ToArray());
+
+            // names only — no schema/description text in the manifest body
+            Assert.DoesNotContain("description", reg.NamesManifestSystemMessage());
+        }
+
+        // ---- reveal ----
+
+        [Fact]
+        public void Exposed_defs_always_lead_with_reveal_tools()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")));
+
+            var exposed = ExposedNames(reg);
+            Assert.Equal(McpToolRegistry.RevealToolsName, exposed[0]);
+            Assert.Single(exposed); // nothing revealed yet
+        }
+
+        [Fact]
+        public void Reveal_adds_defs_and_returns_requested_schemas()
+        {
+            var reg = NewRegistry(8);
+            JObject schema = JObject.Parse("{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}");
+            reg.AddConnection(FakeConn.Ready("files", new ToolDef("read", "Read a file", schema)));
+
+            string result = reg.Reveal(new[] { "files__read" });
+            JArray defs = JArray.Parse(result.Split('\n')[0]);
+            Assert.Single(defs);
+            Assert.Equal("files__read", (string)defs[0]["name"]);
+            Assert.Equal("Read a file", (string)defs[0]["description"]);
+            Assert.NotNull(defs[0]["parameters"]["properties"]["path"]);
+
+            // now exposed in the tools array
+            Assert.Contains("files__read", ExposedNames(reg));
+        }
+
+        [Fact]
+        public void Reveal_notes_unknown_names()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")));
+            string result = reg.Reveal(new[] { "files__read", "files__nope" });
+            Assert.Contains("unknown tool: files__nope", result);
+        }
+
+        // ---- LRU ----
+
+        [Fact]
+        public void Exceeding_cap_evicts_least_recently_used()
+        {
+            var reg = NewRegistry(2);
+            reg.AddConnection(FakeConn.Ready("s", new ToolDef("a"), new ToolDef("b"), new ToolDef("c")));
+
+            reg.Reveal(new[] { "s__a" });
+            reg.Reveal(new[] { "s__b" });
+            reg.Reveal(new[] { "s__c" }); // cap 2 → s__a (oldest) evicted
+
+            var exposed = ExposedNames(reg);
+            Assert.DoesNotContain("s__a", exposed);
+            Assert.Contains("s__b", exposed);
+            Assert.Contains("s__c", exposed);
+
+            // evicted tool is still in the manifest and re-revealable
+            Assert.Contains("s__a", ManifestNames(reg));
+            reg.Reveal(new[] { "s__a" });
+            Assert.Contains("s__a", ExposedNames(reg));
+        }
+
+        [Fact]
+        public void Resolving_bumps_recency_to_prevent_eviction()
+        {
+            var reg = NewRegistry(2);
+            reg.AddConnection(FakeConn.Ready("s", new ToolDef("a"), new ToolDef("b"), new ToolDef("c")));
+
+            reg.Reveal(new[] { "s__a" });
+            reg.Reveal(new[] { "s__b" });
+
+            // touch s__a via a resolve so it's now most-recent
+            McpServerConnection c; string t;
+            Assert.True(reg.TryResolve("s__a", out c, out t));
+
+            reg.Reveal(new[] { "s__c" }); // should evict s__b (now the LRU), not s__a
+
+            var exposed = ExposedNames(reg);
+            Assert.Contains("s__a", exposed);
+            Assert.DoesNotContain("s__b", exposed);
+            Assert.Contains("s__c", exposed);
+        }
+
+        // ---- lifecycle ----
+
+        [Fact]
+        public void Refresh_prunes_removed_tools_from_catalog_and_revealed()
+        {
+            var reg = NewRegistry(8);
+            RegistryFakeTransport ft;
+            var conn = FakeConn.Ready("s", out ft, new ToolDef("a"), new ToolDef("b"));
+            reg.AddConnection(conn);
+            reg.Reveal(new[] { "s__a", "s__b" });
+            Assert.Contains("s__b", ExposedNames(reg));
+
+            // server drops tool "b" on a subsequent tools/list
+            ft.Tools = new List<ToolDef> { new ToolDef("a") };
+            reg.RefreshConnection(conn);
+
+            Assert.Equal(new[] { "s__a" }, ManifestNames(reg).ToArray());
+            Assert.DoesNotContain("s__b", ExposedNames(reg)); // pruned from revealed too
+            McpServerConnection c; string t;
+            Assert.False(reg.TryResolve("s__b", out c, out t));
+        }
+
+        [Fact]
+        public void Remove_drops_a_faulted_servers_tools()
+        {
+            var reg = NewRegistry(8);
+            var conn = FakeConn.Ready("s", new ToolDef("a"));
+            reg.AddConnection(conn);
+            reg.Reveal(new[] { "s__a" });
+
+            reg.RemoveConnection(conn);
+
+            Assert.Empty(ManifestNames(reg));
+            McpServerConnection c; string t;
+            Assert.False(reg.TryResolve("s__a", out c, out t));
+            Assert.Equal(new[] { McpToolRegistry.RevealToolsName }, ExposedNames(reg).ToArray());
+        }
+
+        [Fact]
+        public void Reveal_tools_name_is_never_produced_by_munging()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("reveal", new ToolDef("tools")));
+            Assert.Contains("reveal__tools", ManifestNames(reg)); // double underscore, not "reveal_tools"
+            Assert.DoesNotContain("reveal_tools", ManifestNames(reg));
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using GxPT;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // Golden-JSON assertions for the Newtonsoft-migrated request builder (D16), plus chunk-parsing
+    // checks proving the streaming DTO maps correctly under Newtonsoft. (The curl/SSE transport
+    // itself needs a network and is exercised manually.)
+    public class OpenRouterClientTests
+    {
+        // ---- BuildRequestBody: the no-tools path is unchanged in shape ----
+
+        [Fact]
+        public void No_tools_request_has_system_then_messages_and_no_tools_key()
+        {
+            var messages = new List<ChatMessage> { new ChatMessage("user", "hi") };
+            var body = OpenRouterClient.BuildRequestBody("openai/gpt-4o", messages, null, new ClientProperties { Stream = true });
+            var o = JObject.Parse(body);
+
+            Assert.Equal("openai/gpt-4o", (string)o["model"]);
+            Assert.True((bool)o["stream"]);
+
+            var msgs = (JArray)o["messages"];
+            Assert.Equal(2, msgs.Count);
+            Assert.Equal("system", (string)msgs[0]["role"]);
+            Assert.Contains("Do not use emojis", (string)msgs[0]["content"]);
+            Assert.Equal("user", (string)msgs[1]["role"]);
+            Assert.Equal("hi", (string)msgs[1]["content"]);
+
+            Assert.Null(o["tools"]);       // absent when none provided
+            Assert.Null(o["provider"]);    // absent when no provider options
+        }
+
+        [Fact]
+        public void Defaults_model_when_empty()
+        {
+            var body = OpenRouterClient.BuildRequestBody(null, new List<ChatMessage>(), null, new ClientProperties());
+            Assert.Equal("openai/gpt-4o", (string)JObject.Parse(body)["model"]);
+        }
+
+        // ---- tools / tool_calls / tool messages ----
+
+        [Fact]
+        public void Tools_array_is_emitted_when_provided()
+        {
+            var tools = new List<JObject>
+            {
+                JObject.Parse("{\"type\":\"function\",\"function\":{\"name\":\"files__read\",\"description\":\"d\",\"parameters\":{\"type\":\"object\"}}}")
+            };
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), tools, new ClientProperties());
+            var t = (JArray)JObject.Parse(body)["tools"];
+            Assert.Single(t);
+            Assert.Equal("function", (string)t[0]["type"]);
+            Assert.Equal("files__read", (string)t[0]["function"]["name"]);
+        }
+
+        [Fact]
+        public void Assistant_tool_calls_are_serialized_with_null_content()
+        {
+            var asst = new ChatMessage("assistant", "");
+            asst.ToolCalls = new List<ToolCall> { new ToolCall("call_1", "files__read", "{\"path\":\"a\"}") };
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage> { asst }, null, new ClientProperties());
+
+            var msg = (JObject)((JArray)JObject.Parse(body)["messages"])[1];
+            Assert.Equal("assistant", (string)msg["role"]);
+            Assert.Equal(JTokenType.Null, msg["content"].Type);
+
+            var calls = (JArray)msg["tool_calls"];
+            Assert.Single(calls);
+            Assert.Equal("call_1", (string)calls[0]["id"]);
+            Assert.Equal("function", (string)calls[0]["type"]);
+            Assert.Equal("files__read", (string)calls[0]["function"]["name"]);
+            Assert.Equal("{\"path\":\"a\"}", (string)calls[0]["function"]["arguments"]);
+        }
+
+        [Fact]
+        public void Empty_tool_call_arguments_become_object_literal()
+        {
+            var asst = new ChatMessage("assistant", "text");
+            asst.ToolCalls = new List<ToolCall> { new ToolCall("c", "files__list", null) };
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage> { asst }, null, new ClientProperties());
+            var calls = (JArray)((JArray)JObject.Parse(body)["messages"])[1]["tool_calls"];
+            Assert.Equal("{}", (string)calls[0]["function"]["arguments"]);
+        }
+
+        [Fact]
+        public void Tool_role_message_has_tool_call_id()
+        {
+            var tool = new ChatMessage("tool", "result text");
+            tool.ToolCallId = "call_1";
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage> { tool }, null, new ClientProperties());
+
+            var msg = (JObject)((JArray)JObject.Parse(body)["messages"])[1];
+            Assert.Equal("tool", (string)msg["role"]);
+            Assert.Equal("result text", (string)msg["content"]);
+            Assert.Equal("call_1", (string)msg["tool_call_id"]);
+        }
+
+        // ---- provider options (unchanged behavior) ----
+
+        [Fact]
+        public void Provider_options_are_emitted()
+        {
+            var props = new ClientProperties
+            {
+                ProviderDataCollectionAllowed = false,
+                ProviderOnly = new List<string> { "openai" },
+                ProviderMaxPricePrompt = 1.5m
+            };
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, props);
+            var p = (JObject)JObject.Parse(body)["provider"];
+
+            Assert.Equal("deny", (string)p["data_collection"]);
+            Assert.Equal("openai", (string)((JArray)p["only"])[0]);
+            Assert.Equal(1.5m, (decimal)p["max_price"]["prompt"]);
+        }
+
+        // ---- streaming chunk parsing under Newtonsoft ----
+
+        [Fact]
+        public void Parses_streamed_content_chunk()
+        {
+            var json = "{\"id\":\"x\",\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}";
+            var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
+            Assert.Equal("Hello", chunk.choices[0].delta.content);
+            Assert.Null(chunk.choices[0].finish_reason);
+        }
+
+        [Fact]
+        public void Parses_streamed_tool_call_chunk()
+        {
+            var json = "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"type\":\"function\",\"function\":{\"name\":\"files__read\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}";
+            var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
+            var choice = chunk.choices[0];
+            Assert.Equal("tool_calls", choice.finish_reason);
+            var tc = choice.delta.tool_calls[0];
+            Assert.Equal(0, tc.index);
+            Assert.Equal("c1", tc.id);
+            Assert.Equal("files__read", tc.function.name);
+            Assert.Equal("{}", tc.function.arguments);
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using GxPT;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT.Tests.Mcp
+{
+    // Builds ChatCompletionChunks / chunk sequences ("turns") for driving the orchestrator.
+    internal static class Chunks
+    {
+        public static ChatCompletionChunk TextChunk(string content, string finish)
+        {
+            var c = new ChatCompletionChunk();
+            c.choices = new List<ChatCompletionChunk.Choice>();
+            var ch = new ChatCompletionChunk.Choice();
+            ch.delta = new ChatCompletionChunk.Delta { content = content };
+            ch.finish_reason = finish;
+            c.choices.Add(ch);
+            return c;
+        }
+
+        public static ChatCompletionChunk ToolChunk(int index, string id, string name, string args, string finish)
+        {
+            var c = new ChatCompletionChunk();
+            c.choices = new List<ChatCompletionChunk.Choice>();
+            var ch = new ChatCompletionChunk.Choice();
+            ch.delta = new ChatCompletionChunk.Delta();
+            ch.delta.tool_calls = new List<ToolCallDelta>();
+            ch.delta.tool_calls.Add(new ToolCallDelta
+            {
+                index = index,
+                id = id,
+                type = id != null ? "function" : null,
+                function = new FunctionDelta { name = name, arguments = args }
+            });
+            ch.finish_reason = finish;
+            c.choices.Add(ch);
+            return c;
+        }
+
+        public static ChatCompletionChunk[] Text(string content)
+        {
+            return new[] { TextChunk(content, "stop") };
+        }
+
+        public static ChatCompletionChunk[] OneToolCall(string id, string name, string args)
+        {
+            return new[] { ToolChunk(0, id, name, args, "tool_calls") };
+        }
+    }
+
+    // An IChatStreamer that replays scripted chunk sequences, one per StreamChat call, and records
+    // what it was asked to send. A Fallback supplies chunks once Turns is exhausted (e.g. an
+    // always-tool-call script for the iteration-cap test); an optional error can be injected.
+    internal sealed class ScriptedStreamer : IChatStreamer
+    {
+        public readonly List<ChatCompletionChunk[]> Turns = new List<ChatCompletionChunk[]>();
+        public Func<int, ChatCompletionChunk[]> Fallback;
+        public string ErrorMessage;   // when set, signal onError instead of streaming
+        public int ErrorOnCall = -1;  // -1 = every call; otherwise only this call index
+
+        public int Calls;
+        public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
+        public readonly List<IList<JObject>> SeenTools = new List<IList<JObject>>();
+
+        public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
+                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+        {
+            int idx = Calls++;
+            SeenMessages.Add(messages);
+            SeenTools.Add(tools);
+
+            if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
+            {
+                if (onError != null) onError(ErrorMessage);
+                return;
+            }
+
+            ChatCompletionChunk[] chunks = idx < Turns.Count
+                ? Turns[idx]
+                : (Fallback != null ? Fallback(idx) : null);
+            if (chunks != null)
+                foreach (var ch in chunks)
+                    if (onChunk != null) onChunk(ch);
+        }
+    }
+
+    internal sealed class RecordingUi : IToolLoopUi
+    {
+        public readonly StringBuilder Text = new StringBuilder();
+        public readonly List<string> ToolCalls = new List<string>();
+        public readonly List<string> ToolResults = new List<string>();
+        public readonly List<bool> ToolErrors = new List<bool>();
+        public string Error;
+        public bool Completed;
+
+        public void AppendTextDelta(string text) { Text.Append(text); }
+        public void OnToolCall(string functionName, string argumentsJson) { ToolCalls.Add(functionName); }
+        public void OnToolResult(string functionName, string resultText, bool isError)
+        {
+            ToolResults.Add(resultText);
+            ToolErrors.Add(isError);
+        }
+        public void OnError(string message) { Error = message; }
+        public void Complete() { Completed = true; }
+    }
+}

--- a/GxPT.Tests/Mcp/RegistryTestSupport.cs
+++ b/GxPT.Tests/Mcp/RegistryTestSupport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Mcp35.Client;
+using Mcp35.Core.Errors;
 using Mcp35.Core.Protocol;
 using Mcp35.Core.Rpc;
 using Newtonsoft.Json.Linq;
@@ -31,6 +32,12 @@ namespace GxPT.Tests.Mcp
         public List<ToolDef> Tools = new List<ToolDef>();
         private bool _connected = true;
 
+        // tools/call behavior (orchestrator tests):
+        public Func<string, JObject, JObject> OnCall; // (toolName, args) => CallToolResult JObject
+        public bool ThrowTransportOnCall;             // simulate a transport fault mid-call
+        public bool ErrorOnCall;                      // simulate a JSON-RPC error (e.g. unknown tool)
+        public readonly List<string> CalledTools = new List<string>();
+
         public event EventHandler<JsonRpcInboundEventArgs> Inbound;
 
         public RegistryFakeTransport(IEnumerable<ToolDef> tools)
@@ -47,6 +54,19 @@ namespace GxPT.Tests.Mcp
         {
             if (method == "initialize") return Ok(InitializeResult());
             if (method == "tools/list") return Ok(ToolsListResult());
+            if (method == "tools/call")
+            {
+                if (ThrowTransportOnCall) { _connected = false; throw new McpTransportException("simulated transport fault"); }
+
+                JObject p = @params as JObject;
+                string toolName = p != null && p["name"] != null ? (string)p["name"] : null;
+                JObject args = p != null ? p["arguments"] as JObject : null;
+                CalledTools.Add(toolName);
+
+                if (ErrorOnCall) return Error(-32602, "unknown tool: " + toolName);
+                JObject result = OnCall != null ? OnCall(toolName, args) : TextResult("ok:" + toolName);
+                return Ok(result);
+            }
             return Ok(new JObject());
         }
 
@@ -67,6 +87,26 @@ namespace GxPT.Tests.Mcp
             r.IsError = false;
             r.Result = result;
             return r;
+        }
+
+        private static JsonRpcResponse Error(int code, string message)
+        {
+            JsonRpcResponse r = new JsonRpcResponse();
+            r.Id = RequestId.FromLong(1);
+            r.IsError = true;
+            r.Error = new JsonRpcError(code, message);
+            return r;
+        }
+
+        // A minimal CallToolResult { content: [ { type:"text", text } ] }.
+        public static JObject TextResult(string text)
+        {
+            JObject block = new JObject();
+            block["type"] = "text";
+            block["text"] = text;
+            JObject result = new JObject();
+            result["content"] = new JArray(block);
+            return result;
         }
 
         private static JObject InitializeResult()

--- a/GxPT.Tests/Mcp/RegistryTestSupport.cs
+++ b/GxPT.Tests/Mcp/RegistryTestSupport.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Client;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT.Tests.Mcp
+{
+    // A canned tool definition for seeding a fake connection.
+    internal sealed class ToolDef
+    {
+        public string Name;
+        public string Description;
+        public JObject Schema;
+
+        public ToolDef(string name) : this(name, name + " description", null) { }
+        public ToolDef(string name, string description, JObject schema)
+        {
+            Name = name;
+            Description = description;
+            Schema = schema;
+        }
+    }
+
+    // An in-memory IRpcTransport that answers initialize + tools/list so a real McpServerConnection
+    // reaches Ready and ListTools() returns canned tools. The current tool set is mutable so a
+    // RefreshConnection (which re-sends tools/list) can observe a changed catalog.
+    internal sealed class RegistryFakeTransport : IRpcTransport
+    {
+        public List<ToolDef> Tools = new List<ToolDef>();
+        private bool _connected = true;
+
+        public event EventHandler<JsonRpcInboundEventArgs> Inbound;
+
+        public RegistryFakeTransport(IEnumerable<ToolDef> tools)
+        {
+            if (tools != null) Tools.AddRange(tools);
+        }
+
+        public void Start() { }
+        public bool IsConnected { get { return _connected; } }
+        public void Dispose() { _connected = false; }
+        public void SendNotification(string method, JToken @params) { }
+
+        public JsonRpcResponse SendRequest(string method, JToken @params, int timeoutMs)
+        {
+            if (method == "initialize") return Ok(InitializeResult());
+            if (method == "tools/list") return Ok(ToolsListResult());
+            return Ok(new JObject());
+        }
+
+        public void RaiseInbound(string method)
+        {
+            EventHandler<JsonRpcInboundEventArgs> h = Inbound;
+            if (h == null) return;
+            JsonRpcInboundEventArgs e = new JsonRpcInboundEventArgs();
+            e.Method = method;
+            e.IsRequest = false;
+            h(this, e);
+        }
+
+        private static JsonRpcResponse Ok(JToken result)
+        {
+            JsonRpcResponse r = new JsonRpcResponse();
+            r.Id = RequestId.FromLong(1);
+            r.IsError = false;
+            r.Result = result;
+            return r;
+        }
+
+        private static JObject InitializeResult()
+        {
+            JObject caps = new JObject();
+            caps["tools"] = new JObject();
+            JObject info = new JObject();
+            info["name"] = "fake";
+            info["version"] = "1.0";
+            JObject result = new JObject();
+            result["protocolVersion"] = ProtocolVersions.Default;
+            result["capabilities"] = caps;
+            result["serverInfo"] = info;
+            return result;
+        }
+
+        private JObject ToolsListResult()
+        {
+            JArray arr = new JArray();
+            for (int i = 0; i < Tools.Count; i++)
+            {
+                ToolDef t = Tools[i];
+                JObject o = new JObject();
+                o["name"] = t.Name;
+                o["description"] = t.Description;
+                o["inputSchema"] = t.Schema != null ? (JToken)t.Schema : DefaultSchema();
+                arr.Add(o);
+            }
+            JObject result = new JObject();
+            result["tools"] = arr;
+            return result;
+        }
+
+        private static JObject DefaultSchema()
+        {
+            JObject s = new JObject();
+            s["type"] = "object";
+            return s;
+        }
+    }
+
+    internal static class FakeConn
+    {
+        // Build a connection already Open (Ready) with the given server name and tools.
+        public static McpServerConnection Ready(string serverName, params ToolDef[] tools)
+        {
+            RegistryFakeTransport ignored;
+            return Ready(serverName, out ignored, tools);
+        }
+
+        public static McpServerConnection Ready(string serverName, out RegistryFakeTransport transport, params ToolDef[] tools)
+        {
+            transport = new RegistryFakeTransport(tools);
+            Implementation client = new Implementation();
+            client.Name = "GxPT";
+            client.Version = "test";
+            McpServerConnection conn = new McpServerConnection(serverName, transport, client, null);
+            conn.Open(2000);
+            return conn;
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/ToolCallAssemblerTests.cs
+++ b/GxPT.Tests/Mcp/ToolCallAssemblerTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class ToolCallAssemblerTests
+    {
+        // ---- chunk builders ----
+
+        private static ChatCompletionChunk TextChunk(string content, string finish)
+        {
+            var c = new ChatCompletionChunk();
+            c.choices = new List<ChatCompletionChunk.Choice>();
+            var ch = new ChatCompletionChunk.Choice();
+            ch.delta = new ChatCompletionChunk.Delta { content = content };
+            ch.finish_reason = finish;
+            c.choices.Add(ch);
+            return c;
+        }
+
+        private static ChatCompletionChunk ToolChunk(int index, string id, string name, string argsFragment, string finish)
+        {
+            var c = new ChatCompletionChunk();
+            c.choices = new List<ChatCompletionChunk.Choice>();
+            var ch = new ChatCompletionChunk.Choice();
+            ch.delta = new ChatCompletionChunk.Delta();
+            ch.delta.tool_calls = new List<ToolCallDelta>();
+            ch.delta.tool_calls.Add(new ToolCallDelta
+            {
+                index = index,
+                id = id,
+                type = id != null ? "function" : null,
+                function = new FunctionDelta { name = name, arguments = argsFragment }
+            });
+            ch.finish_reason = finish;
+            c.choices.Add(ch);
+            return c;
+        }
+
+        private static ToolCallAssembler Feed(params ChatCompletionChunk[] chunks)
+        {
+            var asm = new ToolCallAssembler(null);
+            foreach (var c in chunks) asm.OnChunk(c);
+            asm.Finish();
+            return asm;
+        }
+
+        // ---- tests ----
+
+        [Fact]
+        public void Reassembles_single_fragmented_tool_call()
+        {
+            var asm = Feed(
+                ToolChunk(0, "call_1", "files__read", "{\"pa", null),
+                ToolChunk(0, null, null, "th\":\"a.txt\"}", null),
+                ToolChunk(0, null, null, null, "tool_calls"));
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.Single(asm.Calls);
+            Assert.Equal("call_1", asm.Calls[0].Id);
+            Assert.Equal("files__read", asm.Calls[0].Name);
+            Assert.Equal("{\"path\":\"a.txt\"}", asm.Calls[0].ArgumentsJson);
+            Assert.False(asm.Truncated);
+        }
+
+        [Fact]
+        public void Reassembles_multiple_tool_calls_by_index()
+        {
+            var asm = Feed(
+                ToolChunk(0, "call_a", "files__read", "{}", null),
+                ToolChunk(1, "call_b", "git__status", "{\"x\":1}", null),
+                TextChunk(null, "tool_calls"));
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.Equal(2, asm.Calls.Count);
+            Assert.Equal("call_a", asm.Calls[0].Id);
+            Assert.Equal("files__read", asm.Calls[0].Name);
+            Assert.Equal("call_b", asm.Calls[1].Id);
+            Assert.Equal("git__status", asm.Calls[1].Name);
+        }
+
+        [Fact]
+        public void Handles_whole_tool_call_in_one_chunk()
+        {
+            var asm = Feed(ToolChunk(0, "call_x", "web__search", "{\"q\":\"hi\"}", "tool_calls"));
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.Single(asm.Calls);
+            Assert.Equal("{\"q\":\"hi\"}", asm.Calls[0].ArgumentsJson);
+        }
+
+        [Fact]
+        public void Empty_arguments_default_to_object_literal()
+        {
+            // name arrives but no arguments fragments at all → "{}"
+            var asm = Feed(
+                ToolChunk(0, "call_n", "files__list", null, null),
+                TextChunk(null, "tool_calls"));
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.Equal("{}", asm.Calls[0].ArgumentsJson);
+        }
+
+        [Fact]
+        public void Plain_text_answer_produces_no_tool_calls()
+        {
+            var deltas = new List<string>();
+            var asm = new ToolCallAssembler(s => deltas.Add(s));
+            asm.OnChunk(TextChunk("Hello, ", null));
+            asm.OnChunk(TextChunk("world.", "stop"));
+            asm.Finish();
+
+            Assert.False(asm.ProducedToolCalls);
+            Assert.Equal("Hello, world.", asm.Text);
+            Assert.Equal(new[] { "Hello, ", "world." }, deltas.ToArray());
+        }
+
+        [Fact]
+        public void Truncated_tool_call_is_flagged()
+        {
+            var asm = Feed(
+                ToolChunk(0, "call_t", "command__run", "{\"cmd\":\"long", null),
+                TextChunk(null, "length"));
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.True(asm.Truncated);
+            Assert.Equal("length", asm.FinishReason);
+        }
+
+        [Fact]
+        public void Finish_is_idempotent_and_safe_without_finish_reason()
+        {
+            var asm = new ToolCallAssembler(null);
+            asm.OnChunk(ToolChunk(0, "call_1", "files__read", "{}", null)); // no finish_reason in stream
+            asm.Finish();
+            asm.Finish(); // second call must not change anything
+
+            Assert.True(asm.ProducedToolCalls);
+            Assert.Single(asm.Calls);
+        }
+    }
+}

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -101,7 +101,7 @@ namespace GxPT
                 Name = convo.Name,
                 SelectedModel = convo.SelectedModel,
                 LastUpdated = convo.LastUpdated,
-                Messages = convo.History.Select(ToMessageDto).ToList()
+                Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
             return JsonConvert.SerializeObject(dto, _jsonSettings);
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web.Script.Serialization;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace GxPT
 {
@@ -11,6 +11,13 @@ namespace GxPT
     {
         private const string FolderName = "Conversations";
         private const string FileExt = ".json";
+
+        // Newtonsoft (D16): omit null members so non-tool messages keep their compact shape and
+        // existing files stay byte-compatible in spirit. Reads remain backward-compatible — the
+        // PascalCase property names match the previous JavaScriptSerializer output, and Newtonsoft
+        // parses both ISO and the legacy "\/Date(...)\/" timestamps.
+        private static readonly JsonSerializerSettings _jsonSettings =
+            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
         // Per-file metadata cache for ListAll, so repeated sidebar refreshes don't re-read and
         // re-parse every conversation file. Entries are keyed by path and validated against the
@@ -71,19 +78,8 @@ namespace GxPT
         public static void Save(Conversation convo)
         {
             if (convo == null) return;
-            EnsureConversationId(convo);
-
-            var dto = new ConversationDto
-            {
-                Id = convo.Id,
-                Name = convo.Name,
-                SelectedModel = convo.SelectedModel,
-                LastUpdated = convo.LastUpdated,
-                Messages = convo.History.Select(m => new MessageDto { Role = m.Role, Content = m.Content, Attachments = (m.Attachments != null && m.Attachments.Count > 0) ? m.Attachments : null }).ToList()
-            };
-
-            var ser = new JavaScriptSerializer();
-            string json = ser.Serialize(dto);
+            string json = ToJson(convo);
+            if (json == null) return;
 
             string path = GetPathForId(convo.Id);
             if (string.IsNullOrEmpty(path)) return;
@@ -92,14 +88,53 @@ namespace GxPT
             FileSafe.WriteAllTextAtomic(path, json, new UTF8Encoding(false));
         }
 
+        // Serializes a conversation to its on-disk JSON (split out from Save so it is unit-testable
+        // without touching the filesystem).
+        internal static string ToJson(Conversation convo)
+        {
+            if (convo == null) return null;
+            EnsureConversationId(convo);
+
+            var dto = new ConversationDto
+            {
+                Id = convo.Id,
+                Name = convo.Name,
+                SelectedModel = convo.SelectedModel,
+                LastUpdated = convo.LastUpdated,
+                Messages = convo.History.Select(ToMessageDto).ToList()
+            };
+            return JsonConvert.SerializeObject(dto, _jsonSettings);
+        }
+
+        private static MessageDto ToMessageDto(ChatMessage m)
+        {
+            var dto = new MessageDto
+            {
+                Role = m.Role,
+                Content = m.Content,
+                Attachments = (m.Attachments != null && m.Attachments.Count > 0) ? m.Attachments : null,
+                ToolCallId = m.ToolCallId
+            };
+            if (m.ToolCalls != null && m.ToolCalls.Count > 0)
+            {
+                var calls = new List<ToolCallDto>();
+                foreach (var c in m.ToolCalls)
+                {
+                    if (c == null) continue;
+                    calls.Add(new ToolCallDto { Id = c.Id, Name = c.Name, ArgumentsJson = c.ArgumentsJson });
+                }
+                dto.ToolCalls = calls;
+            }
+            return dto;
+        }
+
         public static Conversation Load(OpenRouterClient client, string path)
         {
             try
             {
                 if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
                 string json = File.ReadAllText(path);
-                var ser = new JavaScriptSerializer();
-                var dto = ser.Deserialize<ConversationDto>(json);
+                var dto = JsonConvert.DeserializeObject<ConversationDto>(json);
                 return FromDto(client, dto, path);
             }
             catch { return null; }
@@ -110,8 +145,7 @@ namespace GxPT
             try
             {
                 if (string.IsNullOrEmpty(json)) return null;
-                var ser = new JavaScriptSerializer();
-                var dto = ser.Deserialize<ConversationDto>(json);
+                var dto = JsonConvert.DeserializeObject<ConversationDto>(json);
                 return FromDto(client, dto, null);
             }
             catch { return null; }
@@ -146,7 +180,16 @@ namespace GxPT
                         atts = parsed;
                     }
                     // Add chat message directly to history (no naming trigger needed on load)
-                    convo.History.Add(new ChatMessage(role, content, atts));
+                    var cm = new ChatMessage(role, content, atts);
+                    cm.ToolCallId = m.ToolCallId;
+                    if (m.ToolCalls != null && m.ToolCalls.Count > 0)
+                    {
+                        var calls = new List<ToolCall>();
+                        foreach (var c in m.ToolCalls)
+                            if (c != null) calls.Add(new ToolCall(c.Id, c.Name, c.ArgumentsJson));
+                        cm.ToolCalls = calls;
+                    }
+                    convo.History.Add(cm);
                 }
             }
             return convo;
@@ -215,7 +258,7 @@ namespace GxPT
             try
             {
                 string json = File.ReadAllText(path);
-                var dto = new JavaScriptSerializer().Deserialize<ConversationMetaDto>(json);
+                var dto = JsonConvert.DeserializeObject<ConversationMetaDto>(json);
                 if (dto == null) return null;
                 return new ConversationListItem
                 {
@@ -281,6 +324,16 @@ namespace GxPT
             public string Role { get; set; }
             public string Content { get; set; }
             public List<AttachedFile> Attachments { get; set; }
+            // Tool-call loop (phase 4): assistant tool calls + the id a tool result answers.
+            public List<ToolCallDto> ToolCalls { get; set; }
+            public string ToolCallId { get; set; }
+        }
+
+        internal sealed class ToolCallDto
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string ArgumentsJson { get; set; }
         }
 
         // Extract attachments embedded using the delimiter format:

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -115,6 +115,15 @@
     <Compile Include="Services\OpenRouterClient.cs">
     </Compile>
     <Compile Include="Services\Mcp\IChatStreamer.cs" />
+    <Compile Include="Services\Mcp\IToolApprovalPolicy.cs" />
+    <Compile Include="Services\Mcp\ToolCallAssembler.cs" />
+    <Compile Include="Services\Mcp\McpToolRegistry.cs" />
+    <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />
+    <Compile Include="Services\Mcp\McpServerSpec.cs" />
+    <Compile Include="Services\Mcp\McpConfig.cs" />
+    <Compile Include="Services\Mcp\IServerConnector.cs" />
+    <Compile Include="Services\Mcp\McpHost.cs" />
+    <Compile Include="Services\Mcp\DefaultServerConnector.cs" />
     <Compile Include="Forms\MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -282,6 +291,12 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Mcp35.Client\Mcp35.Client.csproj">
+      <Project>{A043F034-FFF5-44CE-9605-B40FF0016262}</Project>
+      <Name>Mcp35.Client</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -59,6 +59,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\itextsharp.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web.Extensions">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -110,6 +114,7 @@
     <Compile Include="Services\Logger.cs" />
     <Compile Include="Services\OpenRouterClient.cs">
     </Compile>
+    <Compile Include="Services\Mcp\IChatStreamer.cs" />
     <Compile Include="Forms\MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -293,6 +293,13 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <!-- GxPT names Mcp35.Core types directly (ILogSink, Tool, Implementation, CallToolResult, ...),
+         so it needs a direct reference: MSBuild 3.5 / VS2008 does not flow project references
+         transitively through Mcp35.Client. -->
+    <ProjectReference Include="..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\src\Mcp35.Client\Mcp35.Client.csproj">
       <Project>{A043F034-FFF5-44CE-9605-B40FF0016262}</Project>
       <Name>Mcp35.Client</Name>

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -18,10 +18,14 @@ namespace GxPT
 
     internal sealed class ChatMessage
     {
-        public string Role; // "user" | "assistant" | "system"
+        public string Role; // "user" | "assistant" | "system" | "tool"
         public string Content;
         // Internal-only: attachments are kept in-memory for UI; not serialized in ConversationStore
         public List<AttachedFile> Attachments;
+        // Tool-call loop (phase 4): set on assistant messages that request tool calls.
+        public List<ToolCall> ToolCalls;
+        // Tool-call loop (phase 4): set on "tool"-role messages; the id of the call being answered.
+        public string ToolCallId;
 
         public ChatMessage() { }
         public ChatMessage(string role, string content)
@@ -32,6 +36,20 @@ namespace GxPT
         public ChatMessage(string role, string content, List<AttachedFile> attachments)
         {
             Role = role; Content = content ?? string.Empty; Attachments = attachments;
+        }
+    }
+
+    // A single tool call requested by the assistant (phase 4 tool-call loop).
+    internal sealed class ToolCall
+    {
+        public string Id;             // provider-assigned call id (echoed back on the tool result)
+        public string Name;           // qualified function name (e.g. "files__read")
+        public string ArgumentsJson;  // raw JSON string of arguments, as the model emitted it
+
+        public ToolCall() { }
+        public ToolCall(string id, string name, string argumentsJson)
+        {
+            Id = id; Name = name; ArgumentsJson = argumentsJson;
         }
     }
 
@@ -47,12 +65,29 @@ namespace GxPT
         internal sealed class Choice
         {
             public Delta delta { get; set; }
+            public string finish_reason { get; set; }
         }
 
         internal sealed class Delta
         {
             public string role { get; set; }
             public string content { get; set; }
+            public List<ToolCallDelta> tool_calls { get; set; }
         }
+    }
+
+    // A streamed fragment of a tool call; fragments are correlated by index (phase 4, §5).
+    internal sealed class ToolCallDelta
+    {
+        public int index { get; set; }
+        public string id { get; set; }
+        public string type { get; set; }
+        public FunctionDelta function { get; set; }
+    }
+
+    internal sealed class FunctionDelta
+    {
+        public string name { get; set; }
+        public string arguments { get; set; }
     }
 }

--- a/GxPT/Services/Mcp/DefaultServerConnector.cs
+++ b/GxPT/Services/Mcp/DefaultServerConnector.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Text;
+using Mcp35.Client;
+using Mcp35.Client.Transport;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Protocol;
+using Mcp35.Core.Rpc;
+using Mcp35.Core.Transport;
+
+namespace GxPT
+{
+    // The live IServerConnector: turns a spec into a real transport (stdio child process or HTTP)
+    // and an McpServerConnection. GXPT_WORKDIR is injected (and the process working directory set)
+    // for workdir-scoped stdio servers. HTTP servers (GitHub) run over Core's CurlRunner so net35
+    // can reach modern TLS 1.2 endpoints.
+    internal sealed class DefaultServerConnector : IServerConnector
+    {
+        private readonly Implementation _clientInfo;
+        private readonly string _curlPath;
+        private readonly string _caBundlePath;
+        private readonly ILogSink _log;
+
+        public DefaultServerConnector(Implementation clientInfo, string curlPath, string caBundlePath, ILogSink log)
+        {
+            _clientInfo = clientInfo;
+            _curlPath = curlPath;
+            _caBundlePath = caBundlePath;
+            _log = log != null ? log : NullLogSink.Instance;
+        }
+
+        public McpServerConnection Create(McpServerSpec spec, string workdir)
+        {
+            if (spec == null) return null;
+
+            IRpcTransport transport;
+            if (spec.Kind == McpTransportKind.Http)
+            {
+                ICurlRunner curl = new CurlRunner(_curlPath, _caBundlePath, _log);
+                transport = new HttpTransport(spec.Url, spec.Headers, curl, _log);
+            }
+            else
+            {
+                StdioLaunch launch = new StdioLaunch();
+                launch.Command = spec.Command;
+                launch.Arguments = JoinArgs(spec.Args);
+
+                Dictionary<string, string> env = new Dictionary<string, string>(spec.Env);
+                if (spec.WorkdirScoped && !string.IsNullOrEmpty(workdir))
+                {
+                    env[McpConfig.EnvWorkdir] = workdir;
+                    launch.WorkingDirectory = workdir;
+                }
+                launch.Environment = env;
+
+                transport = new StdioTransport(launch, _log);
+            }
+
+            return new McpServerConnection(spec.Name, transport, _clientInfo, _log);
+        }
+
+        // Build a single command-line argument string, quoting tokens that contain spaces/quotes.
+        private static string JoinArgs(string[] args)
+        {
+            if (args == null || args.Length == 0) return string.Empty;
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                string a = args[i] != null ? args[i] : string.Empty;
+                if (a.IndexOf(' ') >= 0 || a.IndexOf('"') >= 0)
+                    sb.Append('"').Append(a.Replace("\"", "\\\"")).Append('"');
+                else
+                    sb.Append(a);
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/GxPT/Services/Mcp/IChatStreamer.cs
+++ b/GxPT/Services/Mcp/IChatStreamer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The chat-streaming seam the orchestrator drives. OpenRouterClient implements this (builds the
+    // request body — including the tools array, assistant tool_calls, and tool-role messages — and
+    // runs the curl/SSE loop). Abstracting it lets the orchestrator be unit-tested with a scripted
+    // stub stream, with no network and no JSON wire format.
+    internal interface IChatStreamer
+    {
+        void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
+                        ClientProperties props,
+                        Action<ChatCompletionChunk> onChunk, Action<string> onError);
+    }
+
+    // The orchestrator's view of the transcript UI. Phase 4 ships a minimal representation: text
+    // deltas stream in, and each tool call/result gets a one-line marker. Rich collapsible rendering
+    // is a separate transcript-UI item.
+    internal interface IToolLoopUi
+    {
+        void AppendTextDelta(string text);
+        void OnToolCall(string functionName, string argumentsJson);
+        void OnToolResult(string functionName, string resultText, bool isError);
+        void OnError(string message);
+        void Complete();
+    }
+}

--- a/GxPT/Services/Mcp/IServerConnector.cs
+++ b/GxPT/Services/Mcp/IServerConnector.cs
@@ -1,0 +1,14 @@
+using Mcp35.Client;
+
+namespace GxPT
+{
+    // Builds an McpServerConnection for a spec (without opening it). Abstracting the actual transport
+    // construction (process spawn / HTTP) behind this seam lets McpHost's assembly + lifecycle logic
+    // be unit-tested with a fake connector — no real servers. DefaultServerConnector is the live impl.
+    internal interface IServerConnector
+    {
+        // workdir is injected as GXPT_WORKDIR for workdir-scoped stdio servers when non-null.
+        // Returns a Created (not yet opened) connection, or null if the spec can't be realized.
+        McpServerConnection Create(McpServerSpec spec, string workdir);
+    }
+}

--- a/GxPT/Services/Mcp/IToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/IToolApprovalPolicy.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The outcome of an approval check for a single tool call.
+    internal enum ApprovalDecision
+    {
+        Allow,
+        Deny
+    }
+
+    // The host's approval gate, called by McpChatOrchestrator before every tool invocation.
+    // Phase 4 ships an allow-all stub (AllowAllApprovalPolicy); phase 6 replaces it with the
+    // tiered allowlist / remember-scope / always-confirm-destructive model. The loop already
+    // calls it at the right point, so swapping the implementation needs no loop changes.
+    internal interface IToolApprovalPolicy
+    {
+        ApprovalDecision Check(string functionName, JObject args);
+    }
+
+    // Phase-4 stub: allow every call. (reveal_tools is handled by the host directly and never
+    // reaches the policy.) Replaced wholesale in phase 6.
+    internal sealed class AllowAllApprovalPolicy : IToolApprovalPolicy
+    {
+        public ApprovalDecision Check(string functionName, JObject args)
+        {
+            return ApprovalDecision.Allow;
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mcp35.Client;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Errors;
+using Mcp35.Core.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The host-side tool-call loop (phase 4): call the model, reassemble streamed tool_calls, run
+    // them through the registry/approval/connection, feed results back as tool-role messages, and
+    // re-call until the model produces a final answer (bounded by MaxIterations). Runs on a worker
+    // thread; the UI callbacks marshal to the form. Approval is pluggable (phase-4 stub → phase-6
+    // tiered policy) and called at the one right point.
+    internal sealed class McpChatOrchestrator
+    {
+        public const int DefaultMaxIterations = 8;
+        public const int DefaultCallTimeoutMs = 60000;
+
+        private readonly IChatStreamer _streamer;
+        private readonly McpToolRegistry _registry;
+        private readonly IToolApprovalPolicy _approval;
+        private readonly string _model;
+        private readonly ILogSink _log;
+        private readonly int _maxIterations;
+        private readonly int _callTimeoutMs;
+
+        public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
+                                   IToolApprovalPolicy approval, string model, ILogSink log)
+            : this(streamer, registry, approval, model, log, DefaultMaxIterations, DefaultCallTimeoutMs)
+        {
+        }
+
+        public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
+                                   IToolApprovalPolicy approval, string model, ILogSink log,
+                                   int maxIterations, int callTimeoutMs)
+        {
+            if (streamer == null) throw new ArgumentNullException("streamer");
+            _streamer = streamer;
+            _registry = registry;
+            _approval = approval != null ? approval : new AllowAllApprovalPolicy();
+            _model = model;
+            _log = log != null ? log : NullLogSink.Instance;
+            _maxIterations = maxIterations > 0 ? maxIterations : DefaultMaxIterations;
+            _callTimeoutMs = callTimeoutMs > 0 ? callTimeoutMs : DefaultCallTimeoutMs;
+        }
+
+        // Run one user turn to completion: appends the user message, then loops model<->tools,
+        // mutating history in place (so the conversation keeps assistant tool_calls + tool results).
+        public void RunTurn(IList<ChatMessage> history, string userText, IToolLoopUi ui)
+        {
+            if (history == null) throw new ArgumentNullException("history");
+            history.Add(new ChatMessage("user", userText));
+
+            for (int iter = 0; iter < _maxIterations; iter++)
+            {
+                IList<JObject> tools = _registry != null ? _registry.ExposedFunctionDefs() : null;
+                string manifest = _registry != null ? _registry.NamesManifestSystemMessage() : null;
+
+                // The names manifest rides as an extra system message in front of history; it is not
+                // persisted (rebuilt each request from the live catalog).
+                List<ChatMessage> requestMessages = new List<ChatMessage>();
+                if (!string.IsNullOrEmpty(manifest))
+                    requestMessages.Add(new ChatMessage("system", manifest));
+                requestMessages.AddRange(history);
+
+                ClientProperties props = new ClientProperties();
+                props.Stream = true;
+
+                Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
+                ToolCallAssembler asm = new ToolCallAssembler(textSink);
+                bool errored = false;
+                string errMessage = null;
+
+                _streamer.StreamChat(_model, requestMessages, tools, props,
+                    asm.OnChunk,
+                    delegate(string err) { errored = true; errMessage = err; });
+                asm.Finish();
+
+                if (errored)
+                {
+                    // A streaming/transport error already failed this request; surface and stop.
+                    if (ui != null) ui.OnError(errMessage);
+                    return;
+                }
+
+                if (!asm.ProducedToolCalls)
+                {
+                    history.Add(new ChatMessage("assistant", asm.Text));
+                    if (ui != null) ui.Complete();
+                    return;
+                }
+
+                // The assistant turn that requested the calls must be recorded with its tool_calls,
+                // or the follow-up tool messages have nothing to answer.
+                ChatMessage assistantMsg = new ChatMessage("assistant", asm.Text);
+                assistantMsg.ToolCalls = asm.Calls;
+                history.Add(assistantMsg);
+
+                // Serial execution (phase 4): one call fully handled before the next.
+                for (int c = 0; c < asm.Calls.Count; c++)
+                {
+                    ToolCall call = asm.Calls[c];
+                    if (ui != null) ui.OnToolCall(call.Name, call.ArgumentsJson);
+
+                    bool isError;
+                    string result = ExecuteCall(call, out isError);
+
+                    if (ui != null) ui.OnToolResult(call.Name, result, isError);
+                    ChatMessage toolMsg = new ChatMessage("tool", result);
+                    toolMsg.ToolCallId = call.Id;
+                    history.Add(toolMsg);
+                }
+                // Loop: re-call the model with the tool results in context.
+            }
+
+            // Bounded: hitting the cap returns a note rather than looping unbounded.
+            history.Add(new ChatMessage("assistant", "[Tool-call limit reached.]"));
+            if (ui != null) ui.Complete();
+        }
+
+        // Executes one tool call, returning the text to feed back as the tool message content.
+        // Failures are returned as content (not thrown) so the model can recover; isError flags the
+        // UI marker. reveal_tools is handled locally without an MCP round-trip.
+        private string ExecuteCall(ToolCall call, out bool isError)
+        {
+            isError = false;
+
+            if (_registry != null && _registry.IsRevealTools(call.Name))
+                return _registry.Reveal(ParseRevealNames(call.ArgumentsJson));
+
+            McpServerConnection conn;
+            string toolName;
+            if (_registry == null || !_registry.TryResolve(call.Name, out conn, out toolName))
+            {
+                isError = true;
+                return "[Unknown tool: " + call.Name + "]";
+            }
+
+            JObject args;
+            if (!TryParseArgs(call.ArgumentsJson, out args))
+            {
+                isError = true;
+                return "[Invalid tool arguments: not valid JSON.]";
+            }
+
+            ApprovalDecision decision = _approval.Check(call.Name, args);
+            if (decision == ApprovalDecision.Deny)
+            {
+                isError = true;
+                return "[Call denied by user.]";
+            }
+
+            try
+            {
+                CallToolResult res = conn.CallTool(toolName, args, _callTimeoutMs);
+                isError = (res != null && res.IsError);
+                return FormatResult(res);
+            }
+            catch (McpTransportException ex)
+            {
+                _log.Log("mcp", "transport fault calling '" + call.Name + "': " + ex.Message);
+                isError = true;
+                return "[Server unavailable.]";
+            }
+            catch (McpTimeoutException ex)
+            {
+                _log.Log("mcp", "timeout calling '" + call.Name + "': " + ex.Message);
+                isError = true;
+                return "[Tool timed out.]";
+            }
+            catch (McpException ex)
+            {
+                isError = true;
+                return "[Tool error: " + ex.Message + "]";
+            }
+        }
+
+        // ---- helpers ----
+
+        private static bool TryParseArgs(string argumentsJson, out JObject args)
+        {
+            args = null;
+            try
+            {
+                if (string.IsNullOrEmpty(argumentsJson))
+                {
+                    args = new JObject();
+                    return true;
+                }
+                JToken t = JToken.Parse(argumentsJson);
+                if (t.Type == JTokenType.Object) { args = (JObject)t; return true; }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string[] ParseRevealNames(string argumentsJson)
+        {
+            List<string> names = new List<string>();
+            try
+            {
+                JObject o = JObject.Parse(argumentsJson);
+                JToken arr = o["names"];
+                if (arr != null && arr.Type == JTokenType.Array)
+                {
+                    foreach (JToken n in (JArray)arr)
+                    {
+                        if (n != null && n.Type == JTokenType.String) names.Add((string)n);
+                    }
+                }
+            }
+            catch
+            {
+                // malformed reveal args → no names; Reveal returns an empty def list.
+            }
+            return names.ToArray();
+        }
+
+        // CallToolResult.content[] → a single string for the tool message. Text blocks are
+        // concatenated; non-text blocks become a short placeholder; structuredContent (if any) is
+        // appended as compact JSON. isError content is still returned verbatim (the model sees it).
+        private static string FormatResult(CallToolResult res)
+        {
+            if (res == null) return string.Empty;
+
+            StringBuilder sb = new StringBuilder();
+            if (res.Content != null)
+            {
+                for (int i = 0; i < res.Content.Count; i++)
+                {
+                    ContentBlock b = res.Content[i];
+                    if (b == null) continue;
+                    string text;
+                    if (b.TryGetText(out text))
+                        sb.Append(text);
+                    else
+                        sb.Append(Placeholder(b));
+                }
+            }
+
+            if (res.StructuredContent != null)
+            {
+                if (sb.Length > 0) sb.Append("\n");
+                sb.Append(res.StructuredContent.ToString(Formatting.None));
+            }
+            return sb.ToString();
+        }
+
+        private static string Placeholder(ContentBlock b)
+        {
+            string type = b.Type != null ? b.Type : "unknown";
+            if (type == "resource" || type == "resource_link")
+            {
+                string uri = null;
+                if (b.Raw != null)
+                {
+                    JToken direct = b.Raw["uri"];
+                    if (direct != null && direct.Type == JTokenType.String) uri = (string)direct;
+                    if (uri == null)
+                    {
+                        JToken resource = b.Raw["resource"];
+                        if (resource != null && resource.Type == JTokenType.Object)
+                        {
+                            JToken nested = resource["uri"];
+                            if (nested != null && nested.Type == JTokenType.String) uri = (string)nested;
+                        }
+                    }
+                }
+                return "[resource: " + (uri != null ? uri : "?") + "]";
+            }
+            return "[" + type + "]";
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Mcp35.Core.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // Builds the host's MCP server specs from the two configuration tiers (architecture §8):
+    //   Tier 1 — bundled first-party servers (web/files/git/command), hardcoded here, never in
+    //            mcp.json (D15); managed via per-server enable toggles + a web-search key.
+    //   Tier 2 — user-defined servers (and GitHub) from %AppData%/GxPT/mcp.json (snake_case).
+    // Pure parsing/assembly (no AppSettings, no Mcp35.Client) so it is fully unit-testable; McpHost
+    // supplies the live settings/paths and turns specs into transports.
+    internal static class McpConfig
+    {
+        // Built-in server names (also their server-qualified prefix in tool names).
+        public const string WebName = "web";
+        public const string FilesName = "files";
+        public const string GitName = "git";
+        public const string CommandName = "command";
+
+        // Env var names the host injects (servers spec §1).
+        public const string EnvWorkdir = "GXPT_WORKDIR";
+        public const string EnvWebSearchKey = "GXPT_WEB_SEARCH_KEY";
+        public const string EnvCurlPath = "GXPT_CURL_PATH";
+        public const string EnvGitPath = "GXPT_GIT_PATH";
+        public const string EnvCmdShell = "GXPT_CMD_SHELL";
+
+        // Seeded into a fresh mcp.json so GitHub is discoverable; the user pastes a real PAT.
+        public const string SeedJson =
+            "{\n" +
+            "  \"mcp_servers\": {\n" +
+            "    \"github\": {\n" +
+            "      \"url\": \"https://api.githubcopilot.com/mcp/\",\n" +
+            "      \"headers\": { \"Authorization\": \"Bearer YOUR_GITHUB_PAT\" }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n";
+
+        // ---- Tier 1: built-in server specs ----
+
+        internal sealed class BuiltInOptions
+        {
+            public bool WebEnabled;
+            public bool FilesEnabled;
+            public bool GitEnabled;
+            public bool CommandEnabled;
+
+            public string WebSearchKey;            // GXPT_WEB_SEARCH_KEY (web)
+            public string CurlPath;                // GXPT_CURL_PATH (web)
+            public string GitPath = "git";         // GXPT_GIT_PATH (git)
+            public string CmdShell = "cmd.exe";    // GXPT_CMD_SHELL (command)
+            public string ServerDir;               // directory holding the built server exes
+        }
+
+        public static IList<McpServerSpec> BuiltInSpecs(BuiltInOptions o)
+        {
+            List<McpServerSpec> list = new List<McpServerSpec>();
+
+            // web — workdir-independent (search over HTTP via curl); launched once.
+            McpServerSpec web = NewBuiltIn(WebName, "WebSearchMcpServer.exe", o.ServerDir, false, o.WebEnabled);
+            if (!string.IsNullOrEmpty(o.WebSearchKey)) web.Env[EnvWebSearchKey] = o.WebSearchKey;
+            if (!string.IsNullOrEmpty(o.CurlPath)) web.Env[EnvCurlPath] = o.CurlPath;
+            list.Add(web);
+
+            // files — sandboxed to GXPT_WORKDIR (injected at launch, per conversation).
+            list.Add(NewBuiltIn(FilesName, "FilesMcpServer.exe", o.ServerDir, true, o.FilesEnabled));
+
+            // git — operates on the repo at GXPT_WORKDIR; git exe path injected.
+            McpServerSpec git = NewBuiltIn(GitName, "GitMcpServer.exe", o.ServerDir, true, o.GitEnabled);
+            if (!string.IsNullOrEmpty(o.GitPath)) git.Env[EnvGitPath] = o.GitPath;
+            list.Add(git);
+
+            // command — runs approved commands via the shell, in GXPT_WORKDIR.
+            McpServerSpec cmd = NewBuiltIn(CommandName, "CommandMcpServer.exe", o.ServerDir, true, o.CommandEnabled);
+            if (!string.IsNullOrEmpty(o.CmdShell)) cmd.Env[EnvCmdShell] = o.CmdShell;
+            list.Add(cmd);
+
+            return list;
+        }
+
+        private static McpServerSpec NewBuiltIn(string name, string exe, string serverDir, bool workdirScoped, bool enabled)
+        {
+            McpServerSpec s = new McpServerSpec();
+            s.Name = name;
+            s.Kind = McpTransportKind.Stdio;
+            s.BuiltIn = true;
+            s.WorkdirScoped = workdirScoped;
+            s.Enabled = enabled;
+            s.Command = string.IsNullOrEmpty(serverDir) ? exe : Path.Combine(serverDir, exe);
+            return s;
+        }
+
+        // ---- Tier 2: mcp.json user/GitHub servers ----
+
+        public static IList<McpServerSpec> ParseUserServers(string mcpJsonText, ILogSink log)
+        {
+            ILogSink sink = log != null ? log : NullLogSink.Instance;
+            List<McpServerSpec> result = new List<McpServerSpec>();
+            if (string.IsNullOrEmpty(mcpJsonText)) return result;
+
+            JObject root;
+            try { root = JObject.Parse(mcpJsonText); }
+            catch
+            {
+                sink.Log("mcp", "mcp.json is not valid JSON; ignoring custom servers.");
+                return result;
+            }
+
+            JToken serversTok = root["mcp_servers"];
+            JObject servers = serversTok as JObject;
+            if (servers == null) return result;
+
+            foreach (KeyValuePair<string, JToken> entry in servers)
+            {
+                string name = entry.Key;
+                JObject val = entry.Value as JObject;
+                if (string.IsNullOrEmpty(name) || val == null) continue;
+
+                McpServerSpec spec = new McpServerSpec();
+                spec.Name = name;
+                spec.BuiltIn = false;
+                spec.Enabled = true;
+
+                string url = AsString(val["url"]);
+                string command = AsString(val["command"]);
+
+                if (!string.IsNullOrEmpty(url))
+                {
+                    // url present → HTTP (with headers).
+                    spec.Kind = McpTransportKind.Http;
+                    spec.Url = url;
+                    ReadStringMap(val["headers"] as JObject, spec.Headers);
+                }
+                else if (!string.IsNullOrEmpty(command))
+                {
+                    // command present → stdio (with args / env).
+                    spec.Kind = McpTransportKind.Stdio;
+                    spec.Command = command;
+                    spec.Args = ReadStringArray(val["args"] as JArray);
+                    ReadStringMap(val["env"] as JObject, spec.Env);
+                }
+                else
+                {
+                    sink.Log("mcp", "mcp.json entry '" + name + "' has neither url nor command; skipped.");
+                    continue;
+                }
+
+                // GitHub PAT gate: a github entry whose Authorization bearer is not a well-formed PAT
+                // (including the unedited placeholder) is simply disabled — no connection attempt.
+                if (name == "github" && spec.Kind == McpTransportKind.Http)
+                {
+                    string token = BearerFromHeaders(spec.Headers);
+                    if (!IsValidGitHubPat(token))
+                    {
+                        spec.Enabled = false;
+                        sink.Log("mcp", "github entry has no valid PAT (placeholder?) — disabled.");
+                    }
+                }
+
+                result.Add(spec);
+            }
+            return result;
+        }
+
+        // Classic (ghp_…) or fine-grained (github_pat_…) PAT shape; rejects the placeholder.
+        public static bool IsValidGitHubPat(string token)
+        {
+            if (string.IsNullOrEmpty(token)) return false;
+            if (Regex.IsMatch(token, "^ghp_[A-Za-z0-9]{36,}$")) return true;
+            if (Regex.IsMatch(token, "^github_pat_[A-Za-z0-9_]{30,}$")) return true;
+            return false;
+        }
+
+        public static string BearerFromHeaders(IDictionary<string, string> headers)
+        {
+            if (headers == null) return null;
+            foreach (KeyValuePair<string, string> h in headers)
+            {
+                if (string.Equals(h.Key, "Authorization", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    string v = h.Value != null ? h.Value.Trim() : null;
+                    if (!string.IsNullOrEmpty(v) && v.StartsWith("Bearer ", System.StringComparison.OrdinalIgnoreCase))
+                        return v.Substring(7).Trim();
+                    return v;
+                }
+            }
+            return null;
+        }
+
+        // ---- helpers ----
+
+        private static string AsString(JToken t)
+        {
+            if (t == null || t.Type != JTokenType.String) return null;
+            return (string)t;
+        }
+
+        private static string[] ReadStringArray(JArray arr)
+        {
+            if (arr == null) return new string[0];
+            List<string> list = new List<string>();
+            foreach (JToken t in arr)
+                if (t != null && t.Type == JTokenType.String) list.Add((string)t);
+            return list.ToArray();
+        }
+
+        private static void ReadStringMap(JObject obj, IDictionary<string, string> into)
+        {
+            if (obj == null) return;
+            foreach (KeyValuePair<string, JToken> kv in obj)
+            {
+                if (kv.Value != null && kv.Value.Type == JTokenType.String)
+                    into[kv.Key] = (string)kv.Value;
+            }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -42,16 +42,22 @@ namespace GxPT
 
         internal sealed class BuiltInOptions
         {
-            public bool WebEnabled;
-            public bool FilesEnabled;
-            public bool GitEnabled;
-            public bool CommandEnabled;
+            public bool WebEnabled { get; set; }
+            public bool FilesEnabled { get; set; }
+            public bool GitEnabled { get; set; }
+            public bool CommandEnabled { get; set; }
 
-            public string WebSearchKey;            // GXPT_WEB_SEARCH_KEY (web)
-            public string CurlPath;                // GXPT_CURL_PATH (web)
-            public string GitPath = "git";         // GXPT_GIT_PATH (git)
-            public string CmdShell = "cmd.exe";    // GXPT_CMD_SHELL (command)
-            public string ServerDir;               // directory holding the built server exes
+            public string WebSearchKey { get; set; }   // GXPT_WEB_SEARCH_KEY (web)
+            public string CurlPath { get; set; }        // GXPT_CURL_PATH (web)
+            public string GitPath { get; set; }         // GXPT_GIT_PATH (git)
+            public string CmdShell { get; set; }        // GXPT_CMD_SHELL (command)
+            public string ServerDir { get; set; }       // directory holding the built server exes
+
+            public BuiltInOptions()
+            {
+                GitPath = "git";
+                CmdShell = "cmd.exe";
+            }
         }
 
         public static IList<McpServerSpec> BuiltInSpecs(BuiltInOptions o)

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using Mcp35.Client;
+using Mcp35.Core.Diagnostics;
+
+namespace GxPT
+{
+    // Owns the host's MCP server connections (D11) and the shared McpToolRegistry. Assembles
+    // connections from config specs, wires each connection's lifecycle into the registry, and
+    // manages the lazy, per-conversation lifecycle of workdir-scoped servers:
+    //   * workdir-independent servers (web + every mcp.json entry) are opened once via Start();
+    //   * workdir-scoped built-ins (files/git/command) are (re)opened by SetActiveWorkingDir with
+    //     GXPT_WORKDIR set to the active conversation's directory, and torn down when it changes.
+    // Transport construction is delegated to an IServerConnector so this logic is testable without
+    // spawning processes. Thread-safe via a single lock; event handlers touch only the (separately
+    // locked) registry, so they never re-enter this lock.
+    internal sealed class McpHost : IDisposable
+    {
+        public const int DefaultOpenTimeoutMs = 15000;
+
+        private readonly IServerConnector _connector;
+        private readonly McpToolRegistry _registry;
+        private readonly ILogSink _log;
+        private readonly int _openTimeoutMs;
+        private readonly object _lock = new object();
+
+        private readonly List<McpServerConnection> _eager = new List<McpServerConnection>();
+        private readonly List<McpServerConnection> _scoped = new List<McpServerConnection>();
+        private List<McpServerSpec> _scopedSpecs = new List<McpServerSpec>();
+        private string _currentWorkdir;
+        private bool _disposed;
+
+        public McpHost(IServerConnector connector, McpToolRegistry registry, ILogSink log)
+            : this(connector, registry, log, DefaultOpenTimeoutMs)
+        {
+        }
+
+        public McpHost(IServerConnector connector, McpToolRegistry registry, ILogSink log, int openTimeoutMs)
+        {
+            if (connector == null) throw new ArgumentNullException("connector");
+            if (registry == null) throw new ArgumentNullException("registry");
+            _connector = connector;
+            _registry = registry;
+            _log = log != null ? log : NullLogSink.Instance;
+            _openTimeoutMs = openTimeoutMs > 0 ? openTimeoutMs : DefaultOpenTimeoutMs;
+        }
+
+        public McpToolRegistry Registry { get { return _registry; } }
+
+        public string ActiveWorkingDir { get { lock (_lock) { return _currentWorkdir; } } }
+
+        // Open all enabled, workdir-independent servers; remember the workdir-scoped specs for
+        // SetActiveWorkingDir. Call once after building specs from config.
+        public void Start(IEnumerable<McpServerSpec> specs)
+        {
+            lock (_lock)
+            {
+                if (_disposed) return;
+                List<McpServerSpec> scoped = new List<McpServerSpec>();
+                if (specs != null)
+                {
+                    foreach (McpServerSpec spec in specs)
+                    {
+                        if (spec == null) continue;
+                        if (spec.WorkdirScoped) { scoped.Add(spec); continue; }
+                        if (!spec.Enabled) continue;
+                        McpServerConnection conn = ConnectAndAdd(spec, null);
+                        if (conn != null) _eager.Add(conn);
+                    }
+                }
+                _scopedSpecs = scoped;
+            }
+        }
+
+        // Make `workdir` the active conversation's directory: tear down the previous workdir-scoped
+        // servers and open fresh ones bound to it. null/empty disconnects them (no scoped tools).
+        public void SetActiveWorkingDir(string workdir)
+        {
+            string wd = string.IsNullOrEmpty(workdir) ? null : workdir;
+            lock (_lock)
+            {
+                if (_disposed) return;
+                if (_currentWorkdir == wd) return;
+
+                for (int i = 0; i < _scoped.Count; i++) Teardown(_scoped[i]);
+                _scoped.Clear();
+                _currentWorkdir = wd;
+
+                if (wd != null)
+                {
+                    for (int i = 0; i < _scopedSpecs.Count; i++)
+                    {
+                        McpServerSpec spec = _scopedSpecs[i];
+                        if (spec == null || !spec.Enabled) continue;
+                        McpServerConnection conn = ConnectAndAdd(spec, wd);
+                        if (conn != null) _scoped.Add(conn);
+                    }
+                }
+            }
+        }
+
+        private McpServerConnection ConnectAndAdd(McpServerSpec spec, string workdir)
+        {
+            McpServerConnection conn;
+            try { conn = _connector.Create(spec, workdir); }
+            catch (Exception ex)
+            {
+                _log.Log("mcp", "connector failed for '" + spec.Name + "': " + ex.Message);
+                return null;
+            }
+            if (conn == null) return null;
+
+            // Wire lifecycle → registry before Open so a fault during/after open is handled.
+            conn.ToolsChanged += OnToolsChanged;
+            conn.StateChanged += OnStateChanged;
+
+            try
+            {
+                if (conn.State == ConnectionState.Created) conn.Open(_openTimeoutMs);
+            }
+            catch (Exception ex)
+            {
+                _log.Log("mcp", "open failed for '" + spec.Name + "': " + ex.Message);
+                Teardown(conn);
+                return null;
+            }
+
+            if (conn.State == ConnectionState.Ready)
+            {
+                _registry.AddConnection(conn);
+                return conn;
+            }
+
+            _log.Log("mcp", "server '" + spec.Name + "' not Ready after open (state=" + conn.State + ").");
+            Teardown(conn);
+            return null;
+        }
+
+        private void OnToolsChanged(object sender, EventArgs e)
+        {
+            McpServerConnection conn = sender as McpServerConnection;
+            if (conn != null) _registry.RefreshConnection(conn);
+        }
+
+        private void OnStateChanged(object sender, ConnectionStateEventArgs e)
+        {
+            if (e == null) return;
+            if (e.NewState == ConnectionState.Faulted || e.NewState == ConnectionState.Closed)
+            {
+                McpServerConnection conn = sender as McpServerConnection;
+                if (conn != null) _registry.RemoveConnection(conn);
+            }
+        }
+
+        // Unsubscribe (so Dispose's Closed event doesn't re-enter), drop from the registry, dispose.
+        private void Teardown(McpServerConnection conn)
+        {
+            if (conn == null) return;
+            try { conn.ToolsChanged -= OnToolsChanged; }
+            catch { }
+            try { conn.StateChanged -= OnStateChanged; }
+            catch { }
+            _registry.RemoveConnection(conn);
+            try { conn.Dispose(); }
+            catch { }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                for (int i = 0; i < _scoped.Count; i++) Teardown(_scoped[i]);
+                for (int i = 0; i < _eager.Count; i++) Teardown(_eager[i]);
+                _scoped.Clear();
+                _eager.Clear();
+            }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpServerSpec.cs
+++ b/GxPT/Services/Mcp/McpServerSpec.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    internal enum McpTransportKind
+    {
+        Stdio,
+        Http
+    }
+
+    // A host-neutral description of one configurable MCP server (built-in Tier-1 or mcp.json Tier-2).
+    // McpHost translates a spec into the actual transport (StdioTransport / HttpTransport) at launch;
+    // keeping config parsing free of Mcp35.Client makes it pure and unit-testable.
+    internal sealed class McpServerSpec
+    {
+        public string Name;
+        public McpTransportKind Kind;
+        public bool Enabled;
+
+        // True for built-in servers sandboxed to a working directory (files/git/command): the host
+        // injects GXPT_WORKDIR and launches them lazily, per conversation. web/HTTP servers are
+        // workdir-independent and may be launched once.
+        public bool WorkdirScoped;
+
+        // True for the four bundled first-party servers (hardcoded launch, never in mcp.json, D15).
+        public bool BuiltIn;
+
+        // stdio
+        public string Command;
+        public string[] Args;
+        public Dictionary<string, string> Env;
+
+        // http
+        public string Url;
+        public Dictionary<string, string> Headers;
+
+        public McpServerSpec()
+        {
+            Args = new string[0];
+            Env = new Dictionary<string, string>();
+            Headers = new Dictionary<string, string>();
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Mcp35.Client;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Core.Protocol;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The host's tool-discovery component (phase 5). Aggregates every connected server's tools into
+    // (a) a cheap names manifest, (b) a small LRU-capped set of "revealed" full definitions, and
+    // (c) reveal_tools, the meta-tool that moves a tool from "known by name" to "callable". Owns the
+    // server-qualified function-name bijection so tool_calls resolve back to (connection, toolName).
+    //
+    // Thread-safe: lifecycle methods are driven from connection reader threads (Ready/ToolsChanged/
+    // fault), while the orchestrator calls the per-request/resolution methods from its worker thread.
+    internal sealed class McpToolRegistry
+    {
+        public const string RevealToolsName = "reveal_tools";
+        public const int DefaultRevealCap = 24; // discovery spec §13
+
+        private sealed class CatalogEntry
+        {
+            public McpServerConnection Conn;
+            public string OriginalName;
+            public string FunctionName;
+            public string Description;
+            public JObject Schema;
+        }
+
+        private readonly object _lock = new object();
+        private readonly Dictionary<string, CatalogEntry> _byFunctionName =
+            new Dictionary<string, CatalogEntry>(StringComparer.Ordinal);
+        private readonly Dictionary<McpServerConnection, List<string>> _byConnection =
+            new Dictionary<McpServerConnection, List<string>>();
+        private readonly Dictionary<string, long> _revealed = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        private readonly int _revealCap;
+        private readonly ILogSink _log;
+        private long _tick;
+        private string _manifestCache;
+        private bool _manifestDirty = true;
+
+        public McpToolRegistry(int revealCap, ILogSink log)
+        {
+            _revealCap = revealCap > 0 ? revealCap : DefaultRevealCap;
+            _log = log != null ? log : NullLogSink.Instance;
+        }
+
+        // ---- lifecycle (driven by McpHost from connection events) ----
+
+        public void AddConnection(McpServerConnection conn)
+        {
+            if (conn == null) return;
+            // ListTools may hit the transport — call it outside the lock, then merge under it.
+            IList<Tool> tools = SafeListTools(conn, false);
+
+            lock (_lock)
+            {
+                List<string> fns;
+                if (!_byConnection.TryGetValue(conn, out fns))
+                {
+                    fns = new List<string>();
+                    _byConnection[conn] = fns;
+                }
+                for (int i = 0; i < tools.Count; i++)
+                {
+                    Tool t = tools[i];
+                    if (t == null || string.IsNullOrEmpty(t.Name)) continue;
+                    string fn = Munge(conn.Name, t.Name);
+
+                    CatalogEntry e = new CatalogEntry();
+                    e.Conn = conn;
+                    e.OriginalName = t.Name;
+                    e.FunctionName = fn;
+                    e.Description = t.Description;
+                    e.Schema = t.InputSchema;
+                    _byFunctionName[fn] = e;
+                    if (!fns.Contains(fn)) fns.Add(fn);
+                }
+                _manifestDirty = true;
+            }
+        }
+
+        public void RefreshConnection(McpServerConnection conn)
+        {
+            if (conn == null) return;
+            IList<Tool> tools = SafeListTools(conn, true);
+
+            lock (_lock)
+            {
+                RemoveConnectionLocked(conn);
+
+                List<string> fns = new List<string>();
+                _byConnection[conn] = fns;
+                for (int i = 0; i < tools.Count; i++)
+                {
+                    Tool t = tools[i];
+                    if (t == null || string.IsNullOrEmpty(t.Name)) continue;
+                    string fn = Munge(conn.Name, t.Name);
+
+                    CatalogEntry e = new CatalogEntry();
+                    e.Conn = conn;
+                    e.OriginalName = t.Name;
+                    e.FunctionName = fn;
+                    e.Description = t.Description;
+                    e.Schema = t.InputSchema;
+                    _byFunctionName[fn] = e;
+                    if (!fns.Contains(fn)) fns.Add(fn);
+                }
+                _manifestDirty = true;
+            }
+        }
+
+        public void RemoveConnection(McpServerConnection conn)
+        {
+            if (conn == null) return;
+            lock (_lock)
+            {
+                RemoveConnectionLocked(conn);
+                _manifestDirty = true;
+            }
+        }
+
+        private void RemoveConnectionLocked(McpServerConnection conn)
+        {
+            List<string> fns;
+            if (_byConnection.TryGetValue(conn, out fns))
+            {
+                for (int i = 0; i < fns.Count; i++)
+                {
+                    _byFunctionName.Remove(fns[i]);
+                    _revealed.Remove(fns[i]);
+                }
+                _byConnection.Remove(conn);
+            }
+        }
+
+        // ---- per-request (from the orchestrator) ----
+
+        public string NamesManifestSystemMessage()
+        {
+            lock (_lock)
+            {
+                if (_manifestDirty || _manifestCache == null)
+                {
+                    List<string> names = new List<string>(_byFunctionName.Keys);
+                    names.Sort(StringComparer.Ordinal); // server__ prefix groups visually
+
+                    StringBuilder sb = new StringBuilder();
+                    sb.Append("Available MCP tools. Call reveal_tools({\"names\":[...]}) to load a tool's ");
+                    sb.Append("full definition before you can call it.");
+                    for (int i = 0; i < names.Count; i++)
+                        sb.Append("\n- ").Append(names[i]);
+                    _manifestCache = sb.ToString();
+                    _manifestDirty = false;
+                }
+                return _manifestCache;
+            }
+        }
+
+        public IList<JObject> ExposedFunctionDefs()
+        {
+            List<JObject> result = new List<JObject>();
+            result.Add(RevealToolsDef());
+            lock (_lock)
+            {
+                // Order the revealed set by recency (oldest first) for a stable, deterministic array.
+                List<string> fns = new List<string>(_revealed.Keys);
+                fns.Sort(delegate(string a, string b) { return _revealed[a].CompareTo(_revealed[b]); });
+                for (int i = 0; i < fns.Count; i++)
+                {
+                    CatalogEntry e;
+                    if (_byFunctionName.TryGetValue(fns[i], out e))
+                        result.Add(FunctionDef(e.FunctionName, e.Description, CloneSchema(e.Schema)));
+                }
+            }
+            return result;
+        }
+
+        // ---- tool_call handling ----
+
+        public bool IsRevealTools(string functionName)
+        {
+            return functionName == RevealToolsName;
+        }
+
+        public string Reveal(string[] names)
+        {
+            JArray defs = new JArray();
+            List<string> notes = new List<string>();
+
+            lock (_lock)
+            {
+                if (names != null)
+                {
+                    for (int i = 0; i < names.Length; i++)
+                    {
+                        string n = names[i];
+                        CatalogEntry e;
+                        if (n != null && _byFunctionName.TryGetValue(n, out e))
+                        {
+                            _revealed[n] = ++_tick; // add or bump recency
+                            JObject d = new JObject();
+                            d["name"] = e.FunctionName;
+                            d["description"] = e.Description != null ? e.Description : string.Empty;
+                            d["parameters"] = CloneSchema(e.Schema);
+                            defs.Add(d);
+                        }
+                        else
+                        {
+                            notes.Add("unknown tool: " + (n != null ? n : "(null)"));
+                        }
+                    }
+                }
+                EnforceCapLocked();
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(defs.ToString(Formatting.None));
+            for (int i = 0; i < notes.Count; i++)
+                sb.Append("\n").Append(notes[i]);
+            return sb.ToString();
+        }
+
+        public bool TryResolve(string functionName, out McpServerConnection conn, out string toolName)
+        {
+            lock (_lock)
+            {
+                CatalogEntry e;
+                if (functionName != null && _byFunctionName.TryGetValue(functionName, out e))
+                {
+                    if (_revealed.ContainsKey(functionName))
+                        _revealed[functionName] = ++_tick; // keep an actively-called tool alive
+                    conn = e.Conn;
+                    toolName = e.OriginalName;
+                    return true;
+                }
+            }
+            conn = null;
+            toolName = null;
+            return false;
+        }
+
+        // ---- internals ----
+
+        private void EnforceCapLocked()
+        {
+            while (_revealed.Count > _revealCap)
+            {
+                string victim = null;
+                long min = long.MaxValue;
+                foreach (KeyValuePair<string, long> kv in _revealed)
+                {
+                    if (kv.Value < min) { min = kv.Value; victim = kv.Key; }
+                }
+                if (victim == null) break;
+                _revealed.Remove(victim);
+            }
+        }
+
+        private static JObject RevealToolsDef()
+        {
+            JObject props = new JObject();
+            JObject namesProp = new JObject();
+            namesProp["type"] = "array";
+            JObject items = new JObject();
+            items["type"] = "string";
+            namesProp["items"] = items;
+            props["names"] = namesProp;
+
+            JObject schema = new JObject();
+            schema["type"] = "object";
+            schema["properties"] = props;
+            schema["required"] = new JArray("names");
+
+            return FunctionDef(RevealToolsName,
+                "Load full definitions for tools by exact name so they become callable.", schema);
+        }
+
+        // Clone so the catalog's stored schema is never reparented into a request-body JObject
+        // (a JToken can have only one parent; exposed defs are rebuilt every request).
+        private static JObject CloneSchema(JObject schema)
+        {
+            return schema != null ? (JObject)schema.DeepClone() : new JObject();
+        }
+
+        private static JObject FunctionDef(string name, string description, JObject parameters)
+        {
+            JObject fn = new JObject();
+            fn["name"] = name;
+            fn["description"] = description != null ? description : string.Empty;
+            fn["parameters"] = parameters != null ? (JToken)parameters : new JObject();
+
+            JObject def = new JObject();
+            def["type"] = "function";
+            def["function"] = fn;
+            return def;
+        }
+
+        // Deterministic, OpenAI-legal, server-qualified name. Collisions/over-length resolved by a
+        // stable hash suffix. Bound (not yet) here — caller binds the returned name to its entry.
+        private string Munge(string serverName, string toolName)
+        {
+            string raw = (serverName != null ? serverName : string.Empty) + "__" +
+                         (toolName != null ? toolName : string.Empty);
+            string baseName = Sanitize(raw);
+
+            if (baseName.Length <= 64 && !CollidesWithDifferentLocked(baseName, serverName, toolName))
+                return baseName;
+
+            string h = ShortHash((serverName != null ? serverName : string.Empty) + "\0" +
+                                 (toolName != null ? toolName : string.Empty));
+            return Truncate(baseName, 64 - 7) + "_" + h;
+        }
+
+        private bool CollidesWithDifferentLocked(string baseName, string serverName, string toolName)
+        {
+            CatalogEntry e;
+            if (!_byFunctionName.TryGetValue(baseName, out e)) return false;
+            // Same identity (e.g. a stale entry being re-added) is not a collision.
+            bool sameServer = (e.Conn != null && e.Conn.Name == serverName);
+            return !(sameServer && e.OriginalName == toolName);
+        }
+
+        private static string Sanitize(string s)
+        {
+            StringBuilder sb = new StringBuilder(s.Length);
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                          (c >= '0' && c <= '9') || c == '_' || c == '-';
+                sb.Append(ok ? c : '_');
+            }
+            return sb.ToString();
+        }
+
+        private static string Truncate(string s, int n)
+        {
+            if (s.Length <= n) return s;
+            return s.Substring(0, n);
+        }
+
+        // FNV-1a over UTF-8 bytes → 6 lowercase hex. Deterministic across runs (no crypto dep).
+        private static string ShortHash(string s)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(s);
+            uint h = 2166136261u;
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                h ^= bytes[i];
+                h *= 16777619u;
+            }
+            return h.ToString("x8", CultureInfo.InvariantCulture).Substring(0, 6);
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -125,6 +125,18 @@ namespace GxPT
             }
         }
 
+        // ListTools may hit the transport; call it outside the lock and never let a fault propagate
+        // into the registry (a faulted server just contributes no tools).
+        private IList<Tool> SafeListTools(McpServerConnection conn, bool refresh)
+        {
+            try { return conn.ListTools(refresh); }
+            catch (Exception ex)
+            {
+                _log.Log("mcp", "ListTools failed for '" + conn.Name + "': " + ex.Message);
+                return new List<Tool>();
+            }
+        }
+
         private void RemoveConnectionLocked(McpServerConnection conn)
         {
             List<string> fns;

--- a/GxPT/Services/Mcp/ToolCallAssembler.cs
+++ b/GxPT/Services/Mcp/ToolCallAssembler.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GxPT
+{
+    // Reassembles fragmented streamed tool calls (phase 4, §5). Providers stream a tool call in
+    // pieces: id/name usually in the first fragment, arguments dribbled across many, correlated by
+    // index. The assembler consumes ChatCompletionChunks (via OnChunk), forwards plain text deltas
+    // to the UI as they arrive, and at stream end exposes either the accumulated assistant text or
+    // the rebuilt list of tool calls.
+    //
+    // Usage: client.StreamRawChunks(body, asm.OnChunk, onError); asm.Finish();
+    //   then read ProducedToolCalls / Calls / Text.
+    internal sealed class ToolCallAssembler
+    {
+        private sealed class Acc
+        {
+            public string Id;
+            public string Type;
+            public readonly StringBuilder Name = new StringBuilder();
+            public readonly StringBuilder Args = new StringBuilder();
+        }
+
+        private readonly Action<string> _onTextDelta;
+        private readonly Dictionary<int, Acc> _accs = new Dictionary<int, Acc>();
+        private readonly StringBuilder _text = new StringBuilder();
+
+        private bool _finalized;
+        private bool _producedToolCalls;
+        private List<ToolCall> _calls;
+        private string _finishReason;
+        private bool _truncated;
+
+        public ToolCallAssembler(Action<string> onTextDelta)
+        {
+            _onTextDelta = onTextDelta;
+        }
+
+        public bool ProducedToolCalls { get { return _producedToolCalls; } }
+        public List<ToolCall> Calls { get { return _calls != null ? _calls : new List<ToolCall>(); } }
+        public string Text { get { return _text.ToString(); } }
+        public string FinishReason { get { return _finishReason; } }
+        // A tool call cut off by finish_reason == "length": its arguments are incomplete.
+        public bool Truncated { get { return _truncated; } }
+
+        public void OnChunk(ChatCompletionChunk chunk)
+        {
+            if (chunk == null || chunk.choices == null || chunk.choices.Count == 0) return;
+
+            // Streaming chat completions use n=1; the first choice carries this turn's deltas.
+            ChatCompletionChunk.Choice choice = chunk.choices[0];
+            if (choice == null) return;
+
+            ChatCompletionChunk.Delta delta = choice.delta;
+            if (delta != null)
+            {
+                if (!string.IsNullOrEmpty(delta.content))
+                {
+                    _text.Append(delta.content);
+                    if (_onTextDelta != null) _onTextDelta(delta.content);
+                }
+
+                if (delta.tool_calls != null)
+                {
+                    for (int i = 0; i < delta.tool_calls.Count; i++)
+                    {
+                        ToolCallDelta f = delta.tool_calls[i];
+                        if (f == null) continue;
+
+                        Acc a;
+                        if (!_accs.TryGetValue(f.index, out a))
+                        {
+                            a = new Acc();
+                            _accs[f.index] = a;
+                        }
+                        if (f.id != null) a.Id = f.id;       // last non-null wins
+                        if (f.type != null) a.Type = f.type;
+                        if (f.function != null)
+                        {
+                            if (f.function.name != null) a.Name.Append(f.function.name);        // concat-safe
+                            if (f.function.arguments != null) a.Args.Append(f.function.arguments);
+                        }
+                    }
+                }
+            }
+
+            if (choice.finish_reason != null)
+                Finalize(choice.finish_reason);
+        }
+
+        // Idempotent; call after the stream ends in case no finish_reason arrived.
+        public void Finish()
+        {
+            Finalize(_finishReason);
+        }
+
+        private void Finalize(string reason)
+        {
+            if (_finalized) return;
+            _finalized = true;
+            _finishReason = reason;
+
+            if (_accs.Count == 0)
+            {
+                // No tool calls — a plain assistant answer.
+                _producedToolCalls = false;
+                return;
+            }
+
+            // Rebuild calls ordered by their streamed index for stable ordering.
+            List<int> indexes = new List<int>(_accs.Keys);
+            indexes.Sort();
+
+            _calls = new List<ToolCall>(indexes.Count);
+            for (int i = 0; i < indexes.Count; i++)
+            {
+                Acc a = _accs[indexes[i]];
+                string args = a.Args.Length > 0 ? a.Args.ToString() : "{}";
+                _calls.Add(new ToolCall(a.Id, a.Name.ToString(), args));
+            }
+            _producedToolCalls = true;
+            // A call cut off by the model's max length leaves arguments JSON incomplete.
+            _truncated = (reason == "length");
+        }
+    }
+}

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using System.Web.Script.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace GxPT
 {
-    internal sealed class OpenRouterClient
+    internal sealed class OpenRouterClient : IChatStreamer
     {
         private readonly string _apiKey;
         private readonly string _curlPath;
@@ -23,74 +24,105 @@ namespace GxPT
             get { return !string.IsNullOrEmpty(_apiKey) && File.Exists(_curlPath); }
         }
 
-        // Build request body using provided client properties (including stream and provider options)
-        private static string BuildRequestBody(string model, IList<ChatMessage> messages, ClientProperties props)
+        // Build the request body (Newtonsoft, D16). Emits the messages (with assistant tool_calls and
+        // tool-role tool_call_id where present), the optional tools array, and provider options.
+        // The emoji-suppression system message is always prepended.
+        internal static string BuildRequestBody(string model, IList<ChatMessage> messages, IList<JObject> tools, ClientProperties props)
         {
             var payload = new Dictionary<string, object>();
             payload["model"] = string.IsNullOrEmpty(model) ? "openai/gpt-4o" : model;
             bool streamFlag = (props != null && props.Stream.HasValue) ? props.Stream.Value : false;
             payload["stream"] = streamFlag;
-            var msgs = new List<Dictionary<string, string>>();
-            // Prepend a system instruction to avoid emoji in all responses
-            msgs.Add(new Dictionary<string, string> {
-                { "role", "system" },
-                { "content", "Do not use emojis or emoticons in any response. Use plain text only." }
-            });
+
+            var msgs = new List<object>();
+            // Prepend a system instruction to avoid emoji in all responses.
+            var sys = new Dictionary<string, object>();
+            sys["role"] = "system";
+            sys["content"] = "Do not use emojis or emoticons in any response. Use plain text only.";
+            msgs.Add(sys);
+
             if (messages != null)
             {
                 foreach (var m in messages)
                 {
-                    msgs.Add(new Dictionary<string, string> { { "role", m.Role }, { "content", m.Content } });
+                    var mm = new Dictionary<string, object>();
+                    mm["role"] = m.Role;
+
+                    if (m.Role == "tool")
+                    {
+                        // Tool result, keyed back to the assistant's call id.
+                        mm["content"] = m.Content != null ? m.Content : string.Empty;
+                        mm["tool_call_id"] = m.ToolCallId;
+                    }
+                    else if (m.ToolCalls != null && m.ToolCalls.Count > 0)
+                    {
+                        // Assistant turn requesting tool calls (content may be null alongside calls).
+                        mm["content"] = string.IsNullOrEmpty(m.Content) ? null : (object)m.Content;
+                        var calls = new List<object>();
+                        foreach (var c in m.ToolCalls)
+                        {
+                            var fn = new Dictionary<string, object>();
+                            fn["name"] = c.Name;
+                            fn["arguments"] = string.IsNullOrEmpty(c.ArgumentsJson) ? "{}" : c.ArgumentsJson;
+                            var call = new Dictionary<string, object>();
+                            call["id"] = c.Id;
+                            call["type"] = "function";
+                            call["function"] = fn;
+                            calls.Add(call);
+                        }
+                        mm["tool_calls"] = calls;
+                    }
+                    else
+                    {
+                        mm["content"] = m.Content != null ? m.Content : string.Empty;
+                    }
+                    msgs.Add(mm);
                 }
             }
             payload["messages"] = msgs;
 
-            // Optionally add provider object if any of the provider properties are set
+            // Expose tools (tool_choice left at the provider default of "auto").
+            if (tools != null && tools.Count > 0)
+            {
+                var toolList = new List<object>();
+                foreach (var t in tools) toolList.Add(t);
+                payload["tools"] = toolList;
+            }
+
+            // Optionally add provider object if any of the provider properties are set.
             try
             {
-                if (props == null)
+                if (props != null)
                 {
-                    var ser0 = new JavaScriptSerializer();
-                    return ser0.Serialize(payload);
-                }
-                var provider = new Dictionary<string, object>();
+                    var provider = new Dictionary<string, object>();
 
-                // data_collection: include if set (true => allow, false => deny)
-                if (props.ProviderDataCollectionAllowed.HasValue)
-                {
-                    provider["data_collection"] = props.ProviderDataCollectionAllowed.Value ? "allow" : "deny";
-                }
+                    // data_collection: include if set (true => allow, false => deny)
+                    if (props.ProviderDataCollectionAllowed.HasValue)
+                        provider["data_collection"] = props.ProviderDataCollectionAllowed.Value ? "allow" : "deny";
 
-                // only: include non-empty list
-                if (props.ProviderOnly != null && props.ProviderOnly.Count > 0)
-                {
-                    // copy to a new list to avoid serializing non-generic types
-                    var onlyList = new List<string>();
-                    foreach (var s in props.ProviderOnly)
+                    // only: include non-empty list
+                    if (props.ProviderOnly != null && props.ProviderOnly.Count > 0)
                     {
-                        if (!string.IsNullOrEmpty(s)) onlyList.Add(s);
+                        var onlyList = new List<string>();
+                        foreach (var s in props.ProviderOnly)
+                            if (!string.IsNullOrEmpty(s)) onlyList.Add(s);
+                        if (onlyList.Count > 0) provider["only"] = onlyList;
                     }
-                    if (onlyList.Count > 0)
-                        provider["only"] = onlyList;
-                }
 
-                // max_price: include any provided fields
-                var maxPrice = new Dictionary<string, object>();
-                if (props.ProviderMaxPricePrompt.HasValue)
-                    maxPrice["prompt"] = props.ProviderMaxPricePrompt.Value;
-                if (props.ProviderMaxPriceCompletion.HasValue)
-                    maxPrice["completion"] = props.ProviderMaxPriceCompletion.Value;
-                if (maxPrice.Count > 0)
-                    provider["max_price"] = maxPrice;
+                    // max_price: include any provided fields
+                    var maxPrice = new Dictionary<string, object>();
+                    if (props.ProviderMaxPricePrompt.HasValue)
+                        maxPrice["prompt"] = props.ProviderMaxPricePrompt.Value;
+                    if (props.ProviderMaxPriceCompletion.HasValue)
+                        maxPrice["completion"] = props.ProviderMaxPriceCompletion.Value;
+                    if (maxPrice.Count > 0) provider["max_price"] = maxPrice;
 
-                if (provider.Count > 0)
-                {
-                    payload["provider"] = provider;
+                    if (provider.Count > 0) payload["provider"] = provider;
                 }
             }
             catch { }
-            var ser = new JavaScriptSerializer();
-            return ser.Serialize(payload);
+
+            return JsonConvert.SerializeObject(payload);
         }
 
         public string CreateCompletion(string model, IList<ChatMessage> messages)
@@ -105,7 +137,7 @@ namespace GxPT
             // Ensure stream flag defaults to false for non-stream API
             if (props == null) props = new ClientProperties();
             if (!props.Stream.HasValue) props.Stream = false;
-            string body = BuildRequestBody(model, messages, props);
+            string body = BuildRequestBody(model, messages, null, props);
             List<string> tempFiles;
             string args = BuildCurlArgs(body, out tempFiles);
 
@@ -143,9 +175,7 @@ namespace GxPT
                         Logger.Log("HTTP", "curl error body: " + output);
                         try
                         {
-                            var ser2 = new JavaScriptSerializer();
-                            var dict2 = ser2.Deserialize<Dictionary<string, object>>(output);
-                            var msg2 = ExtractErrorMessage(dict2);
+                            var msg2 = ExtractErrorMessage(SafeParse(output));
                             if (!string.IsNullOrEmpty(msg2))
                                 Logger.Log("HTTP", "error.message: " + msg2);
                         }
@@ -160,19 +190,53 @@ namespace GxPT
             }
         }
 
+        // IChatStreamer: build the body (with tools) then stream parsed chunks. Used by the
+        // McpChatOrchestrator; the assembler reassembles tool_calls and forwards text deltas.
+        public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
+                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+        {
+            if (props == null) props = new ClientProperties();
+            if (!props.Stream.HasValue) props.Stream = true;
+            string body = BuildRequestBody(model, messages, tools, props);
+            StreamRawChunks(body, onChunk, onError);
+        }
+
         public void CreateCompletionStream(string model, IList<ChatMessage> messages, Action<string> onDelta, Action onDone, Action<string> onError)
         {
             // Backward-compatible API: defaults to stream
             CreateCompletionStream(model, messages, null, onDelta, onDone, onError);
         }
 
-        // New overload accepting ClientProperties
+        // Text-only streaming wrapper over StreamRawChunks (no tools): forwards content deltas.
         public void CreateCompletionStream(string model, IList<ChatMessage> messages, ClientProperties props, Action<string> onDelta, Action onDone, Action<string> onError)
         {
             if (props == null) props = new ClientProperties();
-            // Ensure stream flag defaults to true for stream API
             if (!props.Stream.HasValue) props.Stream = true;
-            string body = BuildRequestBody(model, messages, props);
+            string body = BuildRequestBody(model, messages, null, props);
+
+            bool failed = false;
+            StreamRawChunks(body,
+                delegate(ChatCompletionChunk chunk)
+                {
+                    if (chunk != null && chunk.choices != null)
+                    {
+                        foreach (var ch in chunk.choices)
+                        {
+                            string content = (ch != null && ch.delta != null) ? ch.delta.content : null;
+                            if (!string.IsNullOrEmpty(content) && onDelta != null) onDelta(content);
+                        }
+                    }
+                },
+                delegate(string err) { failed = true; if (onError != null) onError(err); });
+
+            if (!failed && onDone != null) onDone();
+        }
+
+        // The shared curl + SSE streaming loop. Each "data:" line is parsed (Newtonsoft) into a
+        // ChatCompletionChunk and handed to onChunk; if the whole stream yields no chunks, the body
+        // is inspected for a JSON error and onError is called.
+        public void StreamRawChunks(string body, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+        {
             List<string> tempFiles;
             string args = BuildCurlArgs(body, out tempFiles);
 
@@ -191,7 +255,6 @@ namespace GxPT
                 var proc = new Process();
                 proc.StartInfo = psi;
                 proc.EnableRaisingEvents = false;
-                Logger.Log("Stream", "Starting curl for model=" + model + ", messages=" + (messages != null ? messages.Count : 0));
                 proc.Start();
 
                 // Read lines as they arrive (SSE: lines like "data: {...}") with explicit UTF-8 decoding
@@ -199,13 +262,12 @@ namespace GxPT
                 var sr = new StreamReader(proc.StandardOutput.BaseStream, utf8, false);
                 var er = new StreamReader(proc.StandardError.BaseStream, utf8, false);
                 string line;
-                var ser = new JavaScriptSerializer();
-                bool sawAnyDelta = false;
+                bool sawAnyChunk = false;
                 var stdoutBuf = new StringBuilder();
                 while ((line = sr.ReadLine()) != null)
                 {
                     line = line.Trim();
-                    // Buffer all stdout; if no deltas are seen, we'll inspect this for a JSON error body.
+                    // Buffer all stdout; if no chunks are seen, we'll inspect this for a JSON error body.
                     if (line.Length > 0)
                     {
                         try { stdoutBuf.AppendLine(line); }
@@ -214,91 +276,53 @@ namespace GxPT
                     if (line.Length == 0) continue;
                     if (line.StartsWith("data:")) line = line.Substring(5).Trim();
                     if (line == "[DONE]") break;
-                    try
+
+                    ChatCompletionChunk chunk = null;
+                    try { chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(line); }
+                    catch { continue; } // Ignore malformed keepalive/heartbeat lines
+                    if (chunk != null)
                     {
-                        var chunk = ser.Deserialize<ChatCompletionChunk>(line);
-                        if (chunk != null && chunk.choices != null)
-                        {
-                            foreach (var ch in chunk.choices)
-                            {
-                                string content = (ch != null && ch.delta != null) ? ch.delta.content : null;
-                                if (!string.IsNullOrEmpty(content))
-                                {
-                                    sawAnyDelta = true;
-                                    if (onDelta != null) onDelta(content);
-                                }
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        // Ignore malformed keepalive/heartbeat lines
-                        continue;
+                        sawAnyChunk = true;
+                        if (onChunk != null) onChunk(chunk);
                     }
                 }
                 try { proc.WaitForExit(); }
                 catch { }
-                // If process wrote errors and we produced no deltas, surface error
-                try
+
+                // If the process produced no chunks, surface an error from the body/stderr.
+                string err = null;
+                try { err = er.ReadToEnd(); }
+                catch { }
+                if (!sawAnyChunk)
                 {
-                    string err = er.ReadToEnd();
-                    if (!sawAnyDelta)
+                    string rawBody = null;
+                    try { rawBody = stdoutBuf.ToString().Trim(); }
+                    catch { }
+
+                    string extractedMsg = null;
+                    if (!string.IsNullOrEmpty(rawBody))
                     {
-                        // Prefer any JSON error body sent on stdout (with --fail-with-body)
-                        string rawBody = null;
-                        try { rawBody = stdoutBuf.ToString().Trim(); }
+                        try { extractedMsg = ExtractErrorMessage(SafeParse(rawBody)); }
+                        catch { }
+                        try { Logger.Log("HTTP", "curl error body (no chunks): " + rawBody); }
+                        catch { }
+                        if (!string.IsNullOrEmpty(extractedMsg))
+                            try { Logger.Log("HTTP", "error.message: " + extractedMsg); }
+                            catch { }
+                    }
+                    if (!string.IsNullOrEmpty(err))
+                        try { Logger.Log("Stream", "curl stderr (no chunks): " + err); }
                         catch { }
 
-                        string userMsg = null;
-                        string extractedMsg = null;
-                        if (!string.IsNullOrEmpty(rawBody))
-                        {
-                            try
-                            {
-                                // Attempt to parse common error shapes
-                                var dict = ser.Deserialize<Dictionary<string, object>>(rawBody);
-                                extractedMsg = ExtractErrorMessage(dict);
-                                userMsg = extractedMsg ?? rawBody;
-                                try { Logger.Log("HTTP", "curl error body (no deltas): " + rawBody); }
-                                catch { }
-                                try
-                                {
-                                    if (!string.IsNullOrEmpty(extractedMsg))
-                                        Logger.Log("HTTP", "error.message: " + extractedMsg);
-                                }
-                                catch { }
-                            }
-                            catch
-                            {
-                                // Not JSON; fall back to raw body text
-                                userMsg = rawBody;
-                                try { Logger.Log("HTTP", "curl non-JSON body (no deltas): " + rawBody); }
-                                catch { }
-                            }
-                        }
-
-                        // Log stderr too for diagnostics
-                        if (!string.IsNullOrEmpty(err))
-                        {
-                            try { Logger.Log("Stream", "curl stderr (no deltas): " + err); }
-                            catch { }
-                        }
-
-                        if (onError != null)
-                        {
-                            // Prefer API error.message if present; otherwise fall back to curl's stderr summary
-                            var msg = !string.IsNullOrEmpty(extractedMsg) ? extractedMsg : (!string.IsNullOrEmpty(err) ? err : "Request failed");
-                            onError(msg.Trim());
-                        }
-                        // Clean up temp files
-                        CleanupTempFiles(tempFiles);
-                        return;
+                    if (onError != null)
+                    {
+                        var msg = !string.IsNullOrEmpty(extractedMsg) ? extractedMsg : (!string.IsNullOrEmpty(err) ? err : "Request failed");
+                        onError(msg.Trim());
                     }
+                    CleanupTempFiles(tempFiles);
+                    return;
                 }
-                catch { }
 
-                if (onDone != null) onDone();
-                // Clean up temp files
                 CleanupTempFiles(tempFiles);
             }
             catch (Exception ex)
@@ -398,55 +422,46 @@ namespace GxPT
             }
         }
 
-        // Extracts a human-readable error message from common JSON error shapes (C# 3.0 compatible)
-        private static string ExtractErrorMessage(Dictionary<string, object> root)
+        private static JObject SafeParse(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return null;
+            try { return JObject.Parse(json); }
+            catch { return null; }
+        }
+
+        // Extracts a human-readable error message from common JSON error shapes.
+        internal static string ExtractErrorMessage(JObject root)
         {
             if (root == null) return null;
             try
             {
-                // { "error": { "message": "..." } }
-                object errorObj;
-                if (root.TryGetValue("error", out errorObj))
+                // { "error": { "message": "..." } } (or error/detail)
+                JToken errorObj = root["error"];
+                if (errorObj != null && errorObj.Type == JTokenType.Object)
                 {
-                    var errDict = errorObj as Dictionary<string, object>;
-                    if (errDict != null)
-                    {
-                        object v;
-                        if (errDict.TryGetValue("message", out v))
-                        {
-                            var s = v as string;
-                            if (!string.IsNullOrEmpty(s)) return s;
-                        }
-                        if (errDict.TryGetValue("error", out v))
-                        {
-                            var s2 = v as string;
-                            if (!string.IsNullOrEmpty(s2)) return s2;
-                        }
-                        if (errDict.TryGetValue("detail", out v))
-                        {
-                            var s3 = v as string;
-                            if (!string.IsNullOrEmpty(s3)) return s3;
-                        }
-                    }
+                    string m = AsString(errorObj["message"]);
+                    if (!string.IsNullOrEmpty(m)) return m;
+                    string e2 = AsString(errorObj["error"]);
+                    if (!string.IsNullOrEmpty(e2)) return e2;
+                    string d = AsString(errorObj["detail"]);
+                    if (!string.IsNullOrEmpty(d)) return d;
                 }
 
                 // { "message": "..." }
-                object msgVal;
-                if (root.TryGetValue("message", out msgVal))
-                {
-                    var msgStr = msgVal as string;
-                    if (!string.IsNullOrEmpty(msgStr)) return msgStr;
-                }
+                string msg = AsString(root["message"]);
+                if (!string.IsNullOrEmpty(msg)) return msg;
                 // { "detail": "..." }
-                object detVal;
-                if (root.TryGetValue("detail", out detVal))
-                {
-                    var detStr = detVal as string;
-                    if (!string.IsNullOrEmpty(detStr)) return detStr;
-                }
+                string det = AsString(root["detail"]);
+                if (!string.IsNullOrEmpty(det)) return det;
             }
             catch { }
             return null;
+        }
+
+        private static string AsString(JToken t)
+        {
+            if (t == null || t.Type != JTokenType.String) return null;
+            return (string)t;
         }
     }
 


### PR DESCRIPTION
## What this is

The host-side wiring that makes MCP tools usable from GxPT's chat: expose tools to the model, parse streamed `tool_calls`, route them through `McpServerConnection`, and feed results back until a final answer — plus the configuration + `McpHost` that assemble the connection set. Realizes **phases 3§7, 4, and 5**. Approval is a phase-4 stub (phase 6 swaps it). **No WinForms UI in this PR** (see "Not included").

Validated end-to-end: CI green on every commit; the author confirmed a clean **VS2008 net35 build**, live chat (Newtonsoft request/stream path), and that **existing conversations still load** after the `ConversationStore` migration.

## Commits

| # | Commit | What |
|---|--------|------|
| 1 | models + `ToolCallAssembler` + approval seam | streamed `tool_calls` reassembly (fragmented-by-index), `IToolApprovalPolicy` |
| 2 | `McpToolRegistry` | name munging/bijection, names manifest, `reveal_tools`, LRU-capped reveal set |
| 3 | `McpChatOrchestrator` | bounded call→run→re-call loop, against an `IChatStreamer` seam |
| 4 | `OpenRouterClient` → **Newtonsoft** | `tools`/`tool_calls`/`tool` wire format + `StreamRawChunks`/`StreamChat` |
| 5a | config layer | `mcp.json` loader, built-in server specs, GitHub PAT shape gate |
| 5b | `McpHost` + connector | connection assembly, registry lifecycle, **lazy per-conversation** launch; `Mcp35.Client`/`Core` into `GxPT.csproj` |
| 6 | `ConversationStore` → **Newtonsoft** | persist assistant `tool_calls` + `tool` results; backward-compatible reads |

(plus small net35/C#3 + warning fixes surfaced by the VS2008 build)

## Design notes

- **Discovery (D4):** the model always sees a cheap **names manifest**; `reveal_tools(names)` loads full schemas on demand into an LRU-capped set. Deterministic, collision-safe function names via `server__tool` munging + hash suffix.
- **Loop:** bounded by `MaxIterations` (8); tool failures (unknown tool, bad args, denial, JSON-RPC error, transport fault, timeout) are fed back **as content** so the model can recover; serial execution within a turn.
- **`McpHost`:** workdir-independent servers (web + every `mcp.json` entry) open once; workdir-scoped built-ins (files/git/command) open lazily per conversation with `GXPT_WORKDIR`, swapped on conversation change. Connection lifecycle (`Ready`/`ToolsChanged`/fault) drives the registry.
- **JSON (D16):** OpenRouter path + `ConversationStore` on Newtonsoft (`JObject` end-to-end, no `MaxJsonLength` cap); `AppSettings` stays on JavaScriptSerializer. Reads stay backward-compatible (PascalCase keys, legacy `\/Date()\/` timestamps, legacy inline-attachment markers).

## Testing

~60 new `GxPT.Tests` cases (net48, linked-source): assembler reassembly; registry munging/manifest/reveal/LRU/lifecycle; the orchestrator loop (single/multi call, reveal-then-call, iteration cap, error feedback, denial, streaming-error stop); `BuildRequestBody` golden JSON + chunk parsing; config parsing/PAT gate/built-in specs; `McpHost` assembly + lazy-launch lifecycle; `ConversationStore` tool round-trip + backward compat.

> Note: CI builds the **net48 linked-source** tests, not the **net35 app** — so the app's `ProjectReference` graph and C#3-only constraints are validated only by the VS2008 build (both confirmed clean here).

## Not included (deliberate follow-up)

The `MainForm`/`SettingsForm` **UI integration**: constructing `McpHost` from settings, the MCP settings tab (toggles + web-search key + `mcp.json` editor), swapping the active workdir on conversation change, routing chat sends through the orchestrator, and the transcript rendering of tool calls. Nothing calls `McpHost`/the orchestrator yet, so the app behaves exactly as today. Installer (`GxPT.Setup`) will also need the new `Mcp35.*` + `Newtonsoft.Json` DLLs added when the UI lands.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s