### PR TITLE
Add agentic file tools to FilesMcpServer: edit, search, ranged read

### DIFF
--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -25,7 +25,9 @@ namespace GxPT
             var t = new Dictionary<string, ToolPolicy>(StringComparer.Ordinal);
             t["files__read"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             t["files__list"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
+            t["files__search"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             t["files__write"] = new ToolPolicy(ToolTier.Write, RememberScope.Argument, "path");
+            t["files__edit"] = new ToolPolicy(ToolTier.Write, RememberScope.Argument, "path");
             t["files__delete"] = new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "path");
             t["git__status"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             t["git__diff"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);

--- a/docs/mcp35-approval-spec.md
+++ b/docs/mcp35-approval-spec.md
@@ -84,8 +84,8 @@ public interface IToolClassifier {
 2. **First-party → hardcoded table** (authoritative; annotations ignored):
    | Tool | Tier | Scope |
    |------|------|-------|
-   | `files__read`, `files__list` | ReadOnly | Tool |
-   | `files__write` | Write | Argument(`path`) |
+   | `files__read`, `files__list`, `files__search` | ReadOnly | Tool |
+   | `files__write`, `files__edit` | Write | Argument(`path`) |
    | `files__delete` | Destructive | Argument(`path`) |
    | `git__status/diff/log` | ReadOnly | Tool |
    | `git__commit` | Write | Tool |

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -77,16 +77,20 @@ Tools map to the approval table: `read`/`list`/`search` ReadOnly,
 |------|---------------------|----------|
 | `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. |
 | `list` | `path*`, `recursive?` | Directory entries: `{name,type,size}`; capped count. |
-| `search` | `query*`, `path?`, `regex?`, `ignore_case?`, `glob?`, `max_results?` | Grep file contents under root → `{path,line,text}`; recursive, bounded; skips binary/oversize. |
+| `search` | `query*`, `path?`, `regex?`, `ignore_case?`, `glob?`, `max_results?` | Grep file contents under root → `{path,line,text}`; recursive, **streamed (any file size)**, skips binary. |
 | `write` | `path*`, `content*`, `create_dirs?` | Atomic create/overwrite under root. |
 | `edit` | `path*`, `old_string*`, `new_string*`, `replace_all?` | Targeted exact-span replacement; `old_string` must be unique unless `replace_all`. Atomic. |
 | `delete` | `path*` | Delete a file or **empty** dir under root (Destructive). |
 
 The **agentic** additions — `search`, `edit`, and `read`'s line-range/numbering
 options — exist so the model can locate and surgically modify code without
-rewriting whole files (fewer tokens, fewer clobbers). `edit` and `search` share
-the sandbox, size cap (1 MiB), and binary sniff with `read`/`write`; `edit`
-reuses `write`'s atomic temp-then-move.
+rewriting whole files (fewer tokens, fewer clobbers). All share the sandbox and
+binary sniff; `edit` reuses `write`'s atomic temp-then-move. The 1 MiB cap is a
+**context** guard, so it applies only to operations that emit a whole file into
+the model: a *whole-file* `read`. `search` and a *ranged* `read` **stream**
+line-by-line — their output is bounded by `max_results` / the line range, not the
+file size — so large files (where grep matters most) remain searchable and a
+slice is always readable.
 
 **Sandbox — the one rule that matters here:** every `path` is resolved against
 the root and must stay inside it.
@@ -102,18 +106,21 @@ string Resolve(string root, string rel) {
 // NOT a bare StartsWith — so "/root" does not match "/root-evil".
 ```
 
-- `read`: enforce a **max size** (1 MiB); over → `Error`. Detect binary (NUL byte
-  in a head sample) → `Error("not a text file")` rather than emitting garbage into
-  the model context. `start_line`/`end_line` are 1-based inclusive; a `start_line`
-  past EOF → `Error`, `end_line` is clamped to the last line. `line_numbers` prefixes
-  each returned line with a right-aligned number + tab. With no range and no
-  numbering, the content is returned **verbatim** (exact bytes preserved).
+- `read`: a **whole-file** read enforces the **1 MiB** cap (over → `Error`,
+  pointing the model at a line range) and detects binary (NUL byte in a head
+  sample) → `Error("not a text file")`. A **ranged** read (`start_line`/`end_line`,
+  1-based inclusive) **streams** instead: it works on files past the cap, with the
+  *output* capped at 1 MiB (over → `Error`); a `start_line` past EOF → `Error`, an
+  `end_line` past EOF just stops at the last line. `line_numbers` prefixes each
+  returned line with a right-aligned number + tab. With no range and no numbering,
+  content is returned **verbatim** (exact bytes preserved).
 - `list`: cap entries (e.g. 1000) and note truncation; `recursive` bounded depth.
 - `search`: walk the tree under `path` (default root) bounded by the same depth
-  cap as `list`; `regex` toggles literal-substring vs `.NET` regex (invalid regex →
-  `Error`); `ignore_case` and a filename `glob` (`*`/`?`) filter; cap matches
-  (`max_results` default 100, max 1000) and scanned files, noting `truncated`.
-  Skips binary and oversize files silently; per-match line text is length-capped.
+  cap as `list`, **streaming** each file line-by-line (no per-file size cap);
+  `regex` toggles literal-substring vs `.NET` regex (invalid regex → `Error`);
+  `ignore_case` and a filename `glob` (`*`/`?`) filter; cap matches (`max_results`
+  default 100, max 1000) and scanned files, noting `truncated`. Skips binary files
+  silently; per-match line text is length-capped.
 - `write`: write to a temp file in the same dir then `File.Move`/replace (atomic,
   crash-safe — mirrors `AppSettings`' settings.json write); `create_dirs` gates
   parent creation; refuse to overwrite a directory.

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -87,10 +87,10 @@ options — exist so the model can locate and surgically modify code without
 rewriting whole files (fewer tokens, fewer clobbers). All share the sandbox and
 binary sniff; `edit` reuses `write`'s atomic temp-then-move. The 1 MiB cap is a
 **context** guard, so it applies only to operations that emit a whole file into
-the model: a *whole-file* `read`. `search` and a *ranged* `read` **stream**
-line-by-line — their output is bounded by `max_results` / the line range, not the
-file size — so large files (where grep matters most) remain searchable and a
-slice is always readable.
+the model: a *whole-file* `read`. Everything else **streams**, bounding output (or
+memory) rather than file size: `search` and a *ranged* `read` by line, `edit` by a
+chunk + carry buffer. So large files remain searchable, a slice is always readable,
+and any file is editable — only a whole-file `read` is capped.
 
 **Sandbox — the one rule that matters here:** every `path` is resolved against
 the root and must stay inside it.
@@ -124,10 +124,13 @@ string Resolve(string root, string rel) {
 - `write`: write to a temp file in the same dir then `File.Move`/replace (atomic,
   crash-safe — mirrors `AppSettings`' settings.json write); `create_dirs` gates
   parent creation; refuse to overwrite a directory.
-- `edit`: read (size cap + binary sniff), require `old_string` to occur exactly
-  once (or `replace_all` to replace every occurrence), then write back via the same
-  atomic temp-then-move as `write`; missing file / no match / non-unique match →
-  `Error` (file left untouched). Returns the replacement count.
+- `edit`: **streams** the file (binary sniff on the head, no size cap — its output
+  goes to disk, not the model context) through a find/replace into a temp file, then
+  atomic temp-then-move as `write`. A `carry` of `len(old_string)-1` chars bridges a
+  match that straddles a read boundary, and content outside the matched span is
+  copied **verbatim** (line endings preserved). `old_string` must occur exactly once
+  unless `replace_all`; missing file / no match / non-unique match → `Error` (file
+  left untouched — the temp is discarded). Returns the replacement count.
 - `delete`: files and **empty** directories only (never recursive — keeps the
   blast radius of a single approved call bounded); missing path → `Error`.
 - Symlink/junction escapes: on net35/Windows, resolve via `GetFullPath` and the

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -69,16 +69,24 @@ Rules for the contract:
 
 ## 2. FilesMcpServer (server name `files`)
 
-Read/list/write/delete confined to a single **root** (`GXPT_WORKDIR`). Tools map
-to the approval table: `read`/`list` ReadOnly, `write` Write(path-scoped),
-`delete` Destructive(path-scoped).
+Read/list/search/write/edit/delete confined to a single **root** (`GXPT_WORKDIR`).
+Tools map to the approval table: `read`/`list`/`search` ReadOnly,
+`write`/`edit` Write(path-scoped), `delete` Destructive(path-scoped).
 
 | Tool | Schema (required *) | Behavior |
 |------|---------------------|----------|
-| `read` | `path*` | UTF-8 (BOM-aware) text of a file under root. |
+| `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. |
 | `list` | `path*`, `recursive?` | Directory entries: `{name,type,size}`; capped count. |
+| `search` | `query*`, `path?`, `regex?`, `ignore_case?`, `glob?`, `max_results?` | Grep file contents under root → `{path,line,text}`; recursive, bounded; skips binary/oversize. |
 | `write` | `path*`, `content*`, `create_dirs?` | Atomic create/overwrite under root. |
+| `edit` | `path*`, `old_string*`, `new_string*`, `replace_all?` | Targeted exact-span replacement; `old_string` must be unique unless `replace_all`. Atomic. |
 | `delete` | `path*` | Delete a file or **empty** dir under root (Destructive). |
+
+The **agentic** additions — `search`, `edit`, and `read`'s line-range/numbering
+options — exist so the model can locate and surgically modify code without
+rewriting whole files (fewer tokens, fewer clobbers). `edit` and `search` share
+the sandbox, size cap (1 MiB), and binary sniff with `read`/`write`; `edit`
+reuses `write`'s atomic temp-then-move.
 
 **Sandbox — the one rule that matters here:** every `path` is resolved against
 the root and must stay inside it.
@@ -94,13 +102,25 @@ string Resolve(string root, string rel) {
 // NOT a bare StartsWith — so "/root" does not match "/root-evil".
 ```
 
-- `read`: enforce a **max size** (e.g. 1 MiB); over → `Error` (range reads are a
-  later enhancement). Detect binary (NUL byte in a head sample) → `Error("not a
-  text file")` rather than emitting garbage into the model context.
+- `read`: enforce a **max size** (1 MiB); over → `Error`. Detect binary (NUL byte
+  in a head sample) → `Error("not a text file")` rather than emitting garbage into
+  the model context. `start_line`/`end_line` are 1-based inclusive; a `start_line`
+  past EOF → `Error`, `end_line` is clamped to the last line. `line_numbers` prefixes
+  each returned line with a right-aligned number + tab. With no range and no
+  numbering, the content is returned **verbatim** (exact bytes preserved).
 - `list`: cap entries (e.g. 1000) and note truncation; `recursive` bounded depth.
+- `search`: walk the tree under `path` (default root) bounded by the same depth
+  cap as `list`; `regex` toggles literal-substring vs `.NET` regex (invalid regex →
+  `Error`); `ignore_case` and a filename `glob` (`*`/`?`) filter; cap matches
+  (`max_results` default 100, max 1000) and scanned files, noting `truncated`.
+  Skips binary and oversize files silently; per-match line text is length-capped.
 - `write`: write to a temp file in the same dir then `File.Move`/replace (atomic,
   crash-safe — mirrors `AppSettings`' settings.json write); `create_dirs` gates
   parent creation; refuse to overwrite a directory.
+- `edit`: read (size cap + binary sniff), require `old_string` to occur exactly
+  once (or `replace_all` to replace every occurrence), then write back via the same
+  atomic temp-then-move as `write`; missing file / no match / non-unique match →
+  `Error` (file left untouched). Returns the replacement count.
 - `delete`: files and **empty** directories only (never recursive — keeps the
   blast radius of a single approved call bounded); missing path → `Error`.
 - Symlink/junction escapes: on net35/Windows, resolve via `GetFullPath` and the

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -109,9 +109,11 @@ string Resolve(string root, string rel) {
 - `read`: a **whole-file** read enforces the **1 MiB** cap (over → `Error`,
   pointing the model at a line range) and detects binary (NUL byte in a head
   sample) → `Error("not a text file")`. A **ranged** read (`start_line`/`end_line`,
-  1-based inclusive) **streams** instead: it works on files past the cap, with the
-  *output* capped at 1 MiB (over → `Error`); a `start_line` past EOF → `Error`, an
-  `end_line` past EOF just stops at the last line. `line_numbers` prefixes each
+  1-based inclusive) **streams** instead: it works on files past the cap, but its
+  **rendered output** is held to the same 1 MiB — counted as exact UTF-8 bytes (line
+  content + `\n` separators + the line-number prefix when numbering), so a slice that
+  would render over 1 MiB → `Error`. A `start_line` past EOF → `Error`, an `end_line`
+  past EOF just stops at the last line. `line_numbers` prefixes each
   returned line with a right-aligned number + tab. With no range and no numbering,
   content is returned **verbatim** (exact bytes preserved).
 - `list`: cap entries (e.g. 1000) and note truncation; `recursive` bounded depth.

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -74,7 +74,7 @@ namespace FilesMcpServer
                 delegate(ToolCallContext ctx) { return Edit(sandbox, ctx); });
 
             server.AddTool("search", "Search file contents for a string or regex under the workspace root, "
-                + "returning matching {path, line, text}. Recursive, bounded; skips binary and oversize files.",
+                + "returning matching {path, line, text}. Recursive, streamed (any file size), skips binary files.",
                 SchemaBuilder.Object()
                     .Str("query", true, "Text or regex to search for")
                     .Str("path", false, "Directory (or file) to search under; defaults to the workspace root")
@@ -96,45 +96,90 @@ namespace FilesMcpServer
 
             if (!File.Exists(full)) return ToolResults.Error("file not found");
 
-            FileInfo fi = new FileInfo(full);
-            if (fi.Length > MaxReadBytes)
-                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes + ")");
-
-            byte[] bytes = File.ReadAllBytes(full);
-            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
-
-            string text = DecodeUtf8(bytes);
-
             bool hasStart = HasArg(ctx, "start_line");
             bool hasEnd = HasArg(ctx, "end_line");
             bool lineNumbers = BoolArg(ctx, "line_numbers", false);
 
+            // A line range streams, so a slice of a large file is readable even past the whole-file
+            // cap (the output is bounded by the range, not the file size).
+            if (hasStart || hasEnd)
+                return ReadRange(full, ctx, hasStart, hasEnd, lineNumbers);
+
+            // Whole-file read: bounded by the size cap (it all lands in the model context).
+            FileInfo fi = new FileInfo(full);
+            if (fi.Length > MaxReadBytes)
+                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes
+                    + ") — read a line range instead");
+
+            byte[] bytes = File.ReadAllBytes(full);
+            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
+            string text = DecodeUtf8(bytes);
+
             // Fast path: whole file, no numbering -> return content verbatim (preserves exact bytes).
-            if (!hasStart && !hasEnd && !lineNumbers)
+            if (!lineNumbers)
                 return ToolResults.Text(text);
 
             string[] lines = SplitLines(text);
-            int total = lines.Length;
+            int width = lines.Length.ToString().Length;
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                sb.Append((i + 1).ToString().PadLeft(width));
+                sb.Append('\t');
+                sb.Append(lines[i]);
+                if (i < lines.Length - 1) sb.Append('\n');
+            }
+            return ToolResults.Text(sb.ToString());
+        }
 
+        // Stream a 1-based inclusive line range; output bytes are capped (not the file size), so a
+        // slice of an arbitrarily large file is readable. start/end default to file bounds.
+        private static CallToolResult ReadRange(string full, ToolCallContext ctx, bool hasStart, bool hasEnd, bool lineNumbers)
+        {
             int start = hasStart ? IntArg(ctx, "start_line", 1, 1, int.MaxValue) : 1;
-            int end = hasEnd ? IntArg(ctx, "end_line", total, 1, int.MaxValue) : total;
-            if (start > total)
-                return ToolResults.Error("start_line " + start + " exceeds file length (" + total + " lines)");
-            if (end > total) end = total;
+            int end = hasEnd ? IntArg(ctx, "end_line", int.MaxValue, 1, int.MaxValue) : int.MaxValue;
             if (end < start)
                 return ToolResults.Error("end_line (" + end + ") is before start_line (" + start + ")");
 
-            int width = end.ToString().Length;
+            StreamReader sr;
+            try { sr = OpenTextReaderOrNull(full); }
+            catch { return ToolResults.Error("file not found"); }
+            if (sr == null) return ToolResults.Error("not a text file");
+
+            List<string> picked = new List<string>();
+            int lineNo = 0;
+            long outBytes = 0;
+            using (sr)
+            {
+                string line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    lineNo++;
+                    if (lineNo < start) continue;
+                    if (lineNo > end) break;
+                    picked.Add(line);
+                    outBytes += line.Length + 12; // rough per-line overhead (number + tab + newline)
+                    if (outBytes > MaxReadBytes)
+                        return ToolResults.Error("requested range is too large (over " + MaxReadBytes
+                            + " bytes of text) — narrow start_line/end_line");
+                }
+            }
+
+            if (picked.Count == 0)
+                return ToolResults.Error("start_line " + start + " exceeds file length (" + lineNo + " lines)");
+
+            int lastLineNo = start + picked.Count - 1;
+            int width = lastLineNo.ToString().Length;
             StringBuilder sb = new StringBuilder();
-            for (int i = start; i <= end; i++)
+            for (int i = 0; i < picked.Count; i++)
             {
                 if (lineNumbers)
                 {
-                    sb.Append(i.ToString().PadLeft(width));
+                    sb.Append((start + i).ToString().PadLeft(width));
                     sb.Append('\t');
                 }
-                sb.Append(lines[i - 1]);
-                if (i < end) sb.Append('\n');
+                sb.Append(picked[i]);
+                if (i < picked.Count - 1) sb.Append('\n');
             }
             return ToolResults.Text(sb.ToString());
         }
@@ -385,29 +430,31 @@ namespace FilesMcpServer
             if (scanned[0] >= MaxSearchScanFiles) return true; // scanned-file cap -> truncated
             scanned[0]++;
 
-            byte[] bytes;
-            try
-            {
-                FileInfo fi = new FileInfo(file);
-                if (fi.Length > MaxReadBytes) return false; // skip oversize silently
-                bytes = File.ReadAllBytes(file);
-            }
-            catch { return false; }
-            if (LooksBinary(bytes)) return false; // skip binary silently
+            // Stream line-by-line: file size is not a limit (output is bounded by maxResults), so
+            // large files — exactly where grep matters most — are searchable. Binary/unreadable skip.
+            StreamReader sr;
+            try { sr = OpenTextReaderOrNull(file); }
+            catch { return false; } // unreadable -> skip silently
+            if (sr == null) return false; // binary -> skip silently
 
-            string[] lines = SplitLines(DecodeUtf8(bytes));
             string relPath = sandbox.ToRelative(file);
-            for (int i = 0; i < lines.Length; i++)
+            using (sr)
             {
-                bool hit = rx != null ? rx.IsMatch(lines[i]) : lines[i].IndexOf(query, cmp) >= 0;
-                if (!hit) continue;
+                int lineNo = 0;
+                string line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    lineNo++;
+                    bool hit = rx != null ? rx.IsMatch(line) : line.IndexOf(query, cmp) >= 0;
+                    if (!hit) continue;
 
-                JObject m = new JObject();
-                m["path"] = relPath;
-                m["line"] = i + 1;
-                m["text"] = CapText(lines[i]);
-                matches.Add(m);
-                if (matches.Count >= maxResults) return true; // result cap -> truncated
+                    JObject m = new JObject();
+                    m["path"] = relPath;
+                    m["line"] = lineNo;
+                    m["text"] = CapText(line);
+                    matches.Add(m);
+                    if (matches.Count >= maxResults) return true; // result cap -> truncated
+                }
             }
             return false;
         }
@@ -537,10 +584,39 @@ namespace FilesMcpServer
 
         private static bool LooksBinary(byte[] bytes)
         {
-            int n = Math.Min(bytes.Length, BinarySniffBytes);
+            return LooksBinary(bytes, bytes.Length);
+        }
+
+        private static bool LooksBinary(byte[] bytes, int count)
+        {
+            int n = Math.Min(count, BinarySniffBytes);
             for (int i = 0; i < n; i++)
                 if (bytes[i] == 0) return true; // NUL byte → treat as binary
             return false;
+        }
+
+        /// <summary>
+        /// Open a file as BOM-aware UTF-8 text lines after sniffing its head for a NUL byte. Returns
+        /// <c>null</c> (stream disposed) if the file looks binary. Streaming lets search and ranged
+        /// read work on files larger than the whole-file cap — output is bounded by matches / range,
+        /// not file size. Caller owns the returned reader (wrap in <c>using</c>).
+        /// </summary>
+        private static StreamReader OpenTextReaderOrNull(string file)
+        {
+            FileStream fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            try
+            {
+                byte[] head = new byte[BinarySniffBytes];
+                int n = fs.Read(head, 0, head.Length);
+                if (LooksBinary(head, n)) { fs.Dispose(); return null; }
+                fs.Position = 0;
+                return new StreamReader(fs, new UTF8Encoding(false, false), true);
+            }
+            catch
+            {
+                fs.Dispose();
+                throw;
+            }
         }
 
         private static string DecodeUtf8(byte[] bytes)

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -146,9 +146,10 @@ namespace FilesMcpServer
             catch { return ToolResults.Error("file not found"); }
             if (sr == null) return ToolResults.Error("not a text file");
 
+            UTF8Encoding utf8NoBom = new UTF8Encoding(false);
             List<string> picked = new List<string>();
             int lineNo = 0;
-            long outBytes = 0;
+            long contentBytes = 0;
             using (sr)
             {
                 string line;
@@ -158,10 +159,18 @@ namespace FilesMcpServer
                     if (lineNo < start) continue;
                     if (lineNo > end) break;
                     picked.Add(line);
-                    outBytes += line.Length + 12; // rough per-line overhead (number + tab + newline)
-                    if (outBytes > MaxReadBytes)
+                    contentBytes += utf8NoBom.GetByteCount(line);
+
+                    // Cap the exact rendered UTF-8 size, not the char count. The rendered output is:
+                    // the line bytes, '\n' separators (count - 1), and — when numbering — a prefix on
+                    // every line of `width` digits + a '\t', where width is the digit count of the
+                    // LAST line number (right-aligned PadLeft). `lineNo` is that last number so far, so
+                    // applying its width to all picked lines makes this total exact at the final line.
+                    long total = contentBytes + (picked.Count - 1);
+                    if (lineNumbers) total += (long)picked.Count * (DigitCount(lineNo) + 1);
+                    if (total > MaxReadBytes)
                         return ToolResults.Error("requested range is too large (over " + MaxReadBytes
-                            + " bytes of text) — narrow start_line/end_line");
+                            + " bytes of rendered output) — narrow start_line/end_line");
                 }
             }
 
