### PR TITLE
Fix: workdir-scoped MCP servers (files/git/command) never launched after host rebuild

### DIFF
--- a/GxPT.Tests/ConversationStoreTests.cs
+++ b/GxPT.Tests/ConversationStoreTests.cs
@@ -116,6 +116,25 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void WorkingDir_round_trips()
+        {
+            var convo = new Conversation(null);
+            convo.Name = "W";
+            convo.WorkingDir = "C:\\Projects\\report-tool";
+            convo.History.Add(new ChatMessage("user", "hi"));
+
+            var reload = ConversationStore.LoadFromJson(null, ConversationStore.ToJson(convo));
+            Assert.Equal("C:\\Projects\\report-tool", reload.WorkingDir);
+        }
+
+        [Fact]
+        public void Load_legacy_file_without_working_dir_is_null()
+        {
+            var convo = ConversationStore.LoadFromJson(null, "{\"Name\":\"C\",\"Messages\":[]}");
+            Assert.Null(convo.WorkingDir);
+        }
+
+        [Fact]
         public void Load_legacy_file_without_tool_fields_has_null_tool_data()
         {
             string json = "{\"Name\":\"C\",\"Messages\":[{\"Role\":\"assistant\",\"Content\":\"hi\"}]}";

--- a/GxPT.Tests/ConversationStoreTests.cs
+++ b/GxPT.Tests/ConversationStoreTests.cs
@@ -135,6 +135,18 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void WorkspaceStripDismissed_round_trips_and_defaults_false()
+        {
+            var convo = new Conversation(null);
+            convo.WorkspaceStripDismissed = true;
+            var reload = ConversationStore.LoadFromJson(null, ConversationStore.ToJson(convo));
+            Assert.True(reload.WorkspaceStripDismissed);
+
+            var legacy = ConversationStore.LoadFromJson(null, "{\"Name\":\"C\",\"Messages\":[]}");
+            Assert.False(legacy.WorkspaceStripDismissed);
+        }
+
+        [Fact]
         public void Load_legacy_file_without_tool_fields_has_null_tool_data()
         {
             string json = "{\"Name\":\"C\",\"Messages\":[{\"Role\":\"assistant\",\"Content\":\"hi\"}]}";

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -39,6 +39,10 @@
     <Compile Include="..\GxPT\Services\OpenRouterClient.cs" Link="Linked\OpenRouterClient.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IToolApprovalPolicy.cs" Link="Linked\Mcp\IToolApprovalPolicy.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\ToolApproval.cs" Link="Linked\Mcp\ToolApproval.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\ToolClassifier.cs" Link="Linked\Mcp\ToolClassifier.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\ToolApprovalPolicy.cs" Link="Linked\Mcp\ToolApprovalPolicy.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\ApprovalStore.cs" Link="Linked\Mcp\ApprovalStore.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpToolRegistry.cs" Link="Linked\Mcp\McpToolRegistry.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IChatStreamer.cs" Link="Linked\Mcp\IChatStreamer.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpChatOrchestrator.cs" Link="Linked\Mcp\McpChatOrchestrator.cs" />

--- a/GxPT.Tests/Mcp/McpHostTests.cs
+++ b/GxPT.Tests/Mcp/McpHostTests.cs
@@ -69,6 +69,24 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void SetActiveWorkingDir_before_Start_still_launches_scoped_servers()
+        {
+            // Reproduces the startup race: the working folder is applied before Start() has captured
+            // the scoped specs. Start() must honor the already-set workdir and launch them.
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+
+            host.SetActiveWorkingDir("C:\\proj");        // arrives first; no specs yet
+            Assert.Empty(c.CreatedNames);
+
+            host.Start(new[] { Specs.Scoped("command", true), Specs.Eager("web", true) });
+
+            Assert.Contains("command", c.CreatedNames);  // scoped server launched by Start
+            Assert.Contains("command__command_tool", Manifest(reg));
+            Assert.Equal("C:\\proj", host.ActiveWorkingDir);
+        }
+
+        [Fact]
         public void Switching_workdir_tears_down_old_scoped_and_opens_new()
         {
             FakeServerConnector c; McpToolRegistry reg;

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class ToolApprovalTests
+    {
+        // A scripted prompt that records requests and returns a fixed choice.
+        private sealed class ScriptedPrompt : IToolApprovalPrompt
+        {
+            public ApprovalChoice Next = ApprovalChoice.Deny;
+            public int Calls;
+            public ApprovalRequest Last;
+            public ApprovalChoice Ask(ApprovalRequest req) { Calls++; Last = req; return Next; }
+        }
+
+        private static JObject Args(string json) { return JObject.Parse(json); }
+
+        private static ToolApprovalPolicy Policy(ScriptedPrompt prompt, IApprovalStore store)
+        {
+            return new ToolApprovalPolicy(new ToolClassifier(), prompt, store);
+        }
+
+        // ---- classification (spec §2) ----
+
+        [Fact]
+        public void First_party_table_is_authoritative()
+        {
+            var c = new ToolClassifier();
+            var read = c.Classify("files__read", null, true);
+            Assert.Equal(ToolTier.ReadOnly, read.Tier);
+            Assert.Equal(RememberScope.Tool, read.Scope);
+
+            var write = c.Classify("files__write", null, true);
+            Assert.Equal(ToolTier.Write, write.Tier);
+            Assert.Equal(RememberScope.Argument, write.Scope);
+            Assert.Equal("path", write.ScopeArgPath);
+
+            var run = c.Classify("command__run", null, true);
+            Assert.Equal(ToolTier.Destructive, run.Tier);
+            Assert.Equal(RememberScope.Argument, run.Scope);
+            Assert.Equal("command", run.ScopeArgPath);
+
+            var push = c.Classify("git__push", null, true);
+            Assert.Equal(ToolTier.Destructive, push.Tier);
+            Assert.Equal(RememberScope.None, push.Scope);
+        }
+
+        [Fact]
+        public void Third_party_uses_annotations_else_write_tool()
+        {
+            var c = new ToolClassifier();
+            Assert.Equal(ToolTier.ReadOnly, c.Classify("acme__peek", JObject.Parse("{\"readOnlyHint\":true}"), false).Tier);
+
+            var destr = c.Classify("acme__nuke", JObject.Parse("{\"destructiveHint\":true}"), false);
+            Assert.Equal(ToolTier.Destructive, destr.Tier);
+            Assert.Equal(RememberScope.None, destr.Scope); // third-party never gets Argument scope
+
+            var unknown = c.Classify("acme__do", null, false);
+            Assert.Equal(ToolTier.Write, unknown.Tier);
+            Assert.Equal(RememberScope.Tool, unknown.Scope);
+        }
+
+        // ---- decision model (spec §3) ----
+
+        [Fact]
+        public void Tool_scope_prompts_first_then_remembered()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberTool };
+            var store = new InMemoryApprovalStore();
+            var pol = Policy(prompt, store);
+
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"x\"}")));
+            Assert.Equal(1, prompt.Calls);
+            // second call: remembered, no prompt
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"y\"}")));
+            Assert.Equal(1, prompt.Calls);
+        }
+
+        [Fact]
+        public void Allow_once_does_not_persist()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.AllowOnce };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.Check("web__search", Args("{\"query\":\"x\"}"));
+            pol.Check("web__search", Args("{\"query\":\"y\"}"));
+            Assert.Equal(2, prompt.Calls); // prompted both times
+        }
+
+        [Fact]
+        public void Destructive_scope_none_prompts_every_time()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberTool }; // even if user tries to remember
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.Check("git__push", Args("{}"));
+            pol.Check("git__push", Args("{}"));
+            Assert.Equal(2, prompt.Calls); // None scope: never remembered
+        }
+
+        [Fact]
+        public void Deny_returns_deny()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            Assert.Equal(ApprovalDecision.Deny, pol.Check("files__write", Args("{\"path\":\"/a\"}")));
+        }
+
+        // ---- argument rules (spec §3) ----
+
+        [Fact]
+        public void Exact_command_rule_matches_only_exact()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberExactArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("command__run", Args("{\"command\":\"git status\"}")); // remembered exact
+            Assert.Equal(1, prompt.Calls);
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("command__run", Args("{\"command\":\"git status\"}")));
+            Assert.Equal(1, prompt.Calls); // matched, no prompt
+            // different command -> prompts again
+            pol.Check("command__run", Args("{\"command\":\"rm -rf /\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Prefix_command_rule_is_token_aware()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("command__run", Args("{\"command\":\"git status\"}")); // -> prefix "git status"
+            Assert.Equal(1, prompt.Calls);
+
+            // token boundary: "git status -s" matches
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("command__run", Args("{\"command\":\"git status -s\"}")));
+            Assert.Equal(1, prompt.Calls);
+            // "git status-hack" must NOT match
+            pol.Check("command__run", Args("{\"command\":\"git status-hack\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Prefix_path_rule_is_directory_boundary_aware()
+        {
+            Assert.True(ToolApprovalPolicy.PrefixMatches("/a/b/c", "/a/b", true));
+            Assert.False(ToolApprovalPolicy.PrefixMatches("/a/bc", "/a/b", true));
+            Assert.True(ToolApprovalPolicy.PrefixMatches("/a/b", "/a/b", true));
+        }
+
+        [Fact]
+        public void Prefix_command_boundary_helper()
+        {
+            Assert.True(ToolApprovalPolicy.PrefixMatches("git status -s", "git status", false));
+            Assert.False(ToolApprovalPolicy.PrefixMatches("git status-hack", "git status", false));
+        }
+
+        // ---- injection backstop (spec §6) ----
+
+        [Fact]
+        public void Injected_new_command_still_prompts_despite_existing_rule()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberExactArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.Check("command__run", Args("{\"command\":\"ls\"}")); // approve "ls" exactly
+            Assert.Equal(1, prompt.Calls);
+
+            // a malicious/injected different command does not match the narrow rule
+            pol.Check("command__run", Args("{\"command\":\"rm -rf /\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        // ---- persistence round-trip via the store ----
+
+        [Fact]
+        public void Store_round_trips_tools_and_rules()
+        {
+            var store = new InMemoryApprovalStore();
+            store.AddApprovedTool("web__search");
+            store.AddRule(new ApprovalRule("command__run", RuleKind.Prefix, "command", "git status"));
+
+            Assert.True(store.IsToolApproved("web__search"));
+            Assert.False(store.IsToolApproved("files__write"));
+            Assert.Single(store.RulesFor("command__run"));
+            Assert.Empty(store.RulesFor("files__write"));
+
+            // duplicate rule is ignored
+            store.AddRule(new ApprovalRule("command__run", RuleKind.Prefix, "command", "git status"));
+            Assert.Single(store.RulesFor("command__run"));
+        }
+
+        [Fact]
+        public void Reveal_tools_is_never_seen_by_the_policy()
+        {
+            // The orchestrator handles reveal_tools before the gate; if it ever reached here it would
+            // classify as Write/Tool (third-party-style) and prompt — i.e. nothing auto-allows it.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            Assert.Equal(ApprovalDecision.Deny, pol.Check("reveal_tools", Args("{\"names\":[]}")));
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -194,6 +194,35 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Directory_rule_covers_siblings_in_a_nested_folder()
+        {
+            // Multi-level path: the parent dir is "a/b", and a sibling "a/b/y.txt" must match.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("files__write", Args("{\"path\":\"a/b/x.txt\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"a/b/y.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+            // deeper still under a/b is covered
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"a/b/c/z.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+            // sibling directory "a/bc" must NOT match the "a/b" boundary
+            pol.Check("files__write", Args("{\"path\":\"a/bc/w.txt\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Path_matching_normalizes_separators()
+        {
+            // A rule stored with a backslash separator still matches a forward-slash value.
+            Assert.True(ToolApprovalPolicy.PrefixMatches("a/b/y.txt", "a\\b", true));
+            Assert.True(ToolApprovalPolicy.PrefixMatches("a\\b\\y.txt", "a/b", true));
+            Assert.False(ToolApprovalPolicy.PrefixMatches("a/bc/y.txt", "a\\b", true));
+        }
+
+        [Fact]
         public void Prefix_command_boundary_helper()
         {
             Assert.True(ToolApprovalPolicy.PrefixMatches("git status -s", "git status", false));

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -156,16 +156,41 @@ namespace GxPT.Tests.Mcp
             var pol = Policy(prompt, new InMemoryApprovalStore());
 
             // Approve "directory and below" while writing one file...
-            pol.Check("files__write", Args("{\"path\":\"C:\\\\proj\\\\a.txt\"}"));
+            pol.Check("files__write", Args("{\"path\":\"sub/a.txt\"}"));
             Assert.Equal(1, prompt.Calls);
 
             // ...a different file in the SAME directory must match (the bug: it kept prompting).
-            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"C:\\\\proj\\\\b.txt\"}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"sub/b.txt\"}")));
             Assert.Equal(1, prompt.Calls);
 
             // a file in a different directory still prompts
-            pol.Check("files__write", Args("{\"path\":\"C:\\\\other\\\\c.txt\"}"));
+            pol.Check("files__write", Args("{\"path\":\"other/c.txt\"}"));
             Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Directory_rule_for_a_root_level_file_covers_siblings_in_the_root()
+        {
+            // Files server uses paths relative to the workspace root, so a file in the root has no
+            // directory component — the directory rule must still cover its root-level siblings.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("files__write", Args("{\"path\":\"report.txt\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"notes.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+            // a subdirectory file is also under the root
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"sub/x.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+        }
+
+        [Fact]
+        public void Empty_path_pattern_matches_any_relative_path()
+        {
+            Assert.True(ToolApprovalPolicy.PrefixMatches("anything.txt", "", true));
+            Assert.True(ToolApprovalPolicy.PrefixMatches("sub/deep/file.txt", "", true));
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -150,6 +150,25 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Directory_path_rule_covers_sibling_files_in_the_same_folder()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            // Approve "directory and below" while writing one file...
+            pol.Check("files__write", Args("{\"path\":\"C:\\\\proj\\\\a.txt\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // ...a different file in the SAME directory must match (the bug: it kept prompting).
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"C:\\\\proj\\\\b.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+
+            // a file in a different directory still prompts
+            pol.Check("files__write", Args("{\"path\":\"C:\\\\other\\\\c.txt\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
         public void Prefix_command_boundary_helper()
         {
             Assert.True(ToolApprovalPolicy.PrefixMatches("git status -s", "git status", false));

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Newtonsoft.Json;
+
+namespace GxPT
+{
+    // A native panel docked at the bottom of the chat area that asks the user to approve a pending
+    // MCP tool call (approval spec §4, rendered in-transcript rather than as a modal). Shown only
+    // while a call awaits a decision; the buttons offered depend on the tool's remember scope.
+    //
+    // Threading: the tool-loop worker calls Ask (blocking) via TranscriptApprovalPrompt, which
+    // marshals ShowFor onto the UI thread; the user's button click signals back the chosen result.
+    internal sealed class ToolApprovalPanel : Panel
+    {
+        private readonly Label _header;
+        private readonly Label _tierBadge;
+        private readonly Label _previewLabel;
+        private readonly TextBox _preview;
+        private readonly FlowLayoutPanel _buttons;
+
+        private Action<ApprovalChoice> _onChoose;
+
+        public ToolApprovalPanel()
+        {
+            this.Dock = DockStyle.Bottom;
+            this.Visible = false;
+            this.AutoSize = false;
+            this.Height = 150;
+            this.Padding = new Padding(8);
+            this.BorderStyle = BorderStyle.FixedSingle;
+
+            _header = new Label();
+            _header.Dock = DockStyle.Top;
+            _header.Height = 20;
+            _header.Font = new Font(this.Font, FontStyle.Bold);
+            _header.AutoEllipsis = true;
+
+            _tierBadge = new Label();
+            _tierBadge.Dock = DockStyle.Top;
+            _tierBadge.Height = 18;
+
+            _previewLabel = new Label();
+            _previewLabel.Dock = DockStyle.Top;
+            _previewLabel.Height = 16;
+            _previewLabel.Text = "Details:";
+
+            _preview = new TextBox();
+            _preview.Multiline = true;
+            _preview.ReadOnly = true;
+            _preview.ScrollBars = ScrollBars.Vertical;
+            _preview.Dock = DockStyle.Fill;
+            _preview.Font = new Font("Consolas", 9F);
+
+            _buttons = new FlowLayoutPanel();
+            _buttons.Dock = DockStyle.Bottom;
+            _buttons.Height = 34;
+            _buttons.FlowDirection = FlowDirection.RightToLeft;
+            _buttons.WrapContents = false;
+            _buttons.AutoScroll = true;
+
+            // Order added (Fill must be added before docked siblings to lay out correctly):
+            this.Controls.Add(_preview);
+            this.Controls.Add(_previewLabel);
+            this.Controls.Add(_tierBadge);
+            this.Controls.Add(_header);
+            this.Controls.Add(_buttons);
+        }
+
+        // Populate + show for one request. choiceCallback is invoked (on the UI thread) with the
+        // user's decision. Builds the scope-appropriate buttons per approval spec §4.
+        public void ShowFor(ApprovalRequest req, Action<ApprovalChoice> choiceCallback)
+        {
+            _onChoose = choiceCallback;
+
+            _header.Text = (req.ServerName != null ? req.ServerName : "?") + "  ·  " +
+                           (req.ToolName != null ? req.ToolName : req.FunctionName);
+
+            ToolTier tier = req.Policy != null ? req.Policy.Tier : ToolTier.Write;
+            _tierBadge.Text = "Tier: " + tier;
+            _tierBadge.ForeColor = (tier == ToolTier.Destructive) ? Color.Firebrick
+                                  : (tier == ToolTier.Write ? Color.DarkGoldenrod : Color.ForestGreen);
+
+            _preview.Text = BuildPreviewText(req);
+
+            _buttons.Controls.Clear();
+            // Deny is always present (added first => rightmost in RightToLeft flow).
+            AddButton("Deny", ApprovalChoice.Deny, tier == ToolTier.Destructive);
+            AddRememberButtons(req);
+            AddButton("Allow once", ApprovalChoice.AllowOnce, false);
+
+            this.Visible = true;
+            this.BringToFront();
+        }
+
+        public void HidePanel()
+        {
+            this.Visible = false;
+            _onChoose = null;
+        }
+
+        private void AddRememberButtons(ApprovalRequest req)
+        {
+            RememberScope scope = req.Policy != null ? req.Policy.Scope : RememberScope.Tool;
+            string argPath = req.Policy != null ? req.Policy.ScopeArgPath : null;
+
+            if (scope == RememberScope.Tool)
+            {
+                AddButton("Always allow this tool", ApprovalChoice.RememberTool, false);
+            }
+            else if (scope == RememberScope.Argument && argPath == "command")
+            {
+                AddButton("Always allow this exact command", ApprovalChoice.RememberExactArg, false);
+                AddButton("Always allow this base command", ApprovalChoice.RememberPrefixArg, false);
+            }
+            else if (scope == RememberScope.Argument && argPath == "path")
+            {
+                AddButton("Always allow this path", ApprovalChoice.RememberExactArg, false);
+                AddButton("Always allow this directory", ApprovalChoice.RememberPrefixArg, false);
+            }
+            // Scope == None: no remember buttons (Allow once / Deny only).
+        }
+
+        private void AddButton(string text, ApprovalChoice choice, bool defaultFocus)
+        {
+            Button b = new Button();
+            b.Text = text;
+            b.AutoSize = true;
+            b.Margin = new Padding(4, 4, 4, 4);
+            b.Tag = choice;
+            b.Click += delegate
+            {
+                Action<ApprovalChoice> cb = _onChoose;
+                HidePanel();
+                if (cb != null) cb(choice);
+            };
+            _buttons.Controls.Add(b);
+            if (defaultFocus) { try { b.Select(); } catch { } }
+        }
+
+        private static string BuildPreviewText(ApprovalRequest req)
+        {
+            string preview = req.Preview != null ? req.Preview : string.Empty;
+            string args = req.Arguments != null ? req.Arguments.ToString(Formatting.Indented) : "{}";
+            if (!string.IsNullOrEmpty(preview) && preview != args)
+                return preview + "\r\n\r\n" + args;
+            return args;
+        }
+    }
+}

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -115,7 +115,7 @@ namespace GxPT
             }
             else if (scope == RememberScope.Argument && argPath == "path")
             {
-                AddButton("Always allow this path", ApprovalChoice.RememberExactArg, false);
+                AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
                 AddButton("Always allow this directory", ApprovalChoice.RememberPrefixArg, false);
             }
             // Scope == None: no remember buttons (Allow once / Deny only).

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -115,8 +115,8 @@ namespace GxPT
             }
             else if (scope == RememberScope.Argument && argPath == "path")
             {
-                AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
                 AddButton("Always allow this directory", ApprovalChoice.RememberPrefixArg, false);
+                AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
             }
             // Scope == None: no remember buttons (Allow once / Deny only).
         }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -16,7 +16,6 @@ namespace GxPT
         private static readonly Color SetBack = Color.FromArgb(237, 244, 237);   // subtle green-grey
         private static readonly Color UnsetBack = Color.FromArgb(252, 246, 220); // cream / warning
         private static readonly Color TextColor = Color.FromArgb(55, 55, 55);
-        private static readonly Color BorderColor = Color.FromArgb(200, 200, 200);
         private static readonly Color LinkColor = Color.FromArgb(0, 90, 158);
 
         private readonly Label _text;
@@ -78,26 +77,17 @@ namespace GxPT
             if (has)
             {
                 this.BackColor = SetBack;
-                _text.Text = "Working folder:  " + dir + "      file, git & command tools run here";
+                _text.Text = "Working folder:  " + dir;
                 _change.Text = "Change...";
                 _clear.Visible = true;
             }
             else
             {
                 this.BackColor = UnsetBack;
-                _text.Text = "No working folder — file, git & command tools are disabled for this conversation.";
+                _text.Text = "No working folder — file, git, and command tools are disabled for this conversation.";
                 _change.Text = "Set folder...";
                 _clear.Visible = false;
             }
-            this.Invalidate();
-        }
-
-        protected override void OnPaint(PaintEventArgs e)
-        {
-            base.OnPaint(e);
-            // A subtle bottom separator so the strip reads as chrome above the transcript.
-            using (var pen = new Pen(BorderColor))
-                e.Graphics.DrawLine(pen, 0, this.Height - 1, this.Width, this.Height - 1);
         }
     }
 }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -4,13 +4,22 @@ using System.Windows.Forms;
 
 namespace GxPT
 {
-    // A thin strip docked at the top of the chat/transcript area showing the active conversation's
-    // working folder (the MCP files/git/command sandbox root, GXPT_WORKDIR) with controls to set or
-    // clear it. Raised events are handled by MainForm, which updates the tab context + the host.
+    // A thin strip docked at the top of each chat tab, above its transcript, showing that
+    // conversation's working folder (the MCP files/git/command sandbox root, GXPT_WORKDIR) with a
+    // link to set / change / clear it.
+    //
+    // Styling note: this intentionally uses FIXED colors and does NOT follow the app's light/dark
+    // theme — it is meant to match the tab strip above it (which is also un-themed system chrome).
     internal sealed class WorkspaceContextStrip : Panel
     {
-        private readonly Label _icon;
-        private readonly Label _path;
+        // Fixed palette (does not follow the app theme).
+        private static readonly Color SetBack = Color.FromArgb(237, 244, 237);   // subtle green-grey
+        private static readonly Color UnsetBack = Color.FromArgb(252, 246, 220); // cream / warning
+        private static readonly Color TextColor = Color.FromArgb(55, 55, 55);
+        private static readonly Color BorderColor = Color.FromArgb(200, 200, 200);
+        private static readonly Color LinkColor = Color.FromArgb(0, 90, 158);
+
+        private readonly Label _text;
         private readonly LinkLabel _change;
         private readonly LinkLabel _clear;
 
@@ -20,27 +29,17 @@ namespace GxPT
         public WorkspaceContextStrip()
         {
             this.Dock = DockStyle.Top;
-            this.Height = 24;
-            this.Padding = new Padding(8, 3, 8, 3);
-
-            _icon = new Label();
-            _icon.AutoSize = true;
-            _icon.Dock = DockStyle.Left;
-            _icon.Text = "Workspace:";
-            _icon.TextAlign = ContentAlignment.MiddleLeft;
-
-            _path = new Label();
-            _path.AutoSize = false;
-            _path.Dock = DockStyle.Fill;
-            _path.AutoEllipsis = true;
-            _path.TextAlign = ContentAlignment.MiddleLeft;
-            _path.Padding = new Padding(6, 0, 6, 0);
+            this.Height = 26;
+            this.Padding = new Padding(8, 0, 8, 0);
 
             _change = new LinkLabel();
             _change.AutoSize = true;
             _change.Dock = DockStyle.Right;
-            _change.Text = "Set folder";
             _change.TextAlign = ContentAlignment.MiddleRight;
+            _change.LinkColor = LinkColor;
+            _change.ActiveLinkColor = LinkColor;
+            _change.VisitedLinkColor = LinkColor;
+            _change.LinkBehavior = LinkBehavior.HoverUnderline;
             _change.LinkClicked += delegate { if (ChangeRequested != null) ChangeRequested(this, EventArgs.Empty); };
 
             _clear = new LinkLabel();
@@ -48,33 +47,57 @@ namespace GxPT
             _clear.Dock = DockStyle.Right;
             _clear.Text = "Clear";
             _clear.TextAlign = ContentAlignment.MiddleRight;
-            _clear.Padding = new Padding(0, 0, 8, 0);
+            _clear.LinkColor = LinkColor;
+            _clear.ActiveLinkColor = LinkColor;
+            _clear.VisitedLinkColor = LinkColor;
+            _clear.LinkBehavior = LinkBehavior.HoverUnderline;
+            _clear.Padding = new Padding(0, 0, 12, 0);
             _clear.Visible = false;
             _clear.LinkClicked += delegate { if (ClearRequested != null) ClearRequested(this, EventArgs.Empty); };
 
-            // Fill must be added first so the docked siblings flank it correctly.
-            this.Controls.Add(_path);
-            this.Controls.Add(_change);
+            _text = new Label();
+            _text.Dock = DockStyle.Fill;
+            _text.AutoEllipsis = true;
+            _text.TextAlign = ContentAlignment.MiddleLeft;
+            _text.ForeColor = TextColor;
+
+            // Fill first, edge-docked controls after — matches the app's working docking order
+            // (e.g. pnlInput). Do NOT BringToFront the strip itself or the Fill transcript stops
+            // reserving space for it.
+            this.Controls.Add(_text);
             this.Controls.Add(_clear);
-            this.Controls.Add(_icon);
+            this.Controls.Add(_change);
+
+            SetWorkingDir(null);
         }
 
-        // Reflect the given working folder (null/empty => "no folder set").
+        // Reflect the given working folder (null/empty => "no folder" warning state).
         public void SetWorkingDir(string dir)
         {
             bool has = !string.IsNullOrEmpty(dir);
-            _path.Text = has ? dir : "(no folder set — file, git, and command tools are disabled)";
-            _path.ForeColor = has ? this.ForeColor : SystemColors.GrayText;
-            _change.Text = has ? "Change" : "Set folder";
-            _clear.Visible = has;
+            if (has)
+            {
+                this.BackColor = SetBack;
+                _text.Text = "Working folder:  " + dir + "      file, git & command tools run here";
+                _change.Text = "Change...";
+                _clear.Visible = true;
+            }
+            else
+            {
+                this.BackColor = UnsetBack;
+                _text.Text = "No working folder — file, git & command tools are disabled for this conversation.";
+                _change.Text = "Set folder...";
+                _clear.Visible = false;
+            }
+            this.Invalidate();
         }
 
-        // Apply theme colors (called by MainForm's theme application).
-        public void ApplyColors(Color back, Color fore)
+        protected override void OnPaint(PaintEventArgs e)
         {
-            this.BackColor = back;
-            _icon.ForeColor = fore;
-            _path.ForeColor = fore;
+            base.OnPaint(e);
+            // A subtle bottom separator so the strip reads as chrome above the transcript.
+            using (var pen = new Pen(BorderColor))
+                e.Graphics.DrawLine(pen, 0, this.Height - 1, this.Width, this.Height - 1);
         }
     }
 }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -5,8 +5,8 @@ using System.Windows.Forms;
 namespace GxPT
 {
     // A thin strip docked at the top of each chat tab, above its transcript, showing that
-    // conversation's working folder (the MCP files/git/command sandbox root, GXPT_WORKDIR) with a
-    // link to set / change / clear it.
+    // conversation's working folder (the MCP files/git/command sandbox root, GXPT_WORKDIR) with
+    // links to set / change / clear it (and dismiss the strip when unset).
     //
     // Styling note: this intentionally uses FIXED colors and does NOT follow the app's light/dark
     // theme — it is meant to match the tab strip above it (which is also un-themed system chrome).
@@ -19,11 +19,14 @@ namespace GxPT
         private static readonly Color LinkColor = Color.FromArgb(0, 90, 158);
 
         private readonly Label _text;
+        private readonly FlowLayoutPanel _links;
         private readonly LinkLabel _change;
         private readonly LinkLabel _clear;
+        private readonly LinkLabel _dismiss;
 
         public event EventHandler ChangeRequested;
         public event EventHandler ClearRequested;
+        public event EventHandler DismissRequested;
 
         public WorkspaceContextStrip()
         {
@@ -31,28 +34,21 @@ namespace GxPT
             this.Height = 26;
             this.Padding = new Padding(8, 0, 8, 0);
 
-            _change = new LinkLabel();
-            _change.AutoSize = true;
-            _change.Dock = DockStyle.Right;
-            _change.TextAlign = ContentAlignment.MiddleRight;
-            _change.LinkColor = LinkColor;
-            _change.ActiveLinkColor = LinkColor;
-            _change.VisitedLinkColor = LinkColor;
-            _change.LinkBehavior = LinkBehavior.HoverUnderline;
-            _change.LinkClicked += delegate { if (ChangeRequested != null) ChangeRequested(this, EventArgs.Empty); };
+            _change = MakeLink("Set folder...", delegate { Raise(ChangeRequested); });
+            _clear = MakeLink("Clear", delegate { Raise(ClearRequested); });
+            _dismiss = MakeLink("Dismiss", delegate { Raise(DismissRequested); });
 
-            _clear = new LinkLabel();
-            _clear.AutoSize = true;
-            _clear.Dock = DockStyle.Right;
-            _clear.Text = "Clear";
-            _clear.TextAlign = ContentAlignment.MiddleRight;
-            _clear.LinkColor = LinkColor;
-            _clear.ActiveLinkColor = LinkColor;
-            _clear.VisitedLinkColor = LinkColor;
-            _clear.LinkBehavior = LinkBehavior.HoverUnderline;
-            _clear.Padding = new Padding(0, 0, 12, 0);
-            _clear.Visible = false;
-            _clear.LinkClicked += delegate { if (ClearRequested != null) ClearRequested(this, EventArgs.Empty); };
+            // Links flow left-to-right in add order, right-docked as a group.
+            _links = new FlowLayoutPanel();
+            _links.Dock = DockStyle.Right;
+            _links.FlowDirection = FlowDirection.LeftToRight;
+            _links.WrapContents = false;
+            _links.AutoSize = true;
+            _links.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _links.Margin = new Padding(0);
+            _links.Controls.Add(_change);
+            _links.Controls.Add(_clear);
+            _links.Controls.Add(_dismiss);
 
             _text = new Label();
             _text.Dock = DockStyle.Fill;
@@ -60,15 +56,30 @@ namespace GxPT
             _text.TextAlign = ContentAlignment.MiddleLeft;
             _text.ForeColor = TextColor;
 
-            // Fill first, edge-docked controls after — matches the app's working docking order
-            // (e.g. pnlInput). Do NOT BringToFront the strip itself or the Fill transcript stops
-            // reserving space for it.
+            // Fill first, edge-docked controls after — matches the app's working docking order.
             this.Controls.Add(_text);
-            this.Controls.Add(_clear);
-            this.Controls.Add(_change);
+            this.Controls.Add(_links);
 
             SetWorkingDir(null);
         }
+
+        private static LinkLabel MakeLink(string text, EventHandler onClick)
+        {
+            var lnk = new LinkLabel();
+            lnk.AutoSize = true;
+            lnk.Text = text;
+            lnk.TextAlign = ContentAlignment.MiddleLeft;
+            lnk.LinkColor = LinkColor;
+            lnk.ActiveLinkColor = LinkColor;
+            lnk.VisitedLinkColor = LinkColor;
+            lnk.LinkBehavior = LinkBehavior.HoverUnderline;
+            lnk.Margin = new Padding(10, 0, 0, 0);
+            lnk.Anchor = AnchorStyles.None; // vertically centered in the flow panel
+            lnk.LinkClicked += delegate { onClick(null, EventArgs.Empty); };
+            return lnk;
+        }
+
+        private void Raise(EventHandler h) { if (h != null) h(this, EventArgs.Empty); }
 
         // Reflect the given working folder (null/empty => "no folder" warning state).
         public void SetWorkingDir(string dir)
@@ -80,6 +91,7 @@ namespace GxPT
                 _text.Text = "Working folder:  " + dir;
                 _change.Text = "Change...";
                 _clear.Visible = true;
+                _dismiss.Visible = false; // can't dismiss while a folder is set (use Clear)
             }
             else
             {
@@ -87,6 +99,7 @@ namespace GxPT
                 _text.Text = "No working folder — file, git, and command tools are disabled for this conversation.";
                 _change.Text = "Set folder...";
                 _clear.Visible = false;
+                _dismiss.Visible = true;
             }
         }
     }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // A thin strip docked at the top of the chat/transcript area showing the active conversation's
+    // working folder (the MCP files/git/command sandbox root, GXPT_WORKDIR) with controls to set or
+    // clear it. Raised events are handled by MainForm, which updates the tab context + the host.
+    internal sealed class WorkspaceContextStrip : Panel
+    {
+        private readonly Label _icon;
+        private readonly Label _path;
+        private readonly LinkLabel _change;
+        private readonly LinkLabel _clear;
+
+        public event EventHandler ChangeRequested;
+        public event EventHandler ClearRequested;
+
+        public WorkspaceContextStrip()
+        {
+            this.Dock = DockStyle.Top;
+            this.Height = 24;
+            this.Padding = new Padding(8, 3, 8, 3);
+
+            _icon = new Label();
+            _icon.AutoSize = true;
+            _icon.Dock = DockStyle.Left;
+            _icon.Text = "Workspace:";
+            _icon.TextAlign = ContentAlignment.MiddleLeft;
+
+            _path = new Label();
+            _path.AutoSize = false;
+            _path.Dock = DockStyle.Fill;
+            _path.AutoEllipsis = true;
+            _path.TextAlign = ContentAlignment.MiddleLeft;
+            _path.Padding = new Padding(6, 0, 6, 0);
+
+            _change = new LinkLabel();
+            _change.AutoSize = true;
+            _change.Dock = DockStyle.Right;
+            _change.Text = "Set folder";
+            _change.TextAlign = ContentAlignment.MiddleRight;
+            _change.LinkClicked += delegate { if (ChangeRequested != null) ChangeRequested(this, EventArgs.Empty); };
+
+            _clear = new LinkLabel();
+            _clear.AutoSize = true;
+            _clear.Dock = DockStyle.Right;
+            _clear.Text = "Clear";
+            _clear.TextAlign = ContentAlignment.MiddleRight;
+            _clear.Padding = new Padding(0, 0, 8, 0);
+            _clear.Visible = false;
+            _clear.LinkClicked += delegate { if (ClearRequested != null) ClearRequested(this, EventArgs.Empty); };
+
+            // Fill must be added first so the docked siblings flank it correctly.
+            this.Controls.Add(_path);
+            this.Controls.Add(_change);
+            this.Controls.Add(_clear);
+            this.Controls.Add(_icon);
+        }
+
+        // Reflect the given working folder (null/empty => "no folder set").
+        public void SetWorkingDir(string dir)
+        {
+            bool has = !string.IsNullOrEmpty(dir);
+            _path.Text = has ? dir : "(no folder set — file, git, and command tools are disabled)";
+            _path.ForeColor = has ? this.ForeColor : SystemColors.GrayText;
+            _change.Text = has ? "Change" : "Set folder";
+            _clear.Visible = has;
+        }
+
+        // Apply theme colors (called by MainForm's theme application).
+        public void ApplyColors(Color back, Color fore)
+        {
+            this.BackColor = back;
+            _icon.ForeColor = fore;
+            _path.ForeColor = fore;
+        }
+    }
+}

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -100,6 +100,7 @@ namespace GxPT
                 Id = convo.Id,
                 Name = convo.Name,
                 SelectedModel = convo.SelectedModel,
+                WorkingDir = convo.WorkingDir,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -159,6 +160,7 @@ namespace GxPT
                 Id = dto.Id,
                 Name = dto.Name ?? "New Conversation",
                 SelectedModel = dto.SelectedModel,
+                WorkingDir = dto.WorkingDir,
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -315,6 +317,7 @@ namespace GxPT
             public string Id { get; set; }
             public string Name { get; set; }
             public string SelectedModel { get; set; }
+            public string WorkingDir { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -101,6 +101,7 @@ namespace GxPT
                 Name = convo.Name,
                 SelectedModel = convo.SelectedModel,
                 WorkingDir = convo.WorkingDir,
+                WorkspaceStripDismissed = convo.WorkspaceStripDismissed,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -161,6 +162,7 @@ namespace GxPT
                 Name = dto.Name ?? "New Conversation",
                 SelectedModel = dto.SelectedModel,
                 WorkingDir = dto.WorkingDir,
+                WorkspaceStripDismissed = dto.WorkspaceStripDismissed,
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -318,6 +320,7 @@ namespace GxPT
             public string Name { get; set; }
             public string SelectedModel { get; set; }
             public string WorkingDir { get; set; }
+            public bool WorkspaceStripDismissed { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -905,11 +905,29 @@ namespace GxPT
                 var connector = new DefaultServerConnector(clientInfo, curlPath, caBundle, LoggerSink.Instance);
                 _mcpHost = new McpHost(connector, _mcpRegistry, LoggerSink.Instance);
 
+                // Snapshot the active tab's working folder now (on the UI thread) so the rebuilt host
+                // re-binds its workdir-scoped servers (files/git/command) to it. Without this, a host
+                // rebuilt after a Settings save starts with no active workdir and those servers never
+                // launch even though the current conversation has a folder set.
+                string activeWorkdir = null;
+                try
+                {
+                    var actCtx = _tabManager != null ? _tabManager.GetActiveContext() : null;
+                    if (actCtx != null) activeWorkdir = actCtx.WorkingDir;
+                }
+                catch { }
+
                 // Connecting (handshakes / process spawns) can block — do it off the UI thread.
                 McpHost hostRef = _mcpHost;
+                string wd = activeWorkdir;
                 System.Threading.ThreadPool.QueueUserWorkItem(delegate
                 {
-                    try { hostRef.Start(specs); }
+                    try
+                    {
+                        hostRef.Start(specs);
+                        // Launch the workdir-scoped servers for the active conversation's folder.
+                        if (!string.IsNullOrEmpty(wd)) hostRef.SetActiveWorkingDir(wd);
+                    }
                     catch (Exception ex) { try { Logger.Log("mcp", "host start failed: " + ex.Message); } catch { } }
                 });
             }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -441,10 +441,12 @@ namespace GxPT
             {
                 _approvalPanel = new ToolApprovalPanel();
                 if (this.pnlBottom != null) this.pnlBottom.Controls.Add(_approvalPanel);
+                // Remembered approvals are kept only for the lifetime of the app (in-memory), not
+                // persisted to settings.json — a remembered choice lasts the session, then resets.
                 _mcpApproval = new ToolApprovalPolicy(
                     new ToolClassifier(),
                     new TranscriptApprovalPrompt(this, delegate { return _approvalPanel; }),
-                    new SettingsApprovalStore());
+                    new InMemoryApprovalStore());
             }
             catch { }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -473,6 +473,24 @@ namespace GxPT
         {
             this.Resize += MainForm_Resize;
 
+            // Add a "Set Working Folder…" item to the File menu (programmatic so the Designer is
+            // untouched). Sets the active conversation's GXPT_WORKDIR for files/git/command tools.
+            try
+            {
+                if (this.miFile != null)
+                {
+                    var miWorkdir = new ToolStripMenuItem();
+                    miWorkdir.Name = "miSetWorkingFolder";
+                    miWorkdir.Text = "Set &Working Folder...";
+                    miWorkdir.Click += delegate { SetWorkingFolderForActiveTab(); };
+                    // Insert near the top of the File menu (before Settings if present).
+                    int idx = (this.miSettings != null) ? this.miFile.DropDownItems.IndexOf(this.miSettings) : -1;
+                    if (idx < 0) this.miFile.DropDownItems.Add(miWorkdir);
+                    else this.miFile.DropDownItems.Insert(idx, miWorkdir);
+                }
+            }
+            catch { }
+
             // Wire menu items
             try
             {
@@ -526,7 +544,48 @@ namespace GxPT
             SyncComboModelFromActiveTab();
             // Refresh the attachments banner to reflect the active tab's pending attachments
             RebuildAttachmentsBanner();
+            // Point the MCP host's workdir-scoped servers (files/git/command) at the active tab's folder.
+            SyncMcpWorkingDirFromActiveTab();
             if (_inputManager != null) _inputManager.FocusInputSoon();
+        }
+
+        // Bind the MCP host's workdir-scoped servers to the active conversation's working folder
+        // (re-launches files/git/command against it; null disconnects them). Runs off the UI thread
+        // because (re)connecting can block.
+        private void SyncMcpWorkingDirFromActiveTab()
+        {
+            if (_mcpHost == null) return;
+            string wd = null;
+            try
+            {
+                var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
+                if (ctx != null) wd = ctx.WorkingDir;
+            }
+            catch { }
+            if (_mcpHost.ActiveWorkingDir == wd) return; // no change
+            McpHost hostRef = _mcpHost;
+            string target = wd;
+            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            {
+                try { hostRef.SetActiveWorkingDir(target); }
+                catch (Exception ex) { try { Logger.Log("mcp", "SetActiveWorkingDir failed: " + ex.Message); } catch { } }
+            });
+        }
+
+        // Menu/command handler: pick a working folder for the active conversation.
+        private void SetWorkingFolderForActiveTab()
+        {
+            var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
+            if (ctx == null) return;
+            using (var dlg = new FolderBrowserDialog())
+            {
+                dlg.Description = "Select a working folder for file, git, and command tools in this conversation.";
+                if (!string.IsNullOrEmpty(ctx.WorkingDir)) dlg.SelectedPath = ctx.WorkingDir;
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+                ctx.WorkingDir = dlg.SelectedPath;
+            }
+            SyncMcpWorkingDirFromActiveTab();
+            UpdateWindowTitleFromActiveTab();
         }
 
         private void OnTabsChanged()

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -562,6 +562,11 @@ namespace GxPT
             if (ctx == null || ctx.Page == null) return;
             try
             {
+                // Seed from the (possibly loaded) conversation so a re-opened chat keeps its folder.
+                if (string.IsNullOrEmpty(ctx.WorkingDir) && ctx.Conversation != null &&
+                    !string.IsNullOrEmpty(ctx.Conversation.WorkingDir))
+                    ctx.WorkingDir = ctx.Conversation.WorkingDir;
+
                 var strip = new WorkspaceContextStrip();
                 ctx.WorkspaceStrip = strip;
                 var ctxRef = ctx;
@@ -599,6 +604,7 @@ namespace GxPT
                 if (dlg.ShowDialog(this) != DialogResult.OK) return;
                 ctx.WorkingDir = dlg.SelectedPath;
             }
+            PersistWorkingDir(ctx);
             if (ctx.WorkspaceStrip != null)
             {
                 ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
@@ -611,8 +617,33 @@ namespace GxPT
         {
             if (ctx == null) return;
             ctx.WorkingDir = null;
+            PersistWorkingDir(ctx);
             if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.SetWorkingDir(null);
             SyncMcpWorkingDirFromActiveTab();
+        }
+
+        // After a conversation is loaded into a tab, adopt its persisted working folder onto the tab
+        // context + strip and (re)bind the MCP host to it.
+        private void ApplyLoadedWorkingDir(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            ctx.WorkingDir = (ctx.Conversation != null) ? ctx.Conversation.WorkingDir : null;
+            if (ctx.WorkspaceStrip != null)
+            {
+                ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
+                ctx.WorkspaceStrip.Visible = true;
+            }
+            SyncMcpWorkingDirFromActiveTab();
+        }
+
+        // Mirror the tab's working folder onto its persisted conversation and save, so it re-opens
+        // with the same folder. Skipped for brand-new, never-sent conversations (NoSaveUntilUserSend).
+        private void PersistWorkingDir(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Conversation == null) return;
+            ctx.Conversation.WorkingDir = ctx.WorkingDir;
+            try { if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation); }
+            catch { }
         }
 
         private void OnTabsChanged()
@@ -2254,6 +2285,9 @@ namespace GxPT
             // Rebuild transcript UI off the UI thread to avoid freezes on large histories
             RebuildTranscriptAsync(ctx, convo);
 
+            // Adopt the conversation's saved working folder.
+            ApplyLoadedWorkingDir(ctx);
+
             // Update tab title and window
             try
             {
@@ -2292,6 +2326,9 @@ namespace GxPT
 
                 // Rebuild transcript UI off the UI thread to avoid freezes on large histories
                 RebuildTranscriptAsync(ctx, convo);
+
+                // Adopt the conversation's saved working folder.
+                ApplyLoadedWorkingDir(ctx);
 
                 // Hook name updates for this conversation
                 try

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -20,6 +20,8 @@ namespace GxPT
         private OpenRouterClient _client;
         private McpHost _mcpHost;
         private McpToolRegistry _mcpRegistry;
+        private IToolApprovalPolicy _mcpApproval;
+        private ToolApprovalPanel _approvalPanel;
         private const string HelpApiKeysId = "help:api_keys";
         private const string HelpPrivacyId = "help:privacy";
 
@@ -432,6 +434,20 @@ namespace GxPT
 
         private void InitializeManagers()
         {
+            // The MCP tool-approval prompt: a panel docked at the bottom of the chat area, above the
+            // input. Created in code (not the Designer) and added to pnlBottom so it sits over the
+            // input panel when a tool call awaits approval.
+            try
+            {
+                _approvalPanel = new ToolApprovalPanel();
+                if (this.pnlBottom != null) this.pnlBottom.Controls.Add(_approvalPanel);
+                _mcpApproval = new ToolApprovalPolicy(
+                    new ToolClassifier(),
+                    new TranscriptApprovalPrompt(this, delegate { return _approvalPanel; }),
+                    new SettingsApprovalStore());
+            }
+            catch { }
+
             // Initialize managers for UI concerns
             _sidebarManager = new SidebarManager(this, this.splitContainer1, this.miConversationHistory);
             _tabManager = new TabManager(this, this.tabControl1, this.msMain);
@@ -1281,7 +1297,8 @@ namespace GxPT
             {
                 try
                 {
-                    var orch = new McpChatOrchestrator(_client, _mcpRegistry, new AllowAllApprovalPolicy(),
+                    var approval = _mcpApproval != null ? _mcpApproval : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
+                    var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);
                     orch.ProviderDataCollectionAllowed = providerAllow;
                     orch.RequestMessageTransform = delegate(IList<ChatMessage> h)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -576,6 +576,20 @@ namespace GxPT
         private void SetWorkingFolderForActiveTab()
         {
             var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
+            SetWorkingFolderForContext(ctx);
+        }
+
+        // Set the working folder for a specific tab (tab right-click menu).
+        internal void SetWorkingFolderForTab(TabPage page)
+        {
+            if (_tabManager == null || page == null) return;
+            TabManager.ChatTabContext ctx;
+            if (!_tabManager.TabContexts.TryGetValue(page, out ctx) || ctx == null) return;
+            SetWorkingFolderForContext(ctx);
+        }
+
+        private void SetWorkingFolderForContext(TabManager.ChatTabContext ctx)
+        {
             if (ctx == null) return;
             using (var dlg = new FolderBrowserDialog())
             {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -718,7 +718,8 @@ namespace GxPT
                 opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled", false);
                 opts.WebSearchKey = AppSettings.GetString("mcp_websearch_key");
                 opts.CurlPath = curlPath;
-                opts.ServerDir = baseDir; // server exes expected alongside GxPT.exe (deployed later)
+                // Server exes are deployed beside GxPT.exe under 'mcp-servers' (AfterBuild copy / installer).
+                opts.ServerDir = System.IO.Path.Combine(baseDir, "mcp-servers");
 
                 var specs = new List<McpServerSpec>(McpConfig.BuiltInSpecs(opts));
                 specs.Add(McpConfig.GitHubSpec(

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -567,6 +567,7 @@ namespace GxPT
                 var ctxRef = ctx;
                 strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
                 strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
+                strip.DismissRequested += delegate { if (ctxRef.WorkspaceStrip != null) ctxRef.WorkspaceStrip.Visible = false; };
                 // Dock order: the strip is Top and the transcript is Fill. WinForms lays out docked
                 // controls by REVERSE z-order, so the Fill transcript must be the frontmost child for
                 // it to fill the area *below* the Top strip (otherwise the strip overlaps the
@@ -576,6 +577,16 @@ namespace GxPT
                 strip.SetWorkingDir(ctx.WorkingDir);
             }
             catch { }
+        }
+
+        // Entry point for the tab context menu: set the working folder for a specific tab. Useful
+        // when the strip has been dismissed (setting a folder re-shows it).
+        internal void SetWorkingFolderForTab(TabPage page)
+        {
+            if (_tabManager == null || page == null) return;
+            TabManager.ChatTabContext ctx;
+            if (!_tabManager.TabContexts.TryGetValue(page, out ctx) || ctx == null) return;
+            SetWorkingFolderForContext(ctx);
         }
 
         private void SetWorkingFolderForContext(TabManager.ChatTabContext ctx)
@@ -588,7 +599,11 @@ namespace GxPT
                 if (dlg.ShowDialog(this) != DialogResult.OK) return;
                 ctx.WorkingDir = dlg.SelectedPath;
             }
-            if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
+            if (ctx.WorkspaceStrip != null)
+            {
+                ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
+                ctx.WorkspaceStrip.Visible = true; // re-show if it had been dismissed
+            }
             SyncMcpWorkingDirFromActiveTab();
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -567,27 +567,13 @@ namespace GxPT
                 var ctxRef = ctx;
                 strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
                 strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
-                // Add after the (Fill) transcript and bring to front so the Top dock sits above it.
+                // Dock order: the strip is Top and the transcript is Fill. WinForms lays out docked
+                // controls by REVERSE z-order, so the Fill transcript must be the frontmost child for
+                // it to fill the area *below* the Top strip (otherwise the strip overlaps the
+                // transcript's top). Add the strip, then send the transcript to front.
                 ctx.Page.Controls.Add(strip);
-                strip.BringToFront();
+                if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
-                if (_themeManager != null) _themeManager.ApplyWorkspaceStripTheme(strip);
-            }
-            catch { }
-        }
-
-        // Re-theme every tab's workspace strip (called after a theme change).
-        private void RefreshWorkspaceStripThemes()
-        {
-            if (_tabManager == null || _themeManager == null) return;
-            try
-            {
-                foreach (var kv in _tabManager.TabContexts)
-                {
-                    var c = kv.Value;
-                    if (c != null && c.WorkspaceStrip != null)
-                        _themeManager.ApplyWorkspaceStripTheme(c.WorkspaceStrip);
-                }
             }
             catch { }
         }
@@ -760,7 +746,6 @@ namespace GxPT
             // Apply theme across existing transcripts and primary UI
             try { if (_themeManager != null) _themeManager.ApplyThemeToAllTranscripts(); }
             catch { }
-            RefreshWorkspaceStripThemes();
 
             // Sync Dark Mode menu checked state from settings
             try
@@ -2593,7 +2578,6 @@ namespace GxPT
                     _themeManager.ApplyThemeToAllTranscripts();
                     _themeManager.ApplyFontSizeSettingToAllUi(); // keep fonts consistent; no-op for theme but safe
                 }
-                RefreshWorkspaceStripThemes();
 
                 // Also refresh tab headers (font/color may rely on system colors)
                 try { if (this.tabControl1 != null) this.tabControl1.Invalidate(); }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -473,24 +473,6 @@ namespace GxPT
         {
             this.Resize += MainForm_Resize;
 
-            // Add a "Set Working Folder…" item to the File menu (programmatic so the Designer is
-            // untouched). Sets the active conversation's GXPT_WORKDIR for files/git/command tools.
-            try
-            {
-                if (this.miFile != null)
-                {
-                    var miWorkdir = new ToolStripMenuItem();
-                    miWorkdir.Name = "miSetWorkingFolder";
-                    miWorkdir.Text = "Set &Working Folder...";
-                    miWorkdir.Click += delegate { SetWorkingFolderForActiveTab(); };
-                    // Insert near the top of the File menu (before Settings if present).
-                    int idx = (this.miSettings != null) ? this.miFile.DropDownItems.IndexOf(this.miSettings) : -1;
-                    if (idx < 0) this.miFile.DropDownItems.Add(miWorkdir);
-                    else this.miFile.DropDownItems.Insert(idx, miWorkdir);
-                }
-            }
-            catch { }
-
             // Wire menu items
             try
             {
@@ -572,20 +554,42 @@ namespace GxPT
             });
         }
 
-        // Menu/command handler: pick a working folder for the active conversation.
-        private void SetWorkingFolderForActiveTab()
+        // Creates the per-tab workspace strip docked above this tab's transcript, wiring its
+        // Set/Change/Clear actions to that conversation's working folder. Called by TabManager when a
+        // tab context is created.
+        internal void AttachWorkspaceStrip(TabManager.ChatTabContext ctx)
         {
-            var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
-            SetWorkingFolderForContext(ctx);
+            if (ctx == null || ctx.Page == null) return;
+            try
+            {
+                var strip = new WorkspaceContextStrip();
+                ctx.WorkspaceStrip = strip;
+                var ctxRef = ctx;
+                strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
+                strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
+                // Add after the (Fill) transcript and bring to front so the Top dock sits above it.
+                ctx.Page.Controls.Add(strip);
+                strip.BringToFront();
+                strip.SetWorkingDir(ctx.WorkingDir);
+                if (_themeManager != null) _themeManager.ApplyWorkspaceStripTheme(strip);
+            }
+            catch { }
         }
 
-        // Set the working folder for a specific tab (tab right-click menu).
-        internal void SetWorkingFolderForTab(TabPage page)
+        // Re-theme every tab's workspace strip (called after a theme change).
+        private void RefreshWorkspaceStripThemes()
         {
-            if (_tabManager == null || page == null) return;
-            TabManager.ChatTabContext ctx;
-            if (!_tabManager.TabContexts.TryGetValue(page, out ctx) || ctx == null) return;
-            SetWorkingFolderForContext(ctx);
+            if (_tabManager == null || _themeManager == null) return;
+            try
+            {
+                foreach (var kv in _tabManager.TabContexts)
+                {
+                    var c = kv.Value;
+                    if (c != null && c.WorkspaceStrip != null)
+                        _themeManager.ApplyWorkspaceStripTheme(c.WorkspaceStrip);
+                }
+            }
+            catch { }
         }
 
         private void SetWorkingFolderForContext(TabManager.ChatTabContext ctx)
@@ -598,8 +602,16 @@ namespace GxPT
                 if (dlg.ShowDialog(this) != DialogResult.OK) return;
                 ctx.WorkingDir = dlg.SelectedPath;
             }
+            if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
             SyncMcpWorkingDirFromActiveTab();
-            UpdateWindowTitleFromActiveTab();
+        }
+
+        private void ClearWorkingFolderForContext(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            ctx.WorkingDir = null;
+            if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.SetWorkingDir(null);
+            SyncMcpWorkingDirFromActiveTab();
         }
 
         private void OnTabsChanged()
@@ -748,6 +760,7 @@ namespace GxPT
             // Apply theme across existing transcripts and primary UI
             try { if (_themeManager != null) _themeManager.ApplyThemeToAllTranscripts(); }
             catch { }
+            RefreshWorkspaceStripThemes();
 
             // Sync Dark Mode menu checked state from settings
             try
@@ -2580,6 +2593,7 @@ namespace GxPT
                     _themeManager.ApplyThemeToAllTranscripts();
                     _themeManager.ApplyFontSizeSettingToAllUi(); // keep fonts consistent; no-op for theme but safe
                 }
+                RefreshWorkspaceStripThemes();
 
                 // Also refresh tab headers (font/color may rely on system colors)
                 try { if (this.tabControl1 != null) this.tabControl1.Invalidate(); }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -572,7 +572,7 @@ namespace GxPT
                 var ctxRef = ctx;
                 strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
                 strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
-                strip.DismissRequested += delegate { if (ctxRef.WorkspaceStrip != null) ctxRef.WorkspaceStrip.Visible = false; };
+                strip.DismissRequested += delegate { DismissWorkspaceStripForContext(ctxRef); };
                 // Dock order: the strip is Top and the transcript is Fill. WinForms lays out docked
                 // controls by REVERSE z-order, so the Fill transcript must be the frontmost child for
                 // it to fill the area *below* the Top strip (otherwise the strip overlaps the
@@ -580,8 +580,25 @@ namespace GxPT
                 ctx.Page.Controls.Add(strip);
                 if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
+                // Honor a persisted dismissal (only meaningful when no folder is set; setting one
+                // re-shows the strip).
+                if (string.IsNullOrEmpty(ctx.WorkingDir) && ctx.Conversation != null &&
+                    ctx.Conversation.WorkspaceStripDismissed)
+                    strip.Visible = false;
             }
             catch { }
