### PR TITLE
Edit-tool diffs: collapsible history record + approval-prompt diff

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -2317,6 +2317,18 @@ namespace GxPT
                             return; // handled
                         }
                     }
+
+                    // Edit-diff body/scrollbar: shift+wheel scrolls it horizontally.
+                    EditDiffScrollHit edh;
+                    if (HitTestEditDiffScrollArea(e.Location, out edh) && edh.ContentWidth > edh.ViewportWidth)
+                    {
+                        int hStep = Math.Max(16, ScrollStep);
+                        int deltaX = (int)System.Math.Round(-(e.Delta / 120.0) * hStep, MidpointRounding.AwayFromZero);
+                        int maxScroll = Math.Max(0, edh.ContentWidth - edh.ViewportWidth);
+                        SetEditDiffScroll(edh.Key, Math.Max(0, Math.Min(maxScroll, GetEditDiffScroll(edh.Key) + deltaX)));
+                        Invalidate();
+                        return; // handled
+                    }
                 }
             }
             catch { }

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1504,6 +1504,12 @@ namespace GxPT
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
                         Rectangle textRect = new Rectangle(x0, y, maxWidth, bodyH);
+                        // Neutral backing (theme-aware bubble color) so unchanged/blank lines read as
+                        // part of the diff block rather than the transcript background; the per-line
+                        // red/green bands paint over this. History-record only — the shared "diff"
+                        // highlighter (used by ```diff fences) is unchanged.
+                        using (var bg = new SolidBrush(_clrAsstBack))
+                            g.FillRectangle(bg, textRect);
                         SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
                         y += bodyH + EditDiffBodyPad;
                     }

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -2590,6 +2590,20 @@ namespace GxPT
         protected override void OnMouseMove(MouseEventArgs e)
         {
             base.OnMouseMove(e);
+            // An active edit-diff scrollbar drag takes precedence over selection/hover so dragging past
+            // the selection threshold doesn't get hijacked into a text selection.
+            if (_draggingEditDiffScroll && !string.IsNullOrEmpty(_dragEditDiffKey))
+            {
+                int ddx = e.X - _dragEditDiffStartMouseX;
+                int dtrackWidth = Math.Max(1, _dragEditDiffTrack.Width);
+                int dthumbW = Math.Max(CodeHScrollThumbMin, (int)Math.Round((double)dtrackWidth * _dragEditDiffViewportWidth / Math.Max(1, _dragEditDiffContentWidth)));
+                int dtrackRange = Math.Max(1, dtrackWidth - dthumbW);
+                int dmaxScroll = Math.Max(0, _dragEditDiffContentWidth - _dragEditDiffViewportWidth);
+                int ddelta = (int)Math.Round((double)ddx / dtrackRange * dmaxScroll);
+                SetEditDiffScroll(_dragEditDiffKey, Math.Max(0, Math.Min(dmaxScroll, _dragEditDiffStartScroll + ddelta)));
+                Invalidate();
+                return;
+            }
             // If mouse is down over a message but we haven't entered selection yet, start selection on threshold
             if (!_isSelecting && _selectionItem != null && (Control.MouseButtons & MouseButtons.Left) == MouseButtons.Left)
             {
@@ -2614,18 +2628,6 @@ namespace GxPT
                 {
                     _suppressLinkClick = true; _hasSelection = true;
                 }
-                Invalidate();
-                return;
-            }
-            if (_draggingEditDiffScroll && !string.IsNullOrEmpty(_dragEditDiffKey))
-            {
-                int dx = e.X - _dragEditDiffStartMouseX;
-                int trackWidth = Math.Max(1, _dragEditDiffTrack.Width);
-                int thumbW = Math.Max(CodeHScrollThumbMin, (int)Math.Round((double)trackWidth * _dragEditDiffViewportWidth / Math.Max(1, _dragEditDiffContentWidth)));
-                int trackRange = Math.Max(1, trackWidth - thumbW);
-                int maxScroll = Math.Max(0, _dragEditDiffContentWidth - _dragEditDiffViewportWidth);
-                int deltaScroll = (int)Math.Round((double)dx / trackRange * maxScroll);
-                SetEditDiffScroll(_dragEditDiffKey, Math.Max(0, Math.Min(maxScroll, _dragEditDiffStartScroll + deltaScroll)));
                 Invalidate();
                 return;
             }

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -68,6 +68,7 @@ namespace GxPT
         private const int EditDiffHeaderPad = 3;  // vertical padding around the header text
         private const int EditDiffBodyGap = 2;    // gap between header and body
         private const int EditDiffBodyPad = 4;    // padding below the body
+        private const int EditDiffScrollSlack = 6; // overflow under this many px doesn't get a scrollbar
         private const int InlineCodePaddingX = 3;
         private const int InlineCodePaddingY = 1;
 
@@ -221,7 +222,7 @@ namespace GxPT
 
         // ---------- Edit-diff records (collapsible, chromeless; data derived from tool-call args) ----------
         private struct EditDiffHit { public Rectangle Rect; public string Key; }
-        private struct EditDiffScrollHit { public Rectangle Track; public string Key; public int ContentWidth; public int ViewportWidth; }
+        private struct EditDiffScrollHit { public Rectangle Track; public Rectangle Body; public string Key; public int ContentWidth; public int ViewportWidth; }
 
         // Horizontal scroll offset per diff key (UI-thread only); 0 when absent.
         private readonly Dictionary<string, int> _editDiffScroll = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -451,6 +452,18 @@ namespace GxPT
                             Invalidate();
                             return;
                         }
+                    }
+
+                    // Edit-diff body/scrollbar: shift+wheel scrolls it horizontally.
+                    EditDiffScrollHit edh;
+                    if (HitTestEditDiffScrollArea(clientPt, out edh) && edh.ContentWidth > edh.ViewportWidth)
+                    {
+                        int hStep = Math.Max(16, ScrollStep);
+                        int deltaX = (int)System.Math.Round(-(wheelDelta / 120.0) * hStep, MidpointRounding.AwayFromZero);
+                        int maxScroll = Math.Max(0, edh.ContentWidth - edh.ViewportWidth);
+                        SetEditDiffScroll(edh.Key, Math.Max(0, Math.Min(maxScroll, GetEditDiffScroll(edh.Key) + deltaX)));
+                        Invalidate();
+                        return;
                     }
                 }
                 // Fallback to normal vertical scroll
@@ -1013,7 +1026,7 @@ namespace GxPT
                                 var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
                                 Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                                 int bodyH = Math.Max(_monoFont.Height, content.Height);
-                                bool needH = content.Width > maxWidth;
+                                bool needH = content.Width > maxWidth + EditDiffScrollSlack;
                                 h += EditDiffBodyGap + bodyH + (needH ? CodeHScrollHeight : 0) + EditDiffBodyPad;
                                 w = Math.Max(w, Math.Min(maxWidth, content.Width));
                             }
@@ -1526,7 +1539,7 @@ namespace GxPT
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
                         int viewportW = maxWidth;
-                        bool needH = content.Width > viewportW;
+                        bool needH = content.Width > viewportW + EditDiffScrollSlack;
 
                         int scrollX = 0;
                         if (needH)
@@ -1569,7 +1582,7 @@ namespace GxPT
                             if (owner != null)
                             {
                                 if (owner.EditDiffScrollHits == null) owner.EditDiffScrollHits = new List<EditDiffScrollHit>();
-                                owner.EditDiffScrollHits.Add(new EditDiffScrollHit { Track = track, Key = ed.Key, ContentWidth = content.Width, ViewportWidth = viewportW });
+                                owner.EditDiffScrollHits.Add(new EditDiffScrollHit { Track = track, Body = textRect, Key = ed.Key, ContentWidth = content.Width, ViewportWidth = viewportW });
                             }
                             y += CodeHScrollHeight;
                         }
