### PR TITLE
Hide workspace strip by default in help conversations

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -459,6 +459,9 @@ namespace GxPT
                     {
                         string json = sr.ReadToEnd();
                         var convo = ConversationStore.LoadFromJson(_client, json);
+                        // Help conversations start with the workspace strip hidden until the user
+                        // explicitly sets a working folder (right-click tab), which re-shows it.
+                        if (convo != null) convo.WorkspaceStripDismissed = true;
                         return convo;
                     }
                 }
@@ -3103,6 +3106,8 @@ namespace GxPT
                 catch { }
                 if (convo != null)
                 {
+                    // Help starts with the workspace strip hidden until a working folder is set.
+                    convo.WorkspaceStripDismissed = true;
                     // Always treat help templates as no-save until user sends a new message
                     ctx.NoSaveUntilUserSend = true;
                     // Keep the specialized help id from the template for restoration
@@ -3184,6 +3189,8 @@ namespace GxPT
                 catch { }
                 if (convo != null)
                 {
+                    // Help starts with the workspace strip hidden until a working folder is set.
+                    convo.WorkspaceStripDismissed = true;
                     ctx.NoSaveUntilUserSend = true;
                     try { ctx.Page.Text = string.IsNullOrEmpty(convo.Name) ? "Privacy" : convo.Name; }
                     catch { }


### PR DESCRIPTION
## Summary
Help conversations now start with the workspace strip hidden by default. The strip will only be shown when the user explicitly sets a working folder via right-click on the tab.

## Changes
- Set `WorkspaceStripDismissed = true` when loading help conversations from stored JSON in `LoadHelpConversationById()`
- Set `WorkspaceStripDismissed = true` when creating new help conversations in `miApiKeysHelp_Click()` 
- Set `WorkspaceStripDismissed = true` when creating new help conversations in `miPrivacyHelp_Click()`
- Added clarifying comments explaining the behavior in all three locations

## Implementation Details
The workspace strip is now consistently hidden across all help conversation entry points until the user takes explicit action to set a working folder. This provides a cleaner initial experience for help content while preserving the ability to enable workspace functionality when needed.

https://claude.ai/code/session_01VNCqcvcz4w6zMs3dEMZH7s