+        }
+
+        private void DismissWorkspaceStripForContext(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.Visible = false;
+            if (ctx.Conversation != null)
+            {
+                ctx.Conversation.WorkspaceStripDismissed = true;
+                try { if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation); }
+                catch { }
+            }
         }
 
         // Entry point for the tab context menu: set the working folder for a specific tab. Useful
@@ -604,6 +621,8 @@ namespace GxPT
                 if (dlg.ShowDialog(this) != DialogResult.OK) return;
                 ctx.WorkingDir = dlg.SelectedPath;
             }
+            // Setting a folder re-shows the strip, so a prior dismissal no longer applies.
+            if (ctx.Conversation != null) ctx.Conversation.WorkspaceStripDismissed = false;
             PersistWorkingDir(ctx);
             if (ctx.WorkspaceStrip != null)
             {
@@ -631,7 +650,10 @@ namespace GxPT
             if (ctx.WorkspaceStrip != null)
             {
                 ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
-                ctx.WorkspaceStrip.Visible = true;
+                // Hidden only if there's no folder AND the user previously dismissed it.
+                bool dismissed = string.IsNullOrEmpty(ctx.WorkingDir) && ctx.Conversation != null &&
+                                 ctx.Conversation.WorkspaceStripDismissed;
+                ctx.WorkspaceStrip.Visible = !dismissed;
             }
             SyncMcpWorkingDirFromActiveTab();
         }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -203,7 +203,11 @@ namespace GxPT
             sb.AppendLine("  \"enable_logging\": false,")
             ;
             // Default provider data collection allowed (true)
