### PR TITLE
MCP UI (2/n): route chat through the tool-call loop (GitHub + web search)

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -68,7 +68,8 @@ namespace GxPT.Tests.Mcp
             // first request: leading system message is the names manifest, history follows
             var msgs = streamer.SeenMessages[0];
             Assert.Equal("system", msgs[0].Role);
-            Assert.Contains("Available MCP tools", msgs[0].Content);
+            Assert.Contains("reveal_tools", msgs[0].Content);   // manifest instructs reveal-before-call
+            Assert.Contains("files__read", msgs[0].Content);     // and lists tool names
             Assert.Equal("user", msgs[1].Role);
             // exposed tools always lead with reveal_tools
             Assert.Equal("reveal_tools", (string)streamer.SeenTools[0][0]["function"]["name"]);

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -266,6 +266,49 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void RunTurn_overload_does_not_add_a_user_message()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("hi"));
+
+            var history = new List<ChatMessage> { new ChatMessage("user", "already here") };
+            New(streamer, reg).RunTurn(history, new RecordingUi());
+
+            Assert.Equal(2, history.Count); // user(existing) + assistant(final); no duplicate user
+            Assert.Equal("user", history[0].Role);
+            Assert.Equal("already here", history[0].Content);
+            Assert.Equal("assistant", history[1].Role);
+        }
+
+        [Fact]
+        public void RequestMessageTransform_changes_sent_messages_not_history()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var orch = New(streamer, reg);
+            orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
+            {
+                var outp = new List<ChatMessage>();
+                foreach (var m in h) outp.Add(new ChatMessage(m.Role, m.Content + " [T]"));
+                return outp;
+            };
+
+            var history = new List<ChatMessage>();
+            orch.RunTurn(history, "hello", new RecordingUi());
+
+            bool sentTransformed = false;
+            foreach (var m in streamer.SeenMessages[0])
+                if (m.Role == "user" && m.Content == "hello [T]") sentTransformed = true;
+            Assert.True(sentTransformed);             // what's sent is transformed
+            Assert.Equal("hello", history[0].Content); // persisted history is untouched
+        }
+
+        [Fact]
         public void Streaming_error_stops_the_turn()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/Mcp/McpConfigTests.cs
+++ b/GxPT.Tests/Mcp/McpConfigTests.cs
@@ -98,6 +98,21 @@ namespace GxPT.Tests.Mcp
         // ---- Tier 1: built-in specs ----
 
         [Fact]
+        public void GitHubSpec_is_http_and_enabled_only_with_a_valid_pat()
+        {
+            var ok = McpConfig.GitHubSpec(true, ClassicPat);
+            Assert.Equal("github", ok.Name);
+            Assert.Equal(McpTransportKind.Http, ok.Kind);
+            Assert.Equal(McpConfig.GitHubUrl, ok.Url);
+            Assert.Equal("Bearer " + ClassicPat, ok.Headers["Authorization"]);
+            Assert.False(ok.WorkdirScoped);
+            Assert.True(ok.Enabled);
+
+            Assert.False(McpConfig.GitHubSpec(true, "YOUR_GITHUB_PAT").Enabled); // malformed PAT
+            Assert.False(McpConfig.GitHubSpec(false, ClassicPat).Enabled);       // toggle off
+        }
+
+        [Fact]
         public void Builtins_cover_the_four_servers_with_toggles_and_env()
         {
             var o = new McpConfig.BuiltInOptions

--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -250,6 +250,18 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void HasTools_reflects_the_catalog()
+        {
+            var reg = NewRegistry(8);
+            Assert.False(reg.HasTools);
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            reg.AddConnection(conn);
+            Assert.True(reg.HasTools);
+            reg.RemoveConnection(conn);
+            Assert.False(reg.HasTools);
+        }
+
+        [Fact]
         public void Reveal_tools_name_is_never_produced_by_munging()
         {
             var reg = NewRegistry(8);

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -11,7 +11,7 @@ using System.IO;
 
 namespace GxPT
 {
-    public enum MessageRole { User, Assistant, System }
+    public enum MessageRole { User, Assistant, System, Tool }
 
     [ToolboxItem(true)]
     public sealed partial class ChatTranscriptControl : UserControl
@@ -1211,12 +1211,16 @@ namespace GxPT
             else if (it.Role == MessageRole.Assistant) { back = _clrAsstBack; border = _clrAsstBorder; }
             else { back = _clrSysBack; border = _clrSysBorder; }
 
-            using (var path = RoundedRect(r, BubbleRadius))
-            using (var b = new SolidBrush(back))
-            using (var pen = new Pen(border))
+            // Tool-activity messages render as plain text with no bubble chrome (background/border).
+            if (it.Role != MessageRole.Tool)
             {
-                g.FillPath(b, path);
-                g.DrawPath(pen, path);
+                using (var path = RoundedRect(r, BubbleRadius))
+                using (var b = new SolidBrush(back))
+                using (var pen = new Pen(border))
+                {
+                    g.FillPath(b, path);
+                    g.DrawPath(pen, path);
+                }
             }
 
             // Content area

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1076,12 +1076,20 @@ namespace GxPT
                 }
                 ClearAttachmentsBanner();
 
+                var modelToUse = GetSelectedModel();
+
+                // Tool-enabled turn: tool activity renders as a separate chrome-less message above the
+                // answer bubble. BeginToolSend owns the whole turn; the plain path below is unchanged.
+                if (_mcpRegistry != null && _mcpRegistry.HasTools)
+                {
+                    BeginToolSend(ctx, modelToUse);
+                    return;
+                }
+
                 // Add placeholder assistant message to stream into and capture its index
                 int assistantIndex = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
                 Logger.Log("Send", "Assistant placeholder index=" + assistantIndex);
                 var assistantBuilder = new StringBuilder();
-
-                var modelToUse = GetSelectedModel();
 
                 // Throttle UI updates with a WinForms timer (coalesces rapid deltas)
                 var sbLock = new object();
@@ -1150,13 +1158,6 @@ namespace GxPT
                             catch { providerAllow = true; }
                         }
 
-                        if (_mcpRegistry != null && _mcpRegistry.HasTools)
-                        {
-                            // MCP enabled with tools available: run the tool-call loop.
-                            RunMcpToolTurn(ctx, modelToUse, providerAllow, sbLock, assistantBuilder, assistantIndex, renderTimer);
-                        }
-                        else
-                        {
                         _client.CreateCompletionStream(
                             modelToUse,
                             snapshot,
@@ -1207,7 +1208,6 @@ namespace GxPT
                                 });
                             }
                         );
