### PR TITLE
Run MCP scoped servers per working directory (fix cross-tab interference)

### DIFF
--- a/GxPT.Tests/Mcp/McpHostTests.cs
+++ b/GxPT.Tests/Mcp/McpHostTests.cs
@@ -51,71 +51,117 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void SetActiveWorkingDir_opens_scoped_servers_with_the_workdir()
+        public void EnsureWorkingDir_opens_scoped_servers_with_the_workdir()
         {
             FakeServerConnector c; McpToolRegistry reg;
             var host = NewHost(out c, out reg);
             host.Start(new[] { Specs.Scoped("files", true), Specs.Scoped("git", true) });
-            Assert.Empty(c.CreatedNames); // nothing opened until a workdir is active
+            Assert.Empty(c.CreatedNames); // nothing opened until a workdir is ensured
 
-            host.SetActiveWorkingDir("C:\\proj");
+            host.EnsureWorkingDir("C:\\proj");
 
             Assert.Equal(new[] { "files", "git" }, c.CreatedNames.ToArray());
             Assert.True(c.Workdirs.All(w => w == "C:\\proj"));
             var m = Manifest(reg);
             Assert.Contains("files__files_tool", m);
             Assert.Contains("git__git_tool", m);
-            Assert.Equal("C:\\proj", host.ActiveWorkingDir);
+            Assert.Contains("C:\\proj", host.ActiveWorkingDirs);
         }
 
         [Fact]
-        public void SetActiveWorkingDir_before_Start_still_launches_scoped_servers()
+        public void EnsureWorkingDir_is_idempotent_for_the_same_folder()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true) });
+
+            host.EnsureWorkingDir("C:\\a");
+            host.EnsureWorkingDir("C:\\a"); // second call must NOT spawn another set
+
+            Assert.Equal(new[] { "files" }, c.CreatedNames.ToArray());
+        }
+
+        [Fact]
+        public void EnsureWorkingDir_before_Start_still_launches_scoped_servers()
         {
             // Reproduces the startup race: the working folder is applied before Start() has captured
-            // the scoped specs. Start() must honor the already-set workdir and launch them.
+            // the scoped specs. Start() must honor the already-requested workdir and launch them.
             FakeServerConnector c; McpToolRegistry reg;
             var host = NewHost(out c, out reg);
 
-            host.SetActiveWorkingDir("C:\\proj");        // arrives first; no specs yet
+            host.EnsureWorkingDir("C:\\proj");           // arrives first; no specs yet
             Assert.Empty(c.CreatedNames);
 
             host.Start(new[] { Specs.Scoped("command", true), Specs.Eager("web", true) });
 
             Assert.Contains("command", c.CreatedNames);  // scoped server launched by Start
             Assert.Contains("command__command_tool", Manifest(reg));
-            Assert.Equal("C:\\proj", host.ActiveWorkingDir);
+            Assert.Contains("C:\\proj", host.ActiveWorkingDirs);
         }
 
         [Fact]
-        public void Switching_workdir_tears_down_old_scoped_and_opens_new()
+        public void Different_workdirs_get_independent_scoped_sets_and_route_per_folder()
         {
             FakeServerConnector c; McpToolRegistry reg;
             var host = NewHost(out c, out reg);
             host.Start(new[] { Specs.Scoped("files", true) });
 
-            host.SetActiveWorkingDir("C:\\a");
-            var firstConn = c.Created.Last();
-            host.SetActiveWorkingDir("C:\\b");
+            host.EnsureWorkingDir("C:\\a");
+            var connA = c.Created.Last();
+            host.EnsureWorkingDir("C:\\b");
+            var connB = c.Created.Last();
 
+            // Both folders served by their own process; neither torn down by the other.
             Assert.Equal(new[] { "files", "files" }, c.CreatedNames.ToArray());
             Assert.Equal(new[] { "C:\\a", "C:\\b" }, c.Workdirs.ToArray());
-            Assert.Equal(ConnectionState.Closed, firstConn.State); // old one disposed
-            Assert.Contains("files__files_tool", Manifest(reg)); // new one present
+            Assert.NotSame(connA, connB);
+            Assert.Equal(ConnectionState.Ready, connA.State); // NOT closed by ensuring "C:\b"
+            Assert.Equal(ConnectionState.Ready, connB.State);
+
+            // The same tool name routes to the connection bound to the calling folder.
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("files__files_tool", "C:\\a", out r, out tool));
+            Assert.Same(connA, r);
+            Assert.True(reg.TryResolve("files__files_tool", "C:\\b", out r, out tool));
+            Assert.Same(connB, r);
         }
 
         [Fact]
