### PR TITLE
History records + approval previews for the remaining tools

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -242,8 +242,10 @@ namespace GxPT
         }
 
         // A collapsible "tool record": a header label plus a highlighted body in some language.
-        // Used for the files__edit diff (language "diff", red/green bands) and the command__run
-        // record (language "batch"). HeaderText excludes the disclosure triangle (added at draw time).
+        // Used for files__edit (diff), command__run (batch), web__search (plain), and the other tool
+        // records — the caller (MainForm) builds the label/body/language per tool. An empty body makes
+        // it a non-collapsible one-line label (e.g. "Deleted <path>"). HeaderText excludes the
+        // disclosure triangle (added at draw time when there is a body).
         private sealed class EditDiffData { public string HeaderText; public string Body; public string Language; }
         private readonly object _editDiffLock = new object();
         private readonly Dictionary<string, EditDiffData> _editDiffs = new Dictionary<string, EditDiffData>(StringComparer.Ordinal);
@@ -251,34 +253,13 @@ namespace GxPT
 
         // Registers (or refreshes) a tool record, keyed by its (persisted) call id. Called from the
         // streaming worker thread and the history reload path, so it is lock-guarded.
-        private void RegisterToolRecord(string key, string headerText, string body, string language)
+        public void RegisterToolRecord(string key, string headerText, string body, string language)
         {
             if (string.IsNullOrEmpty(key)) return;
             lock (_editDiffLock)
             {
-                _editDiffs[key] = new EditDiffData { HeaderText = headerText ?? string.Empty, Body = body ?? string.Empty, Language = language ?? "diff" };
+                _editDiffs[key] = new EditDiffData { HeaderText = headerText ?? string.Empty, Body = body ?? string.Empty, Language = language ?? "text" };
             }
-        }
-
-        // Edit (files__edit): a "diff"-highlighted body with an "edited <path> (+A −R)" header.
-        public void RegisterEditDiff(string key, string path, string body, int added, int removed)
-        {
-            string p = string.IsNullOrEmpty(path) ? "(file)" : path;
-            string header = "edited " + p + "  (+" + added + " −" + removed + ")";
-            RegisterToolRecord(key, header, body, "diff");
-        }
-
-        // Command (command__run): the command line, highlighted as a cmd batch script.
-        public void RegisterCommandRun(string key, string command)
-        {
-            RegisterToolRecord(key, "Ran a command", command, "batch");
-        }
-
-        // Web search (web__search): the query, plain — "text" has no highlighter, so it renders
-        // without syntax coloring.
-        public void RegisterWebSearch(string key, string query)
-        {
-            RegisterToolRecord(key, "Searched the web", query, "text");
         }
 
         private EditDiffData GetEditDiffData(string key)
@@ -294,12 +275,13 @@ namespace GxPT
             bool c; return _editDiffCollapsed.TryGetValue(key, out c) ? c : true;
         }
 
-        // The header line: disclosure triangle + the record's stored label.
-        private static string BuildEditDiffHeaderText(EditDiffData data, bool collapsed)
+        // The header line. With a body, a disclosure triangle precedes the label (collapsible);
+        // without a body it is a plain one-line label (e.g. "Deleted <path>").
+        private static string BuildEditDiffHeaderText(EditDiffData data, bool collapsed, bool hasBody)
         {
-            string tri = collapsed ? "▸" : "▾";
             string label = (data != null && !string.IsNullOrEmpty(data.HeaderText)) ? data.HeaderText : "(record)";
-            return tri + " " + label;
+            if (!hasBody) return label;
+            return (collapsed ? "▸" : "▾") + " " + label;
         }
 
         // ---------- Batch update state ----------