@@ -612,6 +621,14 @@ namespace FilesMcpServer
             if (normalized.Length > 0 && normalized[normalized.Length - 1] == '\n')
                 normalized = normalized.Substring(0, normalized.Length - 1);
             return normalized.Split('\n');
+        }
+
+        // Number of decimal digits in a non-negative line number (matches its rendered width).
+        private static int DigitCount(int n)
+        {
+            int digits = 1;
+            while (n >= 10) { n /= 10; digits++; }
+            return digits;
         }
 
         private static string CapText(string s)

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -296,6 +296,8 @@ namespace FilesMcpServer
 
         // ---- edit ----
 
+        private const int EditChunkChars = 64 * 1024;
+
         private static CallToolResult Edit(PathSandbox sandbox, ToolCallContext ctx)
         {
             string full;
@@ -311,32 +313,102 @@ namespace FilesMcpServer
             if (newString == null) return ToolResults.Error("new_string is required");
             bool replaceAll = BoolArg(ctx, "replace_all", false);
 
-            FileInfo fi = new FileInfo(full);
-            if (fi.Length > MaxReadBytes)
-                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes + ")");
+            // Stream the file through a transform into a temp file, then atomically move it over the
+            // original (mirrors WriteAtomic). No size cap: edit writes to disk, not the model context,
+            // so memory is the only concern and it stays bounded by one chunk + the carried tail.
+            // A `carry` of (oldString.Length - 1) chars bridges matches that straddle a read boundary.
+            StreamReader sr;
+            try { sr = OpenTextReaderOrNull(full); }
+            catch { return ToolResults.Error("file not found"); }
+            if (sr == null) return ToolResults.Error("not a text file");
 