-        public void SetActiveWorkingDir_null_tears_down_scoped()
+        public void ReleaseWorkingDir_tears_down_only_that_folder()
         {
             FakeServerConnector c; McpToolRegistry reg;
             var host = NewHost(out c, out reg);
             host.Start(new[] { Specs.Scoped("files", true) });
+            host.EnsureWorkingDir("C:\\a");
+            var connA = c.Created.Last();
+            host.EnsureWorkingDir("C:\\b");
+            var connB = c.Created.Last();
 
-            host.SetActiveWorkingDir("C:\\a");
-            Assert.Contains("files__files_tool", Manifest(reg));
+            host.ReleaseWorkingDir("C:\\a");
 
-            host.SetActiveWorkingDir(null);
-            Assert.Empty(Manifest(reg));
-            Assert.Null(host.ActiveWorkingDir);
+            Assert.Equal(ConnectionState.Closed, connA.State);
+            Assert.Equal(ConnectionState.Ready, connB.State);
+            Assert.DoesNotContain("C:\\a", host.ActiveWorkingDirs);
+            Assert.Contains("C:\\b", host.ActiveWorkingDirs);
+            Assert.Contains("files__files_tool", Manifest(reg)); // still provided by "C:\b"
+        }
+
+        [Fact]
+        public void RetainOnly_tears_down_folders_no_longer_in_use()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true) });
+            host.EnsureWorkingDir("C:\\a");
+            var connA = c.Created.Last();
+            host.EnsureWorkingDir("C:\\b");
+            var connB = c.Created.Last();
+
+            host.RetainOnly(new[] { "C:\\b" }); // only the folder with an open tab survives
+
+            Assert.Equal(ConnectionState.Closed, connA.State);
+            Assert.Equal(ConnectionState.Ready, connB.State);
+            Assert.Equal(new[] { "C:\\b" }, host.ActiveWorkingDirs);
         }
 
         [Fact]
@@ -125,7 +171,7 @@ namespace GxPT.Tests.Mcp
             var host = NewHost(out c, out reg);
             host.Start(new[] { Specs.Scoped("files", false) });
 
-            host.SetActiveWorkingDir("C:\\a");
+            host.EnsureWorkingDir("C:\\a");
 
             Assert.Empty(c.CreatedNames);
             Assert.Empty(Manifest(reg));
@@ -150,7 +196,7 @@ namespace GxPT.Tests.Mcp
             FakeServerConnector c; McpToolRegistry reg;
             var host = NewHost(out c, out reg);
             host.Start(new[] { Specs.Eager("web", true), Specs.Scoped("files", true) });
-            host.SetActiveWorkingDir("C:\\a");
+            host.EnsureWorkingDir("C:\\a");
             Assert.Equal(2, Manifest(reg).Count);
 
             host.Dispose();

--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -49,6 +49,61 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Scoped_tool_routes_to_the_connection_for_the_calling_workdir()
+        {
+            // Two instances of the same scoped server (one per working directory) expose the SAME
+            // function name. The model sees it once; resolution picks the folder-specific connection.
+            var reg = NewRegistry(8);
+            var connA = FakeConn.Ready("files", new ToolDef("read"));
+            var connB = FakeConn.Ready("files", new ToolDef("read"));
+            reg.AddConnection(connA, "C:\\a");
+            reg.AddConnection(connB, "C:\\b");
+
+            // Surface is deduped: the name appears once regardless of how many folders provide it.
+            Assert.Single(ManifestNames(reg).FindAll(delegate(string n) { return n == "files__read"; }));
+
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("files__read", "C:\\a", out r, out tool));
+            Assert.Same(connA, r);
+            Assert.True(reg.TryResolve("files__read", "C:\\b", out r, out tool));
+            Assert.Same(connB, r);
+            // A folder with no instance doesn't resolve the scoped tool.
+            Assert.False(reg.TryResolve("files__read", "C:\\other", out r, out tool));
+        }
+
+        [Fact]
+        public void Workdir_independent_tool_resolves_for_any_calling_workdir()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("web", new ToolDef("search")), null);
+
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("web__search", "C:\\a", out r, out tool)); // independent of folder
+            Assert.True(reg.TryResolve("web__search", null, out r, out tool));
+        }
+
+        [Fact]
+        public void Removing_one_workdir_instance_keeps_the_tool_while_another_provides_it()
+        {
+            var reg = NewRegistry(8);
+            var connA = FakeConn.Ready("files", new ToolDef("read"));
+            var connB = FakeConn.Ready("files", new ToolDef("read"));
+            reg.AddConnection(connA, "C:\\a");
+            reg.AddConnection(connB, "C:\\b");
+
+            reg.RemoveConnection(connA);
+
+            Assert.Contains("files__read", ManifestNames(reg)); // still provided by C:\b
+            McpServerConnection r; string tool;
+            Assert.False(reg.TryResolve("files__read", "C:\\a", out r, out tool));
+            Assert.True(reg.TryResolve("files__read", "C:\\b", out r, out tool));
+            Assert.Same(connB, r);
+
+            reg.RemoveConnection(connB);
+            Assert.DoesNotContain("files__read", ManifestNames(reg)); // last instance gone
+        }
+
+        [Fact]
         public void Sanitizes_illegal_characters()
         {
             var reg = NewRegistry(8);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -528,26 +528,40 @@ namespace GxPT
             if (_inputManager != null) _inputManager.FocusInputSoon();
         }
 