@@ -2817,6 +2830,24 @@ namespace GxPT
                 for (int i = 0; i < it.EditDiffScrollHits.Count; i++)
                 {
                     if (it.EditDiffScrollHits[i].Track.Contains(virt)) { hit = it.EditDiffScrollHits[i]; return true; }
+                }
+            }
+            return false;
+        }
+
+        // Like HitTestEditDiffScroll but matches the diff body too (for shift+wheel over the content).
+        private bool HitTestEditDiffScrollArea(Point clientPt, out EditDiffScrollHit hit)
+        {
+            hit = default(EditDiffScrollHit);
+            Point virt = new Point(clientPt.X, clientPt.Y + _scrollOffset);
+            foreach (var it in _items)
+            {
+                if (it.EditDiffScrollHits == null || it.EditDiffScrollHits.Count == 0) continue;
+                if (!it.Bounds.Contains(virt)) continue;
+                for (int i = 0; i < it.EditDiffScrollHits.Count; i++)
+                {
+                    var h = it.EditDiffScrollHits[i];
+                    if (h.Body.Contains(virt) || h.Track.Contains(virt)) { hit = h; return true; }
                 }
             }
             return false;

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1504,11 +1504,11 @@ namespace GxPT
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
                         Rectangle textRect = new Rectangle(x0, y, maxWidth, bodyH);
-                        // Neutral backing (theme-aware inline-code background) so unchanged/blank
-                        // lines read as part of the diff block rather than the transcript background;
-                        // the per-line red/green bands paint over this. History-record only — the
-                        // shared "diff" highlighter (used by ```diff fences) is unchanged.
-                        using (var bg = new SolidBrush(_clrInlineCodeBack))
+                        // Neutral backing (theme-aware code-block background) so unchanged/blank lines
+                        // read as part of the diff block rather than the transcript background; the
+                        // per-line red/green bands paint over this. History-record only — the shared
+                        // "diff" highlighter (used by ```diff fences) is unchanged.
+                        using (var bg = new SolidBrush(_clrCodeBack))
                             g.FillRectangle(bg, textRect);
                         SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
                         y += bodyH + EditDiffBodyPad;

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -206,6 +206,8 @@ namespace GxPT
             public List<LinkHit> LinkHits;
             // Edit-diff header hit rectangles captured at draw time (virtual coords) for collapse toggling
             public List<EditDiffHit> EditDiffHits;
+            // Edit-diff horizontal scrollbar track rects captured at draw time (virtual coords)
+            public List<EditDiffScrollHit> EditDiffScrollHits;
             // Drawn inline text segments for selection/copy (paragraphs, headings, lists, table cells)
             public List<DrawnSeg> DrawnSegments;
             // Unique link run id counter per message (increments when a new link run starts)
@@ -219,6 +221,24 @@ namespace GxPT
 
         // ---------- Edit-diff records (collapsible, chromeless; data derived from tool-call args) ----------
         private struct EditDiffHit { public Rectangle Rect; public string Key; }
+        private struct EditDiffScrollHit { public Rectangle Track; public string Key; public int ContentWidth; public int ViewportWidth; }
+
+        // Horizontal scroll offset per diff key (UI-thread only); 0 when absent.
+        private readonly Dictionary<string, int> _editDiffScroll = new Dictionary<string, int>(StringComparer.Ordinal);
+        // Drag state for an edit-diff scrollbar (self-contained; mirrors the code-block scroll drag).
+        private bool _draggingEditDiffScroll;
+        private string _dragEditDiffKey;
+        private Rectangle _dragEditDiffTrack;
+        private int _dragEditDiffContentWidth, _dragEditDiffViewportWidth, _dragEditDiffStartMouseX, _dragEditDiffStartScroll;
+
+        private int GetEditDiffScroll(string key)
+        {
+            int v; return (!string.IsNullOrEmpty(key) && _editDiffScroll.TryGetValue(key, out v)) ? v : 0;
+        }
+        private void SetEditDiffScroll(string key, int v)
+        {
+            if (!string.IsNullOrEmpty(key)) _editDiffScroll[key] = Math.Max(0, v);
+        }
 
         private sealed class EditDiffData { public string Path; public string Body; public int Added; public int Removed; }
         private readonly object _editDiffLock = new object();
@@ -993,7 +1013,8 @@ namespace GxPT
                                 var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
                                 Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                                 int bodyH = Math.Max(_monoFont.Height, content.Height);
-                                h += EditDiffBodyGap + bodyH + EditDiffBodyPad;
+                                bool needH = content.Width > maxWidth;
+                                h += EditDiffBodyGap + bodyH + (needH ? CodeHScrollHeight : 0) + EditDiffBodyPad;
                                 w = Math.Max(w, Math.Min(maxWidth, content.Width));
                             }
                         }
@@ -1303,6 +1324,7 @@ namespace GxPT
             if (it.LinkHits == null) it.LinkHits = new List<LinkHit>(); else it.LinkHits.Clear();
             // Reset edit-diff header hit rectangles before drawing
             if (it.EditDiffHits == null) it.EditDiffHits = new List<EditDiffHit>(); else it.EditDiffHits.Clear();
+            if (it.EditDiffScrollHits == null) it.EditDiffScrollHits = new List<EditDiffScrollHit>(); else it.EditDiffScrollHits.Clear();
             // Reset drawn text segments list (for selection)
             if (it.DrawnSegments == null) it.DrawnSegments = new List<DrawnSeg>(); else it.DrawnSegments.Clear();
             // Reset link run sequence
@@ -1503,15 +1525,55 @@ namespace GxPT
                         var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
-                        Rectangle textRect = new Rectangle(x0, y, maxWidth, bodyH);
+                        int viewportW = maxWidth;
+                        bool needH = content.Width > viewportW;
+
+                        int scrollX = 0;
+                        if (needH)
+                        {
+                            int maxScroll = Math.Max(0, content.Width - viewportW);
+                            scrollX = Math.Max(0, Math.Min(maxScroll, GetEditDiffScroll(ed.Key)));
+                            SetEditDiffScroll(ed.Key, scrollX);
+                        }
+
+                        Rectangle textRect = new Rectangle(x0, y, viewportW, bodyH);
                         // Neutral backing (theme-aware code-block background) so unchanged/blank lines
                         // read as part of the diff block rather than the transcript background; the
                         // per-line red/green bands paint over this. History-record only — the shared
                         // "diff" highlighter (used by ```diff fences) is unchanged.
                         using (var bg = new SolidBrush(_clrCodeBack))
                             g.FillRectangle(bg, textRect);