-                        }
                     }
                     catch (Exception ex)
                     {
@@ -1232,63 +1232,134 @@ namespace GxPT
             }
         }
 
-        // Runs one MCP tool-call turn synchronously (called on the send worker thread). The
-        // orchestrator streams model text + inline tool markers into assistantBuilder (rendered by the
-        // UI timer) and appends the structured assistant/tool messages to the conversation history;
-        // Complete/Error finalize on the UI thread (no extra AddAssistantMessage — already added).
-        private void RunMcpToolTurn(TabManager.ChatTabContext ctx, string model, bool providerAllow, object sbLock,
-                                    StringBuilder assistantBuilder, int assistantIndex,
-                                    System.Windows.Forms.Timer renderTimer)
+        // Owns a tool-enabled chat turn. Tool activity streams into a chrome-less "Tool" message and
+        // the model's answer into a separate Assistant bubble below it. Both bubbles are created
+        // lazily (in the render timer) so they appear in the order content arrives — tool calls
+        // first, then the answer. Runs the orchestrator on a worker thread; it appends the structured
+        // assistant/tool messages to history itself. Called on the UI thread.
+        private void BeginToolSend(TabManager.ChatTabContext ctx, string model)
         {
-            var orch = new McpChatOrchestrator(_client, _mcpRegistry, new AllowAllApprovalPolicy(),
-                                               model, LoggerSink.Instance);
-            orch.ProviderDataCollectionAllowed = providerAllow;
-            orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
-            {
-                List<ChatMessage> asList = h as List<ChatMessage>;
-                if (asList == null) asList = new List<ChatMessage>(h);
-                return BuildMessagesForModel(asList);
-            };
+            var sbLock = new object();
+            var activitySb = new StringBuilder();
+            var answerSb = new StringBuilder();
+            int[] activityIndex = { -1 };
+            int[] answerIndex = { -1 };
+            int lastActivityLen = -1;
+            int lastAnswerLen = -1;
 
-            Action<string> onAppend = delegate(string t)
+            var renderTimer = new System.Windows.Forms.Timer();
+            renderTimer.Interval = 75;
+            renderTimer.Tick += delegate
             {
-                lock (sbLock) { assistantBuilder.Append(t); }
-            };
-            Action onComplete = delegate
-            {
-                string finalText;
-                lock (sbLock) { finalText = assistantBuilder.ToString(); }
-                BeginInvoke((MethodInvoker)delegate
+                string aSnap = null, ansSnap = null;
+                lock (sbLock)
                 {
-                    try { renderTimer.Stop(); renderTimer.Dispose(); }
-                    catch { }
-                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                    catch { }
-                    ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
-                    // The orchestrator already appended assistant/tool messages to History.
-                    ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                    if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation);
-                    ctx.IsSending = false;
-                    if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
-                });
-            };
-            Action<string> onErr = delegate(string err)
-            {
-                if (string.IsNullOrEmpty(err)) err = "Unknown error.";
-                BeginInvoke((MethodInvoker)delegate
+                    if (activitySb.Length != lastActivityLen) { aSnap = activitySb.ToString(); lastActivityLen = activitySb.Length; }
+                    if (answerSb.Length != lastAnswerLen) { ansSnap = answerSb.ToString(); lastAnswerLen = answerSb.Length; }
+                }
+                if (aSnap != null)
                 {
-                    try { renderTimer.Stop(); renderTimer.Dispose(); }
-                    catch { }
-                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                    catch { }
-                    string cur; lock (sbLock) { cur = assistantBuilder.ToString(); }
-                    ctx.Transcript.UpdateMessageAt(assistantIndex,
-                        (cur.Length > 0 ? cur + "\r\n\r\n" : string.Empty) + "Error: " + err);
-                    ctx.IsSending = false;
-                });
+                    if (activityIndex[0] < 0) activityIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Tool, string.Empty);
+                    ctx.Transcript.UpdateMessageAt(activityIndex[0], aSnap);
+                }
+                if (ansSnap != null)
+                {
+                    if (answerIndex[0] < 0) answerIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
+                    ctx.Transcript.UpdateMessageAt(answerIndex[0], ansSnap);
+                }
             };
+            try { ctx.Transcript.StickToBottomDuringStreaming = true; }
+            catch { }
+            renderTimer.Start();
 
