### PR TITLE
MCP UI (1/n): settings tab — built-in toggles, web/GitHub credentials, custom-server editor

### DIFF
--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -56,6 +56,17 @@
             this.tabJson = new System.Windows.Forms.TabPage();
             this.lblColor = new System.Windows.Forms.Label();
             this.cmbColor = new System.Windows.Forms.ComboBox();
+            this.tabMcp = new System.Windows.Forms.TabPage();
+            this.tblMcp = new System.Windows.Forms.TableLayoutPanel();
+            this.chkMcpWeb = new System.Windows.Forms.CheckBox();
+            this.txtWebSearchKey = new System.Windows.Forms.TextBox();
+            this.chkMcpGithub = new System.Windows.Forms.CheckBox();
+            this.txtGithubPat = new System.Windows.Forms.TextBox();
+            this.chkMcpFiles = new System.Windows.Forms.CheckBox();
+            this.chkMcpGit = new System.Windows.Forms.CheckBox();
+            this.chkMcpCommand = new System.Windows.Forms.CheckBox();
+            this.lblMcpCustom = new System.Windows.Forms.Label();
+            this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
             this.tblSettings.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).BeginInit();
@@ -64,6 +75,8 @@
             this.tabControl1.SuspendLayout();
             this.tabVisual.SuspendLayout();
             this.tabJson.SuspendLayout();
+            this.tabMcp.SuspendLayout();
+            this.tblMcp.SuspendLayout();
             this.SuspendLayout();
             // 
             // flowLayoutPanel1
@@ -366,6 +379,7 @@
             // 
             this.tabControl1.Controls.Add(this.tabVisual);
             this.tabControl1.Controls.Add(this.tabJson);
+            this.tabControl1.Controls.Add(this.tabMcp);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
@@ -394,9 +408,136 @@
             this.tabJson.TabIndex = 1;
             this.tabJson.Text = "JSON";
             this.tabJson.UseVisualStyleBackColor = true;
