### PR TITLE
Surface stream failures in the transcript + harden curl error detection

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -72,10 +72,11 @@ namespace GxPT.Tests.Mcp
             var store = new InMemoryApprovalStore();
             var pol = Policy(prompt, store);
 
-            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"x\"}")));
+            // web__extract is Tool-scope and gated (not auto-allowed), so it prompts the first time.
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__extract", Args("{\"urls\":[\"x\"]}")));
             Assert.Equal(1, prompt.Calls);
             // second call: remembered, no prompt
-            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"y\"}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__extract", Args("{\"urls\":[\"y\"]}")));
             Assert.Equal(1, prompt.Calls);
         }
 
@@ -84,9 +85,21 @@ namespace GxPT.Tests.Mcp
         {
             var prompt = new ScriptedPrompt { Next = ApprovalChoice.AllowOnce };
             var pol = Policy(prompt, new InMemoryApprovalStore());
-            pol.Check("web__search", Args("{\"query\":\"x\"}"));
-            pol.Check("web__search", Args("{\"query\":\"y\"}"));
+            pol.Check("web__extract", Args("{\"urls\":[\"x\"]}"));
+            pol.Check("web__extract", Args("{\"urls\":[\"y\"]}"));
             Assert.Equal(2, prompt.Calls); // prompted both times
+        }
+
+        [Fact]
+        public void Auto_allowed_read_only_tools_never_prompt()
+        {
+            // The read-only built-ins (and web__search) are always allowed without a prompt.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"x\"}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__read", Args("{\"path\":\"a\"}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("git__status", Args("{}")));
+            Assert.Equal(0, prompt.Calls);
         }
 
         [Fact]

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -125,6 +125,7 @@ namespace GxPT
         private Color _clrInlineCodeBack = Color.FromArgb(240, 240, 240);
         private Color _clrInlineCodeBorder = Color.FromArgb(200, 200, 200);
         private Color _clrLink = Color.FromArgb(0, 102, 204);
+        private Color _clrError = Color.FromArgb(200, 0, 0); // red error-notice text (theme-adjusted)
         private Color _clrCopyHover = Color.FromArgb(230, 230, 230);
         private Color _clrCopyPressed = Color.FromArgb(210, 210, 210);
         private Color _clrScrollTrack = Color.FromArgb(235, 235, 235);
@@ -508,6 +509,9 @@ namespace GxPT
             _clrInlineCodeBack = t.InlineCodeBack;
             _clrInlineCodeBorder = t.InlineCodeBorder;
             _clrLink = t.Link;
+            // Error-notice red: a deeper red on light themes, a brighter one on dark so it stays
+            // legible against the background. Not part of ThemeColors (no chrome), derived from dark.
+            _clrError = dark ? Color.FromArgb(255, 120, 120) : Color.FromArgb(200, 0, 0);
             _clrCopyHover = t.CopyHover;
             _clrCopyPressed = t.CopyPressed;
             _clrScrollTrack = t.ScrollTrack;
@@ -588,6 +592,9 @@ namespace GxPT
             AddParsedMessage(role, markdown, blocks, attachments);
         }
 
+        // Number of messages currently in the transcript.
+        public int MessageCount { get { return _items.Count; } }
+
         // Add and return the index of the inserted message (to support targeted updates later)
         public int AddMessageGetIndex(MessageRole role, string markdown)
         {
@@ -602,6 +609,16 @@ namespace GxPT
             _scrollOffset = 0;
             UpdateScrollbar();
             Invalidate();
+        }
+
+        // Remove the last message (e.g. an empty assistant placeholder when a stream fails before any
+        // content arrives). Safe no-op when empty.
+        public void RemoveLastMessage()
+        {
+            if (_items.Count == 0) return;
+            _items.RemoveAt(_items.Count - 1);
+            Invalidate();
+            ReflowSoon();
         }
 
         // Replace the content of the last message if it exists
@@ -878,6 +895,8 @@ namespace GxPT
                     h += 2;
                 else if (blk.Type == BlockType.CodeBlock)
                     h += 4;
+                else if (blk.Type == BlockType.Error)
+                    h += 2;
                 // Lists don't add extra spacing after themselves
 
                 wUsed = Math.Max(wUsed, sz.Width);
@@ -1038,6 +1057,11 @@ namespace GxPT
                         }
                         return new Size(Math.Max(24, Math.Min(maxWidth, w)), h);
                     }
+                case BlockType.Error:
+                    {
+                        var er = (ErrorBlock)blk;
+                        return MeasureInlineParagraph(BuildErrorInlines(er.Message), _baseFont, maxWidth, true);
+                    }
                 case BlockType.Table:
                     {
                         var t = (TableBlock)blk;
@@ -1080,6 +1104,14 @@ namespace GxPT
                     }
             }
             return Size.Empty;