@@ -1034,13 +1016,14 @@ namespace GxPT
                     {
                         var ed = (EditDiffBlock)blk;
                         EditDiffData data = GetEditDiffData(ed.Key);
+                        bool hasBody = data != null && !string.IsNullOrEmpty(data.Body);
                         bool collapsed = IsEditDiffCollapsed(ed.Key);
                         int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
-                        string headerText = BuildEditDiffHeaderText(data, collapsed);
+                        string headerText = BuildEditDiffHeaderText(data, collapsed, hasBody);
                         int headerW = TextRenderer.MeasureText(headerText, _baseFont).Width;
                         int w = headerW;
                         int h = headerH;
-                        if (data != null && !collapsed)
+                        if (hasBody && !collapsed)
                         {
                             using (Graphics g = CreateGraphics())
                             {
@@ -1533,27 +1516,29 @@ namespace GxPT
                 {
                     var ed = (EditDiffBlock)blk;
                     EditDiffData data = GetEditDiffData(ed.Key);
+                    bool hasBody = data != null && !string.IsNullOrEmpty(data.Body);
                     bool collapsed = IsEditDiffCollapsed(ed.Key);
                     int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
 
-                    // Clickable header row (spans the content width); captured for collapse hit-testing.
-                    string headerText = BuildEditDiffHeaderText(data, collapsed);
+                    // Header row. With a body it's a clickable disclosure header (captured for the
+                    // collapse hit test); without one it's a plain non-interactive label.
+                    string headerText = BuildEditDiffHeaderText(data, collapsed, hasBody);
                     using (var brush = new SolidBrush(ForeColor))
                     using (var fmt = StringFormat.GenericTypographic)
                     {
                         fmt.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
                         g.DrawString(headerText, _baseFont, brush, new PointF(x0, y + EditDiffHeaderPad), fmt);
                     }
-                    if (owner != null)
+                    if (hasBody && owner != null)
                     {
                         if (owner.EditDiffHits == null) owner.EditDiffHits = new List<EditDiffHit>();
                         owner.EditDiffHits.Add(new EditDiffHit { Rect = new Rectangle(x0, y, maxWidth, headerH), Key = ed.Key });
                     }
                     y += headerH;
 
-                    // Expanded: chromeless diff body, full-width red/green bands, clipped to width
-                    // (horizontal scroll for wide diffs is a following increment).
-                    if (data != null && !collapsed)
+                    // Expanded: chromeless highlighted body, clipped to width (with horizontal scroll
+                    // for over-wide content).
+                    if (hasBody && !collapsed)
                     {
                         y += EditDiffBodyGap;
                         SyntaxHighlightingRenderer.EnqueueHighlight(data.Language, _isDarkTheme, data.Body, _monoFont);

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -131,6 +131,54 @@ namespace GxPT
                         handled = true;
                     }
                 }
+                else if (string.Equals(req.FunctionName, "files__write", StringComparison.Ordinal))
+                {
+                    string path = req.Arguments.Value<string>("path") ?? string.Empty;
+                    string content = req.Arguments.Value<string>("content") ?? string.Empty;
+                    string lang = SyntaxHighlighter.GetLanguageForFileName(path) ?? "text";
+                    _diffPanel.SetContent(path, content, lang, dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                    _previewLabel.Text = "Write:";
+                    handled = true;
+                }
+                else if (string.Equals(req.FunctionName, "git__commit", StringComparison.Ordinal))
+                {
+                    string msg = req.Arguments.Value<string>("message") ?? string.Empty;
+                    if (msg.Trim().Length > 0)
+                    {
+                        _diffPanel.SetContent(string.Empty, msg, "text", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _previewLabel.Text = "Commit message:";
+                        handled = true;
+                    }
+                }
+                else if (string.Equals(req.FunctionName, "web__extract", StringComparison.Ordinal))
+                {
+                    string urls = JoinUrlArgs(req.Arguments);
+                    if (urls.Length > 0)
+                    {
+                        _diffPanel.SetContent(string.Empty, urls, "text", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _previewLabel.Text = "Fetch URLs:";
+                        handled = true;
+                    }
+                }
+                else if (string.Equals(req.FunctionName, "files__delete", StringComparison.Ordinal))
+                {
+                    string path = req.Arguments.Value<string>("path") ?? string.Empty;
+                    if (path.Length > 0)
+                    {
+                        _diffPanel.SetContent(string.Empty, path, "text", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _previewLabel.Text = "Delete:";
+                        handled = true;
+                    }
+                }
+                else if (string.Equals(req.FunctionName, "git__push", StringComparison.Ordinal))
+                {
+                    string remote = req.Arguments.Value<string>("remote") ?? string.Empty;
+                    string branch = req.Arguments.Value<string>("branch") ?? string.Empty;
+                    string tgt = remote.Length > 0 ? (branch.Length > 0 ? remote + "/" + branch : remote) : (branch.Length > 0 ? branch : "(default remote/branch)");
+                    _diffPanel.SetContent(string.Empty, tgt, "text", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                    _previewLabel.Text = "Push to:";
+                    handled = true;
+                }
             }
 
             if (handled)
@@ -220,6 +268,26 @@ namespace GxPT
                 return File.ReadAllText(full);
             }
             catch { return null; }
+        }
+
+        // One URL per line from the web__extract "urls" array argument.
+        private static string JoinUrlArgs(Newtonsoft.Json.Linq.JObject args)
+        {
+            try
+            {
+                var arr = args["urls"] as Newtonsoft.Json.Linq.JArray;
+                if (arr == null) return string.Empty;
+                var sb = new System.Text.StringBuilder();
+                foreach (var u in arr)
+                {
+                    string s = (string)u;
+                    if (string.IsNullOrEmpty(s)) continue;
+                    if (sb.Length > 0) sb.Append("\r\n");
+                    sb.Append(s);
+                }
+                return sb.ToString();
+            }
+            catch { return string.Empty; }
         }
 
         private static string BuildPreviewText(ApprovalRequest req)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2176,57 +2176,151 @@ namespace GxPT
             }
         }
 
-        // Activity marker for a tool call. For files__edit and command__run, register a collapsible
-        // record with the transcript under a stable key and return its sentinel in place of the generic
-        // "using" marker. Any failure falls back to the generic marker so an edge-case call still renders.
+        // Activity marker for a tool call. If the tool maps to a collapsible/labelled record, register
+        // it with the transcript under a stable key and return its sentinel; otherwise (or on any
+        // failure) return the generic "using <tool>" marker.
         private static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
         {
             if (transcript != null && !string.IsNullOrEmpty(key))
             {
-                if (string.Equals(name, "files__edit", StringComparison.Ordinal))
+                try
                 {
-                    try
+                    var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
+                    string header, body, language;
+                    if (TryBuildToolRecord(name, args, out header, out body, out language))
                     {
-                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
-                        string path = (string)args["path"] ?? string.Empty;
-                        string oldS = (string)args["old_string"] ?? string.Empty;
-                        string newS = (string)args["new_string"] ?? string.Empty;
-                        LineDiffResult diff = DiffUtil.BuildLineDiff(oldS, newS);
-                        transcript.RegisterEditDiff(key, path, diff.Body, diff.Added, diff.Removed);
+                        transcript.RegisterToolRecord(key, header, body, language);
                         return McpMarkers.EditDiff(key);
                     }
-                    catch { /* fall through to the generic marker */ }
                 }
-                else if (string.Equals(name, "command__run", StringComparison.Ordinal))
-                {
-                    try
-                    {
-                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
-                        string cmd = (string)args["command"] ?? string.Empty;
-                        if (cmd.Trim().Length > 0)
-                        {
-                            transcript.RegisterCommandRun(key, cmd);
-                            return McpMarkers.EditDiff(key);
-                        }
-                    }
-                    catch { /* fall through to the generic marker */ }
-                }
-                else if (string.Equals(name, "web__search", StringComparison.Ordinal))
-                {
-                    try
-                    {
-                        var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
-                        string query = (string)args["query"] ?? string.Empty;
-                        if (query.Trim().Length > 0)
-                        {
-                            transcript.RegisterWebSearch(key, query);
-                            return McpMarkers.EditDiff(key);
-                        }
-                    }
-                    catch { /* fall through to the generic marker */ }
-                }
+                catch { /* fall through to the generic marker */ }
             }
             return McpMarkers.Call(name);
+        }
+
+        // Maps a tool call to a transcript record. An empty body yields a one-line label (no expansion);
+        // a non-empty body is a collapsible record highlighted in 'language'. Returns false for tools
+        // that should keep the generic marker.
+        private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language)
+        {
+            header = null; body = string.Empty; language = "text";
+            switch (name)
+            {
+                case "files__edit":
+                {
+                    string path = Str(args, "path");
+                    LineDiffResult diff = DiffUtil.BuildLineDiff(Str(args, "old_string"), Str(args, "new_string"));
+                    header = "edited " + (path.Length > 0 ? path : "(file)") + "  (+" + diff.Added + " −" + diff.Removed + ")";
+                    body = diff.Body; language = "diff"; return true;
+                }
+                case "files__write":
+                {
+                    string path = Str(args, "path");
+                    header = "Wrote " + (path.Length > 0 ? path : "(file)");
+                    body = Str(args, "content");
+                    language = SyntaxHighlighter.GetLanguageForFileName(path) ?? "text";
+                    return true;
+                }
+                case "files__delete":
+                {
+                    string path = Str(args, "path"); if (path.Length == 0) return false;
+                    header = "Deleted " + path; return true;
+                }
+                case "files__read":
+                {
+                    string path = Str(args, "path"); if (path.Length == 0) return false;
+                    header = "Read " + path + LineRangeSuffix(args); return true;
+                }
+                case "files__list":
+                {
+                    string path = Str(args, "path"); if (path.Length == 0) return false;
+                    header = "Listed " + path + (Bool(args, "recursive") ? " (recursive)" : ""); return true;
+                }
+                case "files__search":
+                {
+                    string query = Str(args, "query"); if (query.Length == 0) return false;
+                    header = "Searched files"; body = query;
+                    language = Bool(args, "regex") ? "regex" : "text"; return true;
+                }
+                case "command__run":
+                {
+                    string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
+                    header = "Ran a command"; body = cmd; language = "batch"; return true;
+                }
+                case "web__search":
+                {
+                    string query = Str(args, "query"); if (query.Trim().Length == 0) return false;
+                    header = "Searched the web"; body = query; return true;
+                }
+                case "web__extract":
+                {
+                    string urls = JoinUrls(args); if (urls.Length == 0) return false;
+                    int n = urls.Split('\n').Length;
+                    header = n > 1 ? ("Read " + n + " web pages") : "Read a web page";
+                    body = urls; return true;
+                }
+                case "git__commit":
+                {
+                    string msg = Str(args, "message"); if (msg.Trim().Length == 0) return false;
+                    header = "Committed"; body = msg; return true;
+                }
+                case "git__push":
+                {
+                    string remote = Str(args, "remote"); string branch = Str(args, "branch");
+                    string tgt = remote.Length > 0 ? (branch.Length > 0 ? remote + "/" + branch : remote) : branch;
+                    header = tgt.Length > 0 ? ("Pushed to " + tgt) : "Pushed commits"; return true;
+                }
+                case "git__status": header = "Checked git status"; return true;
+                case "git__log": header = "Viewed git log"; return true;
+                case "git__diff":
+                {
+                    string path = Str(args, "path");
+                    header = "Viewed git diff" + (Bool(args, "staged") ? " (staged)" : "") + (path.Length > 0 ? " of " + path : "");
+                    return true;
+                }
+                case "reveal_tools": header = "Checking available tools"; return true;
+                default: return false;
+            }
+        }
+
+        private static string Str(Newtonsoft.Json.Linq.JObject args, string name)
+        {
+            try { var t = args[name]; return t == null ? string.Empty : ((string)t ?? string.Empty); }
+            catch { return string.Empty; }
+        }
+        private static bool Bool(Newtonsoft.Json.Linq.JObject args, string name)
+        {
+            try { var t = args[name]; return t != null && (bool)t; }
+            catch { return false; }
+        }
+        private static string LineRangeSuffix(Newtonsoft.Json.Linq.JObject args)
+        {
+            try
+            {
+                var s = args["start_line"]; var e = args["end_line"];
+                if (s != null && e != null) return " (lines " + (int)s + "–" + (int)e + ")";
+                if (s != null) return " (from line " + (int)s + ")";
+                if (e != null) return " (through line " + (int)e + ")";
+            }
+            catch { }
+            return string.Empty;
+        }
+        private static string JoinUrls(Newtonsoft.Json.Linq.JObject args)
+        {
+            try
+            {
+                var arr = args["urls"] as Newtonsoft.Json.Linq.JArray;
+                if (arr == null) return string.Empty;
+                var sb = new System.Text.StringBuilder();
+                foreach (var u in arr)
+                {
+                    string s = (string)u; if (string.IsNullOrEmpty(s)) continue;
+                    if (sb.Length > 0) sb.Append('\n');
+                    sb.Append(s);
+                }
+                return sb.ToString();
+            }
+            catch { return string.Empty; }
         }
 
         private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)

--- a/GxPT/Highlighting/LanguageHighlighters.cs
+++ b/GxPT/Highlighting/LanguageHighlighters.cs
@@ -2431,7 +2431,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "ini", "conf", "cfg", "desktop", "reg", "inf", "gitconfig", "config" }; }
+            get { return new string[] { "ini", "conf", "cfg", "desktop", "reg", "inf", "gitconfig" }; }
         }
 
         protected override TokenPattern[] GetPatterns()