-            // 
+            //
+            // tabMcp
+            //
+            this.tabMcp.Controls.Add(this.tblMcp);
+            this.tabMcp.Location = new System.Drawing.Point(4, 22);
+            this.tabMcp.Name = "tabMcp";
+            this.tabMcp.Padding = new System.Windows.Forms.Padding(3);
+            this.tabMcp.Size = new System.Drawing.Size(596, 363);
+            this.tabMcp.TabIndex = 2;
+            this.tabMcp.Text = "MCP";
+            this.tabMcp.UseVisualStyleBackColor = true;
+            //
+            // tblMcp
+            //
+            this.tblMcp.ColumnCount = 2;
+            this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcp.Controls.Add(this.chkMcpWeb, 0, 0);
+            this.tblMcp.Controls.Add(this.txtWebSearchKey, 1, 0);
+            this.tblMcp.Controls.Add(this.chkMcpGithub, 0, 1);
+            this.tblMcp.Controls.Add(this.txtGithubPat, 1, 1);
+            this.tblMcp.Controls.Add(this.chkMcpFiles, 0, 2);
+            this.tblMcp.Controls.Add(this.chkMcpGit, 0, 3);
+            this.tblMcp.Controls.Add(this.chkMcpCommand, 0, 4);
+            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 5);
+            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 6);
+            this.tblMcp.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tblMcp.Location = new System.Drawing.Point(3, 3);
+            this.tblMcp.Name = "tblMcp";
+            this.tblMcp.RowCount = 7;
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcp.SetColumnSpan(this.lblMcpCustom, 2);
+            this.tblMcp.SetColumnSpan(this.rtbMcpJson, 2);
+            this.tblMcp.Size = new System.Drawing.Size(590, 357);
+            this.tblMcp.TabIndex = 0;
+            //
+            // chkMcpWeb
+            //
+            this.chkMcpWeb.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpWeb.AutoSize = true;
+            this.chkMcpWeb.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpWeb.Name = "chkMcpWeb";
+            this.chkMcpWeb.TabIndex = 0;
+            this.chkMcpWeb.Text = "Web search";
+            this.chkMcpWeb.UseVisualStyleBackColor = true;
+            //
+            // txtWebSearchKey
+            //
+            this.txtWebSearchKey.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtWebSearchKey.Name = "txtWebSearchKey";
+            this.txtWebSearchKey.Size = new System.Drawing.Size(450, 20);
+            this.txtWebSearchKey.TabIndex = 1;
+            //
+            // chkMcpGithub
+            //
+            this.chkMcpGithub.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpGithub.AutoSize = true;
+            this.chkMcpGithub.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpGithub.Name = "chkMcpGithub";
+            this.chkMcpGithub.TabIndex = 2;
+            this.chkMcpGithub.Text = "GitHub";
+            this.chkMcpGithub.UseVisualStyleBackColor = true;
+            //
+            // txtGithubPat
+            //
+            this.txtGithubPat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtGithubPat.Name = "txtGithubPat";
+            this.txtGithubPat.Size = new System.Drawing.Size(450, 20);
+            this.txtGithubPat.TabIndex = 3;
+            //
+            // chkMcpFiles
+            //
+            this.chkMcpFiles.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpFiles.AutoSize = true;
+            this.chkMcpFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpFiles.Name = "chkMcpFiles";
+            this.chkMcpFiles.TabIndex = 4;
+            this.chkMcpFiles.Text = "Files";
+            this.chkMcpFiles.UseVisualStyleBackColor = true;
+            //
+            // chkMcpGit
+            //
+            this.chkMcpGit.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpGit.AutoSize = true;
+            this.chkMcpGit.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpGit.Name = "chkMcpGit";
+            this.chkMcpGit.TabIndex = 5;
+            this.chkMcpGit.Text = "Git";
+            this.chkMcpGit.UseVisualStyleBackColor = true;
+            //
+            // chkMcpCommand
+            //
+            this.chkMcpCommand.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpCommand.AutoSize = true;
+            this.chkMcpCommand.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpCommand.Name = "chkMcpCommand";
+            this.chkMcpCommand.TabIndex = 6;
+            this.chkMcpCommand.Text = "Command";
+            this.chkMcpCommand.UseVisualStyleBackColor = true;
+            //
+            // lblMcpCustom
+            //
+            this.lblMcpCustom.AutoSize = true;
+            this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
+            this.lblMcpCustom.Name = "lblMcpCustom";
+            this.lblMcpCustom.TabIndex = 7;
+            this.lblMcpCustom.Text = "Custom servers (mcp.json):";
+            //
+            // rtbMcpJson
+            //
+            this.rtbMcpJson.AcceptsTab = true;
+            this.rtbMcpJson.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.rtbMcpJson.DetectUrls = false;
+            this.rtbMcpJson.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rtbMcpJson.Font = new System.Drawing.Font("Consolas", 9F);
+            this.rtbMcpJson.HideSelection = false;
+            this.rtbMcpJson.Name = "rtbMcpJson";
+            this.rtbMcpJson.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Both;
+            this.rtbMcpJson.TabIndex = 8;
+            this.rtbMcpJson.Text = "";
+            this.rtbMcpJson.WordWrap = false;
+            //
             // lblColor
-            // 
+            //
             this.lblColor.AutoSize = true;
             this.lblColor.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblColor.Location = new System.Drawing.Point(3, 229);
@@ -436,6 +577,10 @@
             this.tabControl1.ResumeLayout(false);
             this.tabVisual.ResumeLayout(false);
             this.tabJson.ResumeLayout(false);
+            this.tabMcp.ResumeLayout(false);
+            this.tabMcp.PerformLayout();
+            this.tblMcp.ResumeLayout(false);
+            this.tblMcp.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -470,5 +615,16 @@
         private System.Windows.Forms.ComboBox cmbProviderDataCollection;
         private System.Windows.Forms.Label lblColor;
         private System.Windows.Forms.ComboBox cmbColor;
+        private System.Windows.Forms.TabPage tabMcp;
+        private System.Windows.Forms.TableLayoutPanel tblMcp;
+        private System.Windows.Forms.CheckBox chkMcpWeb;
+        private System.Windows.Forms.TextBox txtWebSearchKey;
+        private System.Windows.Forms.CheckBox chkMcpGithub;
+        private System.Windows.Forms.TextBox txtGithubPat;
+        private System.Windows.Forms.CheckBox chkMcpFiles;
+        private System.Windows.Forms.CheckBox chkMcpGit;
+        private System.Windows.Forms.CheckBox chkMcpCommand;
+        private System.Windows.Forms.Label lblMcpCustom;
+        private System.Windows.Forms.RichTextBox rtbMcpJson;
     }
 }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.IO;
 using System.Windows.Forms;
 using System.Web.Script.Serialization; // .NET 3.5 JSON serializer