+        }
+
+        // Build the inline runs for an error notice. The message is treated as literal text (no
+        // markdown), so error strings containing '*', '_', '`' etc. render verbatim. Word wrapping is
+        // handled by the normal inline layout (it splits the run on spaces).
+        private static List<InlineRun> BuildErrorInlines(string message)
+        {
+            return new List<InlineRun> { new InlineRun { Text = message ?? string.Empty, Style = RunStyle.Normal } };
         }
 
         private Size MeasureInlineParagraph(List<InlineRun> runs, Font baseFont, int maxWidth, bool addBottomGap)
@@ -1597,6 +1629,17 @@ namespace GxPT
                     }
                     numberedCounters.Clear();
                 }
+                else if (blk.Type == BlockType.Error)
+                {
+                    // Chrome-less red notice (the containing message is a Tool-role bubble, so no
+                    // chrome). Drawn as literal wrapped text in the error color.
+                    var er = (ErrorBlock)blk;
+                    y += DrawInlineParagraph(g, x0, y, maxWidth, BuildErrorInlines(er.Message), _baseFont, owner,
+                                             new InlineCopyContext { ForeOverride = _clrError });
+                    y += 2;
+                    if (owner != null) { if (owner.DrawnSegments == null) owner.DrawnSegments = new List<DrawnSeg>(); owner.DrawnSegments.Add(new DrawnSeg { IsNewLine = true, IsHardBreak = true, Rect = new Rectangle(x0, y, 0, 0), Text = null, Font = _baseFont }); }
+                    numberedCounters.Clear();
+                }
                 else if (blk.Type == BlockType.CodeBlock)
                 {
                     var c = (CodeBlock)blk;
@@ -1916,6 +1959,7 @@ namespace GxPT
             public int TableColIndex;     // 0-based column index
             public int TableColumnCount;  // total columns in the table
             public TableAlign TableAlignment; // alignment for this column
+            public Color? ForeOverride;   // non-null forces a foreground color for normal text (e.g. error red)
         }
 
         private int DrawInlineParagraph(Graphics g, int x, int y, int maxWidth, List<InlineRun> runs, Font baseFont, MessageItem owner, InlineCopyContext ctx)