-            byte[] bytes = File.ReadAllBytes(full);
-            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
-            string text = DecodeUtf8(bytes);
+            string parent = Path.GetDirectoryName(full);
+            string tmp = Path.Combine(parent, "." + Guid.NewGuid().ToString("N") + ".tmp");
+            int oldLen = oldString.Length;
+            int keep = oldLen - 1;
+            int replacements = 0;
+            bool tooMany = false;
+            bool committed = false;
+            try
+            {
+                using (sr)
+                using (StreamWriter sw = new StreamWriter(
+                    new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None),
+                    new UTF8Encoding(false)))
+                {
+                    char[] buf = new char[EditChunkChars];
+                    string carry = string.Empty;
+                    int read;
+                    while (!tooMany && (read = sr.Read(buf, 0, buf.Length)) > 0)
+                    {
+                        string window = carry + new string(buf, 0, read);
+                        carry = ProcessEditWindow(window, oldString, newString, replaceAll, keep,
+                            sw, ref replacements, ref tooMany);
+                    }
+                    // EOF: carry is shorter than oldString, so it cannot contain a full match — emit it.
+                    if (!tooMany) sw.Write(carry);
+                }
 
-            int count = CountOccurrences(text, oldString);
-            if (count == 0) return ToolResults.Error("old_string not found in file");
-            if (count > 1 && !replaceAll)
-                return ToolResults.Error("old_string is not unique (" + count
-                    + " occurrences); add surrounding context or set replace_all");
+                if (tooMany)
+                    return ToolResults.Error("old_string is not unique (matches more than once); "
+                        + "add surrounding context or set replace_all");
+                if (replacements == 0)
+                    return ToolResults.Error("old_string not found in file");
 
