### PR TITLE
Make generic tool-use markers non-italic

### DIFF
--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -12,10 +12,11 @@ namespace GxPT
             return string.IsNullOrEmpty(functionName) ? string.Empty : functionName.Replace("__", " / ");
         }
 
-        // A compact, markdown-safe "using <tool>" marker (italic, no internal underscores).
+        // A compact "using <tool>" marker, plain (not italic) for consistency with the collapsible
+        // tool records. Display() turns the qualified name into "web / search" with no underscores.
         public static string Call(string functionName)
         {
-            return "_using " + Display(functionName) + "_";
+            return "using " + Display(functionName);
         }
 
         // For files__edit / command__run, the generic "using" marker is replaced by a collapsible


### PR DESCRIPTION
## Summary

The generic tool-activity marker (`using <server> / <tool>`, for tools without a specialized record — e.g. `files__read`, `git__status`, `web__extract`) was wrapped in markdown italics, while the collapsible tool records (`edited …`, `Ran a command`, `Searched the web`) render plain. Drop the italics so all tool-activity lines look consistent.

## Change

One line in `McpMarkers.Call`:

```diff
-            return "_using " + Display(functionName) + "_";
+            return "using " + Display(functionName);
```

`Display()` already converts the qualified name to `web / search` (no internal underscores), so the output is plain `using web / search`. All generic markers flow through `Call` (live stream, history reload, and the fallback in the record path), so this covers every case.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_