@@ -2068,7 +2112,8 @@ namespace GxPT
                 }
                 else
                 {
-                    using (var brush = new SolidBrush(ForeColor))
+                    Color textColor = ctx.ForeOverride.HasValue ? ctx.ForeOverride.Value : ForeColor;
+                    using (var brush = new SolidBrush(textColor))
                     {
                         using (var fmt = StringFormat.GenericTypographic)
                         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1480,18 +1480,24 @@ namespace GxPT
                     };
 
                     // Assistant text appends to the current assistant bubble; a tool call closes it so
-                    // the next run of text starts a fresh bubble below the tool record.
+                    // the next run of text starts a fresh bubble below the tool record. Inter-turn
+                    // whitespace (a stray newline some models emit before the next tool call) must NOT
+                    // open a bubble — otherwise it splits two adjacent tool blocks with an empty-looking
+                    // gap instead of letting them merge into one tight block.
                     Action<string> onAppend = delegate(string t)
                     {
                         if (string.IsNullOrEmpty(t)) return;
                         lock (sbLock)
                         {
                             LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
-                            if (cur == null || cur.Role != MessageRole.Assistant)
+                            if (cur != null && cur.Role == MessageRole.Assistant)
                             {
-                                cur = new LiveSeg(MessageRole.Assistant);
-                                segs.Add(cur);
+                                cur.Text.Append(t); // continuation — keep internal whitespace
+                                return;
                             }
+                            if (t.Trim().Length == 0) return; // don't open a bubble on whitespace alone
+                            cur = new LiveSeg(MessageRole.Assistant);
+                            segs.Add(cur);
                             cur.Text.Append(t);
                         }
                     };
@@ -2389,6 +2395,17 @@ namespace GxPT
                 // history order — so multi-turn tool use reads chronologically (text, tools, text, ...),
                 // matching the live streamed view. Tool results are never shown (the model summarizes).
                 var items = new List<ChatMessage>();
+                // Consecutive tool-call runs that aren't separated by real assistant text merge into one
+                // chrome-less block (e.g. reveal_tools followed by the call it enabled), so they read as
+                // tightly as a single multi-call turn instead of two blocks with a gap between them. A
+                // real assistant text bubble or a user message flushes the running block.
+                System.Text.StringBuilder pendingTools = null;
+                Action flushTools = delegate
+                {
+                    if (pendingTools != null && pendingTools.Length > 0)
+                        items.Add(new ChatMessage(ToolActivityRole, pendingTools.ToString()));
+                    pendingTools = null;
+                };
                 foreach (var m in convo.History)
                 {
                     if (m == null) continue;
@@ -2397,29 +2414,33 @@ namespace GxPT
 
                     if (role == "user")
                     {
+                        flushTools();
                         items.Add(m);
                         continue;
                     }
 
-                    // assistant text (intermediate or final) -> its own bubble
+                    // assistant text (intermediate or final) -> its own bubble, closing any tool run
                     if (!string.IsNullOrEmpty(m.Content) && m.Content.Trim().Length > 0)
+                    {
+                        flushTools();
                         items.Add(new ChatMessage("assistant", m.Content));
+                    }
 
-                    // this turn's tool calls -> a chrome-less activity block below that text
+                    // this turn's tool calls -> append to the running chrome-less block
                     if (m.ToolCalls != null && m.ToolCalls.Count > 0)
                     {
-                        var activity = new System.Text.StringBuilder();
+                        if (pendingTools == null) pendingTools = new System.Text.StringBuilder();
                         for (int ti = 0; ti < m.ToolCalls.Count; ti++)
                         {
                             var tc = m.ToolCalls[ti];
                             if (tc == null) continue;
-                            if (activity.Length > 0) activity.Append("\r\n");
+                            if (pendingTools.Length > 0) pendingTools.Append("\r\n");
                             string key = !string.IsNullOrEmpty(tc.Id) ? tc.Id : ("edit" + ti);
-                            activity.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
+                            pendingTools.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
                         }
-                        if (activity.Length > 0) items.Add(new ChatMessage(ToolActivityRole, activity.ToString()));
                     }
                 }
+                flushTools();
 
                 // Producer-consumer: parse off-UI, consume on UI timer in small chunks
                 var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1375,13 +1375,21 @@ namespace GxPT
                             delegate(string err)
                             {
                                 if (string.IsNullOrEmpty(err)) err = "Unknown error.";
+                                string partial;
+                                lock (sbLock) { partial = assistantBuilder.ToString(); }
                                 BeginInvoke((MethodInvoker)delegate
                                 {
                                     try { renderTimer.Stop(); renderTimer.Dispose(); }
                                     catch { }
                                     try { ctx.Transcript.StickToBottomDuringStreaming = false; }
                                     catch { }
-                                    ctx.Transcript.UpdateMessageAt(assistantIndex, "Error: " + err);
+                                    // Keep any partial text in the assistant bubble; otherwise drop the
+                                    // empty placeholder so only the red error notice shows.
+                                    if (partial.Trim().Length > 0)
+                                        ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                                    else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                        ctx.Transcript.RemoveLastMessage();
+                                    ShowTranscriptError(ctx.Transcript, err);
                                     Logger.Log("Send", "Stream error at index=" + assistantIndex + ": " + err);
                                     ctx.IsSending = false;
                                     // don't save on failure; no new assistant content
@@ -1391,13 +1399,19 @@ namespace GxPT
                     }
                     catch (Exception ex)
                     {
+                        string partial;
+                        lock (sbLock) { partial = assistantBuilder.ToString(); }
                         BeginInvoke((MethodInvoker)delegate
                         {
                             try { renderTimer.Stop(); renderTimer.Dispose(); }
                             catch { }
                             try { ctx.Transcript.StickToBottomDuringStreaming = false; }
                             catch { }
-                            ctx.Transcript.UpdateMessageAt(assistantIndex, "Error: " + ex.Message);
+                            if (partial.Trim().Length > 0)
+                                ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                            else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                ctx.Transcript.RemoveLastMessage();
+                            ShowTranscriptError(ctx.Transcript, ex.Message);
                             Logger.Log("Send", "Exception in streaming worker: " + ex.Message);
                             ctx.IsSending = false;
                         });
@@ -1530,15 +1544,16 @@ namespace GxPT
                 ctx.Transcript.UpdateMessageAt(activityIndex[0], aFinal);
             }
 
-            string answerText = ansFinal;
-            if (error != null)
-                answerText = (ansFinal.Length > 0 ? ansFinal + "\r\n\r\n" : string.Empty) + "Error: " + error;
-
-            if (answerText.Trim().Length > 0)
+            // Any answer text the model did produce stays in its own assistant bubble; the error
+            // renders separately as a chrome-less red notice below it (not baked into the bubble).
+            if (ansFinal.Trim().Length > 0)
             {
                 if (answerIndex[0] < 0) answerIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
-                ctx.Transcript.UpdateMessageAt(answerIndex[0], answerText);
+                ctx.Transcript.UpdateMessageAt(answerIndex[0], ansFinal);
             }
+
+            if (error != null)
+                ShowTranscriptError(ctx.Transcript, error);
 
             if (error == null)
             {
@@ -2196,6 +2211,25 @@ namespace GxPT
                 catch { /* fall through to the generic marker */ }
             }
             return McpMarkers.Call(name);
+        }
+
+        // Surface a streaming/transport failure as a chrome-less red notice in the transcript, so a
+        // failed turn (e.g. an unavailable model, or a Claude request that returns nothing) is visible
+        // instead of leaving the user staring at an empty/missing bubble.
+        private static void ShowTranscriptError(ChatTranscriptControl transcript, string rawError)
+        {
+            if (transcript == null) return;
+            transcript.AddMessage(MessageRole.Tool, MarkdownParser.ErrorSentinel(FriendlyStreamError(rawError)));
+        }
+
+        // Light humanization of the raw streamer error for display. Provider messages from OpenRouter
+        // are usually already readable, so we mostly pass them through under a clear prefix.
+        private static string FriendlyStreamError(string raw)
+        {
+            string e = raw == null ? string.Empty : raw.Trim();
+            if (e.Length == 0)
+                return "The request failed before the model responded. Please try again or pick a different model.";
+            return "The request failed: " + e;
         }
 
         // Maps a tool call to a transcript record. An empty body yields a one-line label (no expansion);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1431,37 +1431,31 @@ namespace GxPT
         // lazily (in the render timer) so they appear in the order content arrives — tool calls
         // first, then the answer. Runs the orchestrator on a worker thread; it appends the structured
         // assistant/tool messages to history itself. Called on the UI thread.
+        // One ordered segment of a streaming tool turn: either an assistant-text bubble or a
+        // chrome-less tool-activity block. Text is appended on the orchestrator worker thread (under
+        // the turn's lock); Index/LastLen are assigned on the UI thread when first rendered.
+        private sealed class LiveSeg
+        {
+            public readonly MessageRole Role;
+            public readonly StringBuilder Text = new StringBuilder();
+            public int Index;   // transcript message index, -1 until materialized
+            public int LastLen; // last rendered text length (UI thread only)
+            public LiveSeg(MessageRole role) { Role = role; Index = -1; LastLen = -1; }
+        }
+
         private void BeginToolSend(TabManager.ChatTabContext ctx, string model)
         {
+            // Ordered transcript segments for this turn: assistant-text bubbles and chrome-less
+            // tool-activity blocks, interleaved in arrival order so the view reads chronologically
+            // (text, then the tools it triggered, then the next text, ...). A segment only becomes a
+            // real transcript message once it has content, so a turn that errors before producing any
+            // output never leaves an empty placeholder bubble behind.
             var sbLock = new object();
-            var activitySb = new StringBuilder();
-            var answerSb = new StringBuilder();
-            int[] activityIndex = { -1 };
-            int[] answerIndex = { -1 };
-            int lastActivityLen = -1;
-            int lastAnswerLen = -1;
+            var segs = new List<LiveSeg>();
 
             var renderTimer = new System.Windows.Forms.Timer();
             renderTimer.Interval = 75;
-            renderTimer.Tick += delegate
-            {
-                string aSnap = null, ansSnap = null;
-                lock (sbLock)
-                {
-                    if (activitySb.Length != lastActivityLen) { aSnap = activitySb.ToString(); lastActivityLen = activitySb.Length; }
-                    if (answerSb.Length != lastAnswerLen) { ansSnap = answerSb.ToString(); lastAnswerLen = answerSb.Length; }
-                }
-                if (aSnap != null)
-                {
-                    if (activityIndex[0] < 0) activityIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Tool, string.Empty);
-                    ctx.Transcript.UpdateMessageAt(activityIndex[0], aSnap);
-                }
-                if (ansSnap != null)
-                {
-                    if (answerIndex[0] < 0) answerIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
-                    ctx.Transcript.UpdateMessageAt(answerIndex[0], ansSnap);
-                }
-            };
+            renderTimer.Tick += delegate { MaterializeLiveSegs(ctx, sbLock, segs); };
             try { ctx.Transcript.StickToBottomDuringStreaming = true; }
             catch { }
             renderTimer.Start();
@@ -1485,31 +1479,51 @@ namespace GxPT
                         return BuildMessagesForModel(asList);
                     };
 
-                    Action<string> onAppend = delegate(string t) { lock (sbLock) { answerSb.Append(t); } };
-                    // argsJson is threaded through for files__edit, which renders a collapsible diff
-                    // record instead of the generic "using" marker (wired in a following change).
+                    // Assistant text appends to the current assistant bubble; a tool call closes it so
+                    // the next run of text starts a fresh bubble below the tool record.
+                    Action<string> onAppend = delegate(string t)
+                    {
+                        if (string.IsNullOrEmpty(t)) return;
+                        lock (sbLock)
+                        {
+                            LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
+                            if (cur == null || cur.Role != MessageRole.Assistant)
+                            {
+                                cur = new LiveSeg(MessageRole.Assistant);
+                                segs.Add(cur);
+                            }
+                            cur.Text.Append(t);
+                        }
+                    };
+                    // argsJson is threaded through for files__edit etc., which render a collapsible
+                    // record instead of the generic "using" marker. Register the record (it has its own
+                    // lock) before taking sbLock. Live keys are per-call GUIDs (ephemeral — the reloaded
+                    // view re-derives under the persisted call id). Consecutive calls share one block.
                     Action<string, string> onToolCall = delegate(string name, string argsJson)
                     {
-                        // Register the diff (if an edit) before appending its sentinel, so the data is
-                        // present by the time the marker text renders. Live keys are per-call GUIDs
-                        // (ephemeral — the reloaded view re-derives under the persisted call id).
                         string marker = EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
                         lock (sbLock)
                         {
-                            if (activitySb.Length > 0) activitySb.Append("\r\n");
-                            activitySb.Append(marker);
+                            LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
+                            if (cur == null || cur.Role != MessageRole.Tool)
+                            {
+                                cur = new LiveSeg(MessageRole.Tool);
+                                segs.Add(cur);
+                            }
+                            if (cur.Text.Length > 0) cur.Text.Append("\r\n");
+                            cur.Text.Append(marker);
                         }
                     };
                     Action onComplete = delegate
                     {
                         BeginInvoke((MethodInvoker)delegate
-                        { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, null); });
+                        { FinalizeToolSend(ctx, renderTimer, sbLock, segs, null); });
                     };
                     Action<string> onErr = delegate(string err)
                     {
                         string e2 = string.IsNullOrEmpty(err) ? "Unknown error." : err;
                         BeginInvoke((MethodInvoker)delegate
-                        { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, e2); });
+                        { FinalizeToolSend(ctx, renderTimer, sbLock, segs, e2); });
                     };
 
                     orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolCall, onComplete, onErr));