-        // Bind the MCP host's workdir-scoped servers to the active conversation's working folder
-        // (re-launches files/git/command against it; null disconnects them). Runs off the UI thread
-        // because (re)connecting can block.
+        // Reconcile the MCP host's workdir-scoped servers (files/git/command) with the open tabs:
+        // pre-warm the active conversation's folder and tear down any folder no longer referenced by an
+        // open tab. Each distinct working directory runs its own server set, kept alive across tab
+        // switches, so a tab is never disconnected by activity in another tab. Snapshots the tab state
+        // on the UI thread, then does the (potentially blocking) connect/teardown off-thread. Called on
+        // tab switch, tab open/close, and working-folder changes.
         private void SyncMcpWorkingDirFromActiveTab()
         {
             if (_mcpHost == null) return;
-            string wd = null;
+            string active = null;
+            var inUse = new List<string>();
             try
             {
-                var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
-                if (ctx != null) wd = ctx.WorkingDir;
+                var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
+                if (act != null) active = act.WorkingDir;
+                if (_tabManager != null)
+                {
+                    foreach (var c in _tabManager.TabContexts.Values)
+                        if (c != null && !string.IsNullOrEmpty(c.WorkingDir)) inUse.Add(c.WorkingDir);
+                }
             }
             catch { }
-            if (_mcpHost.ActiveWorkingDir == wd) return; // no change
+
             McpHost hostRef = _mcpHost;
-            string target = wd;
+            string activeRef = active;
+            string[] inUseArr = inUse.ToArray();
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
-                try { hostRef.SetActiveWorkingDir(target); }
-                catch (Exception ex) { try { Logger.Log("mcp", "SetActiveWorkingDir failed: " + ex.Message); } catch { } }
+                try
+                {
+                    if (!string.IsNullOrEmpty(activeRef)) hostRef.EnsureWorkingDir(activeRef);
+                    hostRef.RetainOnly(inUseArr); // release folders whose last tab closed
+                }
+                catch (Exception ex) { try { Logger.Log("mcp", "MCP workdir reconcile failed: " + ex.Message); } catch { } }
             });
         }
 
@@ -686,6 +700,9 @@ namespace GxPT
         private void OnTabsChanged()
         {
             if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
+            // A tab opening/closing changes which working folders are still in use; release the
+            // scoped servers of any folder whose last tab just closed.
+            SyncMcpWorkingDirFromActiveTab();
         }
 
         private void OnSidebarToggled()
@@ -942,7 +959,7 @@ namespace GxPT
                     {
                         hostRef.Start(specs);
                         // Launch the workdir-scoped servers for the active conversation's folder.
-                        if (!string.IsNullOrEmpty(wd)) hostRef.SetActiveWorkingDir(wd);
+                        if (!string.IsNullOrEmpty(wd)) hostRef.EnsureWorkingDir(wd);
                     }
                     catch (Exception ex) { try { Logger.Log("mcp", "host start failed: " + ex.Message); } catch { } }
                 });