-            string updated = replaceAll
-                ? text.Replace(oldString, newString)
-                : ReplaceFirst(text, oldString, newString);
-            int replacements = replaceAll ? count : 1;
-
-            int bytesWritten = WriteAtomic(full, updated);
+                if (File.Exists(full)) File.Delete(full);
+                File.Move(tmp, full);
+                committed = true;
+            }
+            finally
+            {
+                if (!committed)
+                {
+                    try { if (File.Exists(tmp)) File.Delete(tmp); }
+                    catch { }
+                }
+            }
 
             JObject result = new JObject();
             result["path"] = sandbox.ToRelative(full);
             result["replacements"] = replacements;
-            result["bytesWritten"] = bytesWritten;
+            result["bytesWritten"] = new FileInfo(full).Length;
             return ToolResults.Json(result);
+        }
+
+        // Process one window of text: write replaced/verbatim content for everything that can be
+        // resolved now, and return the trailing (up to `keep`) chars to carry — they might be the
+        // prefix of a match completed by the next read. Sets tooMany when a unique edit sees a 2nd hit.
+        private static string ProcessEditWindow(string window, string oldString, string newString,
+            bool replaceAll, int keep, StreamWriter sw, ref int replacements, ref bool tooMany)
+        {
+            int pos = 0;
+            while (true)
+            {
+                int idx = window.IndexOf(oldString, pos, StringComparison.Ordinal);
+                if (idx < 0) break;
+
+                if (!replaceAll && replacements >= 1)
+                {
+                    // A second occurrence in unique mode: abort (caller discards the temp file).
+                    // (Substring, not Write(window, pos, len): that binds to the composite-format
+                    // overload Write(string, object, object) and would emit the whole string.)
+                    sw.Write(window.Substring(pos, idx - pos));
+                    tooMany = true;
+                    return string.Empty;
+                }
+
+                sw.Write(window.Substring(pos, idx - pos));   // verbatim gap before the match
+                sw.Write(newString);                          // the replacement
+                replacements++;
+                pos = idx + oldString.Length;
+            }
+
+            // No more full matches at/after pos. Emit up to the last `keep` chars; carry the rest so a
+            // match spanning into the next read isn't split. (keep == 0 when oldString is a single char.)
+            int emitUpto = window.Length - keep;
+            if (emitUpto < pos) emitUpto = pos;
+            sw.Write(window.Substring(pos, emitUpto - pos));
+            return window.Substring(emitUpto);
         }
 
         // ---- search ----
@@ -540,25 +612,6 @@ namespace FilesMcpServer
             if (normalized.Length > 0 && normalized[normalized.Length - 1] == '\n')
                 normalized = normalized.Substring(0, normalized.Length - 1);
             return normalized.Split('\n');
-        }
-
-        private static int CountOccurrences(string haystack, string needle)
-        {
-            int count = 0;
-            int idx = 0;
-            while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
-            {
-                count++;
-                idx += needle.Length;
-            }
-            return count;
-        }
-
-        private static string ReplaceFirst(string text, string oldValue, string newValue)
-        {
-            int idx = text.IndexOf(oldValue, StringComparison.Ordinal);
-            if (idx < 0) return text;
-            return text.Substring(0, idx) + newValue + text.Substring(idx + oldValue.Length);
         }
 
         private static string CapText(string s)

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using Mcp35.Core.Protocol;
 using Mcp35.Server;
 using Newtonsoft.Json.Linq;
