### PR TITLE
Command-run records: syntax-highlighted command in approval + collapsible history

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -241,20 +241,37 @@ namespace GxPT
             if (!string.IsNullOrEmpty(key)) _editDiffScroll[key] = Math.Max(0, v);
         }
 
-        private sealed class EditDiffData { public string Path; public string Body; public int Added; public int Removed; }
+        // A collapsible "tool record": a header label plus a highlighted body in some language.
+        // Used for the files__edit diff (language "diff", red/green bands) and the command__run
+        // record (language "batch"). HeaderText excludes the disclosure triangle (added at draw time).
+        private sealed class EditDiffData { public string HeaderText; public string Body; public string Language; }
         private readonly object _editDiffLock = new object();
         private readonly Dictionary<string, EditDiffData> _editDiffs = new Dictionary<string, EditDiffData>(StringComparer.Ordinal);
         private readonly Dictionary<string, bool> _editDiffCollapsed = new Dictionary<string, bool>(StringComparer.Ordinal);
 
-        // Registers (or refreshes) the diff for one edit tool call, keyed by its (persisted) call id.
-        // Called from the streaming worker thread and the history reload path, so it is lock-guarded.
-        public void RegisterEditDiff(string key, string path, string body, int added, int removed)
+        // Registers (or refreshes) a tool record, keyed by its (persisted) call id. Called from the
+        // streaming worker thread and the history reload path, so it is lock-guarded.
+        private void RegisterToolRecord(string key, string headerText, string body, string language)
         {
             if (string.IsNullOrEmpty(key)) return;
             lock (_editDiffLock)
             {
-                _editDiffs[key] = new EditDiffData { Path = path ?? string.Empty, Body = body ?? string.Empty, Added = added, Removed = removed };
+                _editDiffs[key] = new EditDiffData { HeaderText = headerText ?? string.Empty, Body = body ?? string.Empty, Language = language ?? "diff" };
             }
+        }
+
+        // Edit (files__edit): a "diff"-highlighted body with an "edited <path> (+A −R)" header.
+        public void RegisterEditDiff(string key, string path, string body, int added, int removed)
+        {
+            string p = string.IsNullOrEmpty(path) ? "(file)" : path;
+            string header = "edited " + p + "  (+" + added + " −" + removed + ")";
+            RegisterToolRecord(key, header, body, "diff");
+        }
+
+        // Command (command__run): the command line, highlighted as a cmd batch script.
+        public void RegisterCommandRun(string key, string command)
+        {
+            RegisterToolRecord(key, "Ran a command", command, "batch");
         }
 
         private EditDiffData GetEditDiffData(string key)
@@ -270,14 +287,12 @@ namespace GxPT
             bool c; return _editDiffCollapsed.TryGetValue(key, out c) ? c : true;
         }
 
-        // The header line, e.g. "▸ edited src/main.py  (+3 −1)" (collapsed) / "▾ …" (expanded).
+        // The header line: disclosure triangle + the record's stored label.
         private static string BuildEditDiffHeaderText(EditDiffData data, bool collapsed)
         {
             string tri = collapsed ? "▸" : "▾";
-            string path = (data != null && !string.IsNullOrEmpty(data.Path)) ? data.Path : "(file)";
-            int add = data != null ? data.Added : 0;
-            int rem = data != null ? data.Removed : 0;
-            return tri + " edited " + path + "  (+" + add + " −" + rem + ")";
+            string label = (data != null && !string.IsNullOrEmpty(data.HeaderText)) ? data.HeaderText : "(record)";
+            return tri + " " + label;
         }
 
         // ---------- Batch update state ----------