@@ -1480,6 +1497,12 @@ namespace GxPT
             {
                 try
                 {
+                    // Make sure THIS conversation's folder has its own scoped server set before the
+                    // turn runs (idempotent; no-op if already connected), and route the turn's tool
+                    // calls to that folder so a concurrent turn in another tab can't interfere.
+                    if (_mcpHost != null && !string.IsNullOrEmpty(ctx.WorkingDir))
+                        _mcpHost.EnsureWorkingDir(ctx.WorkingDir);
+
                     // Per-turn approval policy bound to THIS tab's panel, so the prompt appears on the
                     // conversation that requested the tool. The remembered-choice store is shared
                     // across tabs. Falls back to allow-all only if approvals couldn't be set up.
@@ -1491,6 +1514,7 @@ namespace GxPT
                         : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
                     var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);
+                    orch.WorkingDir = ctx.WorkingDir;
                     orch.ProviderDataCollectionAllowed = providerAllow;
                     orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
                     {

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -37,6 +37,12 @@ namespace GxPT
         // it unset (provider default).
         public bool? ProviderDataCollectionAllowed { get; set; }
 
+        // The working directory of the conversation running this turn. Resolution of workdir-scoped
+        // tools (files/git/command) is routed to the server bound to THIS folder, so concurrent turns
+        // in different tabs hit their own folders' servers. Null = no workspace (scoped tools won't
+        // resolve); workdir-independent tools (web/github/custom) resolve regardless.
+        public string WorkingDir { get; set; }
+
         public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
                                    IToolApprovalPolicy approval, string model, ILogSink log)
             : this(streamer, registry, approval, model, log, DefaultMaxIterations, DefaultCallTimeoutMs)
@@ -156,7 +162,7 @@ namespace GxPT
 
             McpServerConnection conn;
             string toolName;
-            if (_registry == null || !_registry.TryResolve(call.Name, out conn, out toolName))
+            if (_registry == null || !_registry.TryResolve(call.Name, WorkingDir, out conn, out toolName))
             {
                 isError = true;
                 return "[Unknown tool: " + call.Name + "]";

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -7,10 +7,15 @@ namespace GxPT
 {
     // Owns the host's MCP server connections (D11) and the shared McpToolRegistry. Assembles
     // connections from config specs, wires each connection's lifecycle into the registry, and
-    // manages the lazy, per-conversation lifecycle of workdir-scoped servers:
+    // manages the lifecycle of workdir-scoped servers:
     //   * workdir-independent servers (web + every mcp.json entry) are opened once via Start();
-    //   * workdir-scoped built-ins (files/git/command) are (re)opened by SetActiveWorkingDir with
-    //     GXPT_WORKDIR set to the active conversation's directory, and torn down when it changes.
+    //   * workdir-scoped built-ins (files/git/command) run as ONE process set PER working directory.
+    //     EnsureWorkingDir(dir) lazily launches a folder's set (GXPT_WORKDIR=dir) and keeps it alive;
+    //     several conversation tabs sharing a folder share its set, while tabs on different folders get
+    //     independent sets. Switching tabs never tears anything down — only ReleaseWorkingDir/RetainOnly
+    //     (driven by which folders still have an open tab) and Dispose close scoped servers.
+    // Each scoped connection is registered with its workdir so tool calls resolve to the folder that
+    // requested them (McpToolRegistry.TryResolve(name, workdir)).
     // Transport construction is delegated to an IServerConnector so this logic is testable without
     // spawning processes. Thread-safe via a single lock; event handlers touch only the (separately
     // locked) registry, so they never re-enter this lock.
@@ -25,9 +30,13 @@ namespace GxPT
         private readonly object _lock = new object();
 
         private readonly List<McpServerConnection> _eager = new List<McpServerConnection>();
-        private readonly List<McpServerConnection> _scoped = new List<McpServerConnection>();
+        // One scoped connection set per working directory (key = the directory as supplied).
+        private readonly Dictionary<string, List<McpServerConnection>> _scopedByWorkdir =
+            new Dictionary<string, List<McpServerConnection>>(StringComparer.OrdinalIgnoreCase);
+        // Working dirs requested before Start() knew the scoped specs; launched when Start arrives.
+        private readonly List<string> _pendingWorkdirs = new List<string>();
         private List<McpServerSpec> _scopedSpecs = new List<McpServerSpec>();
-        private string _currentWorkdir;
+        private bool _started;
         private bool _disposed;
 
         public McpHost(IServerConnector connector, McpToolRegistry registry, ILogSink log)
@@ -47,10 +56,24 @@ namespace GxPT
 
         public McpToolRegistry Registry { get { return _registry; } }
 
-        public string ActiveWorkingDir { get { lock (_lock) { return _currentWorkdir; } } }
+        // The working directories that currently have a live (or pending) scoped server set. Snapshot;
+        // safe to enumerate.
+        public string[] ActiveWorkingDirs
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    var keys = new List<string>(_scopedByWorkdir.Keys);
+                    for (int i = 0; i < _pendingWorkdirs.Count; i++)
+                        if (!keys.Contains(_pendingWorkdirs[i])) keys.Add(_pendingWorkdirs[i]);
+                    return keys.ToArray();
+                }
+            }
+        }
 
         // Open all enabled, workdir-independent servers; remember the workdir-scoped specs for
-        // SetActiveWorkingDir. Call once after building specs from config.
+        // EnsureWorkingDir. Call once after building specs from config.
         public void Start(IEnumerable<McpServerSpec> specs)
         {
             lock (_lock)
@@ -69,47 +92,98 @@ namespace GxPT
                     }
                 }
                 _scopedSpecs = scoped;
+                _started = true;
 