+using Newtonsoft.Json.Linq;            // mcp.json validation
 
 namespace GxPT
 {
@@ -15,6 +16,16 @@ namespace GxPT
     {
         private readonly string _settingsDir;
         private readonly string _settingsFile;
+        private readonly string _mcpFile;
+
+        // MCP tab (built programmatically in BuildMcpTab so the Designer stays untouched).
+        private TabPage tabMcp;
+        private CheckBox chkMcpWeb;
+        private CheckBox chkMcpFiles;
+        private CheckBox chkMcpGit;
+        private CheckBox chkMcpCommand;
+        private TextBox txtWebSearchKey;
+        private RichTextBox rtbMcpJson;
 
         // In-memory working copy (unsaved until Save/CTRL+S)
         private SettingsData _working = new SettingsData();
@@ -39,6 +50,7 @@ namespace GxPT
             // Compute settings paths under %AppData%\GxPT
             _settingsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GxPT");
             _settingsFile = Path.Combine(_settingsDir, "settings.json");
+            _mcpFile = Path.Combine(_settingsDir, "mcp.json");
 
             // Configure new font size controls
             try
@@ -101,6 +113,10 @@ namespace GxPT
                 }
             }
             catch { }
+
+            // Build the MCP settings tab programmatically (keeps the Designer file untouched).
+            try { BuildMcpTab(); }
+            catch { }
         }
 
         private void SettingsForm_Load(object sender, EventArgs e)
@@ -120,8 +136,12 @@ namespace GxPT
                 {
                     ApplySettingsToVisualControls(_working);
                     UpdateJsonEditorFromSettings(_working);
+                    ApplyMcpToControls(_working);
                 }
                 finally { _isSyncing = false; }
+
+                // mcp.json lives in its own file beside settings.json.
+                LoadMcpJsonEditor();
             }
             catch (Exception ex)
             {
@@ -232,8 +252,15 @@ namespace GxPT
                     return false;
                 }
 
+                // Validate the mcp.json editor before writing anything; fold MCP toggles + web key
+                // into the working settings so they persist to settings.json.
+                string mcpJsonText;
+                if (!TryValidateMcpJson(out mcpJsonText)) return false;
+                CaptureMcpControlsToWorking(_working);
+
                 var json = Serialize(_working);
                 File.WriteAllText(_settingsFile, json, Encoding.UTF8);
+                WriteMcpJson(mcpJsonText);
 
                 // Refresh JSON editor with normalized JSON
                 _isSyncing = true;
@@ -278,6 +305,10 @@ namespace GxPT
         private void TabControl1_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (_isSyncing) return;
+
+            // The MCP tab edits mcp.json + its own settings; it is independent of the settings.json
+            // visual/JSON sync, so don't run that sync when entering it.
+            if (this.tabControl1.SelectedTab == this.tabMcp) return;
 
             bool toJson = this.tabControl1.SelectedTab == this.tabJson;
 
@@ -1123,6 +1154,146 @@ namespace GxPT
             }
         }
 