-            sb.AppendLine("  \"provider_data_collection\": true");
+            sb.AppendLine("  \"provider_data_collection\": true,");
+            // First-party MCP servers enabled by default where no credential is required
+            // (files/command; they connect once a working folder is set).
+            sb.AppendLine("  \"mcp_files_enabled\": true,");
+            sb.AppendLine("  \"mcp_command_enabled\": true");
             sb.AppendLine("}");
             return sb.ToString();
         }
@@ -244,7 +248,10 @@ namespace GxPT
                 transcript_max_width = 1000,
                 // Percent (50-100) under legacy key name
                 message_max_width = 90,
-                provider_data_collection = true
+                provider_data_collection = true,
+                // First-party MCP servers enabled by default where no credential is required.
+                mcp_files_enabled = true,
+                mcp_command_enabled = true
             };
         }
 

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -312,7 +312,24 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- Deploy the first-party MCP server exes next to GxPT.exe in a flat 'mcp-servers' folder, so the
+       host can launch them (ServerDir points here). The servers are independent projects GxPT does
+       NOT reference; build them first via Build > Build Solution, or set Project Dependencies so
+       GxPT depends on the four servers. ContinueOnError keeps GxPT building even if a server hasn't
+       been built yet (that server's tool just won't be available at runtime). -->
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <McpServerFiles Include="..\servers\FilesMcpServer\bin\$(Configuration)\**\*.*" />
+      <McpServerFiles Include="..\servers\GitMcpServer\bin\$(Configuration)\**\*.*" />
+      <McpServerFiles Include="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.*" />
+      <McpServerFiles Include="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(McpServerFiles)"
+          DestinationFiles="@(McpServerFiles->'$(OutDir)mcp-servers\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          ContinueOnError="true" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -321,10 +321,14 @@
        been built yet (that server's tool just won't be available at runtime). -->
   <Target Name="AfterBuild">
     <ItemGroup>