-                // If a working directory was already set (e.g. SetActiveWorkingDir raced ahead of
-                // Start on startup), launch the scoped servers for it now.
-                if (_currentWorkdir != null && _scoped.Count == 0)
+                // Launch any working directories requested before Start knew the scoped specs.
+                if (_pendingWorkdirs.Count > 0)
                 {
-                    for (int i = 0; i < _scopedSpecs.Count; i++)
+                    List<string> pending = new List<string>(_pendingWorkdirs);
+                    _pendingWorkdirs.Clear();
+                    for (int i = 0; i < pending.Count; i++) OpenScopedLocked(pending[i]);
+                }
+            }
+        }
+
+        // Ensure the workdir-scoped servers (files/git/command) for `workdir` are running. Idempotent:
+        // a folder already served returns immediately; other folders' sets are left untouched. A
+        // null/empty workdir is a no-op (no scoped tools for a folderless conversation). Safe to call
+        // from a worker thread right before a tool turn; (re)connecting can block.
+        public void EnsureWorkingDir(string workdir)
+        {
+            if (string.IsNullOrEmpty(workdir)) return;
+            lock (_lock)
+            {
+                if (_disposed) return;
+                if (_scopedByWorkdir.ContainsKey(workdir)) return;
+                if (!_started)
+                {
+                    if (!_pendingWorkdirs.Contains(workdir)) _pendingWorkdirs.Add(workdir);
+                    return;
+                }
+                OpenScopedLocked(workdir);
+            }
+        }
+
+        // Tear down the scoped servers for a single working directory (e.g. its last tab closed).
+        public void ReleaseWorkingDir(string workdir)
+        {
+            if (string.IsNullOrEmpty(workdir)) return;
+            lock (_lock)
+            {
+                _pendingWorkdirs.Remove(workdir);
+                List<McpServerConnection> conns;
+                if (_scopedByWorkdir.TryGetValue(workdir, out conns))
+                {
+                    for (int i = 0; i < conns.Count; i++) Teardown(conns[i]);
+                    _scopedByWorkdir.Remove(workdir);
+                }
+            }
+        }
+
+        // Keep only the scoped server sets whose working directory is still in `keep`; tear down the
+        // rest. Called when the set of open tabs (and thus referenced folders) changes, so processes
+        // for closed conversations don't linger.
+        public void RetainOnly(IEnumerable<string> keep)
+        {
+            var keepSet = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            if (keep != null)
+                foreach (string k in keep)
+                    if (!string.IsNullOrEmpty(k)) keepSet[k] = true;
+
+            lock (_lock)
+            {
+                if (_disposed) return;
+                for (int i = _pendingWorkdirs.Count - 1; i >= 0; i--)
+                    if (!keepSet.ContainsKey(_pendingWorkdirs[i])) _pendingWorkdirs.RemoveAt(i);
+
+                List<string> drop = null;
+                foreach (string wd in _scopedByWorkdir.Keys)
+                    if (!keepSet.ContainsKey(wd)) { (drop ?? (drop = new List<string>())).Add(wd); }
+                if (drop != null)
+                {
+                    for (int i = 0; i < drop.Count; i++)
                     {
-                        McpServerSpec spec = _scopedSpecs[i];
-                        if (spec == null || !spec.Enabled) continue;
-                        McpServerConnection conn = ConnectAndAdd(spec, _currentWorkdir);
-                        if (conn != null) _scoped.Add(conn);
+                        List<McpServerConnection> conns = _scopedByWorkdir[drop[i]];
+                        for (int j = 0; j < conns.Count; j++) Teardown(conns[j]);
+                        _scopedByWorkdir.Remove(drop[i]);
                     }
                 }
             }
         }
 
-        // Make `workdir` the active conversation's directory: tear down the previous workdir-scoped
-        // servers and open fresh ones bound to it. null/empty disconnects them (no scoped tools).
-        public void SetActiveWorkingDir(string workdir)
+        // Launch all enabled scoped specs for `workdir` and record the set. Caller holds _lock.
+        private void OpenScopedLocked(string workdir)
         {
-            string wd = string.IsNullOrEmpty(workdir) ? null : workdir;
-            lock (_lock)
+            if (string.IsNullOrEmpty(workdir) || _scopedByWorkdir.ContainsKey(workdir)) return;
+            List<McpServerConnection> conns = new List<McpServerConnection>();
+            for (int i = 0; i < _scopedSpecs.Count; i++)
             {
-                if (_disposed) return;
-                if (_currentWorkdir == wd) return;
-
-                for (int i = 0; i < _scoped.Count; i++) Teardown(_scoped[i]);
-                _scoped.Clear();
-                _currentWorkdir = wd;
-
-                if (wd != null)
-                {
-                    for (int i = 0; i < _scopedSpecs.Count; i++)
-                    {
-                        McpServerSpec spec = _scopedSpecs[i];
-                        if (spec == null || !spec.Enabled) continue;
-                        McpServerConnection conn = ConnectAndAdd(spec, wd);
-                        if (conn != null) _scoped.Add(conn);
-                    }
-                }
+                McpServerSpec spec = _scopedSpecs[i];
+                if (spec == null || !spec.Enabled) continue;
+                McpServerConnection conn = ConnectAndAdd(spec, workdir);
+                if (conn != null) conns.Add(conn);
             }
+            _scopedByWorkdir[workdir] = conns;
         }
 
         private McpServerConnection ConnectAndAdd(McpServerSpec spec, string workdir)
