### PR TITLE
Add diff/patch syntax highlighter with fixed red/green and background bands

### DIFF
--- a/GxPT/Highlighting/LanguageHighlighters.cs
+++ b/GxPT/Highlighting/LanguageHighlighters.cs
@@ -941,6 +941,53 @@ namespace GxPT
     }
 
     /// <summary>
+    /// Unified-diff / patch highlighter. Special case: it emits the diff-specific token types
+    /// (Addition/Deletion/DiffMeta) that map to a FIXED red/green family rather than the theme
+    /// accent, and that carry a background band (see SyntaxHighlighter color tables). Because
+    /// RegexHighlighterBase runs every pattern in Multiline mode and '.' does not cross '\n', each
+    /// pattern below matches exactly one line — so a '+'/'-' line becomes a single full-line token.
+    /// Header patterns are ordered ahead of the bare +/- patterns so '+++'/'---' file headers and
+    /// '@@' hunks are classified as metadata, not as additions/deletions.
+    /// </summary>
+    public class DiffHighlighter : RegexHighlighterBase
+    {
+        public static readonly string[] FileTypes = new string[] { "*.diff", "*.patch" };
+        public override string Language
+        {
+            get { return "diff"; }
+        }
+
+        public override string[] Aliases
+        {
+            get { return new string[] { "diff", "patch", "udiff" }; }
+        }
+
+        protected override TokenPattern[] GetPatterns()
+        {
+            return new TokenPattern[]
+            {
+                // File headers: "--- a/file" / "+++ b/file" (must beat the +/- line patterns).
+                new TokenPattern(@"^(?:---|\+\+\+) .*$", TokenType.DiffMeta, 1),
+
+                // Git extended-header / metadata lines.
+                new TokenPattern(@"^(?:diff --git |index |new file mode|deleted file mode|old mode |new mode |similarity index |dissimilarity index |rename (?:from|to) |copy (?:from|to) |Binary files |GIT binary patch).*$", TokenType.DiffMeta, 2),
+
+                // Hunk header: "@@ -l,s +l,s @@ optional section".
+                new TokenPattern(@"^@@.*$", TokenType.DiffMeta, 3),
+
+                // "\ No newline at end of file" marker.
+                new TokenPattern(@"^\\ .*$", TokenType.DiffMeta, 4),
+
+                // Added / removed lines (whole line, including the leading marker).
+                new TokenPattern(@"^\+.*$", TokenType.Addition, 5),
+                new TokenPattern(@"^-.*$", TokenType.Deletion, 6)
+
+                // Context lines (leading space) and blank lines fall through to Normal.
+            };
+        }
+    }
+
+    /// <summary>
     /// EBNF (Extended Backus-Naur Form) syntax highlighter
     /// </summary>
     public class EbnfHighlighter : RegexHighlighterBase

--- a/GxPT/Highlighting/RichTextBoxSyntaxHighlighter.cs
+++ b/GxPT/Highlighting/RichTextBoxSyntaxHighlighter.cs
@@ -87,9 +87,10 @@ namespace GxPT
             BeginUpdate(rtb);
             try
             {
-                // Reset all to default color first
+                // Reset all to default color first (and clear any prior background bands)
                 rtb.SelectAll();
                 rtb.SelectionColor = SyntaxHighlighter.GetTokenColorForTheme(TokenType.Normal, darkTheme);
+                rtb.SelectionBackColor = rtb.BackColor;
 
                 // Apply token colors (use .NET text length for token bounds)
                 int maxLen = text.Length;
@@ -115,6 +116,10 @@ namespace GxPT
                     rtb.SelectionStart = selStart;
                     rtb.SelectionLength = selLen;
                     rtb.SelectionColor = SyntaxHighlighter.GetTokenColorForTheme(t.Type, darkTheme);
+                    // Background band for diff add/remove rows (null for every other token type).
+                    // RichTextBox can only tint behind the glyphs, not full-width like the GDI path.
+                    Color? back = SyntaxHighlighter.GetTokenBackgroundColorForTheme(t.Type, darkTheme);
+                    rtb.SelectionBackColor = back.HasValue ? back.Value : rtb.BackColor;
                 }
             }
             finally

--- a/GxPT/Highlighting/SyntaxHighlighter.cs
+++ b/GxPT/Highlighting/SyntaxHighlighter.cs
@@ -21,7 +21,15 @@ namespace GxPT
         Operator,    // Operators (+, -, =, etc.)
         Punctuation, // Braces, brackets, semicolons
         Type,        // Built-in types (int, string, bool)
-        Method       // Method/function names
+        Method,      // Method/function names
+
+        // Diff/patch tokens. Unlike the categories above (whose colors are theme-driven), these
+        // map to a FIXED red/green family in GetTokenColorForTheme — a diff must always read as a
+        // diff regardless of the active accent palette. They are also the only token types that
+        // carry a background color (see GetTokenBackgroundColorForTheme).
+        Addition,    // A '+' line in a unified diff (added)
+        Deletion,    // A '-' line in a unified diff (removed)
+        DiffMeta     // Hunk/file headers and metadata (@@, +++/---, diff --git, ...)
     }
 
     /// <summary>
