### PR TITLE
Show tool-call approvals per conversation tab

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -203,7 +203,11 @@ namespace GxPT
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
 
             this.Visible = true;
-            this.BringToFront();
+            // Keep this Bottom-docked panel BEHIND the Fill transcript in z-order. WinForms fills the
+            // remaining space with the front-most Fill control, so the panel must stay back for the
+            // transcript to shrink *above* it (rather than the panel overlaying the transcript's
+            // bottom edge and its right-docked scrollbar). BringToFront would cause exactly that.
+            this.SendToBack();
         }
 
         public void HidePanel()

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -212,6 +212,24 @@ namespace GxPT
             _onChoose = null;
         }
 
+        // If the panel is torn down (e.g. its tab is closed) while a call still awaits a decision,
+        // resolve the pending request as Deny so the blocked tool-loop worker is released rather than
+        // left waiting on the signal forever.
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Action<ApprovalChoice> cb = _onChoose;
+                _onChoose = null;
+                if (cb != null)
+                {
+                    try { cb(ApprovalChoice.Deny); }
+                    catch { }
+                }
+            }
+            base.Dispose(disposing);
+        }
+
         private void AddRememberButtons(ApprovalRequest req)
         {
             RememberScope scope = req.Policy != null ? req.Policy.Scope : RememberScope.Tool;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -20,8 +20,10 @@ namespace GxPT
         private OpenRouterClient _client;
         private McpHost _mcpHost;
         private McpToolRegistry _mcpRegistry;
-        private IToolApprovalPolicy _mcpApproval;
-        private ToolApprovalPanel _approvalPanel;
+        // Remembered tool approvals are shared across all tabs for the app session (in-memory). The
+        // approval *prompt* is per-tab (each conversation has its own ToolApprovalPanel), but the
+        // remembered choices live in this one store so "remember" applies everywhere.
+        private IApprovalStore _approvalStore;
         private const string HelpApiKeysId = "help:api_keys";
         private const string HelpPrivacyId = "help:privacy";
 
@@ -434,21 +436,13 @@ namespace GxPT
 
         private void InitializeManagers()
         {
-            // The MCP tool-approval prompt: a panel docked at the bottom of the chat area, above the
-            // input. Created in code (not the Designer) and added to pnlBottom so it sits over the
-            // input panel when a tool call awaits approval.
-            try
-            {
-                _approvalPanel = new ToolApprovalPanel();
-                _approvalPanel.WorkingDirProvider = delegate { return _mcpHost != null ? _mcpHost.ActiveWorkingDir : null; };
-                if (this.pnlBottom != null) this.pnlBottom.Controls.Add(_approvalPanel);
-                // Remembered approvals are kept only for the lifetime of the app (in-memory), not
-                // persisted to settings.json — a remembered choice lasts the session, then resets.
-                _mcpApproval = new ToolApprovalPolicy(
-                    new ToolClassifier(),
-                    new TranscriptApprovalPrompt(this, delegate { return _approvalPanel; }),
-                    new InMemoryApprovalStore());
-            }
+            // Remembered approvals are kept only for the lifetime of the app (in-memory), not
+            // persisted to settings.json — a remembered choice lasts the session, then resets. The
+            // approval UI itself is per-tab: each conversation gets its own ToolApprovalPanel (see
+            // AttachApprovalPanel), so a pending approval appears on the tab that requested it rather
+            // than whatever tab happens to be active. The policy is built per turn in BeginToolSend
+            // and bound to that tab's panel, all sharing this one store.
+            try { _approvalStore = new InMemoryApprovalStore(); }
             catch { }
 
             // Initialize managers for UI concerns
@@ -576,11 +570,12 @@ namespace GxPT
                 strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
                 strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
                 strip.DismissRequested += delegate { DismissWorkspaceStripForContext(ctxRef); };
-                // Dock order: the strip is Top and the transcript is Fill. WinForms lays out docked
-                // controls by REVERSE z-order, so the Fill transcript must be the frontmost child for
-                // it to fill the area *below* the Top strip (otherwise the strip overlaps the
-                // transcript's top). Add the strip, then send the transcript to front.
+                // Dock order: the strip is Top, the approval panel is Bottom, and the transcript is
+                // Fill. WinForms lays out docked controls by REVERSE z-order, so the Fill transcript
+                // must be the frontmost child for it to fill the area *between* the Top strip and the
+                // Bottom approval panel. Add the docked siblings, then send the transcript to front.
                 ctx.Page.Controls.Add(strip);
+                AttachApprovalPanel(ctx);
                 if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
                 // Honor a persisted dismissal (only meaningful when no folder is set; setting one
@@ -588,6 +583,23 @@ namespace GxPT
                 if (string.IsNullOrEmpty(ctx.WorkingDir) && ctx.Conversation != null &&
                     ctx.Conversation.WorkspaceStripDismissed)
                     strip.Visible = false;
+            }
+            catch { }
+        }
+
+        // Create this tab's tool-approval panel (docked at the bottom of its transcript area, hidden
+        // until a tool call awaits a decision). Each conversation gets its own panel so an approval is
+        // shown on the tab that requested it; it reads file context from this tab's working dir.
+        internal void AttachApprovalPanel(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Page == null) return;
+            try
+            {
+                var panel = new ToolApprovalPanel();
+                ctx.ApprovalPanel = panel;
+                var ctxRef = ctx;
+                panel.WorkingDirProvider = delegate { return ctxRef.WorkingDir; };
+                ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
         }
