### PR TITLE
Update README: agentic workflows and per-conversation ZDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Windows XP goes agentic.*
 
-A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support — plus agentic workflows and tool calling via the Model Context Protocol (MCP).
+A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to legacy hardware — autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
 
 ## Screenshot
 
@@ -20,8 +20,8 @@ A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to
 - **Code Syntax Highlighting**: Out-of-the-box support for a wide range of languages, including:
    - Ada, ASM, Bash, Basic, Batch, C, Clojure, C++, C#, CSS, CSV, Dart, EBNF, Elixir, Erlang, F#, Fortran, Go, Haskell, HTML, Java, JavaScript, JSON, Kotlin, Lisp (Common, Scheme/Racket, Clojure, Emacs), Lua, OCaml, Pascal, Perl, PHP, PowerShell, Properties, Python, Ruby, Regex, Rust, Scala, SQL, Swift, TypeScript, Visual Basic, XML, YAML, Zig
 - **Conversation Management**: Tabbed conversations and conversation history.
-- **Agentic Workflows**: GxPT autonomously chains multiple tool calls — looping until your task is done — to power **agentic coding** (file, git, and shell tools scoped to a per-conversation working folder) and **web search** (Tavily). Tools connect via the [Model Context Protocol](https://modelcontextprotocol.io/); bundled servers also include **GitHub** access, and custom MCP servers can be added via `mcp.json`.
-- **Tool Approval & Sandboxing**: Every tool call is gated by an in-app approval prompt showing the exact tool and arguments before anything runs; destructive operations (delete, shell commands, `git push`) always confirm. Approvals can be remembered per-tool, per-command, or per-directory for the session. File/git/command tools are confined to the working folder you choose.
+- **Agentic Workflows**: GxPT autonomously chains tool calls until your task is done, powering **agentic coding** (file/git/shell), **web search**, and **GitHub** access. Tools connect via the [Model Context Protocol](https://modelcontextprotocol.io/); add custom servers in `mcp.json`.
+- **Tool Approval & Sandboxing**: Every tool call is gated by an in-app approval prompt showing the exact tool and arguments before it runs, with approvals remembered per session. File/git/command tools are confined to the working folder you choose.
 - **File Attachments**: Add text file attachments to your messages to avoid cluttering up the conversation with long pasted text.
 - **Conversation Editing**: Don't like the response a model gave you? Go back and edit your message and get a new response.
 - **Privacy & Local Storage**: Conversations are stored locally and can be exported/imported to migrate across machines. Enforce **Zero Data Retention (ZDR)** per conversation to route only to providers that won't store your prompts or responses.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Windows XP goes agentic!*
 
-A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to the era of Luna and Aero - autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
+A native chatbot client and coding agent for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to the era of Luna and Aero - autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GxPT
 
-> *Windows XP goes agentic.*
+> *Windows XP goes agentic!*
 
 A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to legacy hardware — autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Windows XP goes agentic!*
 
-A native chatbot client and coding agent for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to the era of Luna and Aero - autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
+A native chatbot client and coding agent for Windows XP. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to the era of Luna and Aero - autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Windows XP goes agentic!*
 
-A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to legacy hardware — autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
+A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support. It also brings agentic workflows to the era of Luna and Aero - autonomously chaining tools for agentic coding and web search via the Model Context Protocol (MCP), with per-conversation privacy controls.
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GxPT
 
-A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support — plus tool calling via the Model Context Protocol (MCP).
+> *Windows XP goes agentic.*
+
+A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to provide a modern and user-friendly chat interface on legacy Windows systems, with robust Markdown and code syntax highlighting support — plus agentic workflows and tool calling via the Model Context Protocol (MCP).
 
 ## Screenshot
 
@@ -18,11 +20,11 @@ A native chatbot client for Windows XP, written in C# and .NET 3.5. GxPT aims to
 - **Code Syntax Highlighting**: Out-of-the-box support for a wide range of languages, including:
    - Ada, ASM, Bash, Basic, Batch, C, Clojure, C++, C#, CSS, CSV, Dart, EBNF, Elixir, Erlang, F#, Fortran, Go, Haskell, HTML, Java, JavaScript, JSON, Kotlin, Lisp (Common, Scheme/Racket, Clojure, Emacs), Lua, OCaml, Pascal, Perl, PHP, PowerShell, Properties, Python, Ruby, Regex, Rust, Scala, SQL, Swift, TypeScript, Visual Basic, XML, YAML, Zig
 - **Conversation Management**: Tabbed conversations and conversation history.
-- **MCP Tool Calling**: Connect AI models to tools via the [Model Context Protocol](https://modelcontextprotocol.io/). Bundled first-party servers provide **web search** (Tavily), **GitHub** (over HTTP), and **file**, **git**, and **shell command** access scoped to a per-conversation working folder. Custom MCP servers can be added via `mcp.json`.
+- **Agentic Workflows**: GxPT autonomously chains multiple tool calls — looping until your task is done — to power **agentic coding** (file, git, and shell tools scoped to a per-conversation working folder) and **web search** (Tavily). Tools connect via the [Model Context Protocol](https://modelcontextprotocol.io/); bundled servers also include **GitHub** access, and custom MCP servers can be added via `mcp.json`.
 - **Tool Approval & Sandboxing**: Every tool call is gated by an in-app approval prompt showing the exact tool and arguments before anything runs; destructive operations (delete, shell commands, `git push`) always confirm. Approvals can be remembered per-tool, per-command, or per-directory for the session. File/git/command tools are confined to the working folder you choose.
 - **File Attachments**: Add text file attachments to your messages to avoid cluttering up the conversation with long pasted text.
 - **Conversation Editing**: Don't like the response a model gave you? Go back and edit your message and get a new response.
-- **Data Stored Locally**: Conversations are stored locally, but may be exported and imported to migrate data across machines.
+- **Privacy & Local Storage**: Conversations are stored locally and can be exported/imported to migrate across machines. Enforce **Zero Data Retention (ZDR)** per conversation to route only to providers that won't store your prompts or responses.
 - **Settings and Customization**: Customize settings with Visual settings UI or built-in JSON editor. 
 - **Frontier Model Support**: Support for a huge range of AI models, including frontier models, from the OpenRouter.ai API. 
 - **Legacy Compatibility**: Runs on Windows XP and .NET 3.5.


### PR DESCRIPTION
Overhauls the README to surface two new major features while keeping the overall length essentially flat.

## Changes
- **Tagline** added near the top: *Windows XP goes agentic!*
- **Intro paragraph** now describes GxPT as a chatbot client **and coding agent**, and mentions agentic workflows ("the era of Luna and Aero") with per-conversation privacy controls.
- **Agentic Workflows** feature bullet (reframed from the old MCP tool-calling bullet) highlights agentic coding, web search, and GitHub access, trimmed to match the other bullets.
- **Tool Approval & Sandboxing** bullet shortened to match the surrounding bullets.
- **Privacy & Local Storage** bullet now surfaces per-conversation **Zero Data Retention (ZDR)** enforcement.

https://claude.ai/code/session_01ASFKycUzA31YNJJ2RttSP3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASFKycUzA31YNJJ2RttSP3)_