### PR TITLE
Steer the model to git tools over command when both are enabled

### DIFF
--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -324,5 +324,34 @@ namespace GxPT.Tests.Mcp
             Assert.Contains("reveal__tools", ManifestNames(reg)); // double underscore, not "reveal_tools"
             Assert.DoesNotContain("reveal_tools", ManifestNames(reg));
         }
+
+        // ---- git-over-command preference note ----
+
+        private const string GitPreferNote = "prefer the dedicated git__ tools";
+
+        [Fact]
+        public void Manifest_steers_to_git_tools_when_command_also_present()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("git", new ToolDef("status")));
+            reg.AddConnection(FakeConn.Ready("command", new ToolDef("run")));
+            Assert.Contains(GitPreferNote, reg.NamesManifestSystemMessage());
+        }
+
+        [Fact]
+        public void Manifest_omits_git_preference_note_without_command()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("git", new ToolDef("status")));
+            Assert.DoesNotContain(GitPreferNote, reg.NamesManifestSystemMessage());
+        }
+
+        [Fact]
+        public void Manifest_omits_git_preference_note_without_git()
+        {
+            var reg = NewRegistry(8);
+            reg.AddConnection(FakeConn.Ready("command", new ToolDef("run")));
+            Assert.DoesNotContain(GitPreferNote, reg.NamesManifestSystemMessage());
+        }
     }
 }

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -262,8 +262,7 @@ namespace GxPT
                     if (hasGit && hasCommand)
                     {
                         sb.Append("\n\nFor Git operations, prefer the dedicated git__ tools over the ");
-                        sb.Append("command tool: each is a separately approvable tool with finer-grained ");
-                        sb.Append("permissions. Only fall back to the command tool for Git functionality ");
+                        sb.Append("command tool. Only fall back to the command tool for Git functionality ");
                         sb.Append("the git__ tools do not provide.");
                     }
 

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -247,8 +247,26 @@ namespace GxPT
                     sb.Append("and makes them callable on the next step. You may reveal several at once. ");
                     sb.Append("Only reveal_tools and tools you have already revealed can be called.");
                     sb.Append("\n\nAvailable tools:");
+                    bool hasGit = false, hasCommand = false;
                     for (int i = 0; i < names.Count; i++)
+                    {
                         sb.Append("\n- ").Append(names[i]);
+                        if (!hasGit && names[i].StartsWith("git__", StringComparison.Ordinal)) hasGit = true;
+                        if (!hasCommand && names[i].StartsWith("command__", StringComparison.Ordinal)) hasCommand = true;
+                    }
+
+                    // When both the git and command toolsets are available, steer the model to the
+                    // dedicated git tools: each git operation is a separately approvable tool (finer-
+                    // grained, auditable permissions), whereas the command tool needs a broad "git"
+                    // command approval. Command stays a fallback for git functionality git__ lacks.
+                    if (hasGit && hasCommand)
+                    {
+                        sb.Append("\n\nFor Git operations, prefer the dedicated git__ tools over the ");
+                        sb.Append("command tool: each is a separately approvable tool with finer-grained ");
+                        sb.Append("permissions. Only fall back to the command tool for Git functionality ");
+                        sb.Append("the git__ tools do not provide.");
+                    }
+
                     _manifestCache = sb.ToString();
                     _manifestDirty = false;
                 }


### PR DESCRIPTION
## What

When **both** the git and command toolsets are enabled, the MCP names-manifest system message now appends:

> For Git operations, prefer the dedicated git__ tools over the command tool. Only fall back to the command tool for Git functionality the git__ tools do not provide.

(No rationale in the message itself — just the instruction. The "why" stays in a code comment.)

## How

The note is added in `McpToolRegistry.NamesManifestSystemMessage()`, gated on the manifest actually containing **both** a `git__`-prefixed and a `command__`-prefixed tool. So it only appears when both are available for the turn, and it's recomputed (cache invalidated) whenever the tool set changes — including the per-workdir connect/disconnect path. No change when only one (or neither) toolset is enabled.

## Tests
Three new registry tests (note present when both, absent without command, absent without git). GxPT.Tests **142/142**.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s