@@ -9,9 +10,10 @@ using Newtonsoft.Json.Linq;
 namespace FilesMcpServer
 {
     /// <summary>
-    /// The Files server's four tools, all confined to the sandbox root. read/list are ReadOnly,
-    /// write is Write(path-scoped), delete is Destructive(path-scoped) — host-gated; the server's
-    /// job is safe construction (servers-spec §2).
+    /// The Files server's tools, all confined to the sandbox root. read/list/search are ReadOnly,
+    /// write/edit are Write(path-scoped), delete is Destructive(path-scoped) — host-gated; the
+    /// server's job is safe construction (servers-spec §2). edit/search and read's line-range/
+    /// numbering options are the agentic enhancements (range reads were flagged as a later add).
     /// </summary>
     internal static class FilesTools
     {
@@ -21,12 +23,24 @@ namespace FilesMcpServer
         private const int MaxRecursiveDepth = 16;
         private const int BinarySniffBytes = 8000;
 
+        // Search caps (servers-spec §2 — bounded blast radius for the model context).
+        private const int DefaultSearchMax = 100;
+        private const int MaxSearchMax = 1000;
+        private const int MaxMatchLineLength = 1000;
+        private const int MaxSearchScanFiles = 5000;
+
         public static void Register(McpServer server, FilesConfig config)
         {
             PathSandbox sandbox = new PathSandbox(config.WorkDir);
 
-            server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root.",
-                SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
+            server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root. "
+                + "Optionally read a line range (1-based, inclusive) and/or prefix each line with its number.",
+                SchemaBuilder.Object()
+                    .Str("path", true, "Path relative to the workspace root")
+                    .Int("start_line", false, "First line to return (1-based, inclusive)")
+                    .Int("end_line", false, "Last line to return (1-based, inclusive)")
+                    .Bool("line_numbers", false, "Prefix each returned line with its 1-based line number")
+                    .Build(),
                 delegate(ToolCallContext ctx) { return Read(sandbox, ctx); });
 
             server.AddTool("list", "List entries of a directory under the workspace root.",
@@ -47,6 +61,29 @@ namespace FilesMcpServer
             server.AddTool("delete", "Delete a file or an empty directory under the workspace root.",
                 SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
                 delegate(ToolCallContext ctx) { return Delete(sandbox, ctx); });
+
+            server.AddTool("edit", "Replace an exact text span in a file under the workspace root. "
+                + "Prefer this over write for large files: it is targeted and never rewrites the whole file. "
+                + "old_string must match exactly and be unique unless replace_all is set.",
+                SchemaBuilder.Object()
+                    .Str("path", true, "Path relative to the workspace root")
+                    .Str("old_string", true, "Exact text to find (must be unique unless replace_all is set)")
+                    .Str("new_string", true, "Replacement text")
+                    .Bool("replace_all", false, "Replace every occurrence instead of requiring a unique match")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Edit(sandbox, ctx); });
+
+            server.AddTool("search", "Search file contents for a string or regex under the workspace root, "
+                + "returning matching {path, line, text}. Recursive, bounded; skips binary and oversize files.",
+                SchemaBuilder.Object()
+                    .Str("query", true, "Text or regex to search for")
+                    .Str("path", false, "Directory (or file) to search under; defaults to the workspace root")
+                    .Bool("regex", false, "Treat query as a .NET regular expression (default: literal substring)")
+                    .Bool("ignore_case", false, "Case-insensitive match")
+                    .Str("glob", false, "Only search files whose name matches this wildcard (e.g. *.cs)")
+                    .Int("max_results", false, "Maximum matches to return (default 100, max 1000)")
+                    .Build(),
+                delegate(ToolCallContext ctx) { return Search(sandbox, ctx); });
         }
 
         // ---- read ----
@@ -66,7 +103,40 @@ namespace FilesMcpServer
             byte[] bytes = File.ReadAllBytes(full);
             if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
 
-            return ToolResults.Text(DecodeUtf8(bytes));
+            string text = DecodeUtf8(bytes);
+
+            bool hasStart = HasArg(ctx, "start_line");
+            bool hasEnd = HasArg(ctx, "end_line");
+            bool lineNumbers = BoolArg(ctx, "line_numbers", false);
+
+            // Fast path: whole file, no numbering -> return content verbatim (preserves exact bytes).
+            if (!hasStart && !hasEnd && !lineNumbers)
+                return ToolResults.Text(text);
+
+            string[] lines = SplitLines(text);
+            int total = lines.Length;
+
+            int start = hasStart ? IntArg(ctx, "start_line", 1, 1, int.MaxValue) : 1;
+            int end = hasEnd ? IntArg(ctx, "end_line", total, 1, int.MaxValue) : total;
+            if (start > total)
+                return ToolResults.Error("start_line " + start + " exceeds file length (" + total + " lines)");
+            if (end > total) end = total;
+            if (end < start)
+                return ToolResults.Error("end_line (" + end + ") is before start_line (" + start + ")");
+
+            int width = end.ToString().Length;
+            StringBuilder sb = new StringBuilder();
+            for (int i = start; i <= end; i++)
+            {
+                if (lineNumbers)
+                {
+                    sb.Append(i.ToString().PadLeft(width));
+                    sb.Append('\t');
+                }
+                sb.Append(lines[i - 1]);
+                if (i < end) sb.Append('\n');
+            }
+            return ToolResults.Text(sb.ToString());
         }
 
         // ---- list ----
@@ -148,7 +218,21 @@ namespace FilesMcpServer
                 Directory.CreateDirectory(parent);
             }
 
-            // Atomic-ish write: temp file in the same dir, then replace (mirrors AppSettings).
+            int bytesWritten = WriteAtomic(full, content);
+
+            JObject result = new JObject();
+            result["path"] = sandbox.ToRelative(full);
+            result["bytesWritten"] = bytesWritten;
+            return ToolResults.Json(result);
+        }
+
+        /// <summary>
+        /// Atomic-ish write: temp file in the same dir, then replace (mirrors AppSettings'
+        /// settings.json write — crash-safe). Returns the UTF-8 (no BOM) byte count written.
+        /// </summary>
+        private static int WriteAtomic(string full, string content)
+        {
+            string parent = Path.GetDirectoryName(full);
             string tmp = Path.Combine(parent, "." + Guid.NewGuid().ToString("N") + ".tmp");
             UTF8Encoding utf8NoBom = new UTF8Encoding(false);
             try
@@ -162,11 +246,170 @@ namespace FilesMcpServer
                 try { if (File.Exists(tmp)) File.Delete(tmp); }
                 catch { }
             }
+            return utf8NoBom.GetByteCount(content);
+        }
+
+        // ---- edit ----
+
+        private static CallToolResult Edit(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string full;
+            CallToolResult err = ResolvePath(sandbox, ctx, out full);
+            if (err != null) return err;
+
+            if (Directory.Exists(full)) return ToolResults.Error("path is a directory");
+            if (!File.Exists(full)) return ToolResults.Error("file not found");
+
+            string oldString = ctx.Arguments.Value<string>("old_string");
+            if (string.IsNullOrEmpty(oldString)) return ToolResults.Error("old_string is required");
+            string newString = ctx.Arguments.Value<string>("new_string");
+            if (newString == null) return ToolResults.Error("new_string is required");
+            bool replaceAll = BoolArg(ctx, "replace_all", false);
+
+            FileInfo fi = new FileInfo(full);
+            if (fi.Length > MaxReadBytes)
+                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes + ")");
+
+            byte[] bytes = File.ReadAllBytes(full);
+            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
+            string text = DecodeUtf8(bytes);
+
+            int count = CountOccurrences(text, oldString);
+            if (count == 0) return ToolResults.Error("old_string not found in file");
+            if (count > 1 && !replaceAll)
+                return ToolResults.Error("old_string is not unique (" + count
+                    + " occurrences); add surrounding context or set replace_all");
+
+            string updated = replaceAll
+                ? text.Replace(oldString, newString)
+                : ReplaceFirst(text, oldString, newString);
+            int replacements = replaceAll ? count : 1;
+
+            int bytesWritten = WriteAtomic(full, updated);
 
             JObject result = new JObject();
             result["path"] = sandbox.ToRelative(full);
-            result["bytesWritten"] = utf8NoBom.GetByteCount(content);
+            result["replacements"] = replacements;
+            result["bytesWritten"] = bytesWritten;
             return ToolResults.Json(result);