-      <McpServerFiles Include="..\servers\FilesMcpServer\bin\$(Configuration)\**\*.*" />
-      <McpServerFiles Include="..\servers\GitMcpServer\bin\$(Configuration)\**\*.*" />
-      <McpServerFiles Include="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.*" />
-      <McpServerFiles Include="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.*" />
+      <McpServerFiles Include="..\servers\FilesMcpServer\bin\$(Configuration)\**\*.*"
+                      Exclude="..\servers\FilesMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\FilesMcpServer\bin\$(Configuration)\**\*.xml" />
+      <McpServerFiles Include="..\servers\GitMcpServer\bin\$(Configuration)\**\*.*"
+                      Exclude="..\servers\GitMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\GitMcpServer\bin\$(Configuration)\**\*.xml" />
+      <McpServerFiles Include="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.*"
+                      Exclude="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\CommandMcpServer\bin\$(Configuration)\**\*.xml" />
+      <McpServerFiles Include="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.*"
+                      Exclude="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.xml" />
     </ItemGroup>
     <Copy SourceFiles="@(McpServerFiles)"
           DestinationFiles="@(McpServerFiles->'$(OutDir)mcp-servers\%(RecursiveDir)%(Filename)%(Extension)')"

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Services\Mcp\ApprovalStore.cs" />
     <Compile Include="Services\Mcp\TranscriptApprovalPrompt.cs" />
     <Compile Include="Controls\ToolApprovalPanel.cs" />