-                        SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
-                        y += bodyH + EditDiffBodyPad;
+                        SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, scrollX);
+                        y += bodyH;
+
+                        if (needH)
+                        {
+                            Rectangle track = new Rectangle(textRect.X, textRect.Bottom + 2, textRect.Width, CodeHScrollHeight - 4);
+                            using (var trackBrush = new SolidBrush(_clrScrollTrack))
+                            using (var trackPen = new Pen(_clrScrollTrackBorder))
+                            {
+                                g.FillRectangle(trackBrush, track);
+                                g.DrawRectangle(trackPen, track);
+                            }
+                            int thumbW = Math.Max(CodeHScrollThumbMin, (int)Math.Round((double)track.Width * viewportW / Math.Max(1, content.Width)));
+                            int trackRange = Math.Max(1, track.Width - thumbW);
+                            int maxScroll = Math.Max(0, content.Width - viewportW);
+                            int thumbX = track.X + (maxScroll > 0 ? (int)Math.Round((double)scrollX / maxScroll * trackRange) : 0);
+                            Rectangle thumb = new Rectangle(thumbX, track.Y, thumbW, track.Height);
+                            using (var thumbBrush = new SolidBrush(_clrScrollThumb))
+                            using (var thumbPen = new Pen(_clrScrollThumbBorder))
+                            {
+                                g.FillRectangle(thumbBrush, thumb);
+                                g.DrawRectangle(thumbPen, thumb);
+                            }
+                            if (owner != null)
+                            {
+                                if (owner.EditDiffScrollHits == null) owner.EditDiffScrollHits = new List<EditDiffScrollHit>();
+                                owner.EditDiffScrollHits.Add(new EditDiffScrollHit { Track = track, Key = ed.Key, ContentWidth = content.Width, ViewportWidth = viewportW });
+                            }
+                            y += CodeHScrollHeight;
+                        }
+                        y += EditDiffBodyPad;
                     }
                     numberedCounters.Clear();
                 }
@@ -2253,6 +2315,11 @@ namespace GxPT
         protected override void OnMouseUp(MouseEventArgs e)
         {
             base.OnMouseUp(e);
+            if (_draggingEditDiffScroll)
+            {
+                _draggingEditDiffScroll = false; _dragEditDiffKey = null; Capture = false; Invalidate();
+                return;
+            }
             if (_draggingHScroll)
             {
                 _draggingHScroll = false; _dragScrollItem = null; _dragScrollCodeIndex = -1; _dragScrollIsTable = false; Capture = false; Invalidate();
@@ -2407,6 +2474,33 @@ namespace GxPT
                     _pressAttachItem = pill.Item; _pressAttachIndex = pill.Index; Invalidate();
                     return;
                 }
+                // Edit-diff horizontal scrollbar: thumb drag or track jump.
+                EditDiffScrollHit edh;
+                if (HitTestEditDiffScroll(e.Location, out edh))
+                {
+                    Point virt = new Point(e.X, e.Y + _scrollOffset);
+                    int trackW = Math.Max(1, edh.Track.Width);
+                    int thumbW = Math.Max(CodeHScrollThumbMin, (int)Math.Round((double)trackW * edh.ViewportWidth / Math.Max(1, edh.ContentWidth)));
+                    int trackRange = Math.Max(1, trackW - thumbW);
+                    int maxScroll = Math.Max(0, edh.ContentWidth - edh.ViewportWidth);
+                    int thumbX = edh.Track.X + (maxScroll > 0 ? (int)Math.Round((double)GetEditDiffScroll(edh.Key) / maxScroll * trackRange) : 0);
+                    bool onThumb = virt.X >= thumbX && virt.X <= thumbX + thumbW;
+                    if (!onThumb)
+                    {
+                        int clickOffset = Math.Max(0, Math.Min(trackRange, virt.X - edh.Track.X - thumbW / 2));
+                        SetEditDiffScroll(edh.Key, (int)Math.Round((double)clickOffset / trackRange * maxScroll));
+                    }
+                    _draggingEditDiffScroll = true;
+                    _dragEditDiffKey = edh.Key;
+                    _dragEditDiffTrack = edh.Track;
+                    _dragEditDiffContentWidth = edh.ContentWidth;
+                    _dragEditDiffViewportWidth = edh.ViewportWidth;
+                    _dragEditDiffStartMouseX = e.X;
+                    _dragEditDiffStartScroll = GetEditDiffScroll(edh.Key);
+                    Capture = true;
+                    Invalidate();
+                    return;
+                }
                 var ui = HitTestCodeUI(e.Location);
                 if (ui.Hit)
                 {
@@ -2507,6 +2601,18 @@ namespace GxPT
                 {
                     _suppressLinkClick = true; _hasSelection = true;
                 }
+                Invalidate();
+                return;
+            }
+            if (_draggingEditDiffScroll && !string.IsNullOrEmpty(_dragEditDiffKey))
+            {
+                int dx = e.X - _dragEditDiffStartMouseX;
+                int trackWidth = Math.Max(1, _dragEditDiffTrack.Width);
+                int thumbW = Math.Max(CodeHScrollThumbMin, (int)Math.Round((double)trackWidth * _dragEditDiffViewportWidth / Math.Max(1, _dragEditDiffContentWidth)));
+                int trackRange = Math.Max(1, trackWidth - thumbW);
+                int maxScroll = Math.Max(0, _dragEditDiffContentWidth - _dragEditDiffViewportWidth);
+                int deltaScroll = (int)Math.Round((double)dx / trackRange * maxScroll);
+                SetEditDiffScroll(_dragEditDiffKey, Math.Max(0, Math.Min(maxScroll, _dragEditDiffStartScroll + deltaScroll)));
                 Invalidate();
                 return;
             }
@@ -2694,6 +2800,23 @@ namespace GxPT
                 for (int i = 0; i < it.EditDiffHits.Count; i++)
                 {
                     if (it.EditDiffHits[i].Rect.Contains(virt)) { key = it.EditDiffHits[i].Key; return true; }
+                }
+            }
+            return false;
+        }
+
+        // Returns true and the scrollbar info if the point is over an edit-diff horizontal scrollbar.
+        private bool HitTestEditDiffScroll(Point clientPt, out EditDiffScrollHit hit)
+        {
+            hit = default(EditDiffScrollHit);
+            Point virt = new Point(clientPt.X, clientPt.Y + _scrollOffset);
+            foreach (var it in _items)
+            {
+                if (it.EditDiffScrollHits == null || it.EditDiffScrollHits.Count == 0) continue;
+                if (!it.Bounds.Contains(virt)) continue;
+                for (int i = 0; i < it.EditDiffScrollHits.Count; i++)
+                {
+                    if (it.EditDiffScrollHits[i].Track.Contains(virt)) { hit = it.EditDiffScrollHits[i]; return true; }
                 }
             }
             return false;

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -62,6 +62,12 @@ namespace GxPT
         private const int BulletIndent = 18;
         private const int BulletGap = 8;
         private const int CodeBlockPadding = 6;
+
+        // Edit-diff record layout: a one-line clickable header, then (when expanded) a chromeless
+        // diff body indented under it.
+        private const int EditDiffHeaderPad = 3;  // vertical padding around the header text
+        private const int EditDiffBodyGap = 2;    // gap between header and body
+        private const int EditDiffBodyPad = 4;    // padding below the body
         private const int InlineCodePaddingX = 3;
         private const int InlineCodePaddingY = 1;
 
@@ -198,6 +204,8 @@ namespace GxPT
             public List<Rectangle> AttachmentPillRects; // computed per-draw for hit testing
             // Link hit rectangles captured at draw time (virtual coordinates)
             public List<LinkHit> LinkHits;
+            // Edit-diff header hit rectangles captured at draw time (virtual coords) for collapse toggling
+            public List<EditDiffHit> EditDiffHits;
             // Drawn inline text segments for selection/copy (paragraphs, headings, lists, table cells)
             public List<DrawnSeg> DrawnSegments;
             // Unique link run id counter per message (increments when a new link run starts)
@@ -208,6 +216,48 @@ namespace GxPT
         private readonly List<MessageItem> _items = new List<MessageItem>();
         private MessageItem _hoverAttachItem; private int _hoverAttachIndex = -1;
         private MessageItem _pressAttachItem; private int _pressAttachIndex = -1;
+
+        // ---------- Edit-diff records (collapsible, chromeless; data derived from tool-call args) ----------
+        private struct EditDiffHit { public Rectangle Rect; public string Key; }
+
+        private sealed class EditDiffData { public string Path; public string Body; public int Added; public int Removed; }
+        private readonly object _editDiffLock = new object();
+        private readonly Dictionary<string, EditDiffData> _editDiffs = new Dictionary<string, EditDiffData>(StringComparer.Ordinal);
+        private readonly Dictionary<string, bool> _editDiffCollapsed = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        // Registers (or refreshes) the diff for one edit tool call, keyed by its (persisted) call id.
+        // Called from the streaming worker thread and the history reload path, so it is lock-guarded.
+        public void RegisterEditDiff(string key, string path, string body, int added, int removed)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            lock (_editDiffLock)
+            {
+                _editDiffs[key] = new EditDiffData { Path = path ?? string.Empty, Body = body ?? string.Empty, Added = added, Removed = removed };
+            }
+        }
+
+        private EditDiffData GetEditDiffData(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return null;
+            lock (_editDiffLock) { EditDiffData d; return _editDiffs.TryGetValue(key, out d) ? d : null; }
+        }
+
+        // Collapse state is UI-thread-only; default (absent) = collapsed.
+        private bool IsEditDiffCollapsed(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return true;
+            bool c; return _editDiffCollapsed.TryGetValue(key, out c) ? c : true;
+        }
+
+        // The header line, e.g. "▸ edited src/main.py  (+3 −1)" (collapsed) / "▾ …" (expanded).
+        private static string BuildEditDiffHeaderText(EditDiffData data, bool collapsed)
+        {
+            string tri = collapsed ? "▸" : "▾";
+            string path = (data != null && !string.IsNullOrEmpty(data.Path)) ? data.Path : "(file)";
+            int add = data != null ? data.Added : 0;
+            int rem = data != null ? data.Removed : 0;
+            return tri + " edited " + path + "  (+" + add + " −" + rem + ")";
+        }
 
         // ---------- Batch update state ----------
         // Coalesce expensive reflow/paint while adding many messages (e.g., when opening history)