+        }
+
+        // ---- search ----
+
+        private static CallToolResult Search(PathSandbox sandbox, ToolCallContext ctx)
+        {
+            string query = ctx.Arguments.Value<string>("query");
+            if (string.IsNullOrEmpty(query)) return ToolResults.Error("query is required");
+
+            string rel = ctx.Arguments.Value<string>("path");
+            string root;
+            if (string.IsNullOrEmpty(rel))
+            {
+                root = sandbox.Root;
+            }
+            else
+            {
+                try { root = sandbox.Resolve(rel); }
+                catch (SandboxException ex) { return ToolResults.Error(ex.Message); }
+            }
+            if (!Directory.Exists(root) && !File.Exists(root))
+                return ToolResults.Error("path not found");
+
+            bool useRegex = BoolArg(ctx, "regex", false);
+            bool ignoreCase = BoolArg(ctx, "ignore_case", false);
+            int maxResults = IntArg(ctx, "max_results", DefaultSearchMax, 1, MaxSearchMax);
+            string glob = ctx.Arguments.Value<string>("glob");
+
+            Regex rx = null;
+            if (useRegex)
+            {
+                try
+                {
+                    RegexOptions opts = RegexOptions.CultureInvariant;
+                    if (ignoreCase) opts |= RegexOptions.IgnoreCase;
+                    rx = new Regex(query, opts);
+                }
+                catch (ArgumentException ex)
+                {
+                    return ToolResults.Error("invalid regex: " + ex.Message);
+                }
+            }
+            Regex globRx = string.IsNullOrEmpty(glob) ? null : GlobToRegex(glob);
+            StringComparison cmp = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            List<JObject> matches = new List<JObject>();
+            int[] scanned = new int[1];
+            bool truncated = SearchWalk(sandbox, root, MaxRecursiveDepth, rx, query, cmp, globRx,
+                maxResults, matches, scanned);
+
+            JObject result = new JObject();
+            JArray arr = new JArray();
+            foreach (JObject m in matches) arr.Add(m);
+            result["matches"] = arr;
+            result["count"] = matches.Count;
+            result["truncated"] = truncated;
+            return ToolResults.Json(result);
+        }
+
+        // Returns true if results were truncated (hit a cap before scanning everything).
+        private static bool SearchWalk(PathSandbox sandbox, string path, int depthLeft, Regex rx,
+            string query, StringComparison cmp, Regex globRx, int maxResults,
+            List<JObject> matches, int[] scanned)
+        {
+            if (File.Exists(path))
+                return SearchFile(sandbox, path, rx, query, cmp, globRx, maxResults, matches, scanned);
+
+            string[] files = Directory.GetFiles(path);
+            foreach (string f in files)
+            {
+                if (SearchFile(sandbox, f, rx, query, cmp, globRx, maxResults, matches, scanned))
+                    return true;
+            }
+            if (depthLeft > 0)
+            {
+                string[] dirs = Directory.GetDirectories(path);
+                foreach (string d in dirs)
+                {
+                    if (SearchWalk(sandbox, d, depthLeft - 1, rx, query, cmp, globRx, maxResults, matches, scanned))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool SearchFile(PathSandbox sandbox, string file, Regex rx, string query,
+            StringComparison cmp, Regex globRx, int maxResults, List<JObject> matches, int[] scanned)
+        {
+            if (globRx != null && !globRx.IsMatch(Path.GetFileName(file))) return false;
+
+            if (scanned[0] >= MaxSearchScanFiles) return true; // scanned-file cap -> truncated
+            scanned[0]++;
+
+            byte[] bytes;
+            try
+            {
+                FileInfo fi = new FileInfo(file);
+                if (fi.Length > MaxReadBytes) return false; // skip oversize silently
+                bytes = File.ReadAllBytes(file);
+            }
+            catch { return false; }
+            if (LooksBinary(bytes)) return false; // skip binary silently
+
+            string[] lines = SplitLines(DecodeUtf8(bytes));
+            string relPath = sandbox.ToRelative(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                bool hit = rx != null ? rx.IsMatch(lines[i]) : lines[i].IndexOf(query, cmp) >= 0;
+                if (!hit) continue;
+
+                JObject m = new JObject();
+                m["path"] = relPath;
+                m["line"] = i + 1;
+                m["text"] = CapText(lines[i]);
+                matches.Add(m);
+                if (matches.Count >= maxResults) return true; // result cap -> truncated
+            }
+            return false;
         }
 
         // ---- delete ----
@@ -221,6 +464,75 @@ namespace FilesMcpServer
             if (t == null || t.Type == JTokenType.Null) return fallback;
             try { return t.Value<bool>(); }
             catch { return fallback; }
+        }
+
+        private static bool HasArg(ToolCallContext ctx, string name)
+        {
+            JToken t = ctx.Arguments[name];
+            return t != null && t.Type != JTokenType.Null;
+        }
+
+        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        // Split into lines on \n, \r\n, or \r, dropping the separators. A trailing newline does
+        // NOT produce a spurious empty final line (so a 3-line file reads as 3 lines).
+        private static string[] SplitLines(string text)
+        {
+            if (text.Length == 0) return new string[] { string.Empty };
+            string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+            if (normalized.Length > 0 && normalized[normalized.Length - 1] == '\n')
+                normalized = normalized.Substring(0, normalized.Length - 1);
+            return normalized.Split('\n');
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0;
+            int idx = 0;
+            while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                idx += needle.Length;
+            }
+            return count;
+        }
+
+        private static string ReplaceFirst(string text, string oldValue, string newValue)
+        {
+            int idx = text.IndexOf(oldValue, StringComparison.Ordinal);
+            if (idx < 0) return text;
+            return text.Substring(0, idx) + newValue + text.Substring(idx + oldValue.Length);
+        }
+
+        private static string CapText(string s)
+        {
+            if (s.Length <= MaxMatchLineLength) return s;
+            return s.Substring(0, MaxMatchLineLength);
+        }
+
+        // Translate a simple filename wildcard (* and ?) into an anchored, case-insensitive regex.
+        private static Regex GlobToRegex(string glob)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('^');
+            foreach (char c in glob)
+            {
+                if (c == '*') sb.Append(".*");
+                else if (c == '?') sb.Append('.');
+                else sb.Append(Regex.Escape(c.ToString()));
+            }
+            sb.Append('$');
+            return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
         private static bool LooksBinary(byte[] bytes)

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -27,7 +27,7 @@ namespace FilesMcpServer.Tests
         // ---- Criterion 1: listing ----
 
         [Fact]
-        public void Lists_the_four_documented_tools_with_schema()
+        public void Lists_the_documented_tools_with_schema()
         {
             var server = Harness.NewFilesServer(_root);
             var msgs = Harness.Exchange(server, Harness.ToolsList(1));
@@ -40,6 +40,8 @@ namespace FilesMcpServer.Tests
             Assert.Contains("list", names);
             Assert.Contains("write", names);
             Assert.Contains("delete", names);
+            Assert.Contains("edit", names);
+            Assert.Contains("search", names);
             // schema intact
             foreach (JToken t in tools)
                 Assert.Equal("object", (string)t["inputSchema"]["type"]);
@@ -189,6 +191,208 @@ namespace FilesMcpServer.Tests
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "bom.txt")));
             Assert.Equal("café", Harness.Text(msgs[0])); // no leading BOM char