@@ -1468,7 +1480,15 @@ namespace GxPT
             {
                 try
                 {
-                    var approval = _mcpApproval != null ? _mcpApproval : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
+                    // Per-turn approval policy bound to THIS tab's panel, so the prompt appears on the
+                    // conversation that requested the tool. The remembered-choice store is shared
+                    // across tabs. Falls back to allow-all only if approvals couldn't be set up.
+                    IToolApprovalPolicy approval = (_approvalStore != null && ctx.ApprovalPanel != null)
+                        ? new ToolApprovalPolicy(
+                            new ToolClassifier(),
+                            new TranscriptApprovalPrompt(this, delegate { return ctx.ApprovalPanel; }),
+                            _approvalStore)
+                        : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
                     var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);
                     orch.ProviderDataCollectionAllowed = providerAllow;

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -41,6 +41,9 @@ namespace GxPT
             public string WorkingDir;
             // The per-tab workspace strip docked above this tab's transcript (set by MainForm).
             public WorkspaceContextStrip WorkspaceStrip;
+            // The per-tab tool-approval panel docked at the bottom of this tab's transcript (set by
+            // MainForm). A pending approval shows only on the conversation that requested it.
+            public ToolApprovalPanel ApprovalPanel;
             public List<AttachedFile> PendingAttachments = new List<AttachedFile>();
             // Pending edit of a prior user message (by transcript/history index)
             public bool PendingEditActive;


### PR DESCRIPTION
## Why

The tool-call approval panel was a **single shared instance** docked in the global bottom panel. So when a conversation in tab B requested a tool while you were viewing tab A, the approval prompt popped up on **tab A**. And two tabs awaiting approval at the same time couldn't both be shown.

## What changed

- **Per-tab panel.** Each `ChatTabContext` now owns its own `ToolApprovalPanel`, docked at the bottom of that tab's transcript area (created in a new `AttachApprovalPanel`, right alongside the per-tab workspace strip — same docking pattern). A pending approval is parented in its tab's page, so it's only visible when that conversation's tab is selected.
- **Per-turn policy.** `BeginToolSend` now builds the `ToolApprovalPolicy` for the turn bound to the requesting tab's panel (via `TranscriptApprovalPrompt`). The **remembered-choice store is shared** across tabs (a field on the form), so "remember this tool / argument" still applies everywhere for the session.
- **Correct file context.** Each panel reads edit-diff file context from its own tab's working dir (`ctx.WorkingDir`) instead of the global active workdir.
- **Safety on tab close.** `ToolApprovalPanel.Dispose` resolves any still-pending request as `Deny`, so closing a tab mid-approval releases the blocked tool-loop worker instead of leaving it parked on the wait handle forever.

## Behavior
- Tab B requests a tool while you're on tab A → nothing pops up on A; the approval is waiting on B and shows when you switch there (the turn is paused at the gate, which is correct — approval needs you present).
- Two tabs can each have their own pending approval simultaneously.

## Notes
- WinForms-only files (MainForm/TabManager/ToolApprovalPanel), so this needs a Windows build to verify visually — I can't compile the legacy project here. The pure-logic test suite still passes (134/134).
- Suggested manual check: start a tool-using turn in one tab, switch to another tab before approving, confirm no prompt leaks over; switch back and approve. Also try two tabs awaiting approval at once.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_