--- a/GxPT/Highlighting/LanguageHighlighters.cs
+++ b/GxPT/Highlighting/LanguageHighlighters.cs
@@ -158,7 +158,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "ada83", "ada95", "ada2005", "ada2012", "ada2022", "gnat", "spark" }; }
+            get { return new string[] { "ada83", "ada95", "ada2005", "ada2012", "ada2022", "gnat", "spark", "adb", "ads", "gpr" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -366,7 +366,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "sh", "shell", "zsh", "ksh" }; }
+            get { return new string[] { "sh", "shell", "zsh", "ksh", "fish", "csh", "tcsh" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -646,7 +646,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "cs", "c#", "dotnet", "c-sharp" }; }
+            get { return new string[] { "cs", "c#", "dotnet", "c-sharp", "csx" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -699,7 +699,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "css3", "stylesheet" }; }
+            get { return new string[] { "css3", "stylesheet", "scss", "sass", "less" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1009,7 +1009,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "bnf", "abnf", "grammar", "yacc", "bison" }; }
+            get { return new string[] { "bnf", "abnf", "grammar", "yacc", "bison", "y", "yy" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1216,7 +1216,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "f77", "f90", "f95", "f2003", "f2008", "f2018", "for", "ftn", "f", "fortran77", "fortran90", "fortran95" }; }
+            get { return new string[] { "f77", "f90", "f95", "f2003", "f2008", "f2018", "for", "ftn", "f", "fortran77", "fortran90", "fortran95", "f03", "f08" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1440,7 +1440,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "gql", "cypher", "opencypher", "neo4j", "pgql", "ngql", "age", "memgraph", "redisgraph" }; }
+            get { return new string[] { "gql", "cypher", "opencypher", "neo4j", "pgql", "ngql", "age", "memgraph", "redisgraph", "cql" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1681,7 +1681,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "js", "node", "nodejs", "mjs", "cjs" }; }
+            get { return new string[] { "js", "node", "nodejs", "mjs", "cjs", "jsx" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1843,7 +1843,7 @@ namespace GxPT
                     "lisp", "commonlisp", "common-lisp", "cl",
                     "scheme", "racket", "guile", 
                     "clojure", "clj", "cljs", "edn",
-                    "elisp", "emacs-lisp", "emacs"
+                    "elisp", "emacs-lisp", "emacs", "lsp", "fasl", "scm", "ss", "sch", "rkt", "cljc", "el"
                 };
             }
         }