@@ -1022,8 +1037,8 @@ namespace GxPT
                         {
                             using (Graphics g = CreateGraphics())
                             {
-                                SyntaxHighlightingRenderer.EnqueueHighlight("diff", _isDarkTheme, data.Body, _monoFont);
-                                var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
+                                SyntaxHighlightingRenderer.EnqueueHighlight(data.Language, _isDarkTheme, data.Body, _monoFont);
+                                var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, data.Language, _monoFont, _isDarkTheme);
                                 Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                                 int bodyH = Math.Max(_monoFont.Height, content.Height);
                                 bool needH = content.Width > maxWidth + EditDiffScrollSlack;
@@ -1534,8 +1549,8 @@ namespace GxPT
                     if (data != null && !collapsed)
                     {
                         y += EditDiffBodyGap;
-                        SyntaxHighlightingRenderer.EnqueueHighlight("diff", _isDarkTheme, data.Body, _monoFont);
-                        var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, "diff", _monoFont, _isDarkTheme);
+                        SyntaxHighlightingRenderer.EnqueueHighlight(data.Language, _isDarkTheme, data.Body, _monoFont);
+                        var colored = SyntaxHighlightingRenderer.GetColoredSegments(data.Body, data.Language, _monoFont, _isDarkTheme);
                         Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                         int bodyH = Math.Max(_monoFont.Height, content.Height);
                         int viewportW = maxWidth;

--- a/GxPT/Controls/DiffPreviewPanel.cs
+++ b/GxPT/Controls/DiffPreviewPanel.cs
@@ -1,7 +1,7 @@
 // DiffPreviewPanel.cs
-// Owner-drawn, auto-scrolling panel that renders a unified-diff body (via the "diff" syntax
-// highlighter) with a path header. Used by the tool approval prompt to show a files__edit change
-// instead of raw JSON. AutoScroll handles both tall and wide diffs.
+// Owner-drawn, auto-scrolling panel that renders a syntax-highlighted body (any registered language)
+// with an optional header line. Used by the tool approval prompt to show a files__edit diff or a
+// command__run command line instead of raw JSON. AutoScroll handles both tall and wide content.
 // Target: .NET 3.5, Windows XP compatible.
 
 using System;
@@ -12,8 +12,9 @@ namespace GxPT
 {
     internal sealed class DiffPreviewPanel : Panel
     {
-        private string _path = string.Empty;
+        private string _header = string.Empty;
         private string _body = string.Empty;
+        private string _language = "diff";
         private bool _dark;
         private Font _monoFont;
         private Color _codeBack = Color.FromArgb(245, 245, 245);
@@ -30,11 +31,14 @@ namespace GxPT
             catch { }
         }
 
-        // Set the diff to display. monoFont is owned by the caller; colors come from the active theme.
-        public void SetDiff(string path, string body, bool dark, Font monoFont, Color codeBack, Color foreColor)
+        // Set the content to display. monoFont is owned by the caller; colors come from the active
+        // theme. An empty header omits the header line. language is any registered highlighter id
+        // (e.g. "diff" for an edit, "batch" for a command).
+        public void SetContent(string header, string body, string language, bool dark, Font monoFont, Color codeBack, Color foreColor)
         {
-            _path = path ?? string.Empty;
+            _header = header ?? string.Empty;
             _body = body ?? string.Empty;
+            _language = string.IsNullOrEmpty(language) ? "diff" : language;
             _dark = dark;
             _monoFont = monoFont;
             _codeBack = codeBack;
@@ -47,7 +51,7 @@ namespace GxPT
 
         private int HeaderHeight
         {
-            get { return (this.Font != null ? this.Font.Height : 14) + Pad; }
+            get { return string.IsNullOrEmpty(_header) ? 0 : (this.Font != null ? this.Font.Height : 14) + Pad; }
         }
 
         private void UpdateScrollSize()
@@ -57,7 +61,7 @@ namespace GxPT
             {
                 using (Graphics g = CreateGraphics())
                 {
-                    var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, "diff", _monoFont, _dark);
+                    var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, _language, _monoFont, _dark);
                     Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
                     int w = content.Width + 2 * Pad;
                     int h = HeaderHeight + Math.Max(_monoFont.Height, content.Height) + Pad;
@@ -78,16 +82,19 @@ namespace GxPT
             // Draw everything in content coordinates; AutoScroll moves the world for both axes.
             g.TranslateTransform(this.AutoScrollPosition.X, this.AutoScrollPosition.Y);
 
-            // Path header (the change is still pending here, so just the path — no tense)
-            Font hf = this.Font ?? _monoFont;
-            using (var br = new SolidBrush(_foreColor))
-                g.DrawString(_path, hf, br, new PointF(Pad, Pad / 2f));
+            // Optional header line
+            if (!string.IsNullOrEmpty(_header))
+            {
+                Font hf = this.Font ?? _monoFont;
+                using (var br = new SolidBrush(_foreColor))
+                    g.DrawString(_header, hf, br, new PointF(Pad, Pad / 2f));
+            }
 
             if (string.IsNullOrEmpty(_body)) return;
 
-            // Diff body
-            SyntaxHighlightingRenderer.EnqueueHighlight("diff", _dark, _body, _monoFont);
-            var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, "diff", _monoFont, _dark);
+            // Highlighted body
+            SyntaxHighlightingRenderer.EnqueueHighlight(_language, _dark, _body, _monoFont);
+            var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, _language, _monoFont, _dark);
             Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
             int bodyH = Math.Max(_monoFont.Height, content.Height);
             int bodyW = Math.Max(content.Width, this.ClientSize.Width - 2 * Pad);

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -95,17 +95,11 @@ namespace GxPT
             _tierBadge.ForeColor = (tier == ToolTier.Destructive) ? Color.Firebrick
                                   : (tier == ToolTier.Write ? Color.DarkGoldenrod : Color.ForestGreen);
 
-            // files__edit: show a colored diff (with a little live file context) instead of raw JSON.
-            bool isEdit = string.Equals(req.FunctionName, "files__edit", StringComparison.Ordinal) && req.Arguments != null;
-            if (isEdit)
+            // files__edit -> a colored diff (with a little live file context); command__run -> the
+            // command line, syntax-highlighted. Either replaces the raw JSON preview.
+            bool handled = false;
+            if (req.Arguments != null)
             {
-                string path = req.Arguments.Value<string>("path") ?? string.Empty;
-                string oldS = req.Arguments.Value<string>("old_string") ?? string.Empty;
-                string newS = req.Arguments.Value<string>("new_string") ?? string.Empty;
-                string workdir = WorkingDirProvider != null ? WorkingDirProvider() : null;
-                string fileText = ReadWorkspaceFile(workdir, path);
-                LineDiffResult diff = DiffUtil.BuildLineDiffWithContext(fileText, oldS, newS, 3);
-
                 bool dark = false;
                 try
                 {
@@ -115,8 +109,32 @@ namespace GxPT
                 catch { }
                 ThemeColors tc = ThemeService.GetColors(dark);
 
-                _diffPanel.SetDiff(path, diff.Body, dark, _monoFont, tc.CodeBack, tc.UiForeground);
-                _previewLabel.Text = "Diff:";
+                if (string.Equals(req.FunctionName, "files__edit", StringComparison.Ordinal))
+                {
+                    string path = req.Arguments.Value<string>("path") ?? string.Empty;
+                    string oldS = req.Arguments.Value<string>("old_string") ?? string.Empty;
+                    string newS = req.Arguments.Value<string>("new_string") ?? string.Empty;
+                    string workdir = WorkingDirProvider != null ? WorkingDirProvider() : null;
+                    string fileText = ReadWorkspaceFile(workdir, path);
+                    LineDiffResult diff = DiffUtil.BuildLineDiffWithContext(fileText, oldS, newS, 3);
+                    _diffPanel.SetContent(path, diff.Body, "diff", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                    _previewLabel.Text = "Diff:";
+                    handled = true;
+                }
+                else if (string.Equals(req.FunctionName, "command__run", StringComparison.Ordinal))
+                {
+                    string cmd = req.Arguments.Value<string>("command") ?? string.Empty;
+                    if (cmd.Trim().Length > 0)
+                    {
+                        _diffPanel.SetContent(string.Empty, cmd, "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _previewLabel.Text = "Command:";
+                        handled = true;
+                    }
+                }
+            }
+
+            if (handled)
+            {
                 _preview.Visible = false;
                 _diffPanel.Visible = true;
                 this.Height = 260;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2176,25 +2176,41 @@ namespace GxPT
             }
         }
 
-        // Activity marker for a tool call. For files__edit, derive a line diff from the (persisted)
-        // arguments, register it with the transcript under a stable key, and return the collapsible
-        // edit-diff sentinel in place of the generic "using" marker. Any failure falls back to the
-        // generic marker so a malformed/edge-case call still renders.
+        // Activity marker for a tool call. For files__edit and command__run, register a collapsible
+        // record with the transcript under a stable key and return its sentinel in place of the generic
+        // "using" marker. Any failure falls back to the generic marker so an edge-case call still renders.
         private static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
         {
-            if (string.Equals(name, "files__edit", StringComparison.Ordinal) && transcript != null && !string.IsNullOrEmpty(key))
+            if (transcript != null && !string.IsNullOrEmpty(key))
             {
-                try
+                if (string.Equals(name, "files__edit", StringComparison.Ordinal))
                 {
-                    var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
-                    string path = (string)args["path"] ?? string.Empty;
-                    string oldS = (string)args["old_string"] ?? string.Empty;
-                    string newS = (string)args["new_string"] ?? string.Empty;
-                    LineDiffResult diff = DiffUtil.BuildLineDiff(oldS, newS);
-                    transcript.RegisterEditDiff(key, path, diff.Body, diff.Added, diff.Removed);
-                    return McpMarkers.EditDiff(key);
+                    try
+                    {
+                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
+                        string path = (string)args["path"] ?? string.Empty;
+                        string oldS = (string)args["old_string"] ?? string.Empty;
+                        string newS = (string)args["new_string"] ?? string.Empty;
+                        LineDiffResult diff = DiffUtil.BuildLineDiff(oldS, newS);
+                        transcript.RegisterEditDiff(key, path, diff.Body, diff.Added, diff.Removed);
+                        return McpMarkers.EditDiff(key);
+                    }
+                    catch { /* fall through to the generic marker */ }
                 }
-                catch { /* fall through to the generic marker */ }
+                else if (string.Equals(name, "command__run", StringComparison.Ordinal))
+                {
+                    try
+                    {
+                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
+                        string cmd = (string)args["command"] ?? string.Empty;
+                        if (cmd.Trim().Length > 0)
+                        {
+                            transcript.RegisterCommandRun(key, cmd);
+                            return McpMarkers.EditDiff(key);
+                        }
+                    }
+                    catch { /* fall through to the generic marker */ }
+                }
             }
             return McpMarkers.Call(name);
         }

--- a/GxPT/Highlighting/LanguageHighlighters.cs
+++ b/GxPT/Highlighting/LanguageHighlighters.cs
@@ -497,17 +497,26 @@ namespace GxPT
                 // Labels: :label at line start
                 new TokenPattern(@"^\s*:[A-Za-z_][A-Za-z0-9_\-.]*", TokenType.Type, 5),
 
-                // Numbers
-                new TokenPattern(@"\b\d+\b", TokenType.Number, 6),
+                // Primary command: the first token of the line, or of each &&/||/|/&/( -separated
+                // command (optionally after a leading @). Colors e.g. "git", "npm", "echo" — whether
+                // or not it's a known batch keyword — so the invoked program always stands out.
+                new TokenPattern(@"(?<=(?:^|&&|\|\||\||&|\()[ \t]*@?)[A-Za-z_][A-Za-z0-9_.\-]*", TokenType.Keyword, 6),
 
-                // Keywords and common commands
-                new TokenPattern(@"\b(?:if|else|not|exist|defined|errorlevel|equ|neq|lss|leq|gtr|geq|for|in|do|call|goto|shift|set|setlocal|endlocal|echo|type|copy|move|ren|del|erase|mkdir|rmdir|rd|dir|pause|choice|start|exit|color|title|cls|pushd|popd|path|prompt|assoc|ftype)\b", TokenType.Keyword, 7),
+                // Flags / switches: --flag, -f, /s, /?. Each must be preceded by whitespace so that
+                // path/ref slashes (e.g. origin/claude) and hyphens inside words are not mis-flagged.
+                new TokenPattern(@"(?<=\s)(?:--?[A-Za-z][A-Za-z0-9\-]*|/[A-Za-z?][A-Za-z0-9\-]*)", TokenType.Method, 7),
+
+                // Numbers
+                new TokenPattern(@"\b\d+\b", TokenType.Number, 8),
+
+                // Keywords and common commands (for ones not in command position, e.g. in/do/exist)
+                new TokenPattern(@"\b(?:if|else|not|exist|defined|errorlevel|equ|neq|lss|leq|gtr|geq|for|in|do|call|goto|shift|set|setlocal|endlocal|echo|type|copy|move|ren|del|erase|mkdir|rmdir|rd|dir|pause|choice|start|exit|color|title|cls|pushd|popd|path|prompt|assoc|ftype)\b", TokenType.Keyword, 9),
 
                 // Operators and redirection
-                new TokenPattern(@"==|\|\||&&|\||>>|>|<|2>&1", TokenType.Operator, 8),
+                new TokenPattern(@"==|\|\||&&|\||>>|>|<|2>&1", TokenType.Operator, 10),
 
                 // Punctuation
-                new TokenPattern(@"[()\[\]{};,]", TokenType.Punctuation, 9)
+                new TokenPattern(@"[()\[\]{};,]", TokenType.Punctuation, 11)
             };
         }
     }

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -18,8 +18,8 @@ namespace GxPT
             return "_using " + Display(functionName) + "_";
         }
 
