### PR TITLE
Color-code the +N/-N line counts on edit-tool records

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -126,6 +126,8 @@ namespace GxPT
         private Color _clrInlineCodeBorder = Color.FromArgb(200, 200, 200);
         private Color _clrLink = Color.FromArgb(0, 102, 204);
         private Color _clrError = Color.FromArgb(200, 0, 0); // red error-notice text (theme-adjusted)
+        private Color _clrDiffAdd = Color.FromArgb(0, 128, 0);   // edit-record +N count (theme-adjusted)
+        private Color _clrDiffDel = Color.FromArgb(200, 0, 0);   // edit-record -N count (theme-adjusted)
         private Color _clrCopyHover = Color.FromArgb(230, 230, 230);
         private Color _clrCopyPressed = Color.FromArgb(210, 210, 210);
         private Color _clrScrollTrack = Color.FromArgb(235, 235, 235);
@@ -246,8 +248,16 @@ namespace GxPT
         // Used for files__edit (diff), command__run (batch), web__search (plain), and the other tool
         // records — the caller (MainForm) builds the label/body/language per tool. An empty body makes
         // it a non-collapsible one-line label (e.g. "Deleted <path>"). HeaderText excludes the
-        // disclosure triangle (added at draw time when there is a body).
-        private sealed class EditDiffData { public string HeaderText; public string Body; public string Language; }
+        // disclosure triangle (added at draw time when there is a body) and the +/- line counts (drawn
+        // separately, color-coded, from Added/Removed; -1 means "no counts for this record").
+        private sealed class EditDiffData
+        {
+            public string HeaderText;
+            public string Body;
+            public string Language;
+            public int Added = -1;
+            public int Removed = -1;
+        }
         private readonly object _editDiffLock = new object();
         private readonly Dictionary<string, EditDiffData> _editDiffs = new Dictionary<string, EditDiffData>(StringComparer.Ordinal);
         private readonly Dictionary<string, bool> _editDiffCollapsed = new Dictionary<string, bool>(StringComparer.Ordinal);
@@ -256,10 +266,24 @@ namespace GxPT
         // streaming worker thread and the history reload path, so it is lock-guarded.
         public void RegisterToolRecord(string key, string headerText, string body, string language)
         {
+            RegisterToolRecord(key, headerText, body, language, -1, -1);
+        }
+
+        // Overload carrying +/- line counts (added/removed) for an edit record, drawn color-coded next
+        // to the header. Pass -1 for records without counts.
+        public void RegisterToolRecord(string key, string headerText, string body, string language, int added, int removed)
+        {
             if (string.IsNullOrEmpty(key)) return;
             lock (_editDiffLock)
             {
-                _editDiffs[key] = new EditDiffData { HeaderText = headerText ?? string.Empty, Body = body ?? string.Empty, Language = language ?? "text" };
+                _editDiffs[key] = new EditDiffData
+                {
+                    HeaderText = headerText ?? string.Empty,
+                    Body = body ?? string.Empty,
+                    Language = language ?? "text",
+                    Added = added,
+                    Removed = removed
+                };
             }
         }
 
@@ -283,6 +307,25 @@ namespace GxPT
             string label = (data != null && !string.IsNullOrEmpty(data.HeaderText)) ? data.HeaderText : "(record)";
             if (!hasBody) return label;
             return (collapsed ? "▸" : "▾") + " " + label;
+        }
+
+        // The "  (+12 −3)" suffix for an edit record (empty when the record carries no counts). Kept
+        // separate from the header label so the +N can paint green and the −N red. The leading spaces
+        // separate it from the label.
+        private static string BuildEditDiffCountsText(EditDiffData data)
+        {
+            if (data == null || data.Added < 0 || data.Removed < 0) return string.Empty;
+            return "  (+" + data.Added + " −" + data.Removed + ")";
+        }
+
+        // Draw one run of the edit-record header at x (advancing x by the run's width) in the given
+        // color, so the label and the green/red +N/-N counts can sit on one line.
+        private static void DrawHeaderSeg(Graphics g, ref float x, float y, string text, Font font, Color color, StringFormat fmt)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            using (var b = new SolidBrush(color))
+                g.DrawString(text, font, b, new PointF(x, y), fmt);
+            x += g.MeasureString(text, font, PointF.Empty, fmt).Width;
         }
 
         // ---------- Batch update state ----------
@@ -512,6 +555,9 @@ namespace GxPT
             // Error-notice red: a deeper red on light themes, a brighter one on dark so it stays
             // legible against the background. Not part of ThemeColors (no chrome), derived from dark.
             _clrError = dark ? Color.FromArgb(255, 120, 120) : Color.FromArgb(200, 0, 0);
+            // +N green / -N red for edit-record line counts, brighter on dark so they stay legible.
+            _clrDiffAdd = dark ? Color.FromArgb(120, 200, 120) : Color.FromArgb(0, 128, 0);
+            _clrDiffDel = dark ? Color.FromArgb(255, 120, 120) : Color.FromArgb(200, 0, 0);
             _clrCopyHover = t.CopyHover;
             _clrCopyPressed = t.CopyPressed;
             _clrScrollTrack = t.ScrollTrack;
@@ -1039,7 +1085,9 @@ namespace GxPT
                         bool collapsed = IsEditDiffCollapsed(ed.Key);
                         int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
                         string headerText = BuildEditDiffHeaderText(data, collapsed, hasBody);
