### PR TITLE
Fix ObjectDisposedException when closing tabs mid-build

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -787,6 +787,10 @@ namespace GxPT
         // ---------- Layout ----------
         private void Reflow()
         {
+            // A disposed/handle-less control has no graphics surface; CreateGraphics would throw
+            // ObjectDisposedException. This can happen when a deferred async rebuild (or a queued
+            // reflow) runs after the tab was closed.
+            if (!IsHandleCreated || IsDisposed) return;
             using (Graphics g = CreateGraphics())
             {
                 int y = MarginOuter;
@@ -857,6 +861,8 @@ namespace GxPT
         // Assumes earlier items' bounds are already valid and control width hasn't changed significantly mid-batch.
         private void ReflowAppendOnly(int startIndex)
         {
+            // See Reflow: never touch the graphics surface of a disposed/handle-less control.
+            if (!IsHandleCreated || IsDisposed) return;
             if (startIndex < 0) { Reflow(); return; }
             using (Graphics g = CreateGraphics())
             {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2577,6 +2577,16 @@ namespace GxPT
                 timer.Interval = 15; // ~60 fps budget for small bursts
                 timer.Tick += (s2, e2) =>
                 {
+                    // The tab may have been closed (e.g. "Close Others") while this build was still
+                    // running — its transcript is then disposed. Stop touching it, or BeginBatchUpdates/
+                    // EndBatchUpdates would throw ObjectDisposedException.
+                    if (ctx == null || ctx.Transcript == null || ctx.Transcript.IsDisposed)
+                    {
+                        try { timer.Stop(); timer.Dispose(); }
+                        catch { }
+                        return;
+                    }
+
                     int avail;
                     lock (gate) { avail = produced - consumed; }
                     if (avail <= 0)


### PR DESCRIPTION
## The bug

`ObjectDisposedException: Cannot access a disposed object. Object name: 'ChatTranscriptControl'` when using **Close Others** (intermittently).

## Cause

`CloseConversationTab` sets `_tabControl.SelectedIndex` to an adjacent tab **before** it disposes the page. Since the lazy-rebuild change (#52), a tab selection starts an async transcript build via `OnTabSelected → HydrateTabIfNeeded → RebuildTranscriptAsync` (a `System.Windows.Forms.Timer`). During **Close Others**, which closes tabs in a loop, each removal transiently selects a neighbor — starting a build on it — and the **next** iteration disposes that neighbor. The orphaned timer keeps ticking on the disposed control: `EndBatchUpdates → ReflowAppendOnly → CreateGraphics()` → the exception. It's intermittent because it depends on a build still being in flight when the tab is disposed (hence "happened at least twice").

This is a regression from #52: before it, `OnTabSelected` didn't start builds, so transient selections during close were harmless.

## Fix

- **Rebuild timer** bails and stops if its tab's transcript is `null`/`IsDisposed`, so it never pokes a closed tab.
- **`Reflow` / `ReflowAppendOnly`** guard with `!IsHandleCreated || IsDisposed` before `CreateGraphics`, hardening *every* reflow entry point (the build timer, a queued `ReflowSoon` that runs post-dispose, resize) against a disposed control — defense-in-depth for any async-build/close race, not just this one.

I left the transient hydrations themselves in place (they now stop harmlessly); suppressing builds during a bulk close would be a minor optimization but isn't needed to fix the crash.

## Notes
WinForms-only; needs a Windows build to confirm. Logic suite still 139/139.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_