### PR TITLE
Default the git MCP to git's availability + clearer missing-git error

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -944,7 +944,10 @@ namespace GxPT
                 var opts = new McpConfig.BuiltInOptions();
                 opts.WebEnabled = AppSettings.GetBool("mcp_web_enabled", false);
                 opts.FilesEnabled = AppSettings.GetBool("mcp_files_enabled", false);
-                opts.GitEnabled = AppSettings.GetBool("mcp_git_enabled", false);
+                // Git defaults ON when git is installed and OFF when it isn't, and is force-disabled
+                // when git is missing regardless of the stored setting — so we never launch a git
+                // server whose tools could only return "git not found".
+                opts.GitEnabled = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
                 opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled", false);
                 opts.WebSearchKey = AppSettings.GetString("mcp_websearch_key");
                 opts.CurlPath = curlPath;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -38,9 +38,13 @@ namespace GxPT
         private Timer _mcpHighlightTimer;
         private bool _isMcpHighlighting = false;
 
+        // Tooltip explaining why the Git toggle is disabled when git isn't on PATH.
+        private readonly ToolTip _mcpTip = new ToolTip();
+
         public SettingsForm()
         {
             InitializeComponent();
+            this.Disposed += delegate { try { _mcpTip.Dispose(); } catch { } };
 
             // Compute settings paths under %AppData%\GxPT
             _settingsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GxPT");
@@ -1208,7 +1212,9 @@ namespace GxPT
             if (s == null) return;
             this.chkMcpWeb.Checked = s.mcp_web_enabled;
             this.chkMcpFiles.Checked = s.mcp_files_enabled;
-            this.chkMcpGit.Checked = s.mcp_git_enabled;
+            // Git defaults ON when git is installed and the user hasn't chosen otherwise; OFF (and
+            // disabled below) when git isn't on PATH.
+            this.chkMcpGit.Checked = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
             this.chkMcpCommand.Checked = s.mcp_command_enabled;
             this.chkMcpGithub.Checked = s.mcp_github_enabled;
             this.txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
@@ -1239,6 +1245,18 @@ namespace GxPT
             bool patOk = McpConfig.IsValidGitHubPat(this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : null);
             this.chkMcpGithub.Enabled = patOk;
             if (!patOk) this.chkMcpGithub.Checked = false;
+
+            // Git requires git on the system; if it isn't found, the toggle can't be enabled.
+            bool gitInstalled = GitProbe.IsInstalled();
+            this.chkMcpGit.Enabled = gitInstalled;
+            if (!gitInstalled) this.chkMcpGit.Checked = false;
+            try
+            {
+                this._mcpTip.SetToolTip(this.chkMcpGit, gitInstalled
+                    ? string.Empty
+                    : "Git was not found on your PATH. Install Git to enable these tools.");
+            }
+            catch { }
         }
 
         // Tavily keys look like "tvly-dev-XXXXXXXX" (or "tvly-XXXXXXXX"). Lenient prefix + length check.

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />
     <Compile Include="Services\Mcp\McpServerSpec.cs" />
     <Compile Include="Services\Mcp\McpConfig.cs" />
+    <Compile Include="Services\Mcp\GitProbe.cs" />
     <Compile Include="Services\Mcp\IServerConnector.cs" />
     <Compile Include="Services\Mcp\McpHost.cs" />
     <Compile Include="Services\Mcp\DefaultServerConnector.cs" />

--- a/GxPT/Services/Mcp/GitProbe.cs
+++ b/GxPT/Services/Mcp/GitProbe.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Diagnostics;
+
+namespace GxPT
+{
+    // Detects whether a usable `git` is available to the host (and therefore to the git MCP server,
+    // which inherits the host's environment). Used to default the git toggle ON when git is installed
+    // and OFF when it isn't, and to avoid launching a git server that could only return errors.
+    //
+    // The probe runs `git --version` once and caches the result for the process — git being installed
+    // doesn't change mid-session in practice (Invalidate() is provided for completeness, not wired to
+    // any UI yet).
+    internal static class GitProbe
+    {
+        private static readonly object _lock = new object();
+        private static bool _done;
+        private static bool _installed;
+
+        public static bool IsInstalled()
+        {
+            lock (_lock)
+            {
+                if (_done) return _installed;
+                _installed = Probe();
+                _done = true;
+                return _installed;
+            }
+        }
+
+        public static void Invalidate()
+        {
+            lock (_lock) { _done = false; }
+        }
+
+        private static bool Probe()
+        {
+            try
+            {
+                ProcessStartInfo psi = new ProcessStartInfo();
+                psi.FileName = "git";              // resolved via PATH, same as the server will use
+                psi.Arguments = "--version";
+                psi.UseShellExecute = false;
+                psi.CreateNoWindow = true;
+                psi.RedirectStandardOutput = true;
+                psi.RedirectStandardError = true;
+
+                using (Process p = Process.Start(psi))
+                {
+                    if (p == null) return false;
+                    // Drain so the child can't block on a full pipe, then bound the wait.
+                    try { p.StandardOutput.ReadToEnd(); } catch { }
+                    try { p.StandardError.ReadToEnd(); } catch { }
+                    if (!p.WaitForExit(3000))
+                    {
+                        try { if (!p.HasExited) p.Kill(); } catch { }
+                        return false;
+                    }
+                    return p.ExitCode == 0;
+                }
+            }
+            catch
+            {
+                // Win32Exception (file not found), etc. -> git is not available.
+                return false;
+            }
+        }
+    }
+}