@@ -1914,7 +1914,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "lua5.1", "lua5.2", "lua5.3", "lua5.4", "luajit", "moonscript" }; }
+            get { return new string[] { "lua5.1", "lua5.2", "lua5.3", "lua5.4", "luajit", "moonscript", "luau" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -1985,7 +1985,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "minecraft", "mcfunction", "datapack", "mc" }; }
+            get { return new string[] { "minecraft", "mcfunction", "datapack", "mc", "mcmeta" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -2198,7 +2198,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "pl", "pm", "perl5", "perl6", "raku" }; }
+            get { return new string[] { "pl", "pm", "perl5", "perl6", "raku", "pod" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -2260,7 +2260,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "php", "phtml" }; }
+            get { return new string[] { "php", "phtml", "php3", "php4", "php5", "phps" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -2431,7 +2431,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "ini", "conf", "cfg", "desktop", "reg", "inf", "gitconfig" }; }
+            get { return new string[] { "ini", "conf", "cfg", "desktop", "reg", "inf", "gitconfig", "config" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -2497,7 +2497,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "py", "python3", "py3" }; }
+            get { return new string[] { "py", "python3", "py3", "pyw", "pyi", "pyx" }; }
         }
 
         protected override TokenPattern[] GetPatterns()
@@ -2547,7 +2547,7 @@ namespace GxPT
 
         public override string[] Aliases
         {
-            get { return new string[] { "rb" }; }
+            get { return new string[] { "rb", "rbw", "rake", "gemspec" }; }
         }
 
         protected override TokenPattern[] GetPatterns()

--- a/GxPT/Highlighting/SyntaxHighlighter.cs
+++ b/GxPT/Highlighting/SyntaxHighlighter.cs
@@ -86,7 +86,6 @@ namespace GxPT
         {
             _highlighters = new Dictionary<string, ISyntaxHighlighter>(StringComparer.OrdinalIgnoreCase);
             RegisterDefaultHighlighters();
-            RegisterFileExtensionAliases(); // also resolve highlighters by file extension (a.cs -> "cs")
         }
 
         /// <summary>