+    <Compile Include="Controls\WorkspaceContextStrip.cs" />
     <Compile Include="Services\Mcp\ToolCallAssembler.cs" />
     <Compile Include="Services\Mcp\McpToolRegistry.cs" />
     <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -120,6 +120,8 @@
     <Compile Include="Services\Mcp\ToolClassifier.cs" />
     <Compile Include="Services\Mcp\ToolApprovalPolicy.cs" />
     <Compile Include="Services\Mcp\ApprovalStore.cs" />
+    <Compile Include="Services\Mcp\TranscriptApprovalPrompt.cs" />
+    <Compile Include="Controls\ToolApprovalPanel.cs" />
     <Compile Include="Services\Mcp\ToolCallAssembler.cs" />
     <Compile Include="Services\Mcp\McpToolRegistry.cs" />
     <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -116,6 +116,10 @@
     </Compile>
     <Compile Include="Services\Mcp\IChatStreamer.cs" />
     <Compile Include="Services\Mcp\IToolApprovalPolicy.cs" />
+    <Compile Include="Services\Mcp\ToolApproval.cs" />
+    <Compile Include="Services\Mcp\ToolClassifier.cs" />
+    <Compile Include="Services\Mcp\ToolApprovalPolicy.cs" />
+    <Compile Include="Services\Mcp\ApprovalStore.cs" />
     <Compile Include="Services\Mcp\ToolCallAssembler.cs" />
     <Compile Include="Services\Mcp\McpToolRegistry.cs" />
     <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -17,6 +17,7 @@ namespace GxPT
         private ToolStripMenuItem _miTabNew;
         private ToolStripMenuItem _miTabClose;
         private ToolStripMenuItem _miTabCloseOthers;