-            orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onComplete, onErr));
+            bool providerAllow = true;
+            try { providerAllow = AppSettings.GetBool("provider_data_collection", true); }
+            catch { providerAllow = true; }
+
+            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            {
+                try
+                {
+                    var orch = new McpChatOrchestrator(_client, _mcpRegistry, new AllowAllApprovalPolicy(),
+                                                       model, LoggerSink.Instance);
+                    orch.ProviderDataCollectionAllowed = providerAllow;
+                    orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
+                    {
+                        List<ChatMessage> asList = h as List<ChatMessage>;
+                        if (asList == null) asList = new List<ChatMessage>(h);
+                        return BuildMessagesForModel(asList);
+                    };
+
+                    Action<string> onAppend = delegate(string t) { lock (sbLock) { answerSb.Append(t); } };
+                    Action<string> onToolCall = delegate(string name)
+                    {
+                        lock (sbLock)
+                        {
+                            if (activitySb.Length > 0) activitySb.Append("\r\n");
+                            activitySb.Append(McpMarkers.Call(name));
+                        }
+                    };
+                    Action onComplete = delegate
+                    {
+                        BeginInvoke((MethodInvoker)delegate
+                        { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, null); });
+                    };
+                    Action<string> onErr = delegate(string err)
+                    {
+                        string e2 = string.IsNullOrEmpty(err) ? "Unknown error." : err;
+                        BeginInvoke((MethodInvoker)delegate
+                        { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, e2); });
+                    };
+
+                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolCall, onComplete, onErr));
+                }
+                catch (Exception ex)
+                {
+                    string msg = ex.Message;
+                    BeginInvoke((MethodInvoker)delegate
+                    { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, msg); });
+                }
+            });
+        }
+
+        // Finalize a tool turn on the UI thread. error == null means success. The orchestrator has
+        // already appended the structured assistant/tool messages to history, so we only flush the
+        // transcript bubbles and save.
+        private void FinalizeToolSend(TabManager.ChatTabContext ctx, System.Windows.Forms.Timer renderTimer,
+                                      object sbLock, StringBuilder activitySb, StringBuilder answerSb,
+                                      int[] activityIndex, int[] answerIndex, string error)
+        {
+            try { renderTimer.Stop(); renderTimer.Dispose(); }
+            catch { }
+            try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+            catch { }
+
+            string aFinal, ansFinal;
+            lock (sbLock) { aFinal = activitySb.ToString(); ansFinal = answerSb.ToString(); }
+
+            if (aFinal.Trim().Length > 0)
+            {
+                if (activityIndex[0] < 0) activityIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Tool, string.Empty);
+                ctx.Transcript.UpdateMessageAt(activityIndex[0], aFinal);
+            }
+
+            string answerText = ansFinal;
+            if (error != null)
+                answerText = (ansFinal.Length > 0 ? ansFinal + "\r\n\r\n" : string.Empty) + "Error: " + error;
+
+            if (answerText.Trim().Length > 0)
+            {
+                if (answerIndex[0] < 0) answerIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
+                ctx.Transcript.UpdateMessageAt(answerIndex[0], answerText);
+            }
+
+            if (error == null)
+            {
+                ctx.Conversation.SelectedModel = ctx.SelectedModel;
+                if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation);
+            }
+            ctx.IsSending = false;
+            if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
         }
 
         // Build a list of messages for the model, appending any attachments to the user message content
@@ -1898,13 +1969,24 @@ namespace GxPT
         // Markdown is parsed on a background thread and the resulting blocks are appended to the
         // transcript in small batches on a UI timer. System messages are skipped; help templates
         // (NoSaveUntilUserSend) are scrolled to the top, otherwise the view sticks to the bottom.
-        // Emits the accumulated assistant turn (model text + tool markers) as one transcript bubble.
-        private static void FlushAssistantBuffer(List<ChatMessage> items, ref System.Text.StringBuilder asst)
+        // Role marker for the coalesced, chrome-less tool-activity message used on reload.
+        private const string ToolActivityRole = "toolactivity";
+
+        // Emits a coalesced turn: a chrome-less tool-activity message (if any tools were used), then
+        // the assistant's answer bubble.
+        private static void FlushTurn(List<ChatMessage> items, ref System.Text.StringBuilder activity, ref string answer)
         {
-            if (asst == null) return;
-            string text = asst.ToString();
-            asst = null;
-            if (text.Trim().Length > 0) items.Add(new ChatMessage("assistant", text));
+            if (activity != null)
+            {
+                string a = activity.ToString();
+                if (a.Trim().Length > 0) items.Add(new ChatMessage(ToolActivityRole, a));
+                activity = null;
+            }
+            if (answer != null)
+            {
+                if (answer.Trim().Length > 0) items.Add(new ChatMessage("assistant", answer));
+                answer = null;
+            }
         }
 
         private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)
@@ -1923,7 +2005,8 @@ namespace GxPT
                 // with the model's text plus compact "using <tool>" markers — never the raw tool
                 // results. This matches the live streamed view.
                 var items = new List<ChatMessage>();