@@ -1518,7 +1532,7 @@ namespace GxPT
                 {
                     string msg = ex.Message;
                     BeginInvoke((MethodInvoker)delegate
-                    { FinalizeToolSend(ctx, renderTimer, sbLock, activitySb, answerSb, activityIndex, answerIndex, msg); });
+                    { FinalizeToolSend(ctx, renderTimer, sbLock, segs, msg); });
                 }
             });
         }
@@ -1527,31 +1541,18 @@ namespace GxPT
         // already appended the structured assistant/tool messages to history, so we only flush the
         // transcript bubbles and save.
         private void FinalizeToolSend(TabManager.ChatTabContext ctx, System.Windows.Forms.Timer renderTimer,
-                                      object sbLock, StringBuilder activitySb, StringBuilder answerSb,
-                                      int[] activityIndex, int[] answerIndex, string error)
+                                      object sbLock, List<LiveSeg> segs, string error)
         {
             try { renderTimer.Stop(); renderTimer.Dispose(); }
             catch { }
             try { ctx.Transcript.StickToBottomDuringStreaming = false; }
             catch { }
 
-            string aFinal, ansFinal;
-            lock (sbLock) { aFinal = activitySb.ToString(); ansFinal = answerSb.ToString(); }
+            // Flush any pending segment content (final delta the timer may not have rendered yet).
+            MaterializeLiveSegs(ctx, sbLock, segs);
 
-            if (aFinal.Trim().Length > 0)
-            {
-                if (activityIndex[0] < 0) activityIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Tool, string.Empty);
-                ctx.Transcript.UpdateMessageAt(activityIndex[0], aFinal);
-            }
-
-            // Any answer text the model did produce stays in its own assistant bubble; the error
-            // renders separately as a chrome-less red notice below it (not baked into the bubble).
-            if (ansFinal.Trim().Length > 0)
-            {
-                if (answerIndex[0] < 0) answerIndex[0] = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
-                ctx.Transcript.UpdateMessageAt(answerIndex[0], ansFinal);
-            }
-
+            // A failed turn surfaces as a chrome-less red notice below whatever (if anything) the model
+            // managed to produce — never baked into a bubble.
             if (error != null)
                 ShowTranscriptError(ctx.Transcript, error);
 