@@ -140,7 +214,8 @@ namespace GxPT
 
             if (conn.State == ConnectionState.Ready)
             {
-                _registry.AddConnection(conn);
+                // Tag the connection with its workdir so tool calls resolve to the right folder.
+                _registry.AddConnection(conn, workdir);
                 return conn;
             }
 
@@ -184,9 +259,11 @@ namespace GxPT
             {
                 if (_disposed) return;
                 _disposed = true;
-                for (int i = 0; i < _scoped.Count; i++) Teardown(_scoped[i]);
+                foreach (List<McpServerConnection> conns in _scopedByWorkdir.Values)
+                    for (int i = 0; i < conns.Count; i++) Teardown(conns[i]);
+                _scopedByWorkdir.Clear();
+                _pendingWorkdirs.Clear();
                 for (int i = 0; i < _eager.Count; i++) Teardown(_eager[i]);
-                _scoped.Clear();
                 _eager.Clear();
             }
         }

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -15,6 +15,13 @@ namespace GxPT
     // (c) reveal_tools, the meta-tool that moves a tool from "known by name" to "callable". Owns the
     // server-qualified function-name bijection so tool_calls resolve back to (connection, toolName).
     //
+    // Workdir-scoped servers (files/git/command) run as one process PER working directory, so several
+    // connections can expose the SAME function name (e.g. files__read) for different folders. The
+    // model-facing surface (manifest / defs / reveal) is therefore deduped by function name — it's
+    // identical across folders — while resolution is workdir-aware: TryResolve(name, workdir) returns
+    // the connection bound to the calling turn's folder. Workdir-independent servers (web/github/
+    // custom) register with a null workdir and resolve for any turn.
+    //
     // Thread-safe: lifecycle methods are driven from connection reader threads (Ready/ToolsChanged/
     // fault), while the orchestrator calls the per-request/resolution methods from its worker thread.
     internal sealed class McpToolRegistry
@@ -29,13 +36,20 @@ namespace GxPT
             public string FunctionName;
             public string Description;
             public JObject Schema;
+            public string Workdir; // null = workdir-independent (web/github/custom)
         }
 
         private readonly object _lock = new object();
-        private readonly Dictionary<string, CatalogEntry> _byFunctionName =
-            new Dictionary<string, CatalogEntry>(StringComparer.Ordinal);
+        // One function name maps to one-or-more candidates: workdir-scoped tools have a candidate per
+        // open working directory (same name, different connection); workdir-independent tools have one.
+        private readonly Dictionary<string, List<CatalogEntry>> _byFunctionName =
+            new Dictionary<string, List<CatalogEntry>>(StringComparer.Ordinal);
         private readonly Dictionary<McpServerConnection, List<string>> _byConnection =
             new Dictionary<McpServerConnection, List<string>>();
+        // Remembers each connection's workdir so RefreshConnection (driven by a ToolsChanged event,
+        // which carries only the connection) can rebuild its entries with the right workdir tag.
+        private readonly Dictionary<McpServerConnection, string> _connWorkdir =
+            new Dictionary<McpServerConnection, string>();
         private readonly Dictionary<string, long> _revealed = new Dictionary<string, long>(StringComparer.Ordinal);
 
         private readonly int _revealCap;
@@ -52,7 +66,15 @@ namespace GxPT
 
         // ---- lifecycle (driven by McpHost from connection events) ----
 
+        // Workdir-independent registration (web/github/custom servers).
         public void AddConnection(McpServerConnection conn)
+        {
+            AddConnection(conn, null);
+        }
+
+        // workdir tags this connection's tools so resolution can pick the folder-specific instance.
+        // null => workdir-independent.
+        public void AddConnection(McpServerConnection conn, string workdir)
         {
             if (conn == null) return;
             // ListTools may hit the transport — call it outside the lock, then merge under it.
@@ -60,6 +82,7 @@ namespace GxPT
 
             lock (_lock)
             {
+                _connWorkdir[conn] = workdir;
                 List<string> fns;
                 if (!_byConnection.TryGetValue(conn, out fns))
                 {
@@ -78,8 +101,8 @@ namespace GxPT
                     e.FunctionName = fn;
                     e.Description = t.Description;
                     e.Schema = t.InputSchema;
-                    _byFunctionName[fn] = e;
-                    if (!fns.Contains(fn)) fns.Add(fn);
+                    e.Workdir = workdir;
+                    AddEntryLocked(fn, e, fns);
                 }
                 _manifestDirty = true;
             }
@@ -92,7 +115,10 @@ namespace GxPT
 
             lock (_lock)
             {
+                string workdir;
+                if (!_connWorkdir.TryGetValue(conn, out workdir)) workdir = null;
                 RemoveConnectionLocked(conn);
+                _connWorkdir[conn] = workdir;
 
                 List<string> fns = new List<string>();
                 _byConnection[conn] = fns;
@@ -108,8 +134,8 @@ namespace GxPT
                     e.FunctionName = fn;
                     e.Description = t.Description;
                     e.Schema = t.InputSchema;
-                    _byFunctionName[fn] = e;
-                    if (!fns.Contains(fn)) fns.Add(fn);
+                    e.Workdir = workdir;
+                    AddEntryLocked(fn, e, fns);
                 }
                 _manifestDirty = true;
             }