+        private ToolStripMenuItem _miTabWorkdir;
         private TabPage _tabCtxTarget;
 
         // Custom toolbar buttons
@@ -92,12 +93,14 @@ namespace GxPT
                 _miTabNew = new ToolStripMenuItem("New Tab");
                 _miTabClose = new ToolStripMenuItem("Close");
                 _miTabCloseOthers = new ToolStripMenuItem("Close Others");
+                _miTabWorkdir = new ToolStripMenuItem("Set Working Folder...");
 
                 _miTabNew.Click += delegate { CreateConversationTab(); };
                 _miTabClose.Click += delegate { if (_tabCtxTarget != null) CloseConversationTab(_tabCtxTarget); };
                 _miTabCloseOthers.Click += delegate { if (_tabCtxTarget != null) CloseOtherTabs(_tabCtxTarget); };
+                _miTabWorkdir.Click += delegate { if (_tabCtxTarget != null) _mainForm.SetWorkingFolderForTab(_tabCtxTarget); };
 
-                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
+                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabWorkdir, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
             }
             catch { }
         }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -17,7 +17,6 @@ namespace GxPT
         private ToolStripMenuItem _miTabNew;
         private ToolStripMenuItem _miTabClose;
         private ToolStripMenuItem _miTabCloseOthers;
-        private ToolStripMenuItem _miTabWorkdir;
         private TabPage _tabCtxTarget;
 
         // Custom toolbar buttons
@@ -39,6 +38,8 @@ namespace GxPT
             // Per-conversation working directory for MCP files/git/command servers (GXPT_WORKDIR);
             // null = no workspace (those tools won't connect for this tab).
             public string WorkingDir;
+            // The per-tab workspace strip docked above this tab's transcript (set by MainForm).
+            public WorkspaceContextStrip WorkspaceStrip;
             public List<AttachedFile> PendingAttachments = new List<AttachedFile>();
             // Pending edit of a prior user message (by transcript/history index)
             public bool PendingEditActive;
@@ -91,14 +92,12 @@ namespace GxPT
                 _miTabNew = new ToolStripMenuItem("New Tab");
                 _miTabClose = new ToolStripMenuItem("Close");
                 _miTabCloseOthers = new ToolStripMenuItem("Close Others");
-                _miTabWorkdir = new ToolStripMenuItem("Set Working Folder...");
 
                 _miTabNew.Click += delegate { CreateConversationTab(); };
                 _miTabClose.Click += delegate { if (_tabCtxTarget != null) CloseConversationTab(_tabCtxTarget); };
                 _miTabCloseOthers.Click += delegate { if (_tabCtxTarget != null) CloseOtherTabs(_tabCtxTarget); };
-                _miTabWorkdir.Click += delegate { if (_tabCtxTarget != null) _mainForm.SetWorkingFolderForTab(_tabCtxTarget); };
 
-                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabWorkdir, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
+                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
             }
             catch { }
         }
@@ -164,6 +163,7 @@ namespace GxPT
                 catch { }
 
                 _tabContexts[initialTab] = ctx;
+                _mainForm.AttachWorkspaceStrip(ctx);
                 if (TabsChanged != null) TabsChanged();
                 return ctx;
             }
@@ -198,6 +198,7 @@ namespace GxPT
             HookNameGenerated(ctx);
 
             _tabContexts[page] = ctx;
+            _mainForm.AttachWorkspaceStrip(ctx);
 
             _tabControl.TabPages.Add(page);
             try { _tabControl.SelectedTab = page; }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -17,6 +17,7 @@ namespace GxPT
         private ToolStripMenuItem _miTabNew;
         private ToolStripMenuItem _miTabClose;
         private ToolStripMenuItem _miTabCloseOthers;
+        private ToolStripMenuItem _miTabWorkdir;
         private TabPage _tabCtxTarget;
 
         // Custom toolbar buttons
@@ -90,12 +91,14 @@ namespace GxPT
                 _miTabNew = new ToolStripMenuItem("New Tab");
                 _miTabClose = new ToolStripMenuItem("Close");
                 _miTabCloseOthers = new ToolStripMenuItem("Close Others");
+                _miTabWorkdir = new ToolStripMenuItem("Set Working Folder...");
 
                 _miTabNew.Click += delegate { CreateConversationTab(); };
                 _miTabClose.Click += delegate { if (_tabCtxTarget != null) CloseConversationTab(_tabCtxTarget); };
                 _miTabCloseOthers.Click += delegate { if (_tabCtxTarget != null) CloseOtherTabs(_tabCtxTarget); };
+                _miTabWorkdir.Click += delegate { if (_tabCtxTarget != null) _mainForm.SetWorkingFolderForTab(_tabCtxTarget); };
 
-                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
+                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabWorkdir, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers });
             }
             catch { }
         }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -35,6 +35,9 @@ namespace GxPT
             public bool IsSending;
             public string SelectedModel;
             public bool NoSaveUntilUserSend;
+            // Per-conversation working directory for MCP files/git/command servers (GXPT_WORKDIR);
+            // null = no workspace (those tools won't connect for this tab).
+            public string WorkingDir;
             public List<AttachedFile> PendingAttachments = new List<AttachedFile>();
             // Pending edit of a prior user message (by transcript/history index)
             public bool PendingEditActive;

--- a/GxPT/Managers/ThemeManager.cs
+++ b/GxPT/Managers/ThemeManager.cs
@@ -168,6 +168,23 @@ namespace GxPT
             catch { }
         }
 
+        // Theme a per-tab workspace context strip to match the current UI colors.
+        public void ApplyWorkspaceStripTheme(WorkspaceContextStrip strip)
+        {
+            if (strip == null) return;
+            try
+            {
+                string theme = null;
+                try { theme = AppSettings.GetString("theme"); }
+                catch { theme = null; }
+                bool dark = !string.IsNullOrEmpty(theme) &&
+                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+                var colors = ThemeService.GetColors(dark);
+                strip.ApplyColors(colors.UiBackground, colors.UiForeground);
+            }
+            catch { }
+        }
+
         public void ApplyThemeToTextBox()
         {
             try

--- a/GxPT/Managers/ThemeManager.cs
+++ b/GxPT/Managers/ThemeManager.cs
@@ -168,23 +168,6 @@ namespace GxPT
             catch { }
         }
 
-        // Theme a per-tab workspace context strip to match the current UI colors.
-        public void ApplyWorkspaceStripTheme(WorkspaceContextStrip strip)
-        {
-            if (strip == null) return;
-            try
-            {
-                string theme = null;
-                try { theme = AppSettings.GetString("theme"); }
-                catch { theme = null; }
-                bool dark = !string.IsNullOrEmpty(theme) &&
-                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
-                var colors = ThemeService.GetColors(dark);
-                strip.ApplyColors(colors.UiBackground, colors.UiForeground);
-            }
-            catch { }
-        }
-
         public void ApplyThemeToTextBox()
         {
             try

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -16,6 +16,9 @@ namespace GxPT
         public string Name { get; internal set; }
         public string Id { get; internal set; } // UUID-like id
         public string SelectedModel { get; set; }
+        // MCP working folder for this conversation (GXPT_WORKDIR sandbox root); null = none. Persisted
+        // so the conversation re-opens with the same folder.
+        public string WorkingDir { get; set; }
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -19,6 +19,9 @@ namespace GxPT
         // MCP working folder for this conversation (GXPT_WORKDIR sandbox root); null = none. Persisted
         // so the conversation re-opens with the same folder.
         public string WorkingDir { get; set; }
+        // Whether the user dismissed the (unset) workspace strip for this conversation; persisted so
+        // the strip stays hidden on reopen until they set a folder.
+        public bool WorkspaceStripDismissed { get; set; }
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 

--- a/GxPT/Services/AppSettings.cs
+++ b/GxPT/Services/AppSettings.cs
@@ -192,6 +192,28 @@ namespace GxPT
             return result;
         }
 
+        // Store a list of strings (round-trips through GetList). Stored as object[] so the
+        // JavaScriptSerializer emits a JSON array.
+        public static void SetList(string key, IList<string> values)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            lock (_gate)
+            {
+                EnsureLoadedLocked();
+                if (values == null)
+                {
+                    _cache[key] = new object[0];
+                }
+                else
+                {
+                    var arr = new object[values.Count];
+                    for (int i = 0; i < values.Count; i++) arr[i] = values[i];
+                    _cache[key] = arr;
+                }
+                PersistLocked();
+            }
+        }
+
         public static double GetDouble(string key, double defaultValue)
         {
             lock (_gate)

--- a/GxPT/Services/Mcp/ApprovalStore.cs
+++ b/GxPT/Services/Mcp/ApprovalStore.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace GxPT
 {
-    // Persistence of remembered approvals (approval spec §5): a set of Tool-scope function names and
-    // a list of Argument-scope rules. Abstracted so the policy is testable with an in-memory store.
+    // Remembered approvals for the current app session (approval spec §5): a set of Tool-scope
+    // function names and a list of Argument-scope rules. Kept in memory only — not persisted, so
+    // remembered choices last until the app closes. Abstracted behind an interface for testing.
     internal interface IApprovalStore
     {
         bool IsToolApproved(string functionName);
@@ -14,7 +14,7 @@ namespace GxPT
         void AddRule(ApprovalRule rule);
     }
 
-    // In-memory store (tests; also the base behavior the settings-backed store builds on).
+    // In-memory store: remembered approvals live for the app session only.
     internal class InMemoryApprovalStore : IApprovalStore
     {
         protected readonly Dictionary<string, bool> _approvedTools = new Dictionary<string, bool>(StringComparer.Ordinal);
@@ -49,77 +49,6 @@ namespace GxPT
                     r.ArgPath == rule.ArgPath && r.Pattern == rule.Pattern) return;
             }
             _rules.Add(rule);
-        }
-    }
-
-    // settings.json-backed store via AppSettings (spec §5): mcp.approvedTools (string list) and
-    // mcp.approvalRules (list of JSON-serialized ApprovalRule). AppSettings stays on
-    // JavaScriptSerializer (D16); rules are serialized with Newtonsoft for a stable shape.
-    internal sealed class SettingsApprovalStore : InMemoryApprovalStore
-    {
-        public const string ApprovedToolsKey = "mcp.approvedTools";
-        public const string ApprovalRulesKey = "mcp.approvalRules";
-
-        public SettingsApprovalStore()
-        {
-            Load();
-        }
-
-        private void Load()
-        {
-            try
-            {
-                IList<string> tools = AppSettings.GetList(ApprovedToolsKey);
-                if (tools != null)
-                    for (int i = 0; i < tools.Count; i++)
-                        if (!string.IsNullOrEmpty(tools[i])) _approvedTools[tools[i]] = true;
-            }
-            catch { }
-
-            try
-            {
-                IList<string> ruleJson = AppSettings.GetList(ApprovalRulesKey);
-                if (ruleJson != null)
-                {
-                    for (int i = 0; i < ruleJson.Count; i++)
-                    {
-                        try
-                        {
-                            ApprovalRule r = JsonConvert.DeserializeObject<ApprovalRule>(ruleJson[i]);
-                            if (r != null && !string.IsNullOrEmpty(r.FunctionName)) _rules.Add(r);
-                        }
-                        catch { }
-                    }
-                }
-            }
-            catch { }
-        }
-
-        public override void AddApprovedTool(string functionName)
-        {
-            base.AddApprovedTool(functionName);
-            Save();
-        }
-
-        public override void AddRule(ApprovalRule rule)
-        {
-            base.AddRule(rule);
-            Save();
-        }
-
-        private void Save()
-        {
-            try
-            {
-                var tools = new List<string>(_approvedTools.Keys);
-                AppSettings.SetList(ApprovedToolsKey, tools);
-
-                var ruleJson = new List<string>();
-                for (int i = 0; i < _rules.Count; i++)
-                    ruleJson.Add(JsonConvert.SerializeObject(_rules[i]));
-                AppSettings.SetList(ApprovalRulesKey, ruleJson);
-            }
-            catch { }
         }
     }
 }