@@ -1562,6 +1563,37 @@ namespace GxPT
             }
             ctx.IsSending = false;
             if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
+        }
+
+        // Create/update the transcript messages backing the ordered live segments. Each segment becomes
+        // a real message only once it has content, so empty placeholder bubbles never appear. Runs on
+        // the UI thread (render timer + finalize). Segment text is snapshotted under sbLock; the
+        // transcript index/last-rendered length live on the segment and are only touched here.
+        private void MaterializeLiveSegs(TabManager.ChatTabContext ctx, object sbLock, List<LiveSeg> segs)
+        {
+            LiveSeg[] snap; string[] texts;
+            lock (sbLock)
+            {
+                snap = segs.ToArray();
+                texts = new string[snap.Length];
+                for (int i = 0; i < snap.Length; i++) texts[i] = snap[i].Text.ToString();
+            }
+            for (int i = 0; i < snap.Length; i++)
+            {
+                LiveSeg seg = snap[i];
+                string text = texts[i];
+                if (text.Length == 0) continue; // not materialized until it actually has content
+                if (seg.Index < 0)
+                {
+                    seg.Index = ctx.Transcript.AddMessageGetIndex(seg.Role, text);
+                    seg.LastLen = text.Length;
+                }
+                else if (text.Length != seg.LastLen)
+                {
+                    ctx.Transcript.UpdateMessageAt(seg.Index, text);
+                    seg.LastLen = text.Length;
+                }
+            }
         }
 
         // Build a list of messages for the model, appending any attachments to the user message content