@@ -123,6 +149,24 @@ namespace GxPT
                 RemoveConnectionLocked(conn);
                 _manifestDirty = true;
             }
+        }
+
+        // Append (or replace, on refresh) this connection's entry for a function name. Several
+        // connections may legitimately share one name (the same scoped server for different folders).
+        private void AddEntryLocked(string fn, CatalogEntry e, List<string> fns)
+        {
+            List<CatalogEntry> list;
+            if (!_byFunctionName.TryGetValue(fn, out list))
+            {
+                list = new List<CatalogEntry>();
+                _byFunctionName[fn] = list;
+            }
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (ReferenceEquals(list[i].Conn, e.Conn)) { list[i] = e; if (!fns.Contains(fn)) fns.Add(fn); return; }
+            }
+            list.Add(e);
+            if (!fns.Contains(fn)) fns.Add(fn);
         }
 
         // ListTools may hit the transport; call it outside the lock and never let a fault propagate
@@ -139,16 +183,42 @@ namespace GxPT
 
         private void RemoveConnectionLocked(McpServerConnection conn)
         {
+            _connWorkdir.Remove(conn);
             List<string> fns;
             if (_byConnection.TryGetValue(conn, out fns))
             {
                 for (int i = 0; i < fns.Count; i++)
                 {
-                    _byFunctionName.Remove(fns[i]);
-                    _revealed.Remove(fns[i]);
+                    string fn = fns[i];
+                    List<CatalogEntry> list;
+                    if (_byFunctionName.TryGetValue(fn, out list))
+                    {
+                        for (int j = list.Count - 1; j >= 0; j--)
+                            if (ReferenceEquals(list[j].Conn, conn)) list.RemoveAt(j);
+                        // The name disappears from the surface only when no connection provides it.
+                        if (list.Count == 0)
+                        {
+                            _byFunctionName.Remove(fn);
+                            _revealed.Remove(fn);
+                        }
+                    }
                 }
                 _byConnection.Remove(conn);
             }
+        }
+
+        // First candidate for a function name (any will do for surface metadata — name, description and
+        // schema are identical across a scoped tool's per-folder instances).
+        private bool TryFirstEntryLocked(string fn, out CatalogEntry e)
+        {
+            List<CatalogEntry> list;
+            if (fn != null && _byFunctionName.TryGetValue(fn, out list) && list.Count > 0)
+            {
+                e = list[0];
+                return true;
+            }
+            e = null;
+            return false;
         }
 
         // ---- per-request (from the orchestrator) ----
@@ -198,7 +268,7 @@ namespace GxPT
                 for (int i = 0; i < fns.Count; i++)
                 {
                     CatalogEntry e;
-                    if (_byFunctionName.TryGetValue(fns[i], out e))
+                    if (TryFirstEntryLocked(fns[i], out e))
                         result.Add(FunctionDef(e.FunctionName, e.Description, CloneSchema(e.Schema)));
                 }
             }
