### PR TITLE
Faster multi-tab launch: lazy transcript build + deferred MCP server launch

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -379,6 +379,11 @@ namespace GxPT
                 // Build only the now-visible tab; the rest stay deferred until first selected.
                 try { HydrateTabIfNeeded(_tabManager != null ? _tabManager.GetActiveContext() : null); }
                 catch { }
+
+                // Pre-warm MCP servers for the visible tab only (one reconcile, off the UI thread).
+                // Other tabs' servers launch lazily when they're sent to or first selected.
+                try { SyncMcpWorkingDirFromActiveTab(); }
+                catch { }
             }
             catch { }
         }
@@ -570,6 +575,11 @@ namespace GxPT
         private void SyncMcpWorkingDirFromActiveTab()
         {
             if (_mcpHost == null) return;
+            // Don't launch MCP servers while restoring a session: opening each tab would otherwise
+            // spin up a files/git/command set per distinct folder, and those process spawns/handshakes
+            // saturate the thread pool and delay the visible tab's transcript from rendering. Servers
+            // are launched lazily on first send (BeginToolSend) and pre-warmed once after restore.
+            if (_restoringTabs) return;
             string active = null;
             var inUse = new List<string>();
             try

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -24,6 +24,10 @@ namespace GxPT
         // approval *prompt* is per-tab (each conversation has its own ToolApprovalPanel), but the
         // remembered choices live in this one store so "remember" applies everywhere.
         private IApprovalStore _approvalStore;
+        // True only while restoring the previous session's tabs at startup. During restore, opening a
+        // conversation marks its transcript for lazy build instead of building it immediately, so only
+        // the visible tab is rendered up front (the rest hydrate when first selected).
+        private bool _restoringTabs;
         private const string HelpApiKeysId = "help:api_keys";
         private const string HelpPrivacyId = "help:privacy";
 
@@ -305,6 +309,12 @@ namespace GxPT
                 SessionState.LoadOpenTabs(out ids, out activeFromFile);
                 if (ids == null || ids.Count == 0) return;
 
+                // Defer transcript builds while every tab is opened, so reopening a session with many
+                // tabs doesn't render them all up front. Only the tab left visible is built below; the
+                // rest hydrate the first time they're selected (OnTabSelected -> HydrateTabIfNeeded).
+                _restoringTabs = true;
+                try
+                {
                 // We'll reuse the initial blank tab for the first item if suitable
                 bool firstUsed = false;
                 for (int i = 0; i < ids.Count; i++)
@@ -363,8 +373,24 @@ namespace GxPT
                     }
                 }
                 catch { }
+                }
+                finally { _restoringTabs = false; }
+
+                // Build only the now-visible tab; the rest stay deferred until first selected.
+                try { HydrateTabIfNeeded(_tabManager != null ? _tabManager.GetActiveContext() : null); }
+                catch { }
             }
             catch { }
+        }
+
+        // Build a tab's transcript if it was deferred at session restore. Idempotent and cheap once
+        // hydrated (the flag is cleared before the rebuild). Called for the visible tab after restore
+        // and for each tab the first time it becomes active.
+        private void HydrateTabIfNeeded(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || !ctx.NeedsTranscriptRebuild) return;
+            ctx.NeedsTranscriptRebuild = false;
+            if (ctx.Conversation != null) RebuildTranscriptAsync(ctx, ctx.Conversation);
         }
 
         private bool IsHelpConversationId(string id)