@@ -2171,25 +2203,8 @@ namespace GxPT
         // Markdown is parsed on a background thread and the resulting blocks are appended to the
         // transcript in small batches on a UI timer. System messages are skipped; help templates
         // (NoSaveUntilUserSend) are scrolled to the top, otherwise the view sticks to the bottom.
-        // Role marker for the coalesced, chrome-less tool-activity message used on reload.
+        // Role marker for the chrome-less tool-activity blocks used on reload.
         private const string ToolActivityRole = "toolactivity";
-
-        // Emits a coalesced turn: a chrome-less tool-activity message (if any tools were used), then
-        // the assistant's answer bubble.
-        private static void FlushTurn(List<ChatMessage> items, ref System.Text.StringBuilder activity, ref string answer)
-        {
-            if (activity != null)
-            {
-                string a = activity.ToString();
-                if (a.Trim().Length > 0) items.Add(new ChatMessage(ToolActivityRole, a));
-                activity = null;
-            }
-            if (answer != null)
-            {
-                if (answer.Trim().Length > 0) items.Add(new ChatMessage("assistant", answer));
-                answer = null;
-            }
-        }
 
         // Activity marker for a tool call. If the tool maps to a collapsible/labelled record, register
         // it with the transcript under a stable key and return its sentinel; otherwise (or on any
@@ -2367,14 +2382,13 @@ namespace GxPT
                 try { ctx.Transcript.RefreshTheme(); }
                 catch { }
 
-                // Snapshot messages to process. System and tool messages are not shown. A tool-using
-                // assistant turn is persisted as several messages (assistant-with-tool_calls, tool
-                // result(s), ..., final assistant); coalesce each such run into ONE assistant bubble
-                // with the model's text plus compact "using <tool>" markers — never the raw tool
-                // results. This matches the live streamed view.
+                // Snapshot messages to process. System and tool-result messages are not shown. A
+                // tool-using assistant turn is persisted as several messages (assistant-with-tool_calls,
+                // tool result(s), ..., final assistant). Emit each assistant message's text as its own
+                // bubble and its tool calls as a chrome-less "using <tool>" block, interleaved in
+                // history order — so multi-turn tool use reads chronologically (text, tools, text, ...),
+                // matching the live streamed view. Tool results are never shown (the model summarizes).
                 var items = new List<ChatMessage>();
-                System.Text.StringBuilder activity = null; // tool-use markers (+ any intermediate text)
-                string answer = null;                       // final assistant content for the turn
                 foreach (var m in convo.History)
                 {
                     if (m == null) continue;
@@ -2383,20 +2397,18 @@ namespace GxPT
 
                     if (role == "user")
                     {
-                        FlushTurn(items, ref activity, ref answer);
                         items.Add(m);
                         continue;
                     }
 
+                    // assistant text (intermediate or final) -> its own bubble
+                    if (!string.IsNullOrEmpty(m.Content) && m.Content.Trim().Length > 0)
+                        items.Add(new ChatMessage("assistant", m.Content));
+
+                    // this turn's tool calls -> a chrome-less activity block below that text
                     if (m.ToolCalls != null && m.ToolCalls.Count > 0)
                     {
-                        // tool-calling assistant message -> tool activity (chrome-less)
-                        if (activity == null) activity = new System.Text.StringBuilder();
-                        if (!string.IsNullOrEmpty(m.Content))
-                        {
-                            if (activity.Length > 0) activity.Append("\r\n");
-                            activity.Append(m.Content);
-                        }
+                        var activity = new System.Text.StringBuilder();
                         for (int ti = 0; ti < m.ToolCalls.Count; ti++)
                         {
                             var tc = m.ToolCalls[ti];
@@ -2405,14 +2417,9 @@ namespace GxPT
                             string key = !string.IsNullOrEmpty(tc.Id) ? tc.Id : ("edit" + ti);
                             activity.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
                         }
-                    }
-                    else
-                    {
-                        // assistant with no tool calls -> the answer
-                        answer = m.Content;
+                        if (activity.Length > 0) items.Add(new ChatMessage(ToolActivityRole, activity.ToString()));
                     }
                 }
-                FlushTurn(items, ref activity, ref answer);
 
                 // Producer-consumer: parse off-UI, consume on UI timer in small chunks
                 var parsed = new List<ParsedMessage>(Math.Max(4, items.Count));

