### PR TITLE
Clarify that the run tool uses Windows cmd syntax

### DIFF
--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -24,11 +24,7 @@ namespace CommandMcpServer
             ProcessRunner runner = new ProcessRunner(null);
 
             server.AddTool("run",
-                "Run a command line on Windows via cmd.exe (/c) and capture its stdout, stderr, and "
-                + "exit code. Use Windows cmd syntax, NOT bash/Unix: e.g. `dir` not `ls`, `type` not "
-                + "`cat`, `copy`/`move`/`del` not `cp`/`mv`/`rm`, `findstr` not `grep`, `%VAR%` not "
-                + "`$VAR`, and chain with `&&`/`&`. Built-in Unix tools are not available unless "
-                + "installed on the machine.",
+                "Run a command line on Windows via cmd.exe (/c) and capture its stdout, stderr, and exit code.",
                 SchemaBuilder.Object()
                     .Str("command", true, "The exact command line to run, in Windows cmd.exe syntax")
                     .Int("timeout_ms", false, "Kill the command after this many milliseconds (default 60000)")

--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -24,9 +24,13 @@ namespace CommandMcpServer
             ProcessRunner runner = new ProcessRunner(null);
 
             server.AddTool("run",
-                "Run a shell command line and capture its stdout, stderr, and exit code.",
+                "Run a command line on Windows via cmd.exe (/c) and capture its stdout, stderr, and "
+                + "exit code. Use Windows cmd syntax, NOT bash/Unix: e.g. `dir` not `ls`, `type` not "
+                + "`cat`, `copy`/`move`/`del` not `cp`/`mv`/`rm`, `findstr` not `grep`, `%VAR%` not "
+                + "`$VAR`, and chain with `&&`/`&`. Built-in Unix tools are not available unless "
+                + "installed on the machine.",
                 SchemaBuilder.Object()
-                    .Str("command", true, "The exact command line to run")
+                    .Str("command", true, "The exact command line to run, in Windows cmd.exe syntax")
                     .Int("timeout_ms", false, "Kill the command after this many milliseconds (default 60000)")
                     .Build(),
                 delegate(ToolCallContext ctx) { return Run(config, runner, ctx); });


### PR DESCRIPTION
## Summary

The `run` tool (`command__run`) executes via **cmd.exe** (`%ComSpec%`, invoked with `/c`), but its description only said *"Run a shell command line…"*. With the shell left ambiguous, models defaulted to bash/Unix commands (`ls`, `cat`, `grep`, `$VAR`) that fail on Windows.

This spells out the cmd.exe context in the tool description and gives the common substitutions, plus a note that Unix tools aren't present unless installed:

> Run a command line on Windows via cmd.exe (/c) and capture its stdout, stderr, and exit code. Use Windows cmd syntax, NOT bash/Unix: e.g. `dir` not `ls`, `type` not `cat`, `copy`/`move`/`del` not `cp`/`mv`/`rm`, `findstr` not `grep`, `%VAR%` not `$VAR`, and chain with `&&`/`&`. Built-in Unix tools are not available unless installed on the machine.

The `command` argument hint is also tagged as cmd.exe syntax.

## Scope

Description text only — no behavior change. No test or doc asserted the old string, and the Command server/test project builds clean.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_