+        }
+
+        // ---- read: line range + numbering ----
+
+        [Fact]
+        public void Read_returns_requested_line_range()
+        {
+            File.WriteAllText(Abs("r.txt"), "one\ntwo\nthree\nfour\nfive");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "r.txt", "start_line", 2, "end_line", 4)));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("two\nthree\nfour", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_with_line_numbers_prefixes_each_line()
+        {
+            File.WriteAllText(Abs("r.txt"), "alpha\nbeta\ngamma");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "r.txt", "line_numbers", true)));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("1\talpha\n2\tbeta\n3\tgamma", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_start_line_past_eof_is_error()
+        {
+            File.WriteAllText(Abs("r.txt"), "only\ntwo");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "r.txt", "start_line", 9)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("exceeds file length", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_whole_file_is_verbatim_when_no_range_or_numbers()
+        {
+            File.WriteAllText(Abs("r.txt"), "trailing\nnewline\n");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "r.txt")));
+            Assert.Equal("trailing\nnewline\n", Harness.Text(msgs[0]));
+        }
+
+        // ---- edit ----
+
+        [Fact]
+        public void Edit_replaces_unique_span()
+        {
+            File.WriteAllText(Abs("e.txt"), "hello world");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "e.txt",
+                    "old_string", "world", "new_string", "there")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+            Assert.Equal("hello there", File.ReadAllText(Abs("e.txt")));
+        }
+
+        [Fact]
+        public void Edit_non_unique_without_replace_all_is_error()
+        {
+            File.WriteAllText(Abs("e.txt"), "a a a");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "e.txt",
+                    "old_string", "a", "new_string", "b")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("not unique", Harness.Text(msgs[0]));
+            Assert.Equal("a a a", File.ReadAllText(Abs("e.txt"))); // unchanged
+        }
+
+        [Fact]
+        public void Edit_replace_all_replaces_every_occurrence()
+        {
+            File.WriteAllText(Abs("e.txt"), "x x x");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "e.txt",
+                    "old_string", "x", "new_string", "y", "replace_all", true)));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(3, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+            Assert.Equal("y y y", File.ReadAllText(Abs("e.txt")));
+        }
+
+        [Fact]
+        public void Edit_missing_old_string_is_error()
+        {
+            File.WriteAllText(Abs("e.txt"), "content");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "e.txt",
+                    "old_string", "absent", "new_string", "z")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("not found", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Edit_nonexistent_file_is_error()
+        {
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "nope.txt",
+                    "old_string", "a", "new_string", "b")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("file not found", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Edit_rejects_parent_traversal()
+        {
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "../escape.txt",
+                    "old_string", "a", "new_string", "b")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("escape", Harness.Text(msgs[0]));
+        }
+
+        // ---- search ----
+
+        [Fact]
+        public void Search_finds_substring_matches_with_line_numbers()
+        {
+            File.WriteAllText(Abs("a.txt"), "alpha\nneedle here\nbeta");
+            File.WriteAllText(Abs("b.txt"), "no match\nanother needle\n");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "needle")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(2, (int)msgs[0]["result"]["structuredContent"]["count"]);
+            JArray m = (JArray)msgs[0]["result"]["structuredContent"]["matches"];
+            // a.txt match is on line 2
+            bool found = false;
+            foreach (JToken t in m)
+                if ((string)t["path"] == "a.txt" && (int)t["line"] == 2) found = true;
+            Assert.True(found);
+        }
+
+        [Fact]
+        public void Search_ignore_case()
+        {
+            File.WriteAllText(Abs("a.txt"), "Hello THERE");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "there", "ignore_case", true)));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["count"]);
+        }
+
+        [Fact]
+        public void Search_regex_mode()
+        {
+            File.WriteAllText(Abs("a.txt"), "id=42\nid=abc\nid=7");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "id=[0-9]+", "regex", true)));
+            Assert.Equal(2, (int)msgs[0]["result"]["structuredContent"]["count"]);
+        }
+
+        [Fact]
+        public void Search_invalid_regex_is_error()
+        {
+            File.WriteAllText(Abs("a.txt"), "x");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "(unclosed", "regex", true)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("invalid regex", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Search_glob_filters_by_filename()
+        {
+            File.WriteAllText(Abs("keep.cs"), "target");
+            File.WriteAllText(Abs("skip.txt"), "target");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "target", "glob", "*.cs")));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["count"]);
+            JArray m = (JArray)msgs[0]["result"]["structuredContent"]["matches"];
+            Assert.Equal("keep.cs", (string)m[0]["path"]);
+        }
+
+        [Fact]
+        public void Search_skips_binary_files()
+        {
+            File.WriteAllBytes(Abs("blob.bin"), new byte[] { (byte)'h', (byte)'i', 0, (byte)'t' });
+            File.WriteAllText(Abs("ok.txt"), "hit");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "hi")));
+            // Only ok.txt's "hit" line counts; the binary blob is skipped.
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["count"]);
+        }
+
+        [Fact]
+        public void Search_recurses_subdirectories()
+        {
+            Directory.CreateDirectory(Abs("sub"));
+            File.WriteAllText(Abs(Path.Combine("sub", "deep.txt")), "buried treasure");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "treasure")));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["count"]);
+        }
+
+        [Fact]
+        public void Search_max_results_truncates()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < 10; i++) sb.Append("match\n");
+            File.WriteAllText(Abs("many.txt"), sb.ToString());
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "match", "max_results", 3)));
+            Assert.Equal(3, (int)msgs[0]["result"]["structuredContent"]["count"]);
+            Assert.True((bool)msgs[0]["result"]["structuredContent"]["truncated"]);
         }
 
         // ---- Criterion 6: lifecycle ----

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -395,6 +395,61 @@ namespace FilesMcpServer.Tests
             Assert.True((bool)msgs[0]["result"]["structuredContent"]["truncated"]);
         }
 
+        // ---- large files: search streams (no size cap); ranged read streams a slice ----
+
+        [Fact]
+        public void Search_finds_matches_in_oversize_file()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < 100000; i++) sb.Append("filler line\n"); // ~1.2 MiB > 1 MiB cap
+            sb.Append("the needle is here\n");
+            File.WriteAllText(Abs("big.txt"), sb.ToString());
+            Assert.True(new FileInfo(Abs("big.txt")).Length > 1024 * 1024);
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "search", Harness.Args("query", "needle")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["count"]);
+            JArray m = (JArray)msgs[0]["result"]["structuredContent"]["matches"];
+            Assert.Equal(100001, (int)m[0]["line"]);
+        }
+
+        [Fact]
+        public void Read_range_works_on_oversize_file_while_whole_file_is_capped()
+        {
+            var sb = new StringBuilder();
+            sb.Append("first line\n");
+            for (int i = 0; i < 120000; i++) sb.Append("padding padding padding\n"); // ~2.8 MiB
+            File.WriteAllText(Abs("big.txt"), sb.ToString());
+            Assert.True(new FileInfo(Abs("big.txt")).Length > 1024 * 1024);
+
+            // Ranged read of the first line succeeds despite the file exceeding the cap.
+            var r = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt", "start_line", 1, "end_line", 1)));
+            Assert.False(Harness.IsError(r[0]));
+            Assert.Equal("first line", Harness.Text(r[0]));
+
+            // Whole-file read is still capped.
+            var w = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
+            Assert.True(Harness.IsError(w[0]));
+            Assert.Contains("too large", Harness.Text(w[0]));
+        }
+
+        [Fact]
+        public void Read_range_rejects_an_oversize_selection()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < 120000; i++) sb.Append("padding padding padding\n"); // ~2.8 MiB
+            File.WriteAllText(Abs("big.txt"), sb.ToString());
+
+            // Asking for the whole thing via an open-ended range hits the output cap.
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt", "start_line", 1)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("too large", Harness.Text(msgs[0]));
+        }
+
         // ---- Criterion 6: lifecycle ----
 
         [Fact]

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -501,6 +501,45 @@ namespace FilesMcpServer.Tests
             Assert.Contains("too large", Harness.Text(msgs[0]));
         }
 
+        [Fact]
+        public void Read_range_cap_counts_utf8_bytes_not_chars()
+        {
+            // 2000 lines × 250 '€' (3 bytes each) ≈ 1.5 MiB of UTF-8, but only ~0.5M chars — under a
+            // char-based cap, over the byte cap. The range read must reject it on real byte size.
+            var sb = new StringBuilder();
+            for (int i = 0; i < 2000; i++) sb.Append(new string('€', 250)).Append('\n');
+            File.WriteAllText(Abs("uni.txt"), sb.ToString(), new UTF8Encoding(false));
+            Assert.True(sb.Length < 1024 * 1024);                                  // char count under cap
+            Assert.True(new FileInfo(Abs("uni.txt")).Length > 1024 * 1024);        // byte count over cap
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "uni.txt", "start_line", 1)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("too large", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_range_at_cap_boundary_returns_just_under_and_rejects_just_over()
+        {
+            // 16-byte ASCII lines; joined by '\n' that is 17 bytes/line. Output for N lines = 17N-1.
+            // 17×61681-1 = 1,048,576 = the 1 MiB cap exactly (fits, since the check is strictly >);
+            // 61682 lines = 1,048,593 bytes, just over.
+            string row = new string('x', 16);
+            var sb = new StringBuilder();
+            for (int i = 0; i < 70000; i++) sb.Append(row).Append('\n');
+            File.WriteAllText(Abs("rows.txt"), sb.ToString(), new UTF8Encoding(false));
+
+            var ok = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", 61681)));
+            Assert.False(Harness.IsError(ok[0]));
+            Assert.Equal(61681 * 17 - 1, Harness.Text(ok[0]).Length); // 61681 rows joined by 61680 '\n'
+
+            var over = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", 61682)));
+            Assert.True(Harness.IsError(over[0]));
+            Assert.Contains("too large", Harness.Text(over[0]));
+        }
+
         // ---- Criterion 6: lifecycle ----
 
         [Fact]

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -303,6 +303,57 @@ namespace FilesMcpServer.Tests
             Assert.Contains("escape", Harness.Text(msgs[0]));
         }
 