@@ -96,6 +104,7 @@ namespace GxPT
             RegisterHighlighter(new CssHighlighter());
             RegisterHighlighter(new CsvHighlighter());
             RegisterHighlighter(new DartHighlighter());
+            RegisterHighlighter(new DiffHighlighter());
             RegisterHighlighter(new EbnfHighlighter());
             RegisterHighlighter(new ElixirHighlighter());
             RegisterHighlighter(new ErlangHighlighter());
@@ -245,6 +254,13 @@ namespace GxPT
                         return ColorTranslator.FromHtml("#74c7ec"); // Sapphire
                     case TokenType.Method:
                         return ColorTranslator.FromHtml("#89b4fa"); // Blue
+                    // Diff: fixed red/green family (NOT theme-arbitrary), tuned for the dark palette.
+                    case TokenType.Addition:
+                        return ColorTranslator.FromHtml("#a6e3a1"); // Green
+                    case TokenType.Deletion:
+                        return ColorTranslator.FromHtml("#f38ba8"); // Red
+                    case TokenType.DiffMeta:
+                        return ColorTranslator.FromHtml("#89dceb"); // Sky
                     case TokenType.Normal:
                     default:
                         return ColorTranslator.FromHtml("#cdd6f4"); // Text
@@ -271,9 +287,50 @@ namespace GxPT
                         return ColorTranslator.FromHtml("#209fb5"); // sapphire
                     case TokenType.Method:
                         return ColorTranslator.FromHtml("#1e66f5"); // blue
+                    // Diff: fixed red/green family (NOT theme-arbitrary), tuned for the light palette.
+                    case TokenType.Addition:
+                        return ColorTranslator.FromHtml("#40a02b"); // green
+                    case TokenType.Deletion:
+                        return ColorTranslator.FromHtml("#d20f39"); // red
+                    case TokenType.DiffMeta:
+                        return ColorTranslator.FromHtml("#209fb5"); // sapphire
                     case TokenType.Normal:
                     default:
                         return SystemColors.WindowText; // Align with renderer/default
+                }
+            }
+        }
+
+        /// <summary>
+        /// Background color for a token type, or null for "no background" (the common case). Only the
+        /// diff token types return a value: a desaturated red/green band behind added/removed lines so
+        /// a diff reads at a glance even past the foreground color. Like the diff foreground colors,
+        /// these are a fixed red/green family — theme-tuned shades, never the accent palette.
+        /// </summary>
+        public static Color? GetTokenBackgroundColorForTheme(TokenType tokenType, bool dark)
+        {
+            if (dark)
+            {
+                switch (tokenType)
+                {
+                    case TokenType.Addition:
+                        return ColorTranslator.FromHtml("#28361f"); // muted green band on dark
+                    case TokenType.Deletion:
+                        return ColorTranslator.FromHtml("#3a2228"); // muted red band on dark
+                    default:
+                        return null;
+                }
+            }
+            else
+            {
+                switch (tokenType)
+                {
+                    case TokenType.Addition:
+                        return ColorTranslator.FromHtml("#e6f3e0"); // pale green band on light
+                    case TokenType.Deletion:
+                        return ColorTranslator.FromHtml("#fbe0e4"); // pale red band on light
+                    default:
+                        return null;
                 }
             }
         }

--- a/GxPT/Services/SyntaxHighlightingRenderer.cs
+++ b/GxPT/Services/SyntaxHighlightingRenderer.cs
@@ -14,14 +14,21 @@ namespace GxPT
     {
         public string Text;
         public Color Color;
+        public Color? BackColor; // optional background band behind the run (e.g. diff add/remove); null = none
         public Font Font;
         public int StartIndex;
         public int Length;
 
         public ColoredSegment(string text, Color color, Font font, int startIndex)
+            : this(text, color, null, font, startIndex)
+        {
+        }
+
+        public ColoredSegment(string text, Color color, Color? backColor, Font font, int startIndex)
         {
             Text = text;
             Color = color;
+            BackColor = backColor;
             Font = font;
             StartIndex = startIndex;
             Length = text != null ? text.Length : 0;
@@ -146,7 +153,8 @@ namespace GxPT
                                 segs.Add(new ColoredSegment(gap, SyntaxHighlighter.GetTokenColorForTheme(TokenType.Normal, wi.Dark), null, lastEnd));
                             }
                             var tokColor = SyntaxHighlighter.GetTokenColorForTheme(t.Type, wi.Dark);
-                            segs.Add(new ColoredSegment(t.Text, tokColor, null, t.StartIndex));
+                            var tokBack = SyntaxHighlighter.GetTokenBackgroundColorForTheme(t.Type, wi.Dark);
+                            segs.Add(new ColoredSegment(t.Text, tokColor, tokBack, null, t.StartIndex));
                             lastEnd = t.StartIndex + t.Length;
                         }
                         if (lastEnd < wi.Code.Length)