--- a/GxPT/Services/MarkdownParser.cs
+++ b/GxPT/Services/MarkdownParser.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 namespace GxPT
 {
     // ---------- Markdown model ----------
-    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table, EditDiff }
+    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table, EditDiff, Error }
 
     [Flags]
     public enum RunStyle { Normal = 0, Bold = 1, Italic = 2, Code = 4, Link = 8 }
@@ -44,6 +44,15 @@ namespace GxPT
     public sealed class EditDiffBlock : Block
     {
         public string Key;
+    }
+
+    // A chrome-less, red, user-facing error notice (e.g. a failed/empty model response). Unlike the
+    // edit-diff record, it is self-contained: the message text travels inside the sentinel (Base64-
+    // encoded), so it renders correctly even after the transcript is reloaded, with no side map.
+    // Anchored in the markdown by a content-free sentinel line — see ErrorSentinel/TryParseErrorMessage.
+    public sealed class ErrorBlock : Block
+    {
+        public string Message;
     }
 
     public sealed class BulletListBlock : Block
@@ -107,6 +116,40 @@ namespace GxPT
             if (len <= 0) return false;
             key = t.Substring(start, len);
             return true;
+        }
+
+        // ---------- Error sentinel ----------
+        // A self-contained anchor for a red error notice. The message is Base64-encoded (UTF-8) so it
+        // can carry arbitrary text on a single line without colliding with markdown or the sentinel
+        // brackets. Same mathematical white square brackets as the edit-diff sentinel.
+        public const string ErrorOpen = "⟦error:";
+        public const string ErrorClose = "⟧";
+
+        public static string ErrorSentinel(string message)
+        {
+            string encoded;
+            try { encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(message ?? string.Empty)); }
+            catch { encoded = string.Empty; }
+            return ErrorOpen + encoded + ErrorClose;
+        }
+
+        public static bool TryParseErrorMessage(string line, out string message)
+        {
+            message = null;
+            if (line == null) return false;
+            string t = line.Trim();
+            if (!t.StartsWith(ErrorOpen, StringComparison.Ordinal) ||
+                !t.EndsWith(ErrorClose, StringComparison.Ordinal)) return false;
+            int start = ErrorOpen.Length;
+            int len = t.Length - start - ErrorClose.Length;
+            if (len < 0) return false;
+            try
+            {
+                byte[] bytes = Convert.FromBase64String(t.Substring(start, len));
+                message = System.Text.Encoding.UTF8.GetString(bytes);
+                return true;
+            }
+            catch { return false; }
         }
 
         // ---------- Public API ----------
@@ -236,6 +279,17 @@ namespace GxPT
                     flushBullets();
                     flushNumbered();
                     blocks.Add(new EditDiffBlock { Type = BlockType.EditDiff, Key = editDiffKey });
+                    continue;
+                }
+
+                // error sentinel → its own chrome-less red notice (message carried inline)
+                string errorMessage;
+                if (TryParseErrorMessage(line, out errorMessage))
+                {
+                    flushParagraph();
+                    flushBullets();
+                    flushNumbered();
+                    blocks.Add(new ErrorBlock { Type = BlockType.Error, Message = errorMessage });
                     continue;
                 }
 

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -263,18 +263,25 @@ namespace GxPT
                 var er = new StreamReader(proc.StandardError.BaseStream, utf8, false);
                 string line;
                 bool sawAnyChunk = false;
+                int chunkCount = 0;
                 var stdoutBuf = new StringBuilder();
                 while ((line = sr.ReadLine()) != null)
                 {
                     line = line.Trim();
-                    // Buffer all stdout; if no chunks are seen, we'll inspect this for a JSON error body.
+                    // Buffer all stdout; if the request failed we'll inspect this for a JSON error body.
                     if (line.Length > 0)
                     {
                         try { stdoutBuf.AppendLine(line); }
                         catch { }
                     }
                     if (line.Length == 0) continue;
-                    if (line.StartsWith("data:")) line = line.Substring(5).Trim();
+                    // SSE events are "data: {...}" lines. Anything else (curl's --fail-with-body HTTP
+                    // error body, SSE ':' heartbeats, etc.) is NOT a content chunk: skip it here so it
+                    // can't be mis-parsed as an empty chunk and silently swallow the failure. It stays
+                    // buffered above for post-loop error extraction.
+                    bool isData = line.StartsWith("data:");
+                    if (!isData) continue;
+                    line = line.Substring(5).Trim();
                     if (line == "[DONE]") break;
 
                     ChatCompletionChunk chunk = null;
@@ -283,40 +290,55 @@ namespace GxPT
                     if (chunk != null)
                     {
                         sawAnyChunk = true;
+                        chunkCount++;
                         if (onChunk != null) onChunk(chunk);
                     }
                 }
+                int exitCode = -1;
                 try { proc.WaitForExit(); }
                 catch { }
+                try { exitCode = proc.ExitCode; }
+                catch { }
 