--- a/GxPT/Services/Mcp/ApprovalStore.cs
+++ b/GxPT/Services/Mcp/ApprovalStore.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GxPT
+{
+    // Persistence of remembered approvals (approval spec §5): a set of Tool-scope function names and
+    // a list of Argument-scope rules. Abstracted so the policy is testable with an in-memory store.
+    internal interface IApprovalStore
+    {
+        bool IsToolApproved(string functionName);
+        void AddApprovedTool(string functionName);
+        IList<ApprovalRule> RulesFor(string functionName);
+        void AddRule(ApprovalRule rule);
+    }
+
+    // In-memory store (tests; also the base behavior the settings-backed store builds on).
+    internal class InMemoryApprovalStore : IApprovalStore
+    {
+        protected readonly Dictionary<string, bool> _approvedTools = new Dictionary<string, bool>(StringComparer.Ordinal);
+        protected readonly List<ApprovalRule> _rules = new List<ApprovalRule>();
+
+        public bool IsToolApproved(string functionName)
+        {
+            return functionName != null && _approvedTools.ContainsKey(functionName);
+        }
+
+        public virtual void AddApprovedTool(string functionName)
+        {
+            if (!string.IsNullOrEmpty(functionName)) _approvedTools[functionName] = true;
+        }
+
+        public IList<ApprovalRule> RulesFor(string functionName)
+        {
+            var outp = new List<ApprovalRule>();
+            for (int i = 0; i < _rules.Count; i++)
+                if (_rules[i] != null && _rules[i].FunctionName == functionName) outp.Add(_rules[i]);
+            return outp;
+        }
+
+        public virtual void AddRule(ApprovalRule rule)
+        {
+            if (rule == null) return;
+            // Skip exact duplicates.
+            for (int i = 0; i < _rules.Count; i++)
+            {
+                ApprovalRule r = _rules[i];
+                if (r.FunctionName == rule.FunctionName && r.Kind == rule.Kind &&
+                    r.ArgPath == rule.ArgPath && r.Pattern == rule.Pattern) return;
+            }
+            _rules.Add(rule);
+        }
+    }
+
+    // settings.json-backed store via AppSettings (spec §5): mcp.approvedTools (string list) and
+    // mcp.approvalRules (list of JSON-serialized ApprovalRule). AppSettings stays on
+    // JavaScriptSerializer (D16); rules are serialized with Newtonsoft for a stable shape.
+    internal sealed class SettingsApprovalStore : InMemoryApprovalStore
+    {
+        public const string ApprovedToolsKey = "mcp.approvedTools";
+        public const string ApprovalRulesKey = "mcp.approvalRules";
+
+        public SettingsApprovalStore()
+        {
+            Load();
+        }
+
+        private void Load()
+        {
+            try
+            {
+                IList<string> tools = AppSettings.GetList(ApprovedToolsKey);
+                if (tools != null)
+                    for (int i = 0; i < tools.Count; i++)
+                        if (!string.IsNullOrEmpty(tools[i])) _approvedTools[tools[i]] = true;
+            }
+            catch { }
+
+            try
+            {
+                IList<string> ruleJson = AppSettings.GetList(ApprovalRulesKey);
+                if (ruleJson != null)
+                {
+                    for (int i = 0; i < ruleJson.Count; i++)
+                    {
+                        try
+                        {
+                            ApprovalRule r = JsonConvert.DeserializeObject<ApprovalRule>(ruleJson[i]);
+                            if (r != null && !string.IsNullOrEmpty(r.FunctionName)) _rules.Add(r);
+                        }
+                        catch { }
+                    }
+                }
+            }
+            catch { }
+        }
+
+        public override void AddApprovedTool(string functionName)
+        {
+            base.AddApprovedTool(functionName);
+            Save();
+        }
+
+        public override void AddRule(ApprovalRule rule)
+        {
+            base.AddRule(rule);
+            Save();
+        }
+
+        private void Save()
+        {
+            try
+            {
+                var tools = new List<string>(_approvedTools.Keys);
+                AppSettings.SetList(ApprovedToolsKey, tools);
+
+                var ruleJson = new List<string>();
+                for (int i = 0; i < _rules.Count; i++)
+                    ruleJson.Add(JsonConvert.SerializeObject(_rules[i]));
+                AppSettings.SetList(ApprovalRulesKey, ruleJson);
+            }
+            catch { }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -69,6 +69,19 @@ namespace GxPT
                     }
                 }
                 _scopedSpecs = scoped;
+
+                // If a working directory was already set (e.g. SetActiveWorkingDir raced ahead of
+                // Start on startup), launch the scoped servers for it now.
+                if (_currentWorkdir != null && _scoped.Count == 0)
+                {
+                    for (int i = 0; i < _scopedSpecs.Count; i++)
+                    {
+                        McpServerSpec spec = _scopedSpecs[i];
+                        if (spec == null || !spec.Enabled) continue;
+                        McpServerConnection conn = ConnectAndAdd(spec, _currentWorkdir);
+                        if (conn != null) _scoped.Add(conn);
+                    }
+                }
             }
         }
 