+        // --- MCP settings tab (built in code; Designer untouched) ---
+
+        private void BuildMcpTab()
+        {
+            if (this.tabControl1 == null) return;
+
+            tabMcp = new TabPage();
+            tabMcp.Text = "MCP";
+            tabMcp.UseVisualStyleBackColor = true;
+            tabMcp.Padding = new Padding(6);
+
+            // mcp.json editor fills the remaining space. Added FIRST so the docked Top panel above
+            // reserves its space and the editor fills what's left.
+            rtbMcpJson = new RichTextBox();
+            rtbMcpJson.Dock = DockStyle.Fill;
+            rtbMcpJson.BorderStyle = BorderStyle.FixedSingle;
+            rtbMcpJson.Font = new Font("Consolas", 9F);
+            rtbMcpJson.AcceptsTab = true;
+            rtbMcpJson.DetectUrls = false;
+            rtbMcpJson.HideSelection = false;
+            rtbMcpJson.WordWrap = false;
+            rtbMcpJson.ScrollBars = RichTextBoxScrollBars.Both;
+
+            Panel top = new Panel();
+            top.Dock = DockStyle.Top;
+            top.Height = 116;
+
+            Label lblTools = new Label();
+            lblTools.Text = "Built-in tool servers:";
+            lblTools.AutoSize = true;
+            lblTools.Location = new Point(3, 8);
+
+            chkMcpWeb = MakeMcpCheck("Web search", 6, 30);
+            chkMcpFiles = MakeMcpCheck("Files", 120, 30);
+            chkMcpGit = MakeMcpCheck("Git", 200, 30);
+            chkMcpCommand = MakeMcpCheck("Command", 260, 30);
+
+            Label lblKey = new Label();
+            lblKey.Text = "Web Search API Key:";
+            lblKey.AutoSize = true;
+            lblKey.Location = new Point(3, 60);
+
+            txtWebSearchKey = new TextBox();
+            txtWebSearchKey.Location = new Point(140, 57);
+            txtWebSearchKey.Width = 420;
+            txtWebSearchKey.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+
+            Label lblJsonHint = new Label();
+            lblJsonHint.Text = "Custom servers and GitHub (mcp.json):";
+            lblJsonHint.AutoSize = true;
+            lblJsonHint.Location = new Point(3, 92);
+
+            top.Controls.Add(lblTools);
+            top.Controls.Add(chkMcpWeb);
+            top.Controls.Add(chkMcpFiles);
+            top.Controls.Add(chkMcpGit);
+            top.Controls.Add(chkMcpCommand);
+            top.Controls.Add(lblKey);
+            top.Controls.Add(txtWebSearchKey);
+            top.Controls.Add(lblJsonHint);
+
+            tabMcp.Controls.Add(rtbMcpJson);
+            tabMcp.Controls.Add(top);
+
+            this.tabControl1.Controls.Add(tabMcp);
+        }
+
+        private static CheckBox MakeMcpCheck(string text, int x, int y)
+        {
+            CheckBox c = new CheckBox();
+            c.Text = text;
+            c.AutoSize = true;
+            c.Location = new Point(x, y);
+            c.UseVisualStyleBackColor = true;
+            return c;
+        }
+
+        private void ApplyMcpToControls(SettingsData s)
+        {
+            if (s == null) return;
+            if (chkMcpWeb != null) chkMcpWeb.Checked = s.mcp_web_enabled;
+            if (chkMcpFiles != null) chkMcpFiles.Checked = s.mcp_files_enabled;
+            if (chkMcpGit != null) chkMcpGit.Checked = s.mcp_git_enabled;
+            if (chkMcpCommand != null) chkMcpCommand.Checked = s.mcp_command_enabled;
+            if (txtWebSearchKey != null) txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
+        }
+
+        private void CaptureMcpControlsToWorking(SettingsData target)
+        {
+            if (target == null) return;
+            if (chkMcpWeb != null) target.mcp_web_enabled = chkMcpWeb.Checked;
+            if (chkMcpFiles != null) target.mcp_files_enabled = chkMcpFiles.Checked;
+            if (chkMcpGit != null) target.mcp_git_enabled = chkMcpGit.Checked;
+            if (chkMcpCommand != null) target.mcp_command_enabled = chkMcpCommand.Checked;
+            if (txtWebSearchKey != null)
+                target.mcp_websearch_key = txtWebSearchKey.Text != null ? txtWebSearchKey.Text.Trim() : string.Empty;
+        }
+
+        private void LoadMcpJsonEditor()
+        {
+            string text = null;
+            try { if (File.Exists(_mcpFile)) text = File.ReadAllText(_mcpFile, Encoding.UTF8); }
+            catch { }
+            if (string.IsNullOrEmpty(text)) text = McpConfig.SeedJson;
+            if (rtbMcpJson != null) rtbMcpJson.Text = text;
+        }
+
+        // Validate the mcp.json editor. Empty -> seed the default (GitHub placeholder). Invalid JSON
+        // blocks the save and switches to the MCP tab.
+        private bool TryValidateMcpJson(out string text)
+        {
+            text = rtbMcpJson != null ? rtbMcpJson.Text : string.Empty;
+            string trimmed = text != null ? text.Trim() : string.Empty;
+            if (trimmed.Length == 0) { text = McpConfig.SeedJson; return true; }
+            try
+            {
+                JObject.Parse(trimmed);
+                text = trimmed;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                try { if (tabMcp != null) this.tabControl1.SelectedTab = tabMcp; }
+                catch { }
+                MessageBox.Show(this, "mcp.json is not valid JSON:\r\n\r\n" + ex.Message,
+                    "Invalid mcp.json", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        private void WriteMcpJson(string text)
+        {
+            try { FileSafe.WriteAllTextAtomic(_mcpFile, text != null ? text : string.Empty, new UTF8Encoding(false)); }
+            catch (Exception ex)
+            {
+                try { Logger.Log("mcp", "Failed to write mcp.json: " + ex.Message); }
+                catch { }
+            }
+        }
+
         // Settings schema
         private sealed class SettingsData
         {
@@ -1137,6 +1308,13 @@ namespace GxPT
             // Store percent (50-100) using legacy key name
             public int message_max_width { get; set; }
             public bool provider_data_collection { get; set; }
+
+            // MCP built-in server toggles + web-search key (read by the host via AppSettings).
+            public bool mcp_web_enabled { get; set; }
+            public bool mcp_files_enabled { get; set; }
+            public bool mcp_git_enabled { get; set; }
+            public bool mcp_command_enabled { get; set; }
+            public string mcp_websearch_key { get; set; }
         }
     }
 }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -18,15 +18,6 @@ namespace GxPT
         private readonly string _settingsFile;
         private readonly string _mcpFile;
 
-        // MCP tab (built programmatically in BuildMcpTab so the Designer stays untouched).
-        private TabPage tabMcp;
-        private CheckBox chkMcpWeb;
-        private CheckBox chkMcpFiles;
-        private CheckBox chkMcpGit;
-        private CheckBox chkMcpCommand;
-        private TextBox txtWebSearchKey;
-        private RichTextBox rtbMcpJson;
-
         // In-memory working copy (unsaved until Save/CTRL+S)
         private SettingsData _working = new SettingsData();
 
@@ -114,9 +105,20 @@ namespace GxPT
             }
             catch { }
 