-                        int headerW = TextRenderer.MeasureText(headerText, _baseFont).Width;
+                        string countsText = BuildEditDiffCountsText(data);
+                        int headerW = TextRenderer.MeasureText(headerText, _baseFont).Width
+                                    + (countsText.Length > 0 ? TextRenderer.MeasureText(countsText, _baseFont).Width : 0);
                         int w = headerW;
                         int h = headerH;
                         if (hasBody && !collapsed)
@@ -1553,13 +1601,24 @@ namespace GxPT
                     int headerH = _baseFont.Height + 2 * EditDiffHeaderPad;
 
                     // Header row. With a body it's a clickable disclosure header (captured for the
-                    // collapse hit test); without one it's a plain non-interactive label.
+                    // collapse hit test); without one it's a plain non-interactive label. The label is
+                    // drawn in the normal text color; an edit record's +N/-N line counts follow it,
+                    // color-coded green/red.
                     string headerText = BuildEditDiffHeaderText(data, collapsed, hasBody);
-                    using (var brush = new SolidBrush(ForeColor))
                     using (var fmt = StringFormat.GenericTypographic)
                     {
                         fmt.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-                        g.DrawString(headerText, _baseFont, brush, new PointF(x0, y + EditDiffHeaderPad), fmt);
+                        float hx = x0;
+                        float hy = y + EditDiffHeaderPad;
+                        DrawHeaderSeg(g, ref hx, hy, headerText, _baseFont, ForeColor, fmt);
+                        if (data != null && data.Added >= 0 && data.Removed >= 0)
+                        {
+                            DrawHeaderSeg(g, ref hx, hy, "  (", _baseFont, ForeColor, fmt);
+                            DrawHeaderSeg(g, ref hx, hy, "+" + data.Added, _baseFont, _clrDiffAdd, fmt);
+                            DrawHeaderSeg(g, ref hx, hy, " ", _baseFont, ForeColor, fmt);
+                            DrawHeaderSeg(g, ref hx, hy, "−" + data.Removed, _baseFont, _clrDiffDel, fmt);
+                            DrawHeaderSeg(g, ref hx, hy, ")", _baseFont, ForeColor, fmt);
+                        }
                     }
                     if (hasBody && owner != null)
                     {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2266,10 +2266,10 @@ namespace GxPT
                 try
                 {
                     var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
-                    string header, body, language;
-                    if (TryBuildToolRecord(name, args, out header, out body, out language))
+                    string header, body, language; int added, removed;
+                    if (TryBuildToolRecord(name, args, out header, out body, out language, out added, out removed))
                     {
-                        transcript.RegisterToolRecord(key, header, body, language);
+                        transcript.RegisterToolRecord(key, header, body, language, added, removed);
                         return McpMarkers.EditDiff(key);
                     }
                 }
@@ -2300,17 +2300,19 @@ namespace GxPT
         // Maps a tool call to a transcript record. An empty body yields a one-line label (no expansion);
         // a non-empty body is a collapsible record highlighted in 'language'. Returns false for tools
         // that should keep the generic marker.
-        private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language)
+        private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language, out int added, out int removed)
         {
-            header = null; body = string.Empty; language = "text";
+            header = null; body = string.Empty; language = "text"; added = -1; removed = -1;
             switch (name)
             {
                 case "files__edit":
                 {
                     string path = Str(args, "path");
                     LineDiffResult diff = DiffUtil.BuildLineDiff(Str(args, "old_string"), Str(args, "new_string"));
-                    header = "edited " + (path.Length > 0 ? path : "(file)") + "  (+" + diff.Added + " −" + diff.Removed + ")";
-                    body = diff.Body; language = "diff"; return true;
+                    // The +N/-N counts ride alongside (color-coded at draw time), so the header label
+                    // is just the path.
+                    header = "edited " + (path.Length > 0 ? path : "(file)");
+                    body = diff.Body; language = "diff"; added = diff.Added; removed = diff.Removed; return true;
                 }
                 case "files__write":
                 {


### PR DESCRIPTION
## What

On an edit-tool history record the header reads `▾ edited path/to/file.cs  (+12 −3)`, but the `(+12 −3)` was drawn in the same color as the path. This colors the counts: **+N green, −N red** (theme-aware, matching the diff body's add/remove colors).

## How

- The `+N`/`−N` no longer live inside the header string. The record now carries `Added`/`Removed` counts (`RegisterToolRecord` gained an overload; the old one defaults to "no counts"), and `MainForm`'s `TryBuildToolRecord` outputs them while the header label stays just the path.
- The header is painted as runs: the disclosure triangle + `edited path` in the normal text color, then `+12` green and `−3` red. A small `DrawHeaderSeg` helper advances the x-cursor per run.
- Two theme-aware colors added (`_clrDiffAdd`/`_clrDiffDel`); the header width measurement includes the counts so block layout/selection bounds are unchanged.
- Applies to both the live stream and reloaded history (both go through the same `EditDiffMarkerOrCall` → `TryBuildToolRecord` path); counts are derived from the persisted tool-call args, so nothing new is stored in the conversation document. Other tool records (write/delete/search/…) pass `-1` and render exactly as before.

## Notes
WinForms-only paint change (`ChatTranscriptControl`/`MainForm`), so it needs a Windows build to confirm visually — the logic suite still passes 139/139.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_