--- a/GxPT/Services/Mcp/ToolApproval.cs
+++ b/GxPT/Services/Mcp/ToolApproval.cs
@@ -1,0 +1,69 @@
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // Approval tiers and remember-scope (approval spec §2).
+    internal enum ToolTier { ReadOnly, Write, Destructive }
+    internal enum RememberScope { None, Tool, Argument }
+
+    // The classification of a tool: how much friction (tier) and how an approval may be remembered.
+    internal sealed class ToolPolicy
+    {
+        public ToolTier Tier;
+        public RememberScope Scope;
+        public string ScopeArgPath;   // argument name when Scope==Argument (e.g. "command", "path")
+
+        public ToolPolicy(ToolTier tier, RememberScope scope, string scopeArgPath)
+        {
+            Tier = tier; Scope = scope; ScopeArgPath = scopeArgPath;
+        }
+    }
+
+    // A remembered argument-scoped rule (approval spec §3). Tool-scope approvals are stored as a
+    // plain function-name set; these cover command__run / files__* granular allowlisting.
+    internal enum RuleKind { ExactArgs, Prefix }
+
+    internal sealed class ApprovalRule
+    {
+        public string FunctionName;
+        public RuleKind Kind;
+        public string ArgPath;   // which argument (e.g. "command", "path")
+        public string Pattern;   // exact value | prefix
+
+        public ApprovalRule() { }
+        public ApprovalRule(string functionName, RuleKind kind, string argPath, string pattern)
+        {
+            FunctionName = functionName; Kind = kind; ArgPath = argPath; Pattern = pattern;
+        }
+    }
+
+    // Everything the gate (and the confirmation UI) needs about one pending call.
+    internal sealed class ApprovalRequest
+    {
+        public string ServerName;
+        public string FunctionName;   // qualified (e.g. "command__run")
+        public string ToolName;       // original server tool name (e.g. "run")
+        public ToolPolicy Policy;
+        public JObject Arguments;
+        public string Preview;        // resolved command line / target path, for the dangerous surface
+    }
+
+    // What the user chose at the confirmation prompt. The policy maps this onto an outcome plus what
+    // (if anything) to persist.
+    internal enum ApprovalChoice
+    {
+        Deny,
+        AllowOnce,
+        RememberTool,        // Tool scope: remember the whole function name
+        RememberExactArg,    // Argument scope: ExactArgs rule on ScopeArgPath
+        RememberPrefixArg    // Argument scope: Prefix rule (base+sub / directory-and-below)
+    }
+
+    // The confirmation surface the policy invokes when a call isn't already allowed. Implemented by
+    // the host (in-transcript confirmation, 3b); tests inject a scripted prompt. Returns synchronously
+    // (the tool-loop worker blocks here while the user decides).
+    internal interface IToolApprovalPrompt
+    {
+        ApprovalChoice Ask(ApprovalRequest req);
+    }
+}

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The real approval gate (approval spec §3) behind the orchestrator's IToolApprovalPolicy.Check.
+    // Classifies the tool, consults remembered approvals (tool-name set + argument rules), and only
+    // prompts (via IToolApprovalPrompt) when not already allowed; persists the user's remembered
+    // choice. Pure logic + an injected prompt + an injected store — no UI here, so it's unit-testable.
+    internal sealed class ToolApprovalPolicy : IToolApprovalPolicy
+    {
+        // Identifies first-party servers (whose tools use the hardcoded classification table).
+        private static readonly Dictionary<string, bool> _firstPartyServers = BuildFirstPartySet();
+
+        private readonly IToolClassifier _classifier;
+        private readonly IToolApprovalPrompt _prompt;
+        private readonly IApprovalStore _store;
+
+        public ToolApprovalPolicy(IToolClassifier classifier, IToolApprovalPrompt prompt, IApprovalStore store)
+        {
+            _classifier = classifier != null ? classifier : new ToolClassifier();
+            _prompt = prompt;
+            _store = store != null ? store : new InMemoryApprovalStore();
+        }
+
+        // The orchestrator calls this. functionName is the qualified name; args already parsed.
+        public ApprovalDecision Check(string functionName, JObject args)
+        {
+            string server = ServerOf(functionName);
+            bool firstParty = server != null && _firstPartyServers.ContainsKey(server);
+            JObject annotations = null; // third-party annotations not yet plumbed; unknown -> Write/Tool
+            ToolPolicy pol = _classifier.Classify(functionName, annotations, firstParty);
+
+            // Already-remembered fast paths.
+            if (pol.Scope == RememberScope.Tool && _store.IsToolApproved(functionName))
+                return ApprovalDecision.Allow;
+            if (pol.Scope == RememberScope.Argument && MatchesAnyRule(functionName, pol, args))
+                return ApprovalDecision.Allow;
+
+            // Not remembered (or Scope==None) -> prompt.
+            if (_prompt == null) return ApprovalDecision.Deny; // no UI available -> safe default
+
+            ApprovalRequest req = new ApprovalRequest();
+            req.ServerName = server;
+            req.FunctionName = functionName;
+            req.ToolName = ToolOf(functionName);
+            req.Policy = pol;
+            req.Arguments = args;
+            req.Preview = BuildPreview(functionName, pol, args);
+
+            ApprovalChoice choice = _prompt.Ask(req);
+            Persist(req, choice);
+            return choice == ApprovalChoice.Deny ? ApprovalDecision.Deny : ApprovalDecision.Allow;
+        }
+
+        // ---- remembered-rule matching (approval spec §3) ----
+
+        private bool MatchesAnyRule(string functionName, ToolPolicy pol, JObject args)
+        {
+            string val = ArgValue(args, pol.ScopeArgPath);
+            if (val == null) return false;
+
+            IList<ApprovalRule> rules = _store.RulesFor(functionName);
+            for (int i = 0; i < rules.Count; i++)
+            {
+                ApprovalRule r = rules[i];
+                if (r == null || r.ArgPath != pol.ScopeArgPath) continue;
+                if (r.Kind == RuleKind.ExactArgs)
+                {
+                    if (string.Equals(val, r.Pattern, StringComparison.Ordinal)) return true;
+                }
+                else // Prefix
+                {
+                    bool isPath = pol.ScopeArgPath == "path";
+                    if (PrefixMatches(val, r.Pattern, isPath)) return true;
+                }
+            }
+            return false;
+        }
+
+        // Boundary-aware prefix match (security, spec §3):
+        //  - path: directory-boundary aware ("/a/b" matches "/a/b/c", not "/a/bc")
+        //  - command: token-aware ("git status" matches "git status -s", not "git status-hack")
+        internal static bool PrefixMatches(string value, string pattern, bool isPath)
+        {
+            if (value == null || pattern == null) return false;
+            if (value.Equals(pattern, StringComparison.Ordinal)) return true;
+            if (!value.StartsWith(pattern, StringComparison.Ordinal)) return false;
+
+            char next = value[pattern.Length];
+            if (isPath)
+            {
+                char last = pattern.Length > 0 ? pattern[pattern.Length - 1] : '\0';
+                if (last == '/' || last == '\\') return true; // pattern already ends at a boundary
+                return next == '/' || next == '\\';
+            }
+            // command: the boundary must be whitespace
+            return next == ' ' || next == '\t';
+        }
+
+        // ---- persistence of the user's choice ----
+
+        private void Persist(ApprovalRequest req, ApprovalChoice choice)
+        {
+            switch (choice)
+            {
+                case ApprovalChoice.RememberTool:
+                    _store.AddApprovedTool(req.FunctionName);
+                    break;
+                case ApprovalChoice.RememberExactArg:
+                    _store.AddRule(new ApprovalRule(req.FunctionName, RuleKind.ExactArgs,
+                        req.Policy.ScopeArgPath, ArgValue(req.Arguments, req.Policy.ScopeArgPath)));
+                    break;
+                case ApprovalChoice.RememberPrefixArg:
+                    _store.AddRule(new ApprovalRule(req.FunctionName, RuleKind.Prefix,
+                        req.Policy.ScopeArgPath, PrefixPattern(req)));
+                    break;
+                // AllowOnce / Deny: nothing persisted.
+            }
+        }
+
+        // The structured prefix for a "base+subcommand" command rule or a "directory and below" path
+        // rule, derived from the actual argument (no free-form entry — spec §3/§4).
+        private static string PrefixPattern(ApprovalRequest req)
+        {
+            string val = ArgValue(req.Arguments, req.Policy.ScopeArgPath);
+            if (val == null) return string.Empty;
+            if (req.Policy.ScopeArgPath == "path")
+                return val; // directory boundary handled by PrefixMatches
+            // command: base + first subcommand (first two whitespace tokens)
+            string trimmed = val.Trim();
+            string[] parts = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length <= 1) return parts.Length == 1 ? parts[0] : trimmed;
+            return parts[0] + " " + parts[1];
+        }
+
+        // ---- helpers ----
+
+        private static string BuildPreview(string functionName, ToolPolicy pol, JObject args)
+        {
+            if (pol.Scope == RememberScope.Argument && pol.ScopeArgPath != null)
+            {
+                string v = ArgValue(args, pol.ScopeArgPath);
+                if (v != null) return v;
+            }
+            return args != null ? args.ToString(Formatting.None) : string.Empty;
+        }
+
+        private static string ArgValue(JObject args, string path)
+        {
+            if (args == null || string.IsNullOrEmpty(path)) return null;
+            JToken t = args[path];
+            if (t == null || t.Type == JTokenType.Null) return null;
+            return t.Type == JTokenType.String ? (string)t : t.ToString(Formatting.None);
+        }
+
+        private static string ServerOf(string functionName)
+        {
+            if (string.IsNullOrEmpty(functionName)) return null;
+            int i = functionName.IndexOf("__", StringComparison.Ordinal);
+            return i > 0 ? functionName.Substring(0, i) : null;
+        }
+
+        private static string ToolOf(string functionName)
+        {
+            if (string.IsNullOrEmpty(functionName)) return functionName;
+            int i = functionName.IndexOf("__", StringComparison.Ordinal);
+            return i >= 0 ? functionName.Substring(i + 2) : functionName;
+        }
+
+        private static Dictionary<string, bool> BuildFirstPartySet()
+        {
+            var s = new Dictionary<string, bool>(StringComparer.Ordinal);
+            s[McpConfig.WebName] = true;
+            s[McpConfig.FilesName] = true;
+            s[McpConfig.GitName] = true;
+            s[McpConfig.CommandName] = true;
+            // GitHub is a first-party-managed HTTP server but a third-party tool surface; classify
+            // its tools via annotations (not the hardcoded table).
+            return s;
+        }
+    }
+}

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -86,6 +86,9 @@ namespace GxPT
         internal static bool PrefixMatches(string value, string pattern, bool isPath)
         {
             if (value == null || pattern == null) return false;
+            // An empty path pattern means the workspace root itself ("this directory and below" for a
+            // file sitting directly in the root) — it matches any relative path under the root.
+            if (isPath && pattern.Length == 0) return true;
             if (value.Equals(pattern, StringComparison.Ordinal)) return true;
             if (!value.StartsWith(pattern, StringComparison.Ordinal)) return false;
 

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -128,7 +128,14 @@ namespace GxPT
             string val = ArgValue(req.Arguments, req.Policy.ScopeArgPath);
             if (val == null) return string.Empty;
             if (req.Policy.ScopeArgPath == "path")
-                return val; // directory boundary handled by PrefixMatches
+            {
+                // "directory and below": the rule covers the file's PARENT directory, so other files
+                // in the same folder match. PrefixMatches enforces the directory boundary.
+                string dir = null;
+                try { dir = System.IO.Path.GetDirectoryName(val); }
+                catch { dir = null; }
+                return string.IsNullOrEmpty(dir) ? val : dir;
+            }
             // command: base + first subcommand (first two whitespace tokens)
             string trimmed = val.Trim();
             string[] parts = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -86,21 +86,40 @@ namespace GxPT
         internal static bool PrefixMatches(string value, string pattern, bool isPath)
         {
             if (value == null || pattern == null) return false;
-            // An empty path pattern means the workspace root itself ("this directory and below" for a
-            // file sitting directly in the root) — it matches any relative path under the root.
-            if (isPath && pattern.Length == 0) return true;
-            if (value.Equals(pattern, StringComparison.Ordinal)) return true;
-            if (!value.StartsWith(pattern, StringComparison.Ordinal)) return false;
 
-            char next = value[pattern.Length];
             if (isPath)
             {
-                char last = pattern.Length > 0 ? pattern[pattern.Length - 1] : '\0';
-                if (last == '/' || last == '\\') return true; // pattern already ends at a boundary
-                return next == '/' || next == '\\';
+                // Normalize separators so a rule stored with one separator (e.g. '\' from
+                // Path.GetDirectoryName on Windows) still matches a value using the other ('/' from
+                // the model). Compare case-insensitively (Windows paths).
+                value = NormalizePath(value);
+                pattern = NormalizePath(pattern);
+
+                // An empty pattern is the workspace root: matches any relative path under it.
+                if (pattern.Length == 0) return true;
+                if (value.Equals(pattern, StringComparison.OrdinalIgnoreCase)) return true;
+                if (!value.StartsWith(pattern, StringComparison.OrdinalIgnoreCase)) return false;
+                // Directory boundary: the char after the pattern must be a separator
+                // ("sub" matches "sub/a", not "subdir/a").
+                return value[pattern.Length] == '/';
             }
-            // command: the boundary must be whitespace
+
+            // command: token-aware prefix.
+            if (value.Equals(pattern, StringComparison.Ordinal)) return true;
+            if (!value.StartsWith(pattern, StringComparison.Ordinal)) return false;
+            char next = value[pattern.Length];
             return next == ' ' || next == '\t';
+        }
+
+        // Canonical relative-path form for comparison: '\' -> '/', collapse a leading './', drop any
+        // trailing separator.
+        private static string NormalizePath(string p)
+        {
+            if (string.IsNullOrEmpty(p)) return string.Empty;
+            p = p.Replace('\\', '/');
+            while (p.StartsWith("./", StringComparison.Ordinal)) p = p.Substring(2);
+            while (p.Length > 1 && p[p.Length - 1] == '/') p = p.Substring(0, p.Length - 1);
+            return p;
         }
 
         // ---- persistence of the user's choice ----
@@ -132,12 +151,13 @@ namespace GxPT
             if (val == null) return string.Empty;
             if (req.Policy.ScopeArgPath == "path")
             {
-                // "directory and below": the rule covers the file's PARENT directory, so other files
-                // in the same folder match. PrefixMatches enforces the directory boundary.
-                string dir = null;
-                try { dir = System.IO.Path.GetDirectoryName(val); }
-                catch { dir = null; }
-                return string.IsNullOrEmpty(dir) ? val : dir;
+                // "directory and below": the rule is the file's PARENT directory, so other files in
+                // the same folder match. Compute it with normalized '/' separators (NOT
+                // Path.GetDirectoryName, which yields '\' on Windows and wouldn't match the model's
+                // forward-slash paths). A root-level file yields "" — the workspace root.
+                string norm = NormalizePath(val);
+                int slash = norm.LastIndexOf('/');
+                return slash < 0 ? string.Empty : norm.Substring(0, slash);
             }
             // command: base + first subcommand (first two whitespace tokens)
             string trimmed = val.Trim();

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // Classifies a tool into a ToolPolicy (tier + remember scope), per approval spec §2:
+    //   1. reveal_tools is handled upstream (never reaches here / never gated).
+    //   2. First-party tools use a hardcoded, authoritative table (annotations ignored).
+    //   3. Third-party tools use advisory annotations (readOnlyHint / destructiveHint); since we
+    //      can't infer their argument semantics, they never get Argument scope.
+    //   4. Unknown / unannotated -> Write/Tool.
+    internal interface IToolClassifier
+    {
+        ToolPolicy Classify(string functionName, JObject annotations, bool isFirstParty);
+    }
+
+    internal sealed class ToolClassifier : IToolClassifier
+    {
+        // First-party table keyed by qualified function name (approval spec §2).
+        private static readonly Dictionary<string, ToolPolicy> _firstParty = BuildFirstPartyTable();
+
+        private static Dictionary<string, ToolPolicy> BuildFirstPartyTable()
+        {
+            var t = new Dictionary<string, ToolPolicy>(StringComparer.Ordinal);
+            t["files__read"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["files__list"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["files__write"] = new ToolPolicy(ToolTier.Write, RememberScope.Argument, "path");
+            t["files__delete"] = new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "path");
+            t["git__status"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["git__diff"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["git__log"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["git__commit"] = new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
+            t["git__push"] = new ToolPolicy(ToolTier.Destructive, RememberScope.None, null);
+            t["command__run"] = new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "command");
+            t["web__search"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["web__extract"] = new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
+            return t;
+        }
+
+        public ToolPolicy Classify(string functionName, JObject annotations, bool isFirstParty)
+        {
+            if (isFirstParty && functionName != null)
+            {
+                ToolPolicy fp;
+                if (_firstParty.TryGetValue(functionName, out fp))
+                    return new ToolPolicy(fp.Tier, fp.Scope, fp.ScopeArgPath);
+                // First-party but not in the table (shouldn't happen) -> conservative Write/Tool.
+                return new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
+            }
+
+            // Third-party: advisory annotation hints only; never Argument scope (we can't infer
+            // which argument is a command/path).
+            if (annotations != null)
+            {
+                if (IsTrue(annotations["destructiveHint"]))
+                    return new ToolPolicy(ToolTier.Destructive, RememberScope.None, null);
+                if (IsTrue(annotations["readOnlyHint"]))
+                    return new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            }
+            // No annotation / unknown -> Write/Tool (remember-eligible only after a first prompt).
+            return new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
+        }
+
+        private static bool IsTrue(JToken t)
+        {
+            return t != null && t.Type == JTokenType.Boolean && (bool)t;
+        }
+    }
+}

--- a/GxPT/Services/Mcp/TranscriptApprovalPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptApprovalPrompt.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // Bridges the synchronous IToolApprovalPrompt (called on the tool-loop worker thread) to the
+    // docked ToolApprovalPanel on the UI thread. Ask blocks the worker until the user clicks a
+    // button; the turn pauses at the gate, which is correct — the user is present (approval spec §7).
+    internal sealed class TranscriptApprovalPrompt : IToolApprovalPrompt
+    {
+        private readonly Control _uiMarshal;          // any control on the UI thread (the form)
+        private readonly Func<ToolApprovalPanel> _getPanel;
+
+        public TranscriptApprovalPrompt(Control uiMarshal, Func<ToolApprovalPanel> getPanel)
+        {
+            _uiMarshal = uiMarshal;
+            _getPanel = getPanel;
+        }
+
+        public ApprovalChoice Ask(ApprovalRequest req)
+        {
+            if (_uiMarshal == null || _getPanel == null) return ApprovalChoice.Deny;
+
+            ApprovalChoice[] result = { ApprovalChoice.Deny };
+            using (ManualResetEvent done = new ManualResetEvent(false))
+            {
+                try
+                {
+                    _uiMarshal.BeginInvoke((MethodInvoker)delegate
+                    {
+                        ToolApprovalPanel panel = _getPanel();
+                        if (panel == null) { done.Set(); return; }
+                        panel.ShowFor(req, delegate(ApprovalChoice choice)
+                        {
+                            result[0] = choice;
+                            done.Set();
+                        });
+                    });
+                }
+                catch
+                {
+                    return ApprovalChoice.Deny; // UI gone (e.g. closing) -> safe default
+                }
+
+                done.WaitOne();
+            }
+            return result[0];
+        }
+    }
+}


### PR DESCRIPTION
## The bug
The model reported no `command` (and `files`/`git`) tools available even with them enabled and a working folder set. Two ordering bugs left the **workdir-scoped** servers unlaunched:

1. **`RebuildMcpHost` dropped the workdir.** It runs on startup *and after every Settings save*, building a fresh `McpHost` with no active workdir — and never re-applied the current conversation's folder. So after enabling `command` and saving Settings, the rebuilt host launched only the eager (web/GitHub) servers; files/git/command never started. Fix: snapshot the active tab's `WorkingDir` and call `SetActiveWorkingDir` immediately after `Start()` on the same worker thread.

2. **Startup race.** `RestoreOpenTabs → ApplyLoadedWorkingDir → SetActiveWorkingDir` (UI thread) could win the host lock before the backgrounded `Start()` captured the scoped specs, leaving `_scopedSpecs` empty → nothing launched, and the workdir then looked "already set" so later syncs were no-ops. Fix: `McpHost.Start` now honors an already-set `_currentWorkdir` and launches the scoped servers itself.

Net: whichever of `Start` / `SetActiveWorkingDir` runs first, the scoped servers come up for the active folder.

## Test
`McpHostTests.SetActiveWorkingDir_before_Start_still_launches_scoped_servers` reproduces the race and asserts the scoped server launches + appears in the manifest.

## Note
The host-side fix (#2) is CI-covered. The `MainForm` rebuild-resync (#1) is WinForms, so it needs a VS2008 build + a live check: enable Command, set a folder, ask the model to run a command → it should now have the tool.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_