-            // Build the MCP settings tab programmatically (keeps the Designer file untouched).
-            try { BuildMcpTab(); }
+            // MCP tab: gate the web-search / GitHub toggles on a plausibly-valid key/PAT.
+            try
+            {
+                this.txtWebSearchKey.TextChanged += McpCredential_TextChanged;
+                this.txtGithubPat.TextChanged += McpCredential_TextChanged;
+            }
             catch { }
+        }
+
+        private void McpCredential_TextChanged(object sender, EventArgs e)
+        {
+            // Suppressed during programmatic population (ApplyMcpToControls runs it once at the end).
+            if (_isSyncing) return;
+            UpdateMcpEnableStates();
         }
 
         private void SettingsForm_Load(object sender, EventArgs e)
@@ -1154,102 +1156,56 @@ namespace GxPT
             }
         }
 
-        // --- MCP settings tab (built in code; Designer untouched) ---
+        // --- MCP settings tab (controls live in the Designer) ---
 
-        private void BuildMcpTab()
-        {
-            if (this.tabControl1 == null) return;
-
-            tabMcp = new TabPage();
-            tabMcp.Text = "MCP";
-            tabMcp.UseVisualStyleBackColor = true;
-            tabMcp.Padding = new Padding(6);
-
-            // mcp.json editor fills the remaining space. Added FIRST so the docked Top panel above
-            // reserves its space and the editor fills what's left.
-            rtbMcpJson = new RichTextBox();
-            rtbMcpJson.Dock = DockStyle.Fill;
-            rtbMcpJson.BorderStyle = BorderStyle.FixedSingle;
-            rtbMcpJson.Font = new Font("Consolas", 9F);
-            rtbMcpJson.AcceptsTab = true;
-            rtbMcpJson.DetectUrls = false;
-            rtbMcpJson.HideSelection = false;
-            rtbMcpJson.WordWrap = false;
-            rtbMcpJson.ScrollBars = RichTextBoxScrollBars.Both;
-
-            Panel top = new Panel();
-            top.Dock = DockStyle.Top;
-            top.Height = 116;
-
-            Label lblTools = new Label();
-            lblTools.Text = "Built-in tool servers:";
-            lblTools.AutoSize = true;
-            lblTools.Location = new Point(3, 8);
-
-            chkMcpWeb = MakeMcpCheck("Web search", 6, 30);
-            chkMcpFiles = MakeMcpCheck("Files", 120, 30);
-            chkMcpGit = MakeMcpCheck("Git", 200, 30);
-            chkMcpCommand = MakeMcpCheck("Command", 260, 30);
-
-            Label lblKey = new Label();
-            lblKey.Text = "Web Search API Key:";
-            lblKey.AutoSize = true;
-            lblKey.Location = new Point(3, 60);
-
-            txtWebSearchKey = new TextBox();
-            txtWebSearchKey.Location = new Point(140, 57);
-            txtWebSearchKey.Width = 420;
-            txtWebSearchKey.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-
-            Label lblJsonHint = new Label();
-            lblJsonHint.Text = "Custom servers and GitHub (mcp.json):";
-            lblJsonHint.AutoSize = true;
-            lblJsonHint.Location = new Point(3, 92);
-
-            top.Controls.Add(lblTools);
-            top.Controls.Add(chkMcpWeb);
-            top.Controls.Add(chkMcpFiles);
-            top.Controls.Add(chkMcpGit);
-            top.Controls.Add(chkMcpCommand);
-            top.Controls.Add(lblKey);
-            top.Controls.Add(txtWebSearchKey);
-            top.Controls.Add(lblJsonHint);
-
-            tabMcp.Controls.Add(rtbMcpJson);
-            tabMcp.Controls.Add(top);
-
-            this.tabControl1.Controls.Add(tabMcp);
-        }
-
-        private static CheckBox MakeMcpCheck(string text, int x, int y)
-        {
-            CheckBox c = new CheckBox();
-            c.Text = text;
-            c.AutoSize = true;
-            c.Location = new Point(x, y);
-            c.UseVisualStyleBackColor = true;
-            return c;
-        }
+        // Empty custom-servers template shown when mcp.json doesn't exist yet. GitHub is configured
+        // via its own toggle + PAT field (settings.json), not here.
+        private const string McpJsonTemplate = "{\r\n  \"mcp_servers\": {\r\n  }\r\n}\r\n";
 
         private void ApplyMcpToControls(SettingsData s)
         {
             if (s == null) return;
-            if (chkMcpWeb != null) chkMcpWeb.Checked = s.mcp_web_enabled;
-            if (chkMcpFiles != null) chkMcpFiles.Checked = s.mcp_files_enabled;
-            if (chkMcpGit != null) chkMcpGit.Checked = s.mcp_git_enabled;
-            if (chkMcpCommand != null) chkMcpCommand.Checked = s.mcp_command_enabled;
-            if (txtWebSearchKey != null) txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
+            this.chkMcpWeb.Checked = s.mcp_web_enabled;
+            this.chkMcpFiles.Checked = s.mcp_files_enabled;
+            this.chkMcpGit.Checked = s.mcp_git_enabled;
+            this.chkMcpCommand.Checked = s.mcp_command_enabled;
+            this.chkMcpGithub.Checked = s.mcp_github_enabled;
+            this.txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
+            this.txtGithubPat.Text = s.mcp_github_pat != null ? s.mcp_github_pat : string.Empty;
+            UpdateMcpEnableStates();
         }
 
         private void CaptureMcpControlsToWorking(SettingsData target)
         {
             if (target == null) return;
-            if (chkMcpWeb != null) target.mcp_web_enabled = chkMcpWeb.Checked;
-            if (chkMcpFiles != null) target.mcp_files_enabled = chkMcpFiles.Checked;
-            if (chkMcpGit != null) target.mcp_git_enabled = chkMcpGit.Checked;
-            if (chkMcpCommand != null) target.mcp_command_enabled = chkMcpCommand.Checked;
-            if (txtWebSearchKey != null)
-                target.mcp_websearch_key = txtWebSearchKey.Text != null ? txtWebSearchKey.Text.Trim() : string.Empty;
+            target.mcp_web_enabled = this.chkMcpWeb.Checked;
+            target.mcp_files_enabled = this.chkMcpFiles.Checked;
+            target.mcp_git_enabled = this.chkMcpGit.Checked;
+            target.mcp_command_enabled = this.chkMcpCommand.Checked;
+            target.mcp_github_enabled = this.chkMcpGithub.Checked;
+            target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
+            target.mcp_github_pat = this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : string.Empty;
+        }
+
+        // A web-search / GitHub toggle is only enableable when its key/PAT looks plausibly valid;
+        // an empty or malformed field disables (and clears) the toggle so it can't be saved on.
+        private void UpdateMcpEnableStates()
+        {
+            bool webOk = LooksLikeTavilyKey(this.txtWebSearchKey.Text);
+            this.chkMcpWeb.Enabled = webOk;
+            if (!webOk) this.chkMcpWeb.Checked = false;
+
+            bool patOk = McpConfig.IsValidGitHubPat(this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : null);
+            this.chkMcpGithub.Enabled = patOk;
+            if (!patOk) this.chkMcpGithub.Checked = false;
+        }
+
+        // Tavily keys look like "tvly-dev-XXXXXXXX" (or "tvly-XXXXXXXX"). Lenient prefix + length check.
+        private static bool LooksLikeTavilyKey(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return false;
+            key = key.Trim();
+            return key.StartsWith("tvly-", StringComparison.OrdinalIgnoreCase) && key.Length >= 12;
         }
 
         private void LoadMcpJsonEditor()