-                System.Text.StringBuilder asst = null;
+                System.Text.StringBuilder activity = null; // tool-use markers (+ any intermediate text)
+                string answer = null;                       // final assistant content for the turn
                 foreach (var m in convo.History)
                 {
                     if (m == null) continue;
@@ -1932,30 +2015,35 @@ namespace GxPT
 
                     if (role == "user")
                     {
-                        FlushAssistantBuffer(items, ref asst);
+                        FlushTurn(items, ref activity, ref answer);
                         items.Add(m);
                         continue;
                     }
 
-                    // assistant (or any unexpected role): accumulate text + tool-call markers
-                    if (asst == null) asst = new System.Text.StringBuilder();
-                    if (!string.IsNullOrEmpty(m.Content))
+                    if (m.ToolCalls != null && m.ToolCalls.Count > 0)
                     {
-                        if (asst.Length > 0) asst.Append("\r\n\r\n");
-                        asst.Append(m.Content);
-                    }
-                    if (m.ToolCalls != null)
-                    {
+                        // tool-calling assistant message -> tool activity (chrome-less)
+                        if (activity == null) activity = new System.Text.StringBuilder();
+                        if (!string.IsNullOrEmpty(m.Content))
+                        {
+                            if (activity.Length > 0) activity.Append("\r\n");
+                            activity.Append(m.Content);
+                        }
                         for (int ti = 0; ti < m.ToolCalls.Count; ti++)
                         {
                             var tc = m.ToolCalls[ti];
                             if (tc == null) continue;
-                            if (asst.Length > 0) asst.Append("\r\n\r\n");
-                            asst.Append(McpMarkers.Call(tc.Name));
+                            if (activity.Length > 0) activity.Append("\r\n");
+                            activity.Append(McpMarkers.Call(tc.Name));
                         }
                     }
+                    else
+                    {
+                        // assistant with no tool calls -> the answer
+                        answer = m.Content;
+                    }
                 }
-                FlushAssistantBuffer(items, ref asst);
+                FlushTurn(items, ref activity, ref answer);
 
                 // Producer-consumer: parse off-UI, consume on UI timer in small chunks
                 var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));
@@ -1977,7 +2065,10 @@ namespace GxPT
                             for (int k = 0; k < count; k++)
                             {
                                 var m = items[i + k];
-                                var role = string.Equals(m.Role, "assistant", StringComparison.OrdinalIgnoreCase) ? MessageRole.Assistant : MessageRole.User;
+                                MessageRole role;
+                                if (string.Equals(m.Role, "assistant", StringComparison.OrdinalIgnoreCase)) role = MessageRole.Assistant;
+                                else if (string.Equals(m.Role, ToolActivityRole, StringComparison.OrdinalIgnoreCase)) role = MessageRole.Tool;
+                                else role = MessageRole.User;
                                 var text = m.Content ?? string.Empty;
                                 var blocks = MarkdownParser.ParseMarkdown(text);
                                 var att = (m.Attachments != null && m.Attachments.Count > 0) ? new List<AttachedFile>(m.Attachments) : null;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -18,6 +18,8 @@ namespace GxPT
     public partial class MainForm : Form
     {
         private OpenRouterClient _client;
+        private McpHost _mcpHost;
+        private McpToolRegistry _mcpRegistry;
         private const string HelpApiKeysId = "help:api_keys";
         private const string HelpPrivacyId = "help:privacy";
 
@@ -247,6 +249,10 @@ namespace GxPT
                 string activeId = GetActiveConversationId();
                 SessionState.SaveOpenTabs(openIds, activeId);
             }
+            catch { }
+
+            // Shut down MCP servers (close stdio children / HTTP sessions).
+            try { if (_mcpHost != null) _mcpHost.Dispose(); }
             catch { }
         }
 
@@ -680,6 +686,80 @@ namespace GxPT
                 }
             }
             catch { }
+
+            // (Re)build the MCP host from the current settings (toggles, web-search key, GitHub PAT,
+            // and mcp.json custom servers). Connecting happens on a background thread.
+            RebuildMcpHost();
+        }
+
+        // Assembles MCP server specs from settings and (re)starts the host. Safe to call repeatedly
+        // (e.g. after Settings is saved). Workdir-independent servers (web + GitHub + custom) connect
+        // here; files/git/command are deferred until a working-directory UX exists.
+        private void RebuildMcpHost()
+        {
+            try
+            {
+                // Tear down any previous host (servers from the old settings).
+                if (_mcpHost != null)
+                {
+                    try { _mcpHost.Dispose(); }
+                    catch { }
+                    _mcpHost = null;
+                }
+
+                string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+                string curlPath = System.IO.Path.Combine(baseDir, "Lib\\curl.exe");
+                string caBundle = System.IO.Path.Combine(baseDir, "Lib\\curl-ca-bundle.crt");
+
+                var opts = new McpConfig.BuiltInOptions();
+                opts.WebEnabled = AppSettings.GetBool("mcp_web_enabled", false);
+                opts.FilesEnabled = AppSettings.GetBool("mcp_files_enabled", false);
+                opts.GitEnabled = AppSettings.GetBool("mcp_git_enabled", false);
+                opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled", false);
+                opts.WebSearchKey = AppSettings.GetString("mcp_websearch_key");
+                opts.CurlPath = curlPath;
+                opts.ServerDir = baseDir; // server exes expected alongside GxPT.exe (deployed later)
+
+                var specs = new List<McpServerSpec>(McpConfig.BuiltInSpecs(opts));
+                specs.Add(McpConfig.GitHubSpec(
+                    AppSettings.GetBool("mcp_github_enabled", false),
+                    AppSettings.GetString("mcp_github_pat")));
+
+                // Custom servers from mcp.json (GitHub is configured above, not here).
+                try
+                {
+                    string mcpFile = System.IO.Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        "GxPT\\mcp.json");
+                    if (System.IO.File.Exists(mcpFile))
+                    {
+                        string mcpText = System.IO.File.ReadAllText(mcpFile);
+                        specs.AddRange(McpConfig.ParseUserServers(mcpText, LoggerSink.Instance));
+                    }
+                }
+                catch { }
+
+                var clientInfo = new Mcp35.Core.Protocol.Implementation();
+                clientInfo.Name = "GxPT";
+                clientInfo.Version = "1.0";
+
+                _mcpRegistry = new McpToolRegistry(McpToolRegistry.DefaultRevealCap, LoggerSink.Instance);
+                var connector = new DefaultServerConnector(clientInfo, curlPath, caBundle, LoggerSink.Instance);
+                _mcpHost = new McpHost(connector, _mcpRegistry, LoggerSink.Instance);
+
+                // Connecting (handshakes / process spawns) can block — do it off the UI thread.
+                McpHost hostRef = _mcpHost;
+                System.Threading.ThreadPool.QueueUserWorkItem(delegate
+                {
+                    try { hostRef.Start(specs); }
+                    catch (Exception ex) { try { Logger.Log("mcp", "host start failed: " + ex.Message); } catch { } }
+                });
+            }
+            catch (Exception ex)
+            {
+                try { Logger.Log("mcp", "RebuildMcpHost failed: " + ex.Message); }
+                catch { }
+            }
         }
 
         // Build a context for the existing designer tab (tabPage1 + chatTranscript)
