### PR TITLE
Fix silver theme window chrome and clarify GxPT version label

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -166,7 +166,10 @@
               var msi = findMsi(releases[i]);
               if (msi) {
                 btn.dataset.href = msi.browser_download_url;
-                var ver = releases[i].tag_name ? (' &middot; v' + releases[i].tag_name) : '';
+                // Label it "GxPT vX.Y.Z" so it's clearly the app version, not
+                // another prerequisite. Normalize the tag's leading "v" first.
+                var tag = releases[i].tag_name ? String(releases[i].tag_name).replace(/^v/i, '') : '';
+                var ver = tag ? (' &middot; GxPT v' + tag) : '';
                 note.innerHTML = baseNote + ver;
                 return;
               }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -12,12 +12,28 @@ html, body {
 
 /* ===== Silver Luna theme =====
    Retints XP.css's default blue Luna chrome to the silver scheme. */
+/* Retint the window frame: XP.css draws the blue beveled border as a stack of
+   inset box-shadows, so we have to restate the whole stack in silver tones
+   (mirrors XP.css's blue stop structure, darkest on the bottom-right edge). */
+body.theme-silver .window {
+  box-shadow:
+    inset -1px -1px #4a4a5a, inset 1px 1px #d6d5e0,
+    inset -2px -2px #6f6e85, inset 2px 2px #b0afc0,
+    inset -3px -3px #8d8ca3, inset 3px 3px #c7c6d6,
+    0 6px 22px rgba(0, 0, 0, 0.45) !important;
+}
 body.theme-silver .title-bar {
   /* Silver caption gradient (mirrors XP.css's blue stop structure) */
   background: linear-gradient(180deg,
     #ebebf2, #c7c6d6 8%, #a3a2b8 45%,
     #8d8ca3 88%, #8d8ca3 93%, #9b9ab0 95%, #76758d 96%, #76758d) !important;
+  /* XP.css gives the caption blue top/left/right borders + a blue text shadow;
+     retint all of them to silver (bottom edge was already handled). */
+  border-top: 1px solid #d6d5e0;
+  border-left: 1px solid #d6d5e0;
+  border-right: 1px solid #8d8ca3;
   border-bottom: 1px solid #6f6e85;
+  text-shadow: 1px 1px #6f6e85;
 }
 /* Desaturate the blue min/max glyphs to silver; Close stays red (correct for Silver Luna) */
 body.theme-silver .title-bar-controls button[aria-label="Minimize"],


### PR DESCRIPTION
## Summary

Two small fixes to the GxPT landing page (`docs/`):

### 1. Silver theme — eliminate remaining blue window chrome
The page applies `body.theme-silver`, but the silver override only retinted the title-bar background and bottom border. XP.css draws the rest of the Luna chrome in blue, which was still showing:
- **Window frame bevel** — XP.css renders it as a stack of blue inset `box-shadow`s. Added a `body.theme-silver .window` rule restating the whole bevel stack in silver tones (preserving the page's drop shadow).
- **Title-bar borders + text shadow** — the blue top/left/right borders and blue caption text-shadow are now silver.

### 2. Download note — label the app version clearly
The download note appended a bare ` · v0.15.0`, which read like another prerequisite next to "Windows XP" and ".NET Framework 3.5". It now reads ` · GxPT v0.15.0`, and the release tag's leading `v` is normalized so it can't produce `vv0.15.0`.

## Verification
Rendered `docs/index.html` headless (Playwright/Chromium):
- Window chrome renders fully silver — no blue border.
- With the GitHub releases API mocked, the note renders `Windows XP or later · .NET Framework 3.5 · GxPT v0.15.0`.

https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS

---
_Generated by [Claude Code](https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS)_