@@ -1257,17 +1213,17 @@ namespace GxPT
             string text = null;
             try { if (File.Exists(_mcpFile)) text = File.ReadAllText(_mcpFile, Encoding.UTF8); }
             catch { }
-            if (string.IsNullOrEmpty(text)) text = McpConfig.SeedJson;
-            if (rtbMcpJson != null) rtbMcpJson.Text = text;
+            if (string.IsNullOrEmpty(text)) text = McpJsonTemplate;
+            this.rtbMcpJson.Text = text;
         }
 
         // Validate the mcp.json editor. Empty -> seed the default (GitHub placeholder). Invalid JSON
         // blocks the save and switches to the MCP tab.
         private bool TryValidateMcpJson(out string text)
         {
-            text = rtbMcpJson != null ? rtbMcpJson.Text : string.Empty;
+            text = this.rtbMcpJson.Text;
             string trimmed = text != null ? text.Trim() : string.Empty;
-            if (trimmed.Length == 0) { text = McpConfig.SeedJson; return true; }
+            if (trimmed.Length == 0) { text = McpJsonTemplate; return true; }
             try
             {
                 JObject.Parse(trimmed);
@@ -1309,12 +1265,14 @@ namespace GxPT
             public int message_max_width { get; set; }
             public bool provider_data_collection { get; set; }
 
-            // MCP built-in server toggles + web-search key (read by the host via AppSettings).
+            // MCP built-in server toggles + credentials (read by the host via AppSettings).
             public bool mcp_web_enabled { get; set; }
             public bool mcp_files_enabled { get; set; }
             public bool mcp_git_enabled { get; set; }
             public bool mcp_command_enabled { get; set; }
+            public bool mcp_github_enabled { get; set; }
             public string mcp_websearch_key { get; set; }
+            public string mcp_github_pat { get; set; }
         }
     }
 }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -34,6 +34,10 @@ namespace GxPT
         private int _pendingHighlightStart = -1;
         private int _pendingHighlightEnd = -1;
 