@@ -1070,6 +1150,13 @@ namespace GxPT
                             catch { providerAllow = true; }
                         }
 
+                        if (_mcpRegistry != null && _mcpRegistry.HasTools)
+                        {
+                            // MCP enabled with tools available: run the tool-call loop.
+                            RunMcpToolTurn(ctx, modelToUse, providerAllow, sbLock, assistantBuilder, assistantIndex, renderTimer);
+                        }
+                        else
+                        {
                         _client.CreateCompletionStream(
                             modelToUse,
                             snapshot,
@@ -1120,6 +1207,7 @@ namespace GxPT
                                 });
                             }
                         );
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1142,6 +1230,65 @@ namespace GxPT
                 ctx.IsSending = false;
                 throw;
             }
+        }
+
+        // Runs one MCP tool-call turn synchronously (called on the send worker thread). The
+        // orchestrator streams model text + inline tool markers into assistantBuilder (rendered by the
+        // UI timer) and appends the structured assistant/tool messages to the conversation history;
+        // Complete/Error finalize on the UI thread (no extra AddAssistantMessage — already added).
+        private void RunMcpToolTurn(TabManager.ChatTabContext ctx, string model, bool providerAllow, object sbLock,
+                                    StringBuilder assistantBuilder, int assistantIndex,
+                                    System.Windows.Forms.Timer renderTimer)
+        {
+            var orch = new McpChatOrchestrator(_client, _mcpRegistry, new AllowAllApprovalPolicy(),
+                                               model, LoggerSink.Instance);
+            orch.ProviderDataCollectionAllowed = providerAllow;
+            orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
+            {
+                List<ChatMessage> asList = h as List<ChatMessage>;
+                if (asList == null) asList = new List<ChatMessage>(h);
+                return BuildMessagesForModel(asList);
+            };
+
+            Action<string> onAppend = delegate(string t)
+            {
+                lock (sbLock) { assistantBuilder.Append(t); }
+            };
+            Action onComplete = delegate
+            {
+                string finalText;
+                lock (sbLock) { finalText = assistantBuilder.ToString(); }
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try { renderTimer.Stop(); renderTimer.Dispose(); }
+                    catch { }
+                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                    catch { }
+                    ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
+                    // The orchestrator already appended assistant/tool messages to History.
+                    ctx.Conversation.SelectedModel = ctx.SelectedModel;
+                    if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation);
+                    ctx.IsSending = false;
+                    if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
+                });
+            };
+            Action<string> onErr = delegate(string err)
+            {
+                if (string.IsNullOrEmpty(err)) err = "Unknown error.";
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try { renderTimer.Stop(); renderTimer.Dispose(); }
+                    catch { }
+                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                    catch { }
+                    string cur; lock (sbLock) { cur = assistantBuilder.ToString(); }
+                    ctx.Transcript.UpdateMessageAt(assistantIndex,
+                        (cur.Length > 0 ? cur + "\r\n\r\n" : string.Empty) + "Error: " + err);
+                    ctx.IsSending = false;
+                });
+            };
+
+            orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onComplete, onErr));
         }
 
         // Build a list of messages for the model, appending any attachments to the user message content
@@ -1169,7 +1316,11 @@ namespace GxPT
                     }
                     content = sb.ToString();
                 }
-                list.Add(new ChatMessage(m.Role, content));
+                var nm = new ChatMessage(m.Role, content);
+                // Preserve tool-call linkage so this is safe as the orchestrator's request transform.
+                nm.ToolCalls = m.ToolCalls;
+                nm.ToolCallId = m.ToolCallId;
+                list.Add(nm);
             }
             return list;
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1898,6 +1898,15 @@ namespace GxPT
         // Markdown is parsed on a background thread and the resulting blocks are appended to the
         // transcript in small batches on a UI timer. System messages are skipped; help templates
         // (NoSaveUntilUserSend) are scrolled to the top, otherwise the view sticks to the bottom.