@@ -925,6 +975,30 @@ namespace GxPT
                             return new Size(Math.Max(24, boxW), Math.Max(headerH + 2 * CodeBlockPadding, boxH));
                         }
                     }
+                case BlockType.EditDiff:
+                    {
+                        var ed = (EditDiffBlock)blk;
+                        EditDiffData data = GetEditDiffData(ed.Key);
+                        bool collapsed = IsEditDiffCollapsed(ed.Key);
+                        int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
+                        string headerText = BuildEditDiffHeaderText(data, collapsed);
+                        int headerW = TextRenderer.MeasureText(headerText, _baseFont).Width;
+                        int w = headerW;
+                        int h = headerH;
+                        if (data != null && !collapsed)
+                        {
+                            using (Graphics g = CreateGraphics())
+                            {
+                                SyntaxHighlightingRenderer.EnqueueHighlight("diff", _isDarkTheme, data.Body, _monoFont);
+                                var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
+                                Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
+                                int bodyH = Math.Max(_monoFont.Height, content.Height);
+                                h += EditDiffBodyGap + bodyH + EditDiffBodyPad;
+                                w = Math.Max(w, Math.Min(maxWidth, content.Width));
+                            }
+                        }
+                        return new Size(Math.Max(24, Math.Min(maxWidth, w)), h);
+                    }
                 case BlockType.Table:
                     {
                         var t = (TableBlock)blk;
@@ -1227,6 +1301,8 @@ namespace GxPT
             Rectangle content = new Rectangle(r.X + BubblePadding, r.Y + BubblePadding, r.Width - 2 * BubblePadding, r.Height - 2 * BubblePadding);
             // Reset link hit rectangles for this item before drawing
             if (it.LinkHits == null) it.LinkHits = new List<LinkHit>(); else it.LinkHits.Clear();
+            // Reset edit-diff header hit rectangles before drawing
+            if (it.EditDiffHits == null) it.EditDiffHits = new List<EditDiffHit>(); else it.EditDiffHits.Clear();
             // Reset drawn text segments list (for selection)
             if (it.DrawnSegments == null) it.DrawnSegments = new List<DrawnSeg>(); else it.DrawnSegments.Clear();
             // Reset link run sequence
@@ -1395,6 +1471,43 @@ namespace GxPT
                         if (owner != null) { if (owner.DrawnSegments == null) owner.DrawnSegments = new List<DrawnSeg>(); owner.DrawnSegments.Add(new DrawnSeg { IsNewLine = true, IsHardBreak = true, Rect = new Rectangle(x0, y, 0, 0), Text = null, Font = _baseFont }); }
                     }
                     // Avoid extra block-level newline to prevent double spacing
+                }
+                else if (blk.Type == BlockType.EditDiff)
+                {
+                    var ed = (EditDiffBlock)blk;
+                    EditDiffData data = GetEditDiffData(ed.Key);
+                    bool collapsed = IsEditDiffCollapsed(ed.Key);
+                    int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
+
+                    // Clickable header row (spans the content width); captured for collapse hit-testing.
+                    string headerText = BuildEditDiffHeaderText(data, collapsed);
+                    using (var brush = new SolidBrush(ForeColor))
+                    using (var fmt = StringFormat.GenericTypographic)
+                    {
+                        fmt.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
+                        g.DrawString(headerText, _baseFont, brush, new PointF(x0, y + EditDiffHeaderPad), fmt);
+                    }
+                    if (owner != null)
+                    {
+                        if (owner.EditDiffHits == null) owner.EditDiffHits = new List<EditDiffHit>();
+                        owner.EditDiffHits.Add(new EditDiffHit { Rect = new Rectangle(x0, y, maxWidth, headerH), Key = ed.Key });
+                    }
+                    y += headerH;
+
+                    // Expanded: chromeless diff body, full-width red/green bands, clipped to width
+                    // (horizontal scroll for wide diffs is a following increment).
+                    if (data != null && !collapsed)
+                    {
+                        y += EditDiffBodyGap;
+                        SyntaxHighlightingRenderer.EnqueueHighlight("diff", _isDarkTheme, data.Body, _monoFont);
+                        var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
+                        Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
+                        int bodyH = Math.Max(_monoFont.Height, content.Height);
+                        Rectangle textRect = new Rectangle(x0, y, maxWidth, bodyH);
+                        SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
+                        y += bodyH + EditDiffBodyPad;
+                    }
+                    numberedCounters.Clear();
                 }
                 else if (blk.Type == BlockType.CodeBlock)
                 {
@@ -2224,6 +2337,15 @@ namespace GxPT
                     OpenAttachmentInViewer(pill.Item, pill.Index);
                     return;
                 }
+                // Edit-diff header click → toggle collapse and re-layout
+                string edKey;
+                if (HitTestEditDiff(e.Location, out edKey))
+                {
+                    _editDiffCollapsed[edKey] = !IsEditDiffCollapsed(edKey);
+                    Reflow();
+                    Invalidate();
+                    return;
+                }
                 // Copy button click
                 var ui = HitTestCodeUI(e.Location);
                 if (ui.Hit && ui.Which == CodeUiHit.CopyButton && ui.Item != null)
@@ -2552,6 +2674,23 @@ namespace GxPT
                     return _items[i];
             }
             return null;
+        }
+
+        // Returns true and the diff key if the point is over an edit-diff header row.
+        private bool HitTestEditDiff(Point clientPt, out string key)
+        {
+            key = null;
+            Point virt = new Point(clientPt.X, clientPt.Y + _scrollOffset);
+            foreach (var it in _items)
+            {
+                if (it.EditDiffHits == null || it.EditDiffHits.Count == 0) continue;
+                if (!it.Bounds.Contains(virt)) continue;
+                for (int i = 0; i < it.EditDiffHits.Count; i++)
+                {
+                    if (it.EditDiffHits[i].Rect.Contains(virt)) { key = it.EditDiffHits[i].Key; return true; }
+                }
+            }
+            return false;
         }
 
         private string HitTestLink(Point clientPt)

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1504,11 +1504,11 @@ namespace GxPT
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
                         Rectangle textRect = new Rectangle(x0, y, maxWidth, bodyH);