@@ -373,10 +372,9 @@ namespace GxPT
 
         /// <summary>
         /// Resolves a highlighter language id from a file name by stripping the extension's dot
-        /// (e.g. "src/a.cs" -> "cs"). The highlighter table itself understands extensions — every
-        /// highlighter's FileTypes are registered as lookup keys (see RegisterFileExtensionAliases) —
-        /// so an a.cs file and a ```cs fence resolve through the same path. Returns null when there is
-        /// no extension (caller renders plain text).
+        /// (e.g. "src/a.cs" -> "cs"). Highlighters already register their extensions as aliases, so this
+        /// resolves through the same lookup (GetHighlighter) as a code-fence language name. Returns null
+        /// when there is no extension; an unknown extension simply falls back to plain at lookup time.
         /// </summary>
         public static string GetLanguageForFileName(string fileName)
         {
@@ -386,78 +384,6 @@ namespace GxPT
             catch { return null; }
             if (string.IsNullOrEmpty(ext) || ext.Length < 2) return null;
             return ext.Substring(1).ToLowerInvariant(); // drop the leading dot; the lookup does the rest
-        }
-
-        // Registers each highlighter's FileTypes extensions (without the dot) as additional lookup keys,
-        // so file extensions resolve through the same table as code-fence language names. First-wins, so
-        // it never clobbers a primary language id or explicit alias; "winners" are listed first to settle
-        // extensions shared by multiple highlighters (.php, .config, .ps1xml).
-        private static void RegisterFileExtensionAliases()
-        {
-            AddExtAliases(PhpHighlighter.FileTypes, "php");
-            AddExtAliases(PropertiesHighlighter.FileTypes, "properties");
-            AddExtAliases(PowerShellHighlighter.FileTypes, "powershell");
-            AddExtAliases(AdaHighlighter.FileTypes, "ada");
-            AddExtAliases(AssemblyHighlighter.FileTypes, "assembly");
-            AddExtAliases(BashHighlighter.FileTypes, "bash");
-            AddExtAliases(BasicHighlighter.FileTypes, "basic");
-            AddExtAliases(BatchHighlighter.FileTypes, "batch");
-            AddExtAliases(CHighlighter.FileTypes, "c");
-            AddExtAliases(CppHighlighter.FileTypes, "cpp");
-            AddExtAliases(CSharpHighlighter.FileTypes, "csharp");
-            AddExtAliases(CssHighlighter.FileTypes, "css");
-            AddExtAliases(CsvHighlighter.FileTypes, "csv");
-            AddExtAliases(DartHighlighter.FileTypes, "dart");
-            AddExtAliases(DiffHighlighter.FileTypes, "diff");
-            AddExtAliases(EbnfHighlighter.FileTypes, "ebnf");
-            AddExtAliases(ElixirHighlighter.FileTypes, "elixir");
-            AddExtAliases(ErlangHighlighter.FileTypes, "erlang");
-            AddExtAliases(FortranHighlighter.FileTypes, "fortran");
-            AddExtAliases(FSharpHighlighter.FileTypes, "fsharp");
-            AddExtAliases(GoHighlighter.FileTypes, "go");
-            AddExtAliases(GqlHighlighter.FileTypes, "gql");
-            AddExtAliases(HaskellHighlighter.FileTypes, "haskell");
-            AddExtAliases(HtmlHighlighter.FileTypes, "html");
-            AddExtAliases(JavaHighlighter.FileTypes, "java");
-            AddExtAliases(JavaScriptHighlighter.FileTypes, "javascript");
-            AddExtAliases(JsonHighlighter.FileTypes, "json");
-            AddExtAliases(KotlinHighlighter.FileTypes, "kotlin");
-            AddExtAliases(LispHighlighter.FileTypes, "lisp");
-            AddExtAliases(LuaHighlighter.FileTypes, "lua");
-            AddExtAliases(McfunctionHighlighter.FileTypes, "mcfunction");
-            AddExtAliases(OcamlHighlighter.FileTypes, "ocaml");
-            AddExtAliases(PascalHighlighter.FileTypes, "pascal");
-            AddExtAliases(PerlHighlighter.FileTypes, "perl");
-            AddExtAliases(PythonHighlighter.FileTypes, "python");
-            AddExtAliases(RegexHighlighter.FileTypes, "regex");
-            AddExtAliases(RubyHighlighter.FileTypes, "ruby");
-            AddExtAliases(RustHighlighter.FileTypes, "rust");
-            AddExtAliases(ScalaHighlighter.FileTypes, "scala");
-            AddExtAliases(SqlHighlighter.FileTypes, "sql");
-            AddExtAliases(SwiftHighlighter.FileTypes, "swift");
-            AddExtAliases(TypeScriptHighlighter.FileTypes, "typescript");
-            AddExtAliases(VisualBasicHighlighter.FileTypes, "visualbasic");
-            AddExtAliases(XmlHighlighter.FileTypes, "xml");
-            AddExtAliases(YamlHighlighter.FileTypes, "yaml");
-            AddExtAliases(ZigHighlighter.FileTypes, "zig");
-        }
-
-        // Maps each "*.ext" pattern to the registered highlighter for 'language', under the bare
-        // extension key ("*.cs" -> "cs"). First-wins, so existing language ids / aliases are preserved.
-        private static void AddExtAliases(string[] fileTypes, string language)
-        {
-            if (fileTypes == null) return;
-            ISyntaxHighlighter h;
-            if (!_highlighters.TryGetValue(language, out h) || h == null) return;
-            for (int i = 0; i < fileTypes.Length; i++)
-            {
-                string p = fileTypes[i];
-                if (string.IsNullOrEmpty(p)) continue;
-                int dot = p.LastIndexOf('.');
-                if (dot < 0 || dot >= p.Length - 1) continue;
-                string key = p.Substring(dot + 1); // "*.cs" -> "cs"
-                if (!_highlighters.ContainsKey(key)) _highlighters[key] = h;
-            }
         }
 
         /// <summary>