+        // Emits the accumulated assistant turn (model text + tool markers) as one transcript bubble.
+        private static void FlushAssistantBuffer(List<ChatMessage> items, ref System.Text.StringBuilder asst)
+        {
+            if (asst == null) return;
+            string text = asst.ToString();
+            asst = null;
+            if (text.Trim().Length > 0) items.Add(new ChatMessage("assistant", text));
+        }
+
         private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)
         {
             if (ctx == null || ctx.Transcript == null || convo == null) return;
@@ -1908,14 +1917,45 @@ namespace GxPT
                 try { ctx.Transcript.RefreshTheme(); }
                 catch { }
 
-                // Snapshot messages to process (skip system for transcript)
+                // Snapshot messages to process. System and tool messages are not shown. A tool-using
+                // assistant turn is persisted as several messages (assistant-with-tool_calls, tool
+                // result(s), ..., final assistant); coalesce each such run into ONE assistant bubble
+                // with the model's text plus compact "using <tool>" markers — never the raw tool
+                // results. This matches the live streamed view.
                 var items = new List<ChatMessage>();
+                System.Text.StringBuilder asst = null;
                 foreach (var m in convo.History)
                 {
                     if (m == null) continue;
-                    if (string.Equals(m.Role, "system", StringComparison.OrdinalIgnoreCase)) continue;
-                    items.Add(m);
+                    string role = (m.Role ?? string.Empty).ToLowerInvariant();
+                    if (role == "system" || role == "tool") continue; // not shown
+
+                    if (role == "user")
+                    {
+                        FlushAssistantBuffer(items, ref asst);
+                        items.Add(m);
+                        continue;
+                    }
+
+                    // assistant (or any unexpected role): accumulate text + tool-call markers
+                    if (asst == null) asst = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(m.Content))
+                    {
+                        if (asst.Length > 0) asst.Append("\r\n\r\n");
+                        asst.Append(m.Content);
+                    }
+                    if (m.ToolCalls != null)
+                    {
+                        for (int ti = 0; ti < m.ToolCalls.Count; ti++)
+                        {
+                            var tc = m.ToolCalls[ti];
+                            if (tc == null) continue;
+                            if (asst.Length > 0) asst.Append("\r\n\r\n");
+                            asst.Append(McpMarkers.Call(tc.Name));
+                        }
+                    }
                 }
+                FlushAssistantBuffer(items, ref asst);
 
                 // Producer-consumer: parse off-UI, consume on UI timer in small chunks
                 var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -124,6 +124,8 @@
     <Compile Include="Services\Mcp\IServerConnector.cs" />
     <Compile Include="Services\Mcp\McpHost.cs" />
     <Compile Include="Services\Mcp\DefaultServerConnector.cs" />
+    <Compile Include="Services\Mcp\DelegateToolLoopUi.cs" />
+    <Compile Include="Services\Mcp\LoggerSink.cs" />
     <Compile Include="Forms\MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -19,18 +19,21 @@ namespace GxPT
         }
     }
 
-    // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can stream tool-call
-    // turns into the existing transcript: model text and a compact per-call marker go to appendText;
-    // Complete/OnError finalize the turn. Tool results are never shown (the model summarizes them).
+    // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can render a tool-call
+    // turn as a chrome-less "tool activity" message plus a separate answer bubble: model text ->
+    // appendText, each tool call -> onToolCall (its own message), Complete/OnError finalize. Tool
+    // results are never shown (the model summarizes them).
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
+        private readonly Action<string> _onToolCall;
         private readonly Action _complete;
         private readonly Action<string> _error;
 
-        public DelegateToolLoopUi(Action<string> appendText, Action complete, Action<string> error)
+        public DelegateToolLoopUi(Action<string> appendText, Action<string> onToolCall, Action complete, Action<string> error)
         {
             _appendText = appendText;
+            _onToolCall = onToolCall;
             _complete = complete;
             _error = error;
         }
@@ -42,7 +45,7 @@ namespace GxPT
 
         public void OnToolCall(string functionName, string argumentsJson)
         {
-            if (_appendText != null) _appendText("\r\n\r\n" + McpMarkers.Call(functionName) + "\r\n\r\n");
+            if (_onToolCall != null) _onToolCall(functionName);
         }
 
         public void OnToolResult(string functionName, string resultText, bool isError)

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -2,10 +2,26 @@ using System;
 
 namespace GxPT
 {
+    // Shared formatting for tool activity shown in the transcript, so the live stream and the
+    // reloaded view render identically. The qualified function name ("web__search") is displayed
+    // as "web / search" — this also avoids the double-underscore being mangled by markdown emphasis.
+    internal static class McpMarkers
+    {
+        public static string Display(string functionName)
+        {
+            return string.IsNullOrEmpty(functionName) ? string.Empty : functionName.Replace("__", " / ");
+        }
+
+        // A compact, markdown-safe "using <tool>" marker (italic, no internal underscores).
+        public static string Call(string functionName)
+        {
+            return "_using " + Display(functionName) + "_";
+        }
+    }
+
     // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can stream tool-call
-    // turns into the existing transcript: model text and a minimal inline marker per tool call go to
-    // appendText; Complete/OnError finalize the turn. (Tool results are not dumped into the bubble —
-    // the model summarizes them; only errors get a short marker.)
+    // turns into the existing transcript: model text and a compact per-call marker go to appendText;
+    // Complete/OnError finalize the turn. Tool results are never shown (the model summarizes them).
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
@@ -26,12 +42,12 @@ namespace GxPT
 
         public void OnToolCall(string functionName, string argumentsJson)
         {
-            if (_appendText != null) _appendText("\r\n\r\n_[calling " + functionName + "]_\r\n\r\n");
+            if (_appendText != null) _appendText("\r\n\r\n" + McpMarkers.Call(functionName) + "\r\n\r\n");
         }
 
         public void OnToolResult(string functionName, string resultText, bool isError)
         {
-            if (isError && _appendText != null) _appendText("\r\n\r\n_[" + functionName + " failed]_\r\n\r\n");
+            // Results are not rendered — the model incorporates them into its next message.
         }
 
         public void OnError(string message)
@@ -45,3 +61,4 @@ namespace GxPT
         }
     }
 }