+        [Fact]
+        public void Edit_works_on_oversize_file()
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < 60000; i++) sb.Append("padding padding padding\n"); // ~1.4 MiB
+            sb.Append("UNIQUE_MARKER stays here\n");
+            for (int i = 0; i < 60000; i++) sb.Append("more more more more more\n");
+            File.WriteAllText(Abs("big.txt"), sb.ToString());
+            Assert.True(new FileInfo(Abs("big.txt")).Length > 1024 * 1024);
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "big.txt",
+                    "old_string", "UNIQUE_MARKER", "new_string", "REPLACED")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+
+            string after = File.ReadAllText(Abs("big.txt"));
+            Assert.Contains("REPLACED stays here", after);
+            Assert.DoesNotContain("UNIQUE_MARKER", after);
+            // surrounding content is preserved verbatim
+            Assert.True(after.StartsWith("padding padding padding\n"));
+            Assert.True(after.EndsWith("more more more more more\n"));
+        }
+
+        [Fact]
+        public void Edit_replaces_match_spanning_a_read_chunk_boundary()
+        {
+            // The streaming reader chunks at 64K chars; place a match straddling that boundary so
+            // only the carry-buffer logic can catch it. 65535 dots + "NEEDLE" => 'N' is char #65536.
+            string prefix = new string('.', 65535);
+            File.WriteAllText(Abs("span.txt"), prefix + "NEEDLE" + "tail");
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "span.txt",
+                    "old_string", "NEEDLE", "new_string", "FOUND")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+            Assert.Equal(prefix + "FOUND" + "tail", File.ReadAllText(Abs("span.txt")));
+        }
+
+        [Fact]
+        public void Edit_preserves_crlf_line_endings_outside_the_span()
+        {
+            File.WriteAllText(Abs("crlf.txt"), "one\r\ntwo\r\nthree");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "crlf.txt",
+                    "old_string", "two", "new_string", "TWO")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("one\r\nTWO\r\nthree", File.ReadAllText(Abs("crlf.txt")));
+        }
+
         // ---- search ----
 
         [Fact]


### PR DESCRIPTION
## Summary

Gives the model the tools to **locate and surgically modify code** without rewriting whole files — fewer tokens, fewer accidental clobbers. Three additions to the `files` MCP server, all confined to the existing `GXPT_WORKDIR` sandbox and gated by the existing approval tiers.

| Tool | Tier | What it does |
|------|------|--------------|
| **`search`** (`files__search`) | ReadOnly | Recursive content grep under the workspace root → `{path, line, text}`. Literal substring or `.NET` regex, `ignore_case`, filename `glob` (`*`/`?`), `max_results` (default 100, max 1000). **Streams every file line-by-line (any size)**, skips binary, caps scanned files and per-match line length, reports `truncated`. Invalid regex → `Error`. |
| **`edit`** (`files__edit`) | Write (path-scoped) | Exact `old_string` → `new_string` replacement. Requires a unique match unless `replace_all`; missing file / no match / non-unique match → `Error` with the file left untouched. **Streams** through a temp file then atomic move; **no size cap**. |
| **`read`** (extended) | ReadOnly | Optional 1-based inclusive `start_line`/`end_line` range and `line_numbers` prefixing. A **ranged** read **streams**, so it works on files past the cap — but its **rendered output is itself capped at 1 MiB** (see below). A whole-file read with neither option stays **byte-for-byte verbatim**. |

`edit` is deliberately **string-replacement only** — content matching fails safe, whereas raw line-number edits silently corrupt on a stale snapshot. Ranged `read` already gives the model the line context it needs to build a unique `old_string`.

## The size cap is a *context* guard — where 1 MiB applies to `read`

The 1 MiB cap exists to protect the **model context window**. For `read` it applies to whatever lands in context:

- A **whole-file `read`** is capped on the **file size** (over → `Error`, pointing the model at a line range).
- A **ranged `read`** is capped on the **rendered output** instead — so it works on arbitrarily large files, but a *slice* that would render over 1 MiB → `Error`. That cap is counted as **exact UTF-8 bytes**: line content + `\n` separators + the line-number prefix (digits + tab) when `line_numbers` is on. (An earlier char-count heuristic could under-count multi-byte/CJK text and only roughly accounted for the prefix; it's now byte-exact, verified at the 1,048,576-byte boundary.)

Everything else streams so file size is never the limit — output (or memory) is bounded instead:

- **`search`** streams each file line-by-line via a shared `OpenTextReaderOrNull` (head NUL-sniff for binary, then a `StreamReader`). Output stays bounded by `max_results`, so large files — exactly where grep matters most — are searchable.
- **`edit`** streams the file in 64K-char chunks through find/replace into the temp file, with a **carry buffer** of `len(old_string)-1` chars so a match straddling a chunk boundary isn't missed. Content outside the matched span is copied **verbatim** (exact bytes and line endings preserved); memory stays bounded by one chunk. Uniqueness is enforced mid-stream (first hit replaced, second hit aborts and discards the temp). It writes to disk rather than context, so it carries **no size cap**.

A pathological no-newline file (e.g. minified JS) still materializes one long "line" in memory for `search`/`read`, bounded by file size; the stored match text is length-capped so it can't bloat the model context.

## Host wiring

`ToolClassifier` first-party table: `files__search` → ReadOnly/Tool, `files__edit` → Write/Argument(`path`), mirroring `files__read` and `files__write`.

## Docs

Updated `mcp35-servers-spec.md` §2 (the 1 MiB cap reframed as a context guard: file-size cap on a whole-file `read`, exact-UTF-8-byte output cap on a ranged `read`; `search`/`edit` stream with no size cap) and `mcp35-approval-spec.md` §2.

## Tests

27 new tests across four commits — ranged/numbered reads, edit uniqueness / `replace_all` / error paths / traversal, search regex / glob / case / binary-skip / recursion / truncation, plus the streaming/cap paths: search over a ~1.2 MiB file, a ranged read slice of a ~2.8 MiB file (while a whole-file read of it still errors), an edit of a >1 MiB file, a match **straddling the 64K read boundary**, CRLF preservation, a multi-byte slice that's under a char cap but over the byte cap, and the **exact 1 MiB byte boundary** (61681 rows fit, 61682 over). **Full Files suite: 41/41 green.**

> A streaming-`edit` bug was caught by these tests: `sw.Write(window, pos, len)` binds to the composite-format overload `Write(string, object, object)` (no substring-write overload exists), so it emitted the whole window — fixed with `Substring` before committing. The net48 *build* alone wouldn't have caught it.

Code is net35-safe (only `Regex`, `StringBuilder`, `StreamReader`/`StreamWriter`, `string.Substring`, `IndexOf(string,int,StringComparison)`, `Encoding.UTF8.GetByteCount`); the net48 linked-source build compiles clean. (Validated locally by retargeting the test project to net8.0 since the Linux SDK has no net48 test host — CI on Windows/net48 is the real gate.)

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_