### PR TITLE
Web search: collapsible history record + auto-allow web__search

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -274,6 +274,13 @@ namespace GxPT
             RegisterToolRecord(key, "Ran a command", command, "batch");
         }
 
+        // Web search (web__search): the query, plain — "text" has no highlighter, so it renders
+        // without syntax coloring.
+        public void RegisterWebSearch(string key, string query)
+        {
+            RegisterToolRecord(key, "Searched the web", query, "text");
+        }
+
         private EditDiffData GetEditDiffData(string key)
         {
             if (string.IsNullOrEmpty(key)) return null;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2211,6 +2211,20 @@ namespace GxPT
                     }
                     catch { /* fall through to the generic marker */ }
                 }
+                else if (string.Equals(name, "web__search", StringComparison.Ordinal))
+                {
+                    try
+                    {
+                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
+                        string query = (string)args["query"] ?? string.Empty;
+                        if (query.Trim().Length > 0)
+                        {
+                            transcript.RegisterWebSearch(key, query);
+                            return McpMarkers.EditDiff(key);
+                        }
+                    }
+                    catch { /* fall through to the generic marker */ }
+                }
             }
             return McpMarkers.Call(name);
         }

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -25,9 +25,23 @@ namespace GxPT
             _store = store != null ? store : new InMemoryApprovalStore();
         }
 
+        // Tools that never require approval (always allowed, no prompt). web__search is read-only and
+        // high-frequency, so prompting adds friction without meaningful risk; web__extract (which
+        // fetches arbitrary pages) deliberately stays gated.
+        private static readonly Dictionary<string, bool> _autoAllow = BuildAutoAllowSet();
+        private static Dictionary<string, bool> BuildAutoAllowSet()
+        {
+            var s = new Dictionary<string, bool>(StringComparer.Ordinal);
+            s["web__search"] = true;
+            return s;
+        }
+
         // The orchestrator calls this. functionName is the qualified name; args already parsed.
         public ApprovalDecision Check(string functionName, JObject args)
         {
+            if (functionName != null && _autoAllow.ContainsKey(functionName))
+                return ApprovalDecision.Allow;
+
             string server = ServerOf(functionName);
             bool firstParty = server != null && _firstPartyServers.ContainsKey(server);
             JObject annotations = null; // third-party annotations not yet plumbed; unknown -> Write/Tool


### PR DESCRIPTION
## Summary

1. **History** — a `web__search` call now renders as a collapsible **`▸ Searched the web`** record (collapsed by default) that expands to the **query, plain** (no syntax highlighting, no JSON), reusing the tool-record infrastructure from the edit/command work. Replaces the generic `using web / search` marker, in both the live stream and history reload.
2. **Approval** — **`web__search` is auto-allowed** (never prompts). It's read-only and high-frequency, so the gate was pure friction. **`web__extract` stays gated** (it fetches arbitrary pages).

## How

- `RegisterWebSearch(key, query)` feeds the generic tool record with language `"text"` — which has no registered highlighter, so the body renders as plain text.
- `MainForm`'s tool marker gets a `web__search` branch (parallel to `files__edit` / `command__run`).
- Auto-allow is an explicit always-allow set checked first in `ToolApprovalPolicy.Check` (just `web__search` today) — clean and discoverable, and it short-circuits before any prompt/store logic.

As with the other records, the history entry is derived from the persisted tool-call arguments at render time — nothing new is stored in the conversation document.

## Verification

Needs a Windows build (legacy v3.5 WinExe). Worth confirming: a search no longer shows an approval prompt, and the `▸ Searched the web` record expands to the query. `web__extract` should still prompt.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_