+

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace GxPT
+{
+    // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can stream tool-call
+    // turns into the existing transcript: model text and a minimal inline marker per tool call go to
+    // appendText; Complete/OnError finalize the turn. (Tool results are not dumped into the bubble —
+    // the model summarizes them; only errors get a short marker.)
+    internal sealed class DelegateToolLoopUi : IToolLoopUi
+    {
+        private readonly Action<string> _appendText;
+        private readonly Action _complete;
+        private readonly Action<string> _error;
+
+        public DelegateToolLoopUi(Action<string> appendText, Action complete, Action<string> error)
+        {
+            _appendText = appendText;
+            _complete = complete;
+            _error = error;
+        }
+
+        public void AppendTextDelta(string text)
+        {
+            if (!string.IsNullOrEmpty(text) && _appendText != null) _appendText(text);
+        }
+
+        public void OnToolCall(string functionName, string argumentsJson)
+        {
+            if (_appendText != null) _appendText("\r\n\r\n_[calling " + functionName + "]_\r\n\r\n");
+        }
+
+        public void OnToolResult(string functionName, string resultText, bool isError)
+        {
+            if (isError && _appendText != null) _appendText("\r\n\r\n_[" + functionName + " failed]_\r\n\r\n");
+        }
+
+        public void OnError(string message)
+        {
+            if (_error != null) _error(message);
+        }
+
+        public void Complete()
+        {
+            if (_complete != null) _complete();
+        }
+    }
+}