-                        // Neutral backing (theme-aware bubble color) so unchanged/blank lines read as
-                        // part of the diff block rather than the transcript background; the per-line
-                        // red/green bands paint over this. History-record only — the shared "diff"
-                        // highlighter (used by ```diff fences) is unchanged.
-                        using (var bg = new SolidBrush(_clrAsstBack))
+                        // Neutral backing (theme-aware inline-code background) so unchanged/blank
+                        // lines read as part of the diff block rather than the transcript background;
+                        // the per-line red/green bands paint over this. History-record only — the
+                        // shared "diff" highlighter (used by ```diff fences) is unchanged.
+                        using (var bg = new SolidBrush(_clrInlineCodeBack))
                             g.FillRectangle(bg, textRect);
                         SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
                         y += bodyH + EditDiffBodyPad;

--- a/GxPT/Controls/DiffPreviewPanel.cs
+++ b/GxPT/Controls/DiffPreviewPanel.cs
@@ -1,0 +1,98 @@
+// DiffPreviewPanel.cs
+// Owner-drawn, auto-scrolling panel that renders a unified-diff body (via the "diff" syntax
+// highlighter) with a path header. Used by the tool approval prompt to show a files__edit change
+// instead of raw JSON. AutoScroll handles both tall and wide diffs.
+// Target: .NET 3.5, Windows XP compatible.
+
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    internal sealed class DiffPreviewPanel : Panel
+    {
+        private string _path = string.Empty;
+        private string _body = string.Empty;
+        private bool _dark;
+        private Font _monoFont;
+        private Color _codeBack = Color.FromArgb(245, 245, 245);
+        private Color _foreColor = SystemColors.WindowText;
+
+        private const int Pad = 6;
+
+        public DiffPreviewPanel()
+        {
+            this.AutoScroll = true;
+            this.BorderStyle = BorderStyle.None;
+            this.BackColor = _codeBack;
+            try { this.DoubleBuffered = true; }
+            catch { }
+        }
+
+        // Set the diff to display. monoFont is owned by the caller; colors come from the active theme.
+        public void SetDiff(string path, string body, bool dark, Font monoFont, Color codeBack, Color foreColor)
+        {
+            _path = path ?? string.Empty;
+            _body = body ?? string.Empty;
+            _dark = dark;
+            _monoFont = monoFont;
+            _codeBack = codeBack;
+            _foreColor = foreColor;
+            this.BackColor = codeBack;
+            UpdateScrollSize();
+            this.AutoScrollPosition = new Point(0, 0);
+            Invalidate();
+        }
+
+        private int HeaderHeight
+        {
+            get { return (this.Font != null ? this.Font.Height : 14) + Pad; }
+        }
+
+        private void UpdateScrollSize()
+        {
+            if (_monoFont == null || string.IsNullOrEmpty(_body)) { this.AutoScrollMinSize = Size.Empty; return; }
+            try
+            {
+                using (Graphics g = CreateGraphics())
+                {
+                    var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, "diff", _monoFont, _dark);
+                    Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
+                    int w = content.Width + 2 * Pad;
+                    int h = HeaderHeight + Math.Max(_monoFont.Height, content.Height) + Pad;
+                    this.AutoScrollMinSize = new Size(w, h);
+                }
+            }
+            catch { this.AutoScrollMinSize = Size.Empty; }
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            Graphics g = e.Graphics;
+            using (var bg = new SolidBrush(_codeBack))
+                g.FillRectangle(bg, this.ClientRectangle);
+            if (_monoFont == null) return;
+
+            // Draw everything in content coordinates; AutoScroll moves the world for both axes.
+            g.TranslateTransform(this.AutoScrollPosition.X, this.AutoScrollPosition.Y);
+
+            // Path header (the change is still pending here, so just the path — no tense)
+            Font hf = this.Font ?? _monoFont;
+            using (var br = new SolidBrush(_foreColor))
+                g.DrawString(_path, hf, br, new PointF(Pad, Pad / 2f));
+
+            if (string.IsNullOrEmpty(_body)) return;
+
+            // Diff body
+            SyntaxHighlightingRenderer.EnqueueHighlight("diff", _dark, _body, _monoFont);
+            var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, "diff", _monoFont, _dark);
+            Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
+            int bodyH = Math.Max(_monoFont.Height, content.Height);
+            int bodyW = Math.Max(content.Width, this.ClientSize.Width - 2 * Pad);
+            Rectangle textRect = new Rectangle(Pad, HeaderHeight, bodyW, bodyH);
+            SyntaxHighlightingRenderer.DrawColoredSegmentsNoWrap(g, colored, textRect, 0);
+        }
+    }
+}

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 using Newtonsoft.Json;
 
@@ -17,9 +18,15 @@ namespace GxPT
         private readonly Label _tierBadge;
         private readonly Label _previewLabel;
         private readonly TextBox _preview;
+        private readonly DiffPreviewPanel _diffPanel;   // shown instead of _preview for files__edit
+        private readonly Font _monoFont;
         private readonly FlowLayoutPanel _buttons;
 
         private Action<ApprovalChoice> _onChoose;