--- a/GxPT/Highlighting/SyntaxHighlighter.cs
+++ b/GxPT/Highlighting/SyntaxHighlighter.cs
@@ -86,6 +86,7 @@ namespace GxPT
         {
             _highlighters = new Dictionary<string, ISyntaxHighlighter>(StringComparer.OrdinalIgnoreCase);
             RegisterDefaultHighlighters();
+            RegisterFileExtensionAliases(); // also resolve highlighters by file extension (a.cs -> "cs")
         }
 
         /// <summary>
@@ -371,8 +372,11 @@ namespace GxPT
         }
 
         /// <summary>
-        /// Resolves a highlighter language id from a file name's extension (e.g. "src/a.cs" -> "csharp").
-        /// Returns null when the extension is unknown, in which case callers should render plain text.
+        /// Resolves a highlighter language id from a file name by stripping the extension's dot
+        /// (e.g. "src/a.cs" -> "cs"). The highlighter table itself understands extensions — every
+        /// highlighter's FileTypes are registered as lookup keys (see RegisterFileExtensionAliases) —
+        /// so an a.cs file and a ```cs fence resolve through the same path. Returns null when there is
+        /// no extension (caller renders plain text).
         /// </summary>
         public static string GetLanguageForFileName(string fileName)
         {
@@ -380,54 +384,79 @@ namespace GxPT
             string ext;
             try { ext = System.IO.Path.GetExtension(fileName); }
             catch { return null; }
-            if (string.IsNullOrEmpty(ext)) return null;
-            switch (ext.ToLowerInvariant())
+            if (string.IsNullOrEmpty(ext) || ext.Length < 2) return null;
+            return ext.Substring(1).ToLowerInvariant(); // drop the leading dot; the lookup does the rest
+        }
+
+        // Registers each highlighter's FileTypes extensions (without the dot) as additional lookup keys,
+        // so file extensions resolve through the same table as code-fence language names. First-wins, so
+        // it never clobbers a primary language id or explicit alias; "winners" are listed first to settle
+        // extensions shared by multiple highlighters (.php, .config, .ps1xml).
+        private static void RegisterFileExtensionAliases()
+        {
+            AddExtAliases(PhpHighlighter.FileTypes, "php");
+            AddExtAliases(PropertiesHighlighter.FileTypes, "properties");
+            AddExtAliases(PowerShellHighlighter.FileTypes, "powershell");
+            AddExtAliases(AdaHighlighter.FileTypes, "ada");
+            AddExtAliases(AssemblyHighlighter.FileTypes, "assembly");
+            AddExtAliases(BashHighlighter.FileTypes, "bash");
+            AddExtAliases(BasicHighlighter.FileTypes, "basic");
+            AddExtAliases(BatchHighlighter.FileTypes, "batch");
+            AddExtAliases(CHighlighter.FileTypes, "c");
+            AddExtAliases(CppHighlighter.FileTypes, "cpp");
+            AddExtAliases(CSharpHighlighter.FileTypes, "csharp");
+            AddExtAliases(CssHighlighter.FileTypes, "css");
+            AddExtAliases(CsvHighlighter.FileTypes, "csv");
+            AddExtAliases(DartHighlighter.FileTypes, "dart");
+            AddExtAliases(DiffHighlighter.FileTypes, "diff");
+            AddExtAliases(EbnfHighlighter.FileTypes, "ebnf");
+            AddExtAliases(ElixirHighlighter.FileTypes, "elixir");
+            AddExtAliases(ErlangHighlighter.FileTypes, "erlang");
+            AddExtAliases(FortranHighlighter.FileTypes, "fortran");
+            AddExtAliases(FSharpHighlighter.FileTypes, "fsharp");
+            AddExtAliases(GoHighlighter.FileTypes, "go");
+            AddExtAliases(GqlHighlighter.FileTypes, "gql");
+            AddExtAliases(HaskellHighlighter.FileTypes, "haskell");
+            AddExtAliases(HtmlHighlighter.FileTypes, "html");
+            AddExtAliases(JavaHighlighter.FileTypes, "java");
+            AddExtAliases(JavaScriptHighlighter.FileTypes, "javascript");
+            AddExtAliases(JsonHighlighter.FileTypes, "json");
+            AddExtAliases(KotlinHighlighter.FileTypes, "kotlin");
+            AddExtAliases(LispHighlighter.FileTypes, "lisp");
+            AddExtAliases(LuaHighlighter.FileTypes, "lua");
+            AddExtAliases(McfunctionHighlighter.FileTypes, "mcfunction");
+            AddExtAliases(OcamlHighlighter.FileTypes, "ocaml");
+            AddExtAliases(PascalHighlighter.FileTypes, "pascal");
+            AddExtAliases(PerlHighlighter.FileTypes, "perl");
+            AddExtAliases(PythonHighlighter.FileTypes, "python");
+            AddExtAliases(RegexHighlighter.FileTypes, "regex");
+            AddExtAliases(RubyHighlighter.FileTypes, "ruby");
+            AddExtAliases(RustHighlighter.FileTypes, "rust");
+            AddExtAliases(ScalaHighlighter.FileTypes, "scala");
+            AddExtAliases(SqlHighlighter.FileTypes, "sql");
+            AddExtAliases(SwiftHighlighter.FileTypes, "swift");
+            AddExtAliases(TypeScriptHighlighter.FileTypes, "typescript");
+            AddExtAliases(VisualBasicHighlighter.FileTypes, "visualbasic");
+            AddExtAliases(XmlHighlighter.FileTypes, "xml");
+            AddExtAliases(YamlHighlighter.FileTypes, "yaml");
+            AddExtAliases(ZigHighlighter.FileTypes, "zig");
+        }
+
+        // Maps each "*.ext" pattern to the registered highlighter for 'language', under the bare
+        // extension key ("*.cs" -> "cs"). First-wins, so existing language ids / aliases are preserved.
+        private static void AddExtAliases(string[] fileTypes, string language)
+        {
+            if (fileTypes == null) return;
+            ISyntaxHighlighter h;
+            if (!_highlighters.TryGetValue(language, out h) || h == null) return;
+            for (int i = 0; i < fileTypes.Length; i++)
             {
-                case ".cs": case ".csx": return "csharp";
-                case ".js": case ".jsx": case ".mjs": case ".cjs": return "javascript";
-                case ".ts": case ".tsx": return "typescript";
-                case ".json": case ".jsonc": case ".json5": return "json";
-                case ".py": case ".pyw": case ".pyi": case ".pyx": return "python";
-                case ".html": case ".htm": case ".xhtml": return "html";
-                case ".css": case ".scss": case ".sass": case ".less": return "css";
-                case ".xml": case ".xaml": case ".xsd": case ".xsl": case ".xslt": case ".svg":
-                case ".csproj": case ".vbproj": case ".resx": case ".props": case ".targets": return "xml";
-                case ".yml": case ".yaml": return "yaml";
-                case ".sh": case ".bash": case ".zsh": case ".ksh": return "bash";
-                case ".bat": case ".cmd": return "batch";
-                case ".ps1": case ".psm1": case ".psd1": return "powershell";
-                case ".c": case ".h": return "c";
-                case ".cpp": case ".cxx": case ".cc": case ".hpp": case ".hxx": case ".hh": return "cpp";
-                case ".go": return "go";
-                case ".rs": return "rust";
-                case ".java": case ".jav": return "java";
-                case ".rb": case ".rake": case ".gemspec": return "ruby";
-                case ".php": case ".phtml": return "php";
-                case ".sql": return "sql";
-                case ".swift": return "swift";
-                case ".kt": case ".kts": return "kotlin";
-                case ".lua": return "lua";
-                case ".pl": case ".pm": return "perl";
-                case ".scala": case ".sc": return "scala";
-                case ".dart": return "dart";
-                case ".ex": case ".exs": return "elixir";
-                case ".erl": case ".hrl": return "erlang";
-                case ".hs": case ".lhs": return "haskell";
-                case ".fs": case ".fsi": case ".fsx": return "fsharp";
-                case ".ml": case ".mli": return "ocaml";
-                case ".pas": case ".pp": return "pascal";
-                case ".vb": case ".vbs": case ".vba": return "visualbasic";
-                case ".zig": return "zig";
-                case ".diff": case ".patch": return "diff";
-                case ".csv": return "csv";
-                case ".gql": case ".graphql": return "gql";
-                case ".ini": case ".cfg": case ".conf": case ".properties": case ".toml": return "properties";
-                case ".asm": case ".s": case ".nasm": return "assembly";
-                case ".ada": case ".adb": case ".ads": return "ada";
-                case ".f": case ".for": case ".f90": case ".f95": return "fortran";
-                case ".bas": return "basic";
-                case ".mcfunction": return "mcfunction";
-                default: return null;
+                string p = fileTypes[i];
+                if (string.IsNullOrEmpty(p)) continue;
+                int dot = p.LastIndexOf('.');
+                if (dot < 0 || dot >= p.Length - 1) continue;
+                string key = p.Substring(dot + 1); // "*.cs" -> "cs"
+                if (!_highlighters.ContainsKey(key)) _highlighters[key] = h;
             }
         }
 