-                // If the process produced no chunks, surface an error from the body/stderr.
                 string err = null;
                 try { err = er.ReadToEnd(); }
                 catch { }
-                if (!sawAnyChunk)
+                string rawBody = null;
+                try { rawBody = stdoutBuf.ToString().Trim(); }
+                catch { }
+                string extractedMsg = null;
+                if (!string.IsNullOrEmpty(rawBody))
                 {
-                    string rawBody = null;
-                    try { rawBody = stdoutBuf.ToString().Trim(); }
+                    try { extractedMsg = ExtractErrorMessage(SafeParse(rawBody)); }
                     catch { }
+                }
 
-                    string extractedMsg = null;
+                try { Logger.Log("Stream", "curl exit=" + exitCode + " chunks=" + chunkCount + (sawAnyChunk ? string.Empty : " (no chunks)")); }
+                catch { }
+
+                // Treat the request as failed if curl reported a non-zero exit (--fail-with-body makes
+                // it exit non-zero on every HTTP error), if no content chunks arrived at all, or if the
+                // body carried a JSON error payload. Any of these means the user got no real answer.
+                bool failed = !sawAnyChunk || exitCode != 0 || !string.IsNullOrEmpty(extractedMsg);
+                if (failed)
+                {
                     if (!string.IsNullOrEmpty(rawBody))
-                    {
-                        try { extractedMsg = ExtractErrorMessage(SafeParse(rawBody)); }
+                        try { Logger.Log("HTTP", "curl error body: " + rawBody); }
                         catch { }
-                        try { Logger.Log("HTTP", "curl error body (no chunks): " + rawBody); }
+                    if (!string.IsNullOrEmpty(extractedMsg))
+                        try { Logger.Log("HTTP", "error.message: " + extractedMsg); }
                         catch { }
-                        if (!string.IsNullOrEmpty(extractedMsg))
-                            try { Logger.Log("HTTP", "error.message: " + extractedMsg); }
-                            catch { }
-                    }
                     if (!string.IsNullOrEmpty(err))
-                        try { Logger.Log("Stream", "curl stderr (no chunks): " + err); }
+                        try { Logger.Log("Stream", "curl stderr: " + err); }
                         catch { }
 
                     if (onError != null)
                     {
-                        var msg = !string.IsNullOrEmpty(extractedMsg) ? extractedMsg : (!string.IsNullOrEmpty(err) ? err : "Request failed");
+                        string msg = !string.IsNullOrEmpty(extractedMsg)
+                            ? extractedMsg
+                            : (!string.IsNullOrEmpty(err)
+                                ? err
+                                : (exitCode != 0 ? ("Request failed (curl exit " + exitCode + ")") : "Request failed"));
                         onError(msg.Trim());
                     }
                     CleanupTempFiles(tempFiles);


### PR DESCRIPTION
## Why

Certain models (notably some Claude slugs, and any turn where a tool call hit an upstream error) were **failing silently** — the user got an empty/missing bubble with no explanation. Two root causes:

1. **The streaming path swallowed HTTP errors.** curl runs with `--fail-with-body`, so on an HTTP error it writes the JSON error body to stdout and exits non-zero. That bare JSON object (`{"error":{...}}`) was being deserialized into an *empty* `ChatCompletionChunk`, which set `sawAnyChunk = true` — so the "no chunks → surface error" branch never ran and the failure vanished. The non-streaming title path logged errors fine; the streaming path did not.
2. **No diagnostics.** The streaming path logged nothing about curl's outcome, so the logs couldn't tell you *why* a model didn't respond.

## What changed

**`OpenRouterClient.StreamRawChunks` (logging + robustness)**
- Logs `curl exit=<code> chunks=<n>` on every request.
- Only real SSE `data:` lines count as content chunks now; non-data lines (the HTTP error body, `:` heartbeats) are skipped so they can't masquerade as an empty chunk. They're still buffered for error extraction.
- A request is treated as failed on **non-zero curl exit**, **no chunks**, or an **extractable JSON error payload** — and the body/stderr are logged in all of those cases.

**Chat window error handling (the requested UI)**
- Errors now render as a **chrome-less red notice** in the transcript — like a tool-call record, but red. Implemented as a self-contained `ErrorBlock` + sentinel (the message rides inline, Base64-encoded), surfaced via `ShowTranscriptError()` in both the plain and tool-enabled send paths.
- When a stream fails before any content arrives, the empty assistant placeholder is dropped; any partial text stays in its bubble and the error shows separately below it.

## Notes
- This is a behavior/UX change to the streaming + error path; please build on Windows and try a known-bad model slug to confirm the red notice and check `gxpt.log` for the new `curl exit=… chunks=…` lines.
- I did **not** change any model slugs. With this in place, the next failed run will log exactly what OpenRouter returns (e.g. an unavailable-model message), which should pinpoint the Claude issue.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_