-        // For files__edit, the generic "using" marker is replaced by a collapsible diff record,
-        // anchored by this content-free sentinel line (resolved to the diff by the transcript).
+        // For files__edit / command__run, the generic "using" marker is replaced by a collapsible
+        // record, anchored by this content-free sentinel (resolved to the record by the transcript).
         public static string EditDiff(string key)
         {
             return MarkdownParser.EditDiffSentinel(key);


### PR DESCRIPTION
## Summary

Extends the edit-tool diff treatment to **`command__run`**:

1. **Approval prompt** — a pending command shows the **command line, syntax-highlighted** (cmd/batch), replacing the raw JSON (`Command:` label).
2. **Transcript history** — a command call renders as a **collapsible record** `▸ Ran a command` (collapsed by default) that expands to the syntax-highlighted command. Same chromeless look, code-block backing, and horizontal scrollbar as the edit-diff record.

## How

Rather than duplicate the (substantial) collapsible-record + scroll machinery, I **generalized** the edit-diff record into a generic **tool record** = *header label + highlighted body + language*:

- `RegisterEditDiff` keeps the diff behavior (language `diff`, `edited <path> (+A −R)` header, red/green bands).
- New `RegisterCommandRun` stores the command with header `Ran a command` and language `batch`.
- Measure/paint use the record's language, so the red/green bands stay **diff-only** while commands get normal syntax colors on the same neutral code-block backing — and the **horizontal scrollbar** works for long commands for free.
- `DiffPreviewPanel` (approval) generalized to `SetContent(header, body, language, …)`; the approval panel routes `files__edit` → diff and `command__run` → highlighted command.
- `MainForm`'s tool marker now also turns `command__run` into the collapsible record (live stream + history reload), in place of the generic `using command / run` marker.

Like the edit diffs, the history record is **derived from the persisted tool-call arguments** at render time — nothing new is stored in the conversation document.

## Notes / choices

- **Highlighter:** commands are highlighted as **`batch`** (cmd), matching the command server's cmd.exe execution. If you'd prefer `bash`, it's a one-word change.
- The internal sentinel/types still carry the historical `EditDiff` name (now a generic tool record) to avoid a large rename across the working scroll machinery; comments note the generalization.

## Verification

Needs a Windows build (legacy v3.5 WinExe; not buildable on the Linux session). Worth a look: the approval prompt for a command (highlighting + `Command:` label), and the history `▸ Ran a command` record collapsing/expanding with a long command scrolling horizontally.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_