--- a/GxPT/Highlighting/SyntaxHighlighter.cs
+++ b/GxPT/Highlighting/SyntaxHighlighter.cs
@@ -371,6 +371,67 @@ namespace GxPT
         }
 
         /// <summary>
+        /// Resolves a highlighter language id from a file name's extension (e.g. "src/a.cs" -> "csharp").
+        /// Returns null when the extension is unknown, in which case callers should render plain text.
+        /// </summary>
+        public static string GetLanguageForFileName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName)) return null;
+            string ext;
+            try { ext = System.IO.Path.GetExtension(fileName); }
+            catch { return null; }
+            if (string.IsNullOrEmpty(ext)) return null;
+            switch (ext.ToLowerInvariant())
+            {
+                case ".cs": case ".csx": return "csharp";
+                case ".js": case ".jsx": case ".mjs": case ".cjs": return "javascript";
+                case ".ts": case ".tsx": return "typescript";
+                case ".json": case ".jsonc": case ".json5": return "json";
+                case ".py": case ".pyw": case ".pyi": case ".pyx": return "python";
+                case ".html": case ".htm": case ".xhtml": return "html";
+                case ".css": case ".scss": case ".sass": case ".less": return "css";
+                case ".xml": case ".xaml": case ".xsd": case ".xsl": case ".xslt": case ".svg":
+                case ".csproj": case ".vbproj": case ".resx": case ".props": case ".targets": return "xml";
+                case ".yml": case ".yaml": return "yaml";
+                case ".sh": case ".bash": case ".zsh": case ".ksh": return "bash";
+                case ".bat": case ".cmd": return "batch";
+                case ".ps1": case ".psm1": case ".psd1": return "powershell";
+                case ".c": case ".h": return "c";
+                case ".cpp": case ".cxx": case ".cc": case ".hpp": case ".hxx": case ".hh": return "cpp";
+                case ".go": return "go";
+                case ".rs": return "rust";
+                case ".java": case ".jav": return "java";
+                case ".rb": case ".rake": case ".gemspec": return "ruby";
+                case ".php": case ".phtml": return "php";
+                case ".sql": return "sql";
+                case ".swift": return "swift";
+                case ".kt": case ".kts": return "kotlin";
+                case ".lua": return "lua";
+                case ".pl": case ".pm": return "perl";
+                case ".scala": case ".sc": return "scala";
+                case ".dart": return "dart";
+                case ".ex": case ".exs": return "elixir";
+                case ".erl": case ".hrl": return "erlang";
+                case ".hs": case ".lhs": return "haskell";
+                case ".fs": case ".fsi": case ".fsx": return "fsharp";
+                case ".ml": case ".mli": return "ocaml";
+                case ".pas": case ".pp": return "pascal";
+                case ".vb": case ".vbs": case ".vba": return "visualbasic";
+                case ".zig": return "zig";
+                case ".diff": case ".patch": return "diff";
+                case ".csv": return "csv";
+                case ".gql": case ".graphql": return "gql";
+                case ".ini": case ".cfg": case ".conf": case ".properties": case ".toml": return "properties";
+                case ".asm": case ".s": case ".nasm": return "assembly";
+                case ".ada": case ".adb": case ".ads": return "ada";
+                case ".f": case ".for": case ".f90": case ".f95": return "fortran";
+                case ".bas": return "basic";
+                case ".mcfunction": return "mcfunction";
+                default: return null;
+            }
+        }
+
+        /// <summary>
         /// Returns a deduplicated set of file dialog patterns (e.g., "*.cs") contributed by
         /// built-in highlighters. This avoids reflection by referencing the known types.
         /// </summary>

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -25,13 +25,19 @@ namespace GxPT
             _store = store != null ? store : new InMemoryApprovalStore();
         }
 