+        // Debounce + guard for the mcp.json editor's syntax highlighting (mirrors the JSON tab).
+        private Timer _mcpHighlightTimer;
+        private bool _isMcpHighlighting = false;
+
         public SettingsForm()
         {
             InitializeComponent();
@@ -90,6 +94,12 @@ namespace GxPT
             _jsonHighlightTimer.Interval = 200; // ms
             _jsonHighlightTimer.Tick += JsonHighlightTimer_Tick;
             this.rtbJson.TextChanged += RtbJson_TextChanged;
+
+            // mcp.json editor: same JSON highlighting, debounced.
+            _mcpHighlightTimer = new Timer();
+            _mcpHighlightTimer.Interval = 200; // ms
+            _mcpHighlightTimer.Tick += McpHighlightTimer_Tick;
+            this.rtbMcpJson.TextChanged += RtbMcpJson_TextChanged;
 
             // Configure message max width as percentage UI (50-100)
             try
@@ -309,8 +319,13 @@ namespace GxPT
             if (_isSyncing) return;
 
             // The MCP tab edits mcp.json + its own settings; it is independent of the settings.json
-            // visual/JSON sync, so don't run that sync when entering it.
-            if (this.tabControl1.SelectedTab == this.tabMcp) return;
+            // visual/JSON sync. Just (re)highlight its editor on entry.
+            if (this.tabControl1.SelectedTab == this.tabMcp)
+            {
+                try { BeginInvoke(new Action(HighlightMcpJsonNow)); }
+                catch { /* ignore */ }
+                return;
+            }
 
             bool toJson = this.tabControl1.SelectedTab == this.tabJson;
 
@@ -506,20 +521,24 @@ namespace GxPT
 
         private void HighlightJsonNow()
         {
+            try { _isHighlighting = true; ApplyJsonHighlightFull(this.rtbJson); }
+            catch { /* ignore */ }
+            finally { _isHighlighting = false; }
+        }
+
+        // Full-document JSON highlight for any RichTextBox (shared by the settings JSON tab and the
+        // mcp.json editor) so both render identically.
+        private static void ApplyJsonHighlightFull(RichTextBox rtb)
+        {
+            if (rtb == null || rtb.IsDisposed) return;
+
+            string text = rtb.Text ?? string.Empty;
+            int savedStart = rtb.SelectionStart;
+            int savedLength = rtb.SelectionLength;
+
+            rtb.SuspendLayout();
             try
             {
-                _isHighlighting = true;
-                var rtb = this.rtbJson;
-                if (rtb == null || rtb.IsDisposed) return;
-
-                string text = rtb.Text ?? string.Empty;
-                // Save caret
-                int savedStart = rtb.SelectionStart;
-                int savedLength = rtb.SelectionLength;
-
-                // Disable redraw
-                rtb.SuspendLayout();
-
                 // Reset to default color
                 rtb.SelectionStart = 0;
                 rtb.SelectionLength = rtb.TextLength;
@@ -552,16 +571,31 @@ namespace GxPT
                 rtb.SelectionStart = Math.Max(0, Math.Min(savedStart, rtb.TextLength));
                 rtb.SelectionLength = Math.Max(0, Math.Min(savedLength, rtb.TextLength - rtb.SelectionStart));
             }
-            catch
-            {
-                // ignore
-            }
             finally
             {
-                this.rtbJson.ResumeLayout();
-                this.rtbJson.Invalidate();
-                _isHighlighting = false;
+                rtb.ResumeLayout();
+                rtb.Invalidate();
             }
+        }
+
+        // --- mcp.json editor highlighting (debounced; reuses the JSON tab's tokenizer/colors) ---
+        private void RtbMcpJson_TextChanged(object sender, EventArgs e)
+        {
+            if (_isSyncing || _isMcpHighlighting) return;
+            if (_mcpHighlightTimer != null) { _mcpHighlightTimer.Stop(); _mcpHighlightTimer.Start(); }
+        }
+
+        private void McpHighlightTimer_Tick(object sender, EventArgs e)
+        {
+            _mcpHighlightTimer.Stop();
+            HighlightMcpJsonNow();
+        }
+
+        private void HighlightMcpJsonNow()
+        {
+            try { _isMcpHighlighting = true; ApplyJsonHighlightFull(this.rtbMcpJson); }
+            catch { /* ignore */ }
+            finally { _isMcpHighlighting = false; }
         }
 
         private void HighlightJsonRange(int start, int length)


### PR DESCRIPTION
First slice of the MCP **UI integration** — **config surface only**. A new **MCP** tab in `SettingsForm`. **No chat-behavior change; nothing reads these settings yet** (host wiring is the next PR).

## What it adds
- An **MCP** tab in `SettingsForm`, defined in **`SettingsForm.Designer.cs`** (a `TabControl` page + a 2-column `TableLayoutPanel`).
- **Built-in tool toggles**, each row a checkbox (+ credential field where applicable):
  - **Web search** + Tavily **API key** field
  - **GitHub** + **PAT** field  *(GitHub is configured here now, not in `mcp.json`)*
  - **Files**, **Git**, **Command** (plain toggles)
- A Consolas **`mcp.json` editor** for **custom servers only** (seeds an empty `{ "mcp_servers": {} }` template).

## Behavior
- **Credential-gated toggles:** the **Web search** and **GitHub** checkboxes are **disabled (and cleared)** unless their field looks valid — Tavily `tvly-…`, GitHub `ghp_…` / `github_pat_…`. Updates live as you type; Files/Git/Command are always toggleable.
- **Persistence:** toggles + Tavily key + GitHub PAT → `settings.json` (`mcp_web_enabled`, `mcp_github_enabled`, `mcp_github_pat`, `mcp_websearch_key`, …) so the host reads them via `AppSettings`; the custom-servers editor → `%AppData%/GxPT/mcp.json`.
- **Save** validates the `mcp.json` editor as JSON (invalid blocks the save + focuses the tab); the MCP tab is excluded from the existing settings.json visual/JSON sync.

## ⚠️ Not CI-validated
WinForms — `GxPT.Tests` doesn't compile `SettingsForm`, so **CI passing means nothing here**. Validate with a **VS2008 build**:
- the **MCP** tab renders (toggles, key/PAT fields, `mcp.json` editor);
- Web search / GitHub toggles are disabled until a valid-looking key/PAT is entered, and re-disable if cleared;
- toggles + key + PAT persist across reopen (in `settings.json`); the editor round-trips to `%AppData%/GxPT/mcp.json`;
- invalid JSON in the editor is rejected on Save;
- **regression:** existing Visual/JSON tabs still save/load and tab-switching sync still works.

## Next (PR-2)
Construct `McpHost` at startup from these settings + `DefaultServerConnector`, route sends through `McpChatOrchestrator`, render tool markers — proven with **GitHub (HTTP, from the PAT field)** + web search.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s