+
+        // Supplies the active workspace root so an edit approval can show a few lines of real file
+        // context around the change. Set by the host (MainForm); null disables context (bare diff).
+        public Func<string> WorkingDirProvider;
 
         public ToolApprovalPanel()
         {
@@ -45,12 +52,18 @@ namespace GxPT
             _previewLabel.Height = 16;
             _previewLabel.Text = "Details:";
 
+            _monoFont = new Font("Consolas", 9F);
+
             _preview = new TextBox();
             _preview.Multiline = true;
             _preview.ReadOnly = true;
             _preview.ScrollBars = ScrollBars.Vertical;
             _preview.Dock = DockStyle.Fill;
-            _preview.Font = new Font("Consolas", 9F);
+            _preview.Font = _monoFont;
+
+            _diffPanel = new DiffPreviewPanel();
+            _diffPanel.Dock = DockStyle.Fill;
+            _diffPanel.Visible = false;
 
             _buttons = new FlowLayoutPanel();
             _buttons.Dock = DockStyle.Bottom;
@@ -60,6 +73,7 @@ namespace GxPT
             _buttons.AutoScroll = true;
 
             // Order added (Fill must be added before docked siblings to lay out correctly):
+            this.Controls.Add(_diffPanel);
             this.Controls.Add(_preview);
             this.Controls.Add(_previewLabel);
             this.Controls.Add(_tierBadge);
@@ -81,7 +95,40 @@ namespace GxPT
             _tierBadge.ForeColor = (tier == ToolTier.Destructive) ? Color.Firebrick
                                   : (tier == ToolTier.Write ? Color.DarkGoldenrod : Color.ForestGreen);
 
-            _preview.Text = BuildPreviewText(req);
+            // files__edit: show a colored diff (with a little live file context) instead of raw JSON.
+            bool isEdit = string.Equals(req.FunctionName, "files__edit", StringComparison.Ordinal) && req.Arguments != null;
+            if (isEdit)
+            {
+                string path = req.Arguments.Value<string>("path") ?? string.Empty;
+                string oldS = req.Arguments.Value<string>("old_string") ?? string.Empty;
+                string newS = req.Arguments.Value<string>("new_string") ?? string.Empty;
+                string workdir = WorkingDirProvider != null ? WorkingDirProvider() : null;
+                string fileText = ReadWorkspaceFile(workdir, path);
+                LineDiffResult diff = DiffUtil.BuildLineDiffWithContext(fileText, oldS, newS, 3);
+
+                bool dark = false;
+                try
+                {
+                    string th = AppSettings.GetString("theme");
+                    dark = !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+                }
+                catch { }
+                ThemeColors tc = ThemeService.GetColors(dark);
+
+                _diffPanel.SetDiff(path, diff.Body, dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                _previewLabel.Text = "Diff:";
+                _preview.Visible = false;
+                _diffPanel.Visible = true;
+                this.Height = 260;
+            }
+            else
+            {
+                _preview.Text = BuildPreviewText(req);
+                _previewLabel.Text = "Details:";
+                _diffPanel.Visible = false;
+                _preview.Visible = true;
+                this.Height = 150;
+            }
 
             _buttons.Controls.Clear();
             // Deny is always present (added first => rightmost in RightToLeft flow).
@@ -136,6 +183,25 @@ namespace GxPT
             };
             _buttons.Controls.Add(b);
             if (defaultFocus) { try { b.Select(); } catch { } }
+        }
+
+        // Reads a workspace-relative file for diff context. Mirrors the files sandbox: relative paths
+        // only, must resolve inside the workspace root. Returns null on any failure (→ bare diff).
+        private static string ReadWorkspaceFile(string workdir, string relPath)
+        {
+            if (string.IsNullOrEmpty(workdir) || string.IsNullOrEmpty(relPath)) return null;
+            try
+            {
+                if (Path.IsPathRooted(relPath)) return null;
+                string root = Path.GetFullPath(workdir);
+                string full = Path.GetFullPath(Path.Combine(root, relPath));
+                string rootSep = root.EndsWith(Path.DirectorySeparatorChar.ToString()) ? root : root + Path.DirectorySeparatorChar;
+                if (!string.Equals(full, root, StringComparison.OrdinalIgnoreCase) &&
+                    !full.StartsWith(rootSep, StringComparison.OrdinalIgnoreCase)) return null;
+                if (!File.Exists(full)) return null;
+                return File.ReadAllText(full);
+            }
+            catch { return null; }
         }
 
         private static string BuildPreviewText(ApprovalRequest req)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1471,7 +1471,9 @@ namespace GxPT
                     };
 
                     Action<string> onAppend = delegate(string t) { lock (sbLock) { answerSb.Append(t); } };
-                    Action<string> onToolCall = delegate(string name)
+                    // argsJson is threaded through for files__edit, which renders a collapsible diff
+                    // record instead of the generic "using" marker (wired in a following change).
+                    Action<string, string> onToolCall = delegate(string name, string argsJson)
                     {
                         lock (sbLock)
                         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -440,6 +440,7 @@ namespace GxPT
             try
             {
                 _approvalPanel = new ToolApprovalPanel();
+                _approvalPanel.WorkingDirProvider = delegate { return _mcpHost != null ? _mcpHost.ActiveWorkingDir : null; };
                 if (this.pnlBottom != null) this.pnlBottom.Controls.Add(_approvalPanel);
                 // Remembered approvals are kept only for the lifetime of the app (in-memory), not
                 // persisted to settings.json — a remembered choice lasts the session, then resets.

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1475,10 +1475,14 @@ namespace GxPT
                     // record instead of the generic "using" marker (wired in a following change).
                     Action<string, string> onToolCall = delegate(string name, string argsJson)
                     {
+                        // Register the diff (if an edit) before appending its sentinel, so the data is
+                        // present by the time the marker text renders. Live keys are per-call GUIDs
+                        // (ephemeral — the reloaded view re-derives under the persisted call id).
+                        string marker = EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
                         lock (sbLock)
                         {
                             if (activitySb.Length > 0) activitySb.Append("\r\n");
-                            activitySb.Append(McpMarkers.Call(name));
+                            activitySb.Append(marker);
                         }
                     };
                     Action onComplete = delegate
@@ -2171,6 +2175,29 @@ namespace GxPT
             }
         }
 
+        // Activity marker for a tool call. For files__edit, derive a line diff from the (persisted)
+        // arguments, register it with the transcript under a stable key, and return the collapsible
+        // edit-diff sentinel in place of the generic "using" marker. Any failure falls back to the
+        // generic marker so a malformed/edge-case call still renders.
+        private static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
+        {
+            if (string.Equals(name, "files__edit", StringComparison.Ordinal) && transcript != null && !string.IsNullOrEmpty(key))
+            {
+                try
+                {
+                    var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
+                    string path = (string)args["path"] ?? string.Empty;
+                    string oldS = (string)args["old_string"] ?? string.Empty;
+                    string newS = (string)args["new_string"] ?? string.Empty;
+                    LineDiffResult diff = DiffUtil.BuildLineDiff(oldS, newS);
+                    transcript.RegisterEditDiff(key, path, diff.Body, diff.Added, diff.Removed);
+                    return McpMarkers.EditDiff(key);
+                }
+                catch { /* fall through to the generic marker */ }
+            }
+            return McpMarkers.Call(name);
+        }
+
         private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)
         {
             if (ctx == null || ctx.Transcript == null || convo == null) return;
@@ -2216,7 +2243,8 @@ namespace GxPT
                             var tc = m.ToolCalls[ti];
                             if (tc == null) continue;
                             if (activity.Length > 0) activity.Append("\r\n");
-                            activity.Append(McpMarkers.Call(tc.Name));
+                            string key = !string.IsNullOrEmpty(tc.Id) ? tc.Id : ("edit" + ti);
+                            activity.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
                         }
                     }
                     else

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -107,6 +107,7 @@
       <DependentUpon>FileViewerForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Services\AttachmentService.cs" />
+    <Compile Include="Services\DiffUtil.cs" />
     <Compile Include="Services\DocxAttachmentExtractor.cs" />
     <Compile Include="Services\HoverWheelRouter.cs" />
     <Compile Include="Managers\InputManager.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -95,6 +95,9 @@
     <Compile Include="Controls\ChatTranscriptControl.Designer.cs">
       <DependentUpon>ChatTranscriptControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\DiffPreviewPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Managers\ImportExportManager.cs" />
     <Compile Include="Services\AppSettings.cs" />
     <Compile Include="Models\ChatModels.cs" />

--- a/GxPT/Services/DiffUtil.cs
+++ b/GxPT/Services/DiffUtil.cs
@@ -46,6 +46,65 @@ namespace GxPT
             return Render(a, b, ops);
         }
 