-        // Tools that never require approval (always allowed, no prompt). web__search is read-only and
-        // high-frequency, so prompting adds friction without meaningful risk; web__extract (which
-        // fetches arbitrary pages) deliberately stays gated.
+        // Tools that never require approval (always allowed, no prompt): the read-only built-ins, which
+        // are high-frequency and don't modify anything. Tools that write, delete, run commands, push, or
+        // fetch arbitrary pages (web__extract) deliberately stay gated.
         private static readonly Dictionary<string, bool> _autoAllow = BuildAutoAllowSet();
         private static Dictionary<string, bool> BuildAutoAllowSet()
         {
             var s = new Dictionary<string, bool>(StringComparer.Ordinal);
+            s["files__read"] = true;
+            s["files__list"] = true;
+            s["files__search"] = true;
+            s["git__status"] = true;
+            s["git__diff"] = true;
+            s["git__log"] = true;
             s["web__search"] = true;
             return s;
         }


### PR DESCRIPTION
## Summary

Extends the collapsible tool-record + approval-preview treatment across the remaining tools (Tiers 1–3), and auto-allows the read-only built-ins.

### Transcript history records
Collapsed by default; an **empty body makes a plain one-line label** (non-collapsible).

| Tool | Record |
|------|--------|
| `files__write` | `▸ Wrote <path>` → content, **highlighted by file extension** |
| `web__extract` | `▸ Read N web pages` → the URL list |
| `git__commit` | `▸ Committed` → the message |
| `files__search` | `▸ Searched files` → the query (**regex-highlighted** when `regex`) |
| `files__delete` | `Deleted <path>` (label) |
| `files__read` | `Read <path> (lines a–b)` (label) |
| `files__list` | `Listed <path>` (label) |
| `git__push` | `Pushed to <remote/branch>` (label) |
| `git__status` / `git__diff` / `git__log` | labels |
| `reveal_tools` | `Checking available tools` (label) |

### Approval previews (gated tools)
Now show content instead of JSON: **write** (content, highlighted), **commit** (message), **web__extract** (URLs), **delete** (path), **push** (target).

### Auto-allow (bonus)
Read-only built-ins (`files__read` / `files__list` / `files__search`, `git__status` / `git__diff` / `git__log`) join `web__search` in the always-allow set. Write/edit/delete/commit/push/command/`web__extract` stay gated.

## Infra notes
- Per-tool record building is centralized in `MainForm.TryBuildToolRecord`; the transcript now exposes one public `RegisterToolRecord` (the old edit/command/search helpers are gone). Records support label-only entries.
- `SyntaxHighlighter.GetLanguageForFileName(path)` resolves a highlighter from a file's extension (for write highlighting) — there was no existing path→language lookup; the fence matchers map language *names*, not extensions.
- Everything is derived from the persisted tool-call args, so nothing new is stored.

## Verification

Needs a Windows build. Spot-checks worth doing: a write shows highlighted content (history + approval), the read-only tools no longer prompt, the label-only records read cleanly, and `reveal_tools` shows "Checking available tools".

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_