### PR TITLE
Fix conversation naming: replace retired model with google/gemma-4-26b-a4b-it

### DIFF
--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -79,7 +79,7 @@ namespace GxPT
                     }
 
                     string json = _client.CreateCompletion(
-                        "google/gemini-2.0-flash-001",
+                        "google/gemma-4-26b-a4b-it",
                         msgs,
                         new ClientProperties { Stream = false, ProviderDataCollectionAllowed = providerAllow }
                     );


### PR DESCRIPTION
## Summary

`google/gemini-2.0-flash-001` — the model used for **automatic conversation title generation** — was retired upstream (OpenRouter/Google), which silently broke naming (the naming call is wrapped in a `try/catch`, so failures just left conversations unnamed).

Replaces it with **`google/gemma-4-26b-a4b-it`**.

## Change

One line in `Conversation.cs` (the `_client.CreateCompletion(...)` call in the background naming task). It's the only reference to the old id; the `gemini-2.5-*` entries elsewhere are user-selectable *chat* models and are unaffected.

```diff
-                        "google/gemini-2.0-flash-001",
+                        "google/gemma-4-26b-a4b-it",
```

Naming is a non-streaming, side-thread call; no other behavior changes.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_