@@ -519,6 +545,13 @@ namespace GxPT
         // Event handlers for manager events
         private void OnTabSelected(TabPage selectedTab)
         {
+            // Build this tab's transcript if it was deferred at session restore (first time it's shown).
+            // Skipped while the restore loop is still opening tabs — the visible one is built afterward.
+            if (!_restoringTabs && _tabManager != null && selectedTab != null)
+            {
+                TabManager.ChatTabContext sel;
+                if (_tabManager.TabContexts.TryGetValue(selectedTab, out sel)) HydrateTabIfNeeded(sel);
+            }
             UpdateWindowTitleFromActiveTab();
             SyncComboModelFromActiveTab();
             // Refresh the attachments banner to reflect the active tab's pending attachments
@@ -2588,8 +2621,10 @@ namespace GxPT
             if (_sidebarManager != null && ctx.Conversation != null)
                 _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
 
-            // Rebuild transcript UI off the UI thread to avoid freezes on large histories
-            RebuildTranscriptAsync(ctx, convo);
+            // Rebuild transcript UI off the UI thread to avoid freezes on large histories. During
+            // session restore this is deferred (see HydrateTabIfNeeded) so only the visible tab renders.
+            if (_restoringTabs) ctx.NeedsTranscriptRebuild = true;
+            else RebuildTranscriptAsync(ctx, convo);
 
             // Adopt the conversation's saved working folder.
             ApplyLoadedWorkingDir(ctx);
@@ -2630,8 +2665,11 @@ namespace GxPT
                 if (_sidebarManager != null && ctx.Conversation != null)
                     _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
 
-                // Rebuild transcript UI off the UI thread to avoid freezes on large histories
-                RebuildTranscriptAsync(ctx, convo);
+                // Rebuild transcript UI off the UI thread to avoid freezes on large histories. During
+                // session restore this is deferred (see HydrateTabIfNeeded) so only the visible tab
+                // renders up front; the rest build when first selected.
+                if (_restoringTabs) ctx.NeedsTranscriptRebuild = true;
+                else RebuildTranscriptAsync(ctx, convo);
 
                 // Adopt the conversation's saved working folder.
                 ApplyLoadedWorkingDir(ctx);

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -44,6 +44,9 @@ namespace GxPT
             // The per-tab tool-approval panel docked at the bottom of this tab's transcript (set by
             // MainForm). A pending approval shows only on the conversation that requested it.
             public ToolApprovalPanel ApprovalPanel;
+            // True when this tab's conversation has been opened but its transcript has NOT yet been
+            // built (deferred at startup so only the visible tab pays the cost; built on first view).
+            public bool NeedsTranscriptRebuild;
             public List<AttachedFile> PendingAttachments = new List<AttachedFile>();
             // Pending edit of a prior user message (by transcript/history index)
             public bool PendingEditActive;

--- a/docs/transcript-performance.md
+++ b/docs/transcript-performance.md
@@ -1,0 +1,121 @@
+# Chat Transcript — Rendering Performance
+
+**Status:** Partially implemented (lazy tab rebuild done; the rest are open).
+**Last updated:** 2026-06-02
+
+This note documents a startup/rendering performance problem in the custom chat
+transcript widget (`ChatTranscriptControl`) and the work to address it. One fix
+(lazy per-tab rebuild) is implemented; the remaining items are recorded here as
+deliberately deferred follow-ups.
+
+---
+
+## 1. Symptom
+
+When the app reopens a previous session with **many tabs**, startup is slow: the
+UI appears to hang and then all transcripts render at once. Closing most tabs
+before exit makes the next launch much faster. The slowdown scales with the
+**total content across all tabs**, even though only one tab is visible at a time
+and only a small slice of that tab's transcript is on screen.
+
+## 2. Root causes
+
+### 2.1 Eager rebuild of every restored tab  *(fixed — see §3)*
+
+`RestoreOpenTabsOnStartup` reopens every saved tab, and each open historically
+called `RebuildTranscriptAsync` immediately. So all N transcripts were fully
+parsed and laid out up front, regardless of visibility. Parsing runs off the UI
+thread (a `ThreadPool` producer feeding a UI-timer consumer), but **layout runs
+on the UI thread**, so N tabs means N producers and N UI timers all competing for
+the UI thread — hence the "frozen, then everything appears" behavior.
+
+### 2.2 Measurement is not virtualized  *(open)*
+
+Painting *is* virtualized: `ChatTranscriptControl.OnPaint` skips items outside
+the viewport. **Measurement is not.** `Reflow()` iterates every `MessageItem` and
+calls `MeasureBubble` → `MeasureBlock` for every block to compute `_contentHeight`
+(needed for the scrollbar range). So even a single long transcript pays
+`O(all blocks)` on its first layout, and any later full reflow (resize, tab
+activation) re-measures everything.
+
+There is an append-only fast path (`ReflowAppendOnly`) that avoids re-measuring
+earlier items during incremental batch consumption, so building a transcript is
+not quadratic — but the first full measure still touches every block.
+
+### 2.3 Per-code-block measurement is expensive  *(open)*
+
+`MeasureBlock` for a `CodeBlock` creates a `Graphics`, enqueues syntax
+highlighting, and calls `MeasureColoredSegmentsNoWrap`. This is the priciest path
+in layout, and it runs for every code block in the transcript during measurement
+— including code far off screen.
+
+---
+
+## 3. Implemented: lazy per-tab rebuild
+
+At session restore, only the tab left **visible** has its transcript built; every
+other restored tab is marked and built the first time it is selected. This makes
+"many tabs" launch about as fast as "one tab" and directly matches the observed
+behavior (closing tabs before exit reduces eager work).
+
+Mechanism:
+
+- `ChatTabContext.NeedsTranscriptRebuild` — set when a tab is opened but its
+  transcript is deferred.
+- `MainForm._restoringTabs` — true only during the restore loop. `OpenConversation*`
+  checks it: while restoring, it sets `NeedsTranscriptRebuild` instead of calling
+  `RebuildTranscriptAsync`.
+- After the restore loop, `HydrateTabIfNeeded` builds the active tab.
+- `OnTabSelected` calls `HydrateTabIfNeeded` for the selected tab (skipped while
+  `_restoringTabs` is true), so deferred tabs build on first view.
+
+This change is confined to the restore / tab-switch path in `MainForm` and the
+flag on `ChatTabContext`; it does **not** touch the widget's measure/paint
+internals. A hydrated transcript persists for the session (tab switches don't
+tear it down), so a tab is built at most once.
+
+Non-goals of this change: it does not speed up a *single* very long transcript,
+and it doesn't reduce work when the user eventually visits every tab.
+
+---
+
+## 4. Deferred follow-ups
+
+These were intentionally left for later; they address the remaining cost,
+especially for a single long transcript.
+
+### 4.1 Measure-time virtualization  *(biggest, structural)*
+
+Avoid measuring off-screen items exactly. Options:
+- Cache each item's last-measured height and reuse it until its width or content
+  changes, so a full reflow re-measures only dirty items.
+- Estimate off-screen heights (e.g. from line/char counts) for the scrollbar
+  range and perform the exact, expensive measure lazily as items scroll into
+  view — true virtualization rather than paint-only.
+
+This is the most impactful for long transcripts but the most invasive: it touches
+`Reflow`, `_contentHeight`, scrollbar math, and hit-testing, which all currently
+assume every item has exact bounds.
+
+### 4.2 Defer syntax-highlight measurement  *(medium)*
+
+Give code blocks a cheap height estimate (line count × line height + chrome)
+during layout and only measure colored segments when the block is actually
+painted/visible. Cuts the worst per-block cost (§2.3) without full virtualization.
+
+### 4.3 Idle-scheduled hydration  *(small, optional)*
+
+If pre-building all tabs is desirable (so later switches are instant), hydrate
+deferred tabs one at a time on `Application.Idle` after the active tab is ready,
+rather than all at once — keeping the UI responsive while warming the rest.
+
+---
+
+## 5. Key code references
+
+- `MainForm.RestoreOpenTabsOnStartup`, `HydrateTabIfNeeded`, `OnTabSelected`,
+  `OpenConversationInTab` / `OpenConversationInNewTab` — restore + lazy hydrate.
+- `TabManager.ChatTabContext.NeedsTranscriptRebuild` — deferral flag.
+- `ChatTranscriptControl.Reflow` / `ReflowAppendOnly` / `MeasureBubble` /
+  `MeasureBlock` — the (non-virtualized) measurement path.
+- `ChatTranscriptControl.OnPaint` — the virtualized paint path (for contrast).

--- a/docs/transcript-performance.md
+++ b/docs/transcript-performance.md
@@ -49,6 +49,18 @@ highlighting, and calls `MeasureColoredSegmentsNoWrap`. This is the priciest pat
 in layout, and it runs for every code block in the transcript during measurement
 — including code far off screen.
 
+### 2.4 MCP servers launched per folder during restore  *(fixed — see §3)*
+
+With per-working-directory MCP servers, each restored tab's `ApplyLoadedWorkingDir`
+called `SyncMcpWorkingDirFromActiveTab`, which queued `EnsureWorkingDir` for that
+tab's folder. So reopening a session launched a **files/git/command set per
+distinct folder** (3 processes each) up front. Those spawns/handshakes — though
+off the UI thread — saturate the `ThreadPool`, and the visible tab's
+transcript-parse work item queues *behind* them, so the transcript appears late.
+(The earlier single-active-workdir model only ever kept one set, so this was a
+regression introduced with per-workdir servers.) MCP servers aren't needed until
+a message is actually sent.
+
 ---
 
 ## 3. Implemented: lazy per-tab rebuild
@@ -73,6 +85,13 @@ This change is confined to the restore / tab-switch path in `MainForm` and the
 flag on `ChatTabContext`; it does **not** touch the widget's measure/paint
 internals. A hydrated transcript persists for the session (tab switches don't
 tear it down), so a tab is built at most once.
+
+**MCP launch deferral (§2.4).** `SyncMcpWorkingDirFromActiveTab` is a no-op while
+`_restoringTabs` is true, so no servers spawn during restore. After restore it is
+called once to pre-warm the visible tab's folder; every other tab's servers
+launch lazily on first send (`BeginToolSend` already calls `EnsureWorkingDir`) or
+when the tab is first selected. This keeps the thread pool free for the visible
+tab's transcript parse.
 
 Non-goals of this change: it does not speed up a *single* very long transcript,
 and it doesn't reduce work when the user eventually visits every tab.


### PR DESCRIPTION
## What

Reopening a session with many tabs was slow to show transcripts. Two startup costs, both now deferred:

1. **Every restored tab's transcript was built up front** on the UI thread, even though only one tab is visible.
2. **A files/git/command MCP server set was launched per distinct working folder** during restore (a regression from the per-workdir servers change) — those process spawns/handshakes saturated the thread pool and queued the visible tab's transcript parse behind them.

## How

**Lazy transcript build**
- `ChatTabContext.NeedsTranscriptRebuild` marks a deferred tab; `MainForm._restoringTabs` is true only during the restore loop.
- While restoring, `OpenConversation*` sets the flag instead of calling `RebuildTranscriptAsync`. After restore, `HydrateTabIfNeeded` builds the visible tab; `OnTabSelected` builds others on first view. Each tab builds at most once and persists for the session.

**Deferred MCP server launch**
- `SyncMcpWorkingDirFromActiveTab` is a no-op while `_restoringTabs` is true, so no scoped servers spawn during restore. After restore it runs once to pre-warm only the visible tab's folder; other tabs' servers launch lazily on first send (`BeginToolSend` already calls `EnsureWorkingDir`) or first selection.

Confined to `MainForm`'s restore/tab-switch path plus one flag on `ChatTabContext` — no changes to the transcript widget's measure/paint internals.

## Docs

`docs/transcript-performance.md` documents both causes/fixes and the deliberately-deferred follow-ups (measure-time virtualization, deferred syntax-highlight measurement, idle-scheduled hydration).

## Notes
- Trade-off: first visit to a not-yet-built tab triggers its async rebuild (brief empty → populated); first tool-using send in a tab pays the server spawn then. Startup no longer pays either.
- WinForms-only; needs a Windows build to confirm. Logic suite 139/139.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s