--- a/GxPT/Services/Mcp/LoggerSink.cs
+++ b/GxPT/Services/Mcp/LoggerSink.cs
@@ -1,0 +1,17 @@
+using Mcp35.Core.Diagnostics;
+
+namespace GxPT
+{
+    // Bridges Mcp35 diagnostics into GxPT's Logger so MCP connection/tool issues (a missing server
+    // exe, GitHub auth failures, etc.) show up in the app log when logging is enabled.
+    internal sealed class LoggerSink : ILogSink
+    {
+        public static readonly LoggerSink Instance = new LoggerSink();
+
+        public void Log(string category, string message)
+        {
+            try { Logger.Log("mcp:" + (category ?? string.Empty), message ?? string.Empty); }
+            catch { }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -33,6 +33,10 @@ namespace GxPT
         // preserve assistant ToolCalls and tool-role ToolCallId.
         public Func<IList<ChatMessage>, IList<ChatMessage>> RequestMessageTransform { get; set; }
 
+        // Provider data-collection (ZDR) preference applied to every request in the turn. Null leaves
+        // it unset (provider default).
+        public bool? ProviderDataCollectionAllowed { get; set; }
+
         public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
                                    IToolApprovalPolicy approval, string model, ILogSink log)
             : this(streamer, registry, approval, model, log, DefaultMaxIterations, DefaultCallTimeoutMs)
@@ -86,6 +90,7 @@ namespace GxPT
 
                 ClientProperties props = new ClientProperties();
                 props.Stream = true;
+                props.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
 
                 Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
                 ToolCallAssembler asm = new ToolCallAssembler(textSink);

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -28,6 +28,11 @@ namespace GxPT
         private readonly int _maxIterations;
         private readonly int _callTimeoutMs;
 
+        // Optional hook to transform history into the messages actually sent (e.g. inline file
+        // attachments) without mutating the persisted history. Identity transform when null. Must
+        // preserve assistant ToolCalls and tool-role ToolCallId.
+        public Func<IList<ChatMessage>, IList<ChatMessage>> RequestMessageTransform { get; set; }
+
         public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
                                    IToolApprovalPolicy approval, string model, ILogSink log)
             : this(streamer, registry, approval, model, log, DefaultMaxIterations, DefaultCallTimeoutMs)
@@ -54,6 +59,14 @@ namespace GxPT
         {
             if (history == null) throw new ArgumentNullException("history");
             history.Add(new ChatMessage("user", userText));
+            RunTurn(history, ui);
+        }
+
+        // Same loop, but over a history whose last message is already the user's turn — the host's
+        // chat path adds the user message to the conversation itself. history is mutated in place.
+        public void RunTurn(IList<ChatMessage> history, IToolLoopUi ui)
+        {
+            if (history == null) throw new ArgumentNullException("history");
 
             for (int iter = 0; iter < _maxIterations; iter++)
             {
@@ -65,7 +78,11 @@ namespace GxPT
                 List<ChatMessage> requestMessages = new List<ChatMessage>();
                 if (!string.IsNullOrEmpty(manifest))
                     requestMessages.Add(new ChatMessage("system", manifest));
-                requestMessages.AddRange(history);
+                // Build the sent messages from history, optionally transformed (e.g. attachments
+                // inlined). The transform must not drop tool_calls / tool_call_id.
+                IList<ChatMessage> contextMessages = RequestMessageTransform != null
+                    ? RequestMessageTransform(history) : history;
+                requestMessages.AddRange(contextMessages);
 
                 ClientProperties props = new ClientProperties();
                 props.Stream = true;

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -19,6 +19,8 @@ namespace GxPT
         public const string FilesName = "files";
         public const string GitName = "git";
         public const string CommandName = "command";
+        public const string GitHubName = "github";
+        public const string GitHubUrl = "https://api.githubcopilot.com/mcp/";
 
         // Env var names the host injects (servers spec §1).
         public const string EnvWorkdir = "GXPT_WORKDIR";
@@ -58,6 +60,23 @@ namespace GxPT
                 GitPath = "git";
                 CmdShell = "cmd.exe";
             }
+        }
+
+        // The GitHub HTTP server, configured from settings.json (enable toggle + PAT) rather than
+        // mcp.json. Enabled only when the toggle is on and the PAT is well-formed; workdir-independent.
+        public static McpServerSpec GitHubSpec(bool enabled, string pat)
+        {
+            string token = pat != null ? pat.Trim() : string.Empty;
+            McpServerSpec s = new McpServerSpec();
+            s.Name = GitHubName;
+            s.Kind = McpTransportKind.Http;
+            s.BuiltIn = true;
+            s.WorkdirScoped = false;
+            s.Url = GitHubUrl;
+            if (!string.IsNullOrEmpty(token))
+                s.Headers["Authorization"] = "Bearer " + token;
+            s.Enabled = enabled && IsValidGitHubPat(token);
+            return s;
         }
 
         public static IList<McpServerSpec> BuiltInSpecs(BuiltInOptions o)

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -170,8 +170,13 @@ namespace GxPT
                     names.Sort(StringComparer.Ordinal); // server__ prefix groups visually
 
                     StringBuilder sb = new StringBuilder();
-                    sb.Append("Available MCP tools. Call reveal_tools({\"names\":[...]}) to load a tool's ");
-                    sb.Append("full definition before you can call it.");
+                    sb.Append("The following MCP tools are available, listed by name only. ");
+                    sb.Append("You CANNOT call any of these tools directly from this list. ");
+                    sb.Append("Before calling a tool, you MUST first call reveal_tools({\"names\":[...]}) ");
+                    sb.Append("with the exact names you intend to use; that loads their full definitions ");
+                    sb.Append("and makes them callable on the next step. You may reveal several at once. ");
+                    sb.Append("Only reveal_tools and tools you have already revealed can be called.");
+                    sb.Append("\n\nAvailable tools:");
                     for (int i = 0; i < names.Count; i++)
                         sb.Append("\n- ").Append(names[i]);
                     _manifestCache = sb.ToString();

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -153,6 +153,13 @@ namespace GxPT
 
         // ---- per-request (from the orchestrator) ----
 
+        // True when at least one connected server has contributed a tool — the host uses this to
+        // decide whether to route a chat turn through the tool-call loop at all.
+        public bool HasTools
+        {
+            get { lock (_lock) { return _byFunctionName.Count > 0; } }
+        }
+
         public string NamesManifestSystemMessage()
         {
             lock (_lock)

--- a/servers/WebSearchMcpServer/WebSearchTools.cs
+++ b/servers/WebSearchMcpServer/WebSearchTools.cs
@@ -23,12 +23,14 @@ namespace WebSearchMcpServer
             TavilyClient client = new TavilyClient(config, null);
 
             server.AddTool("search",
-                "Search the web and return relevant results (title, url, content snippet), optionally with a synthesized answer.",
+                "Search the web and return relevant results, each with a title, URL, and content snippet (optionally a synthesized answer). " +
+                "Start here when you need current information. The returned URLs can be passed to web__extract to read full page content.",
                 BuildSearchSchema(),
                 delegate(ToolCallContext ctx) { return Search(config, client, ctx); });
 
             server.AddTool("extract",
-                "Fetch and extract the full text content of one or more web pages by URL.",
+                "Fetch the full text of specific web pages you ALREADY have URLs for (for example, URLs returned by web__search). " +
+                "Requires the 'urls' argument: one or more absolute http(s) URLs. Do not call this without URLs — run web__search first to find them.",
                 BuildExtractSchema(),
                 delegate(ToolCallContext ctx) { return Extract(config, client, ctx); });
         }
@@ -64,7 +66,7 @@ namespace WebSearchMcpServer
             JObject depth = StrEnum("Extraction depth: 'basic' (faster) or 'advanced' (more thorough).", new string[] { "basic", "advanced" });
 
             return SchemaBuilder.Object()
-                .Arr("urls", "string", true, "One or more page URLs to fetch and extract")
+                .Arr("urls", "string", true, "Required. One or more absolute http(s) page URLs to fetch (e.g. URLs returned by web__search). Must not be empty.")
                 .Raw("extract_depth", depth, false)
                 .Raw("format", fmt, false)
                 .Bool("include_images", false, "Include image URLs found on the pages")


### PR DESCRIPTION
**Status: WIP / draft.** PR-2 of the UI integration — wiring the tool-call loop into the live chat path, proven with **GitHub (HTTP)** + web search. Opened early so CI validates the testable core before the WinForms change.

## Plan (stacked)
1. ✅ **2a — orchestrator/registry/config seams** (this commit; CI-tested, no behavior change)
2. ⏳ **2b — MainForm host wiring** (untestable WinForms): construct `McpHost` at startup from settings + `DefaultServerConnector` (curl + CA bundle); on send, if `registry.HasTools`, route through `McpChatOrchestrator` (else the existing path, unchanged); map the loop's UI callbacks to the transcript (streamed text + inline tool-call/result markers); dispose host on close.

## In 2a
- `McpChatOrchestrator`: new `RunTurn(history, ui)` overload (app adds the user message itself, so the orchestrator shouldn't re-add it); `RequestMessageTransform` hook to inline attachments into *sent* messages without mutating persisted history (preserving `tool_calls`/`tool_call_id`).
- `McpToolRegistry.HasTools` — the routing gate (only run the loop when tools exist → MCP-off is byte-identical to today).
- `McpConfig.GitHubSpec(enabled, pat)` — GitHub configured from `settings.json` (toggle + PAT), not `mcp.json`.
- Tests for all four.

## Note
2b is WinForms and **not CI-validatable** — it'll need your VS2008 build + a live run (enable GitHub with a PAT, ask something that needs a tool, watch it call + answer). I'll flag the behavioral diffs and keep the loop strictly behind `HasTools`.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_