+        /// <summary>
+        /// Like <see cref="BuildLineDiff"/> but surrounds the change with up to <paramref name="contextLines"/>
+        /// lines of real file context (for the approval prompt). Locates old_string in the file, expands to
+        /// full-line boundaries N lines out each way, and diffs the context-wrapped old/new blocks so the
+        /// surrounding lines render as context. Falls back to a bare old/new diff if the file text is
+        /// unavailable or old_string isn't found verbatim.
+        /// </summary>
+        public static LineDiffResult BuildLineDiffWithContext(string fileText, string oldText, string newText, int contextLines)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(fileText) || string.IsNullOrEmpty(oldText) || contextLines <= 0)
+                    return BuildLineDiff(oldText, newText);
+                int idx = fileText.IndexOf(oldText, StringComparison.Ordinal);
+                if (idx < 0) return BuildLineDiff(oldText, newText);
+                int endIdx = idx + oldText.Length;
+
+                int ctxStart = LineStartNAbove(fileText, idx, contextLines);
+                int ctxEnd = LineEndNBelow(fileText, endIdx, contextLines);
+
+                string before = fileText.Substring(ctxStart, idx - ctxStart);
+                string after = fileText.Substring(endIdx, ctxEnd - endIdx);
+                return BuildLineDiff(before + oldText + after, before + newText + after);
+            }
+            catch
+            {
+                return BuildLineDiff(oldText, newText);
+            }
+        }
+
+        // Char index of the start of the line that is `n` lines above the line containing `pos`.
+        private static int LineStartNAbove(string s, int pos, int n)
+        {
+            int p = pos < 0 ? 0 : (pos > s.Length ? s.Length : pos);
+            while (p > 0 && s[p - 1] != '\n') p--; // start of the line containing pos
+            for (int k = 0; k < n && p > 0; k++)
+            {
+                int prevStart = p - 1;               // the '\n' ending the previous line
+                while (prevStart > 0 && s[prevStart - 1] != '\n') prevStart--;
+                p = prevStart;
+            }
+            return p;
+        }
+
+        // Char index of the end (exclusive of the trailing '\n') of the line `n` lines below the line
+        // containing `pos`.
+        private static int LineEndNBelow(string s, int pos, int n)
+        {
+            int p = pos < 0 ? 0 : (pos > s.Length ? s.Length : pos);
+            while (p < s.Length && s[p] != '\n') p++;  // end of the line containing pos
+            for (int k = 0; k < n && p < s.Length; k++)
+            {
+                int nextEnd = p + 1;                  // start of the next line
+                while (nextEnd < s.Length && s[nextEnd] != '\n') nextEnd++;
+                p = nextEnd;
+            }
+            return p;
+        }
+
         // ---- line splitting ----
 
         // Split into lines on '\n', dropping a trailing '\r' (so "\r\n" and "\n" compare equal) and a

--- a/GxPT/Services/DiffUtil.cs
+++ b/GxPT/Services/DiffUtil.cs
@@ -1,0 +1,166 @@
+// DiffUtil.cs
+// Line-level text diff for the edit-tool diff views (approval dialog + transcript history).
+// Target: .NET 3.5, Windows XP compatible (no external deps).
+//
+// Produces a unified-diff BODY (no ---/+++/@@ file headers; the UI supplies its own path header):
+// each output line is prefixed with ' ' (context / unchanged), '-' (removed) or '+' (added), so it
+// renders directly through the existing "diff" syntax highlighter (DiffHighlighter + the
+// Addition/Deletion/Normal token colors and background bands).
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GxPT
+{
+    /// <summary>Result of a line-level diff: the prefixed body plus added/removed line counts.</summary>
+    internal sealed class LineDiffResult
+    {
+        public string Body;     // ' '/'-'/'+' prefixed lines joined by '\n' (no trailing newline)
+        public int Added;       // number of '+' lines
+        public int Removed;     // number of '-' lines
+    }
+
+    internal static class DiffUtil
+    {
+        // Cap on the LCS table size (rows * cols). Edit spans are small in practice; beyond this we
+        // fall back to a naive "remove all old, add all new" diff rather than allocate a huge table.
+        private const int MaxLcsCells = 4000000; // ~2000 x 2000 lines
+
+        /// <summary>
+        /// Build a line-level diff body from two text spans (e.g. an edit's old_string / new_string).
+        /// Common lines render as context; only genuine changes get '-'/'+'. Within a change region
+        /// removals are listed before additions (the familiar git-diff grouping).
+        /// </summary>
+        public static LineDiffResult BuildLineDiff(string oldText, string newText)
+        {
+            string[] a = SplitLines(oldText);
+            string[] b = SplitLines(newText);
+
+            List<int> ops; // see EmitOps: 0 = context(a&b), -1 = delete(a), +1 = insert(b)
+            if ((long)a.Length * b.Length > MaxLcsCells)
+                ops = NaiveOps(a.Length, b.Length);
+            else
+                ops = LcsOps(a, b);
+
+            return Render(a, b, ops);
+        }
+
+        // ---- line splitting ----
+
+        // Split into lines on '\n', dropping a trailing '\r' (so "\r\n" and "\n" compare equal) and a
+        // single trailing empty line caused by a final newline. Empty/null input yields no lines.
+        private static string[] SplitLines(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return new string[0];
+            string[] raw = s.Split('\n');
+            int count = raw.Length;
+            if (count > 0 && raw[count - 1].Length == 0) count--; // drop trailing "" from a final '\n'
+
+            string[] outArr = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                string line = raw[i];
+                if (line.Length > 0 && line[line.Length - 1] == '\r')
+                    line = line.Substring(0, line.Length - 1);
+                outArr[i] = line;
+            }
+            return outArr;
+        }
+
+        // ---- diff core ----
+
+        // Classic LCS over lines, then a backtrack into an op list (-1 delete a[x], +1 insert b[y],
+        // 0 keep both). Ordinal comparison.
+        private static List<int> LcsOps(string[] a, string[] b)
+        {
+            int n = a.Length, m = b.Length;
+            // lcs[i,j] = length of LCS of a[i..] and b[j..]
+            int[,] lcs = new int[n + 1, m + 1];
+            for (int i = n - 1; i >= 0; i--)
+            {
+                for (int j = m - 1; j >= 0; j--)
+                {
+                    if (string.Equals(a[i], b[j], StringComparison.Ordinal))
+                        lcs[i, j] = lcs[i + 1, j + 1] + 1;
+                    else
+                        lcs[i, j] = lcs[i + 1, j] >= lcs[i, j + 1] ? lcs[i + 1, j] : lcs[i, j + 1];
+                }
+            }
+
+            List<int> ops = new List<int>(n + m);
+            int x = 0, y = 0;
+            while (x < n && y < m)
+            {
+                if (string.Equals(a[x], b[y], StringComparison.Ordinal)) { ops.Add(0); x++; y++; }
+                else if (lcs[x + 1, y] >= lcs[x, y + 1]) { ops.Add(-1); x++; }
+                else { ops.Add(1); y++; }
+            }
+            while (x < n) { ops.Add(-1); x++; }
+            while (y < m) { ops.Add(1); y++; }
+            return ops;
+        }
+
+        // Fallback for pathologically large inputs: delete everything, then add everything.
+        private static List<int> NaiveOps(int n, int m)
+        {
+            List<int> ops = new List<int>(n + m);
+            for (int i = 0; i < n; i++) ops.Add(-1);
+            for (int j = 0; j < m; j++) ops.Add(1);
+            return ops;
+        }
+
+        // Render ops into prefixed text. Buffer consecutive deletes/inserts and flush as all '-' then
+        // all '+' so a replaced block reads like a git diff rather than interleaving line by line.
+        private static LineDiffResult Render(string[] a, string[] b, List<int> ops)
+        {
+            StringBuilder sb = new StringBuilder();
+            List<string> pendingDel = new List<string>();
+            List<string> pendingIns = new List<string>();
+            int added = 0, removed = 0;
+            int x = 0, y = 0;
+            bool first = true;
+
+            for (int k = 0; k < ops.Count; k++)
+            {
+                int op = ops[k];
+                if (op == 0)
+                {
+                    FlushChange(sb, pendingDel, pendingIns, ref first);
+                    AppendLine(sb, " ", a[x], ref first);
+                    x++; y++;
+                }
+                else if (op == -1)
+                {
+                    pendingDel.Add(a[x]); x++; removed++;
+                }
+                else
+                {
+                    pendingIns.Add(b[y]); y++; added++;
+                }
+            }
+            FlushChange(sb, pendingDel, pendingIns, ref first);
+
+            LineDiffResult r = new LineDiffResult();
+            r.Body = sb.ToString();
+            r.Added = added;
+            r.Removed = removed;
+            return r;
+        }
+
+        private static void FlushChange(StringBuilder sb, List<string> del, List<string> ins, ref bool first)
+        {
+            for (int i = 0; i < del.Count; i++) AppendLine(sb, "-", del[i], ref first);
+            for (int i = 0; i < ins.Count; i++) AppendLine(sb, "+", ins[i], ref first);
+            del.Clear();
+            ins.Clear();
+        }
+
+        private static void AppendLine(StringBuilder sb, string prefix, string text, ref bool first)
+        {
+            if (!first) sb.Append('\n');
+            sb.Append(prefix).Append(text);
+            first = false;
+        }
+    }
+}

--- a/GxPT/Services/MarkdownParser.cs
+++ b/GxPT/Services/MarkdownParser.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 namespace GxPT
 {
     // ---------- Markdown model ----------
-    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table }
+    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table, EditDiff }
 
     [Flags]
     public enum RunStyle { Normal = 0, Bold = 1, Italic = 2, Code = 4, Link = 8 }
@@ -34,6 +34,16 @@ namespace GxPT
     {
         public string Text;
         public string Language; // Language for syntax highlighting
+    }
+
+    // A bespoke, chromeless, collapsible edit-diff record (files__edit). Carries only a stable key;
+    // the {path, diff body, +/- counts, collapse state} are looked up at render time from the
+    // transcript control's side map (the diff is derived from the persisted tool-call arguments, so
+    // nothing diff-specific is stored in the conversation document). Anchored in the markdown by a
+    // content-free sentinel line — see EditDiffSentinel/TryParseEditDiffKey.
+    public sealed class EditDiffBlock : Block
+    {
+        public string Key;
     }
 
     public sealed class BulletListBlock : Block
@@ -73,6 +83,32 @@ namespace GxPT
 
     public static class MarkdownParser
     {
+        // ---------- Edit-diff sentinel ----------
+        // A content-free anchor line emitted in place of the generic "using files / edit" marker.
+        // Uses mathematical white square brackets (U+27E6/U+27E7) so it can't collide with model text
+        // or ordinary markdown. The transcript control resolves the key to the actual diff record.
+        public const string EditDiffOpen = "⟦editdiff:";
+        public const string EditDiffClose = "⟧";
+
+        public static string EditDiffSentinel(string key)
+        {
+            return EditDiffOpen + (key ?? string.Empty) + EditDiffClose;
+        }
+
+        public static bool TryParseEditDiffKey(string line, out string key)
+        {
+            key = null;
+            if (line == null) return false;
+            string t = line.Trim();
+            if (!t.StartsWith(EditDiffOpen, StringComparison.Ordinal) ||
+                !t.EndsWith(EditDiffClose, StringComparison.Ordinal)) return false;
+            int start = EditDiffOpen.Length;
+            int len = t.Length - start - EditDiffClose.Length;
+            if (len <= 0) return false;
+            key = t.Substring(start, len);
+            return true;
+        }
+
         // ---------- Public API ----------
         public static List<Block> ParseMarkdown(string md)
         {
@@ -189,6 +225,17 @@ namespace GxPT
                     flushParagraph();
                     flushBullets();
                     flushNumbered();
+                    continue;
+                }
+
+                // edit-diff sentinel → its own bespoke block (content looked up at render time)
+                string editDiffKey;
+                if (TryParseEditDiffKey(line, out editDiffKey))
+                {
+                    flushParagraph();
+                    flushBullets();
+                    flushNumbered();
+                    blocks.Add(new EditDiffBlock { Type = BlockType.EditDiff, Key = editDiffKey });
                     continue;
                 }
 

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -17,6 +17,13 @@ namespace GxPT
         {
             return "_using " + Display(functionName) + "_";
         }
+
+        // For files__edit, the generic "using" marker is replaced by a collapsible diff record,
+        // anchored by this content-free sentinel line (resolved to the diff by the transcript).
+        public static string EditDiff(string key)
+        {
+            return MarkdownParser.EditDiffSentinel(key);
+        }
     }
 
     // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can render a tool-call
@@ -26,11 +33,11 @@ namespace GxPT
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
-        private readonly Action<string> _onToolCall;
+        private readonly Action<string, string> _onToolCall; // (functionName, argumentsJson)
         private readonly Action _complete;
         private readonly Action<string> _error;
 
-        public DelegateToolLoopUi(Action<string> appendText, Action<string> onToolCall, Action complete, Action<string> error)
+        public DelegateToolLoopUi(Action<string> appendText, Action<string, string> onToolCall, Action complete, Action<string> error)
         {
             _appendText = appendText;
             _onToolCall = onToolCall;
@@ -45,7 +52,7 @@ namespace GxPT
 
         public void OnToolCall(string functionName, string argumentsJson)
         {
-            if (_onToolCall != null) _onToolCall(functionName);
+            if (_onToolCall != null) _onToolCall(functionName, argumentsJson);
         }
 
         public void OnToolResult(string functionName, string resultText, bool isError)


### PR DESCRIPTION
## Summary

Adds **diffs for the edit tool** in two places, derived from the edit's `old_string`/`new_string`:

1. **Transcript history** — when a `files__edit` runs, it renders as a **chromeless, collapsible diff record** (`▸ edited <path>  (+N −M)`) in place of the generic "using files / edit" marker. Collapsed by default; expands to a red/green diff on a neutral code-block backing.
2. **Approval prompt** — a pending `files__edit` shows a **colored diff with a path header and a few lines of live file context**, replacing the raw JSON arguments.

Both reuse the `diff` syntax highlighter (from the earlier diff-highlighter work). The diff is **derived from the persisted tool-call arguments at render time**, so nothing diff-specific is stored in the conversation document — the file format is unchanged.

## Pieces

- **`DiffUtil`** — line-level LCS diff (git-style grouping; CRLF≡LF; large-input fallback). `BuildLineDiffWithContext` wraps the change in real file context for the approval prompt.
- **`MarkdownParser`** — `EditDiffBlock` + a content-free `⟦editdiff:KEY⟧` sentinel (can't collide with model text/markdown); the diff `{path, body, +/−}` is looked up at render time from a side map keyed by the (persisted) tool-call id.
- **`ChatTranscriptControl`** — owner-drawn collapsible record: measure/paint/hit-test, click-to-toggle (collapsed by default, state survives re-parse), neutral code-block backing behind the body, and a **self-contained horizontal scrollbar** for wide diffs (thumb drag, track-jump, and shift+wheel — kept isolated from the code/table scroll machinery).
- **`DiffPreviewPanel`** — auto-scrolling owner-drawn control for the approval prompt's diff.
- **`ToolApprovalPanel`** — swaps the JSON `TextBox` for the diff panel on `files__edit` (sandbox-contained file read via an injected workdir provider, graceful no-context fallback).
- Threads the tool call's `argumentsJson` (and registers the diff) through both the live and reload paths.

## Notes

- The diff highlighter (already on `main`) is untouched here; the neutral body backing is applied only in the bespoke record, so ` ```diff ` fenced blocks are unaffected.
- New files registered in the non-SDK `GxPT.csproj`.

## Verification

Built and exercised on Windows by the author across this branch: the collapsible record (collapse/expand, neutral backing color iterated to the code-block background), the approval-prompt diff, and the horizontal scroll (thumb drag, track-jump, and shift+wheel in both the focused and hover wheel paths). `DiffUtil`'s algorithm was validated standalone (replace/insert/delete/block/CRLF/mid-span). The GxPT app is a legacy v3.5 WinExe (Windows/MSBuild only), so it isn't built by the Linux session.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_