@@ -249,7 +257,7 @@ namespace GxPT
                     for (int i = 0; i < cached.Count; i++)
                     {
                         var s = cached[i];
-                        rebuilt.Add(new ColoredSegment(s.Text, s.Color, monoFont, s.StartIndex));
+                        rebuilt.Add(new ColoredSegment(s.Text, s.Color, s.BackColor, monoFont, s.StartIndex));
                     }
                     return rebuilt;
                 }
@@ -497,6 +505,18 @@ namespace GxPT
                                 y += lineHeight;
                                 x = viewport.X - scrollX;
                             }
+
+                            // Full-width row band (e.g. diff add/remove). Painted at the fixed
+                            // viewport left/width — not the scrolled x — so it highlights the whole
+                            // visible row regardless of horizontal scroll, then the text draws on top.
+                            // Diff color tokens are single-line (see DiffHighlighter), so a banded
+                            // segment owns its row; this never paints over a neighbouring run.
+                            if (segment.BackColor.HasValue && lineHeight > 0f)
+                            {
+                                using (var bgBrush = new SolidBrush(segment.BackColor.Value))
+                                    g.FillRectangle(bgBrush, new RectangleF(viewport.X, y, viewport.Width, lineHeight));
+                            }
+
                             if (line.Length == 0)
                                 continue;
 


### PR DESCRIPTION
## Summary

Adds a **diff / patch** syntax highlighter. Diffs are a special case versus the existing 40+ highlighters: their colors must always read as **red/green** (not the theme accent), and the add/remove signal wants a **background band**, not just colored text. Both are handled *without* making the renderer diff-aware.

## How the two concerns are solved

**Fixed red/green (not theme-arbitrary):** new `TokenType`s `Addition` / `Deletion` / `DiffMeta`, mapped in `GetTokenColorForTheme` to a fixed red/green family — theme-*tuned* light/dark shades, but never the accent palette. The diff highlighter stays purely semantic like every other one; the "always red/green" rule lives in the theme table.

**Background color (general capability):** `ColoredSegment` gains an optional `Color? BackColor`, fed by a new `GetTokenBackgroundColorForTheme(TokenType, dark)` that returns `null` for all existing token types and red/green tints only for diff add/remove. The renderer just learns "a run may have a background"; the diff highlighter is its only consumer today.

- The code-block draw path (`DrawColoredSegmentsNoWrap`) fills a **full-width row band** at the fixed viewport bounds, then draws text on top. Each diff line is a single full-line token (patterns run `Multiline`; `.` never crosses `\n`), so a banded segment owns its row and never paints over a neighbour.
- The `RichTextBox` path mirrors via `SelectionBackColor` (behind-glyph only — it can't do full-width; used by the settings editor, not the transcript).

**Highlighter:** `DiffHighlighter` (registered as `diff`/`patch`/`udiff`, `*.diff`/`*.patch`) with line-anchored patterns; file/hunk/git headers (`+++`/`---`/`@@`/`diff --git`/`index`/`\ No newline`) ordered ahead of the bare `+`/`-` lines so they classify as metadata, not additions/deletions.

## Scope of this pass

Per the design discussion: **full-width row bands** + **whole-line green/red** (terminal `git diff` look). Syntax-highlighting the code *inside* diff lines (GitHub style — code colored, only the background signals add/remove) can layer on later; it needs a two-pass renderer (fill all bands, then draw all text).

## Verification

Tokenization was validated against a real unified diff in a standalone harness that replicates the base tokenizer + the diff patterns: file headers, `@@` hunks, `index`/`diff --git`, `\ No newline`, context lines, and `+`/`-` lines (including empty `+`/`-`) all classify correctly, and **every diff line is exactly one full-line token** — the invariant the full-width band depends on. I also traced the renderer's row advancement over that segment stream; every band lands on its correct row.

**Build/visual check is the Windows/CI gate:** the GxPT app is a legacy `v3.5 WinExe` referencing `System.Windows.Forms`, so it only builds under MSBuild on Windows — it can't be compiled on the Linux session box. Code was written for .NET 3.5 (`Color?`, `SelectionBackColor`, chained constructor — all 2.0+). A screenshot of an actual diff fence rendered in the app would be the ideal final confirmation.

## Files

- `GxPT/Highlighting/SyntaxHighlighter.cs` — token types, fixed fg colors, new bg color table, registration
- `GxPT/Highlighting/LanguageHighlighters.cs` — `DiffHighlighter`
- `GxPT/Services/SyntaxHighlightingRenderer.cs` — `ColoredSegment.BackColor` + worker threading + full-width band fill
- `GxPT/Highlighting/RichTextBoxSyntaxHighlighter.cs` — `SelectionBackColor` parity

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_