@@ -225,7 +295,7 @@ namespace GxPT
                     {
                         string n = names[i];
                         CatalogEntry e;
-                        if (n != null && _byFunctionName.TryGetValue(n, out e))
+                        if (n != null && TryFirstEntryLocked(n, out e))
                         {
                             _revealed[n] = ++_tick; // add or bump recency
                             JObject d = new JObject();
@@ -250,18 +320,39 @@ namespace GxPT
             return sb.ToString();
         }
 
+        // Workdir-agnostic resolve (workdir-independent tools only). Kept for callers/tests that don't
+        // run a folder-scoped turn.
         public bool TryResolve(string functionName, out McpServerConnection conn, out string toolName)
+        {
+            return TryResolve(functionName, null, out conn, out toolName);
+        }
+
+        // Resolve a function name to the connection for this turn's working directory. Scoped tools
+        // match on workdir; workdir-independent tools (Workdir == null) match any turn.
+        public bool TryResolve(string functionName, string workdir, out McpServerConnection conn, out string toolName)
         {
             lock (_lock)
             {
-                CatalogEntry e;
-                if (functionName != null && _byFunctionName.TryGetValue(functionName, out e))
+                List<CatalogEntry> list;
+                if (functionName != null && _byFunctionName.TryGetValue(functionName, out list) && list.Count > 0)
                 {
-                    if (_revealed.ContainsKey(functionName))
-                        _revealed[functionName] = ++_tick; // keep an actively-called tool alive
-                    conn = e.Conn;
-                    toolName = e.OriginalName;
-                    return true;
+                    CatalogEntry best = null;
+                    // 1) exact workdir match (covers scoped tools, and null==null for independents).
+                    for (int i = 0; i < list.Count; i++)
+                        if (WorkdirEquals(list[i].Workdir, workdir)) { best = list[i]; break; }
+                    // 2) fall back to a workdir-independent candidate for an independent tool called
+                    //    from within a folder turn (e.g. web__search during a files turn).
+                    if (best == null)
+                        for (int i = 0; i < list.Count; i++)
+                            if (list[i].Workdir == null) { best = list[i]; break; }
+                    if (best != null)
+                    {
+                        if (_revealed.ContainsKey(functionName))
+                            _revealed[functionName] = ++_tick; // keep an actively-called tool alive
+                        conn = best.Conn;
+                        toolName = best.OriginalName;
+                        return true;
+                    }
                 }
             }
             conn = null;
@@ -270,6 +361,13 @@ namespace GxPT
         }
 
         // ---- internals ----
+
+        private static bool WorkdirEquals(string a, string b)
+        {
+            if (a == null) return b == null;
+            if (b == null) return false;
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        }
 
         private void EnforceCapLocked()
         {
@@ -344,8 +442,9 @@ namespace GxPT
         private bool CollidesWithDifferentLocked(string baseName, string serverName, string toolName)
         {
             CatalogEntry e;
-            if (!_byFunctionName.TryGetValue(baseName, out e)) return false;
-            // Same identity (e.g. a stale entry being re-added) is not a collision.
+            if (!TryFirstEntryLocked(baseName, out e)) return false;
+            // Same identity (a stale entry being re-added, or the same scoped server for another
+            // folder) is not a collision — those legitimately share the function name.
             bool sameServer = (e.Conn != null && e.Conn.Name == serverName);
             return !(sameServer && e.OriginalName == toolName);
         }


### PR DESCRIPTION
## The bug

All tabs shared **one** `McpHost` with a single global "active working directory." Switching to (or sending from) a tab whose folder differed tore down and relaunched the shared files/git/command server processes — faulting any tool call **in flight on another tab** with `[Server unavailable.]` (which is the "MCP closed" you saw). Even absent a teardown, the single global workdir was a correctness hazard: a concurrent turn could run a tool against the *wrong* folder.

(Diagnosis confirmed: writes are serialized and the server is single-threaded and contains tool exceptions, so concurrency itself is safe — the crash came from the shared-server teardown, and the wrong-folder risk from the single global workdir.)

## The fix — scoped servers per working directory

- **`McpHost`** keeps a pool keyed by workdir (`_scopedByWorkdir`). `EnsureWorkingDir(dir)` lazily launches a folder's set and keeps it alive; **switching tabs never tears anything down**. `ReleaseWorkingDir`/`RetainOnly` close a folder's servers only once no open tab still references it (ref-counted by reconciling against open tabs, on tab close + app exit). `SetActiveWorkingDir` is gone.
- **`McpToolRegistry`** resolution is workdir-aware: a scoped tool (e.g. `files__read`) can have one candidate per folder, all sharing a single model-facing name (the surface/manifest/reveal stay deduped). `TryResolve(name, workdir)` routes to the connection bound to the calling turn's folder; workdir-independent tools (web/github/custom) resolve for any turn. Backward-compatible overloads default workdir to `null`.
- **`McpChatOrchestrator`** carries the turn's `WorkingDir` and passes it to resolution.
- **`MainForm`** ensures a tab's folder servers exist before its turn, routes that turn to its folder, reconciles the pool with the open tabs (releasing folders whose last tab closed), and reads edit-approval file context from the active tab's folder.

## Result
- The teardown-mid-call crash is gone — a turn in one tab is never disconnected by activity in another.
- Each tab's tool calls always hit its **own** folder's server (no wrong-folder execution).
- Same-folder tabs share one server set (per your choice); concurrent same-file edits remain serialized server-side — a lost-update there surfaces as a normal tool error, not a crash (no extra lock added, per your choice).

## Tests
Core host/registry/orchestrator are linked into `GxPT.Tests`, so they compile and run here — **139/139 pass**, including new coverage: per-folder routing, independent sets that survive a tab switch, release/retain teardown, and surface dedup. `MainForm` (WinForms) still needs a Windows build to verify visually.

Suggested manual check: two tabs on **different** folders, edit in one then immediately switch/send in the other — the first must not get `[Server unavailable.]`; and two tabs on the **same** folder editing the same file concurrently.

Independent of the still-open per-tab-approval PR #49 (branched from `main`).

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_