--- a/servers/GitMcpServer/GitTools.cs
+++ b/servers/GitMcpServer/GitTools.cs
@@ -157,6 +157,11 @@ namespace GitMcpServer
             {
                 result = runner.Run(req);
             }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                // The git executable couldn't be launched at all (not installed / not on PATH).
+                return ToolResults.Error("git was not found. Install Git and ensure it is on your PATH (or set GXPT_GIT_PATH).");
+            }
             catch (Exception ex)
             {
                 return ToolResults.Error("failed to run git: " + ex.Message);

--- a/tests/GitMcpServer.Tests/GitToolsTests.cs
+++ b/tests/GitMcpServer.Tests/GitToolsTests.cs
@@ -191,5 +191,17 @@ namespace GitMcpServer.Tests
             var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "commit", new JObject()));
             Assert.True(Harness.IsError(msgs[0]));
         }
+
+        [Fact]
+        public void Missing_git_executable_returns_clear_error()
+        {
+            // Point GXPT_GIT_PATH at a path that doesn't exist -> Process.Start throws Win32Exception,
+            // which the tool turns into a clear "git was not found" error for the model.
+            string noGit = Path.Combine(_dir, "definitely-not-git" + (IsWindows ? ".exe" : ""));
+            var server = Harness.NewGitServer(noGit, _work);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "status", new JObject()));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("git was not found", Harness.Text(msgs[0]));
+        }
     }
 }


### PR DESCRIPTION
## Insights — what happens today

- **At launch:** the git server starts and registers all tools regardless of whether git is installed (`GitConfig` just reads `GXPT_GIT_PATH`, default `"git"`; no check).
- **When the model calls a tool:** `RunGit` → `Process.Start("git", …)` throws a `Win32Exception`, which is caught and returned as `"failed to run git: The system cannot find the file specified"` — so the model *does* get an error, but a cryptic one, and the useless tools stay exposed.
- **Default:** `mcp_git_enabled` defaults to `false`, with no awareness of installation.

So both fixes are worthwhile: don't launch/enable git when it's missing, **and** give a clear error if a call still hits a missing git.

## What this changes

- **`GitProbe` (new, host):** runs `git --version` once, caches whether git is on PATH (3s timeout guard; never throws).
- **`RebuildMcpHost`:** `opts.GitEnabled = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true)`. Net effect:
  - git **not installed** → force-disabled (server never launched), regardless of any stored setting;
  - git **installed**, unset → **enabled by default** (was `false`);
  - git installed, explicit choice → respected.
- **Settings form:** the Git toggle is **disabled with an explanatory tooltip** ("Git was not found on your PATH…") when git is missing, and **defaults checked** when git is installed and unset — kept consistent with the host via the same probe + default.
- **`GitMcpServer`:** a failed git launch (`Win32Exception`) now returns `"git was not found. Install Git and ensure it is on your PATH (or set GXPT_GIT_PATH)."` instead of the raw OS message.

This delivers both of the options you mentioned: the server effectively **shuts down / isn't launched** when git is missing, **and** there's a **clean error** if a call ever does hit a missing git (e.g., git removed after the probe).

## Tests
New server test (`Missing_git_executable_returns_clear_error`) points `GXPT_GIT_PATH` at a nonexistent path and asserts the clear message. GitMcpServer.Tests **18/18** (run under mono). Host files (`GitProbe`/`MainForm`/`SettingsForm`) are WinForms — verified by review; need a Windows build.

## Note on stacking
Independent of #54 (git tools) and #55 (settings reorder). It touches the same Git settings checkbox as #55 only at runtime (tooltip/enabled state) — no Designer conflict — so the order they merge doesn't matter.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s)_