### PR TITLE
fix: files__edit fails on CRLF files with an LF old_string

### DIFF
--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -333,8 +333,7 @@ namespace FilesMcpServer
 
             string parent = Path.GetDirectoryName(full);
             string tmp = Path.Combine(parent, "." + Guid.NewGuid().ToString("N") + ".tmp");
-            int oldLen = oldString.Length;
-            int keep = oldLen - 1;
+            int keep = oldString.Length - 1;
             int replacements = 0;
             bool tooMany = false;
             bool committed = false;
@@ -347,10 +346,28 @@ namespace FilesMcpServer
                 {
                     char[] buf = new char[EditChunkChars];
                     string carry = string.Empty;
+                    bool eolResolved = false;
                     int read;
                     while (!tooMany && (read = sr.Read(buf, 0, buf.Length)) > 0)
                     {
-                        string window = carry + new string(buf, 0, read);
+                        string chunk = new string(buf, 0, read);
+
+                        // Match against the file's OWN line endings. The read tools (numbered/ranged
+                        // reads, search) normalize CRLF/CR to LF before the caller sees them, so an
+                        // old_string copied from a read is LF-only even when the file on disk is CRLF.
+                        // A byte-exact Ordinal match would then never find a multi-line span. Sniff the
+                        // file's dominant newline from the first chunk and translate old/new to it (which
+                        // also keeps new_string consistent with the file instead of injecting bare LFs).
+                        if (!eolResolved)
+                        {
+                            string fileNewline = DetectDominantNewline(chunk);
+                            oldString = NormalizeNewlines(oldString, fileNewline);
+                            newString = NormalizeNewlines(newString, fileNewline);
+                            keep = oldString.Length - 1;
+                            eolResolved = true;
+                        }
+
+                        string window = carry + chunk;
                         carry = ProcessEditWindow(window, oldString, newString, replaceAll, keep,
                             sw, ref replacements, ref tooMany);
                     }
@@ -621,6 +638,31 @@ namespace FilesMcpServer
             if (normalized.Length > 0 && normalized[normalized.Length - 1] == '\n')
                 normalized = normalized.Substring(0, normalized.Length - 1);
             return normalized.Split('\n');
+        }
+
+        // The file's dominant line-ending style, used by Edit to match against the file's own
+        // endings rather than the LF-normalized form the read tools expose. CRLF wins ties (a file
+        // with any CRLF is treated as CRLF) since mixed files are almost always CRLF-with-stray-LFs.
+        // Returns "\n" when there are no newlines (translation is then a no-op).
+        private static string DetectDominantNewline(string sample)
+        {
+            int crlf = 0;
+            int loneLf = 0;
+            for (int i = 0; i < sample.Length; i++)
+            {
+                if (sample[i] != '\n') continue;
+                if (i > 0 && sample[i - 1] == '\r') crlf++;
+                else loneLf++;
+            }
+            return (crlf > 0 && crlf >= loneLf) ? "\r\n" : "\n";
+        }
+
+        // Rewrite all line endings in s to `target` (first collapse CRLF/CR to LF, then expand).
+        private static string NormalizeNewlines(string s, string target)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            string lf = s.Replace("\r\n", "\n").Replace('\r', '\n');
+            return target == "\r\n" ? lf.Replace("\n", "\r\n") : lf;
         }
 
         // Number of decimal digits in a non-negative line number (matches its rendered width).

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -354,6 +354,71 @@ namespace FilesMcpServer.Tests
             Assert.Equal("one\r\nTWO\r\nthree", File.ReadAllText(Abs("crlf.txt")));
         }
 
+        [Fact]
+        public void Edit_matches_lf_old_string_against_crlf_file()
+        {
+            // The reported bug: the read tools hand back LF-normalized text, so a multi-line
+            // old_string copied from a read is LF-only — but the file on disk is CRLF. The match
+            // must still succeed (and surrounding CRLFs are preserved).
+            File.WriteAllText(Abs("crlf.txt"), "alpha\r\nbeta\r\ngamma\r\ndelta");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "crlf.txt",
+                    "old_string", "beta\ngamma", "new_string", "BETA\nGAMMA")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+            Assert.Equal("alpha\r\nBETA\r\nGAMMA\r\ndelta", File.ReadAllText(Abs("crlf.txt")));
+        }
+
+        [Fact]
+        public void Edit_normalizes_new_string_newlines_to_a_crlf_file()
+        {
+            // new_string's LFs are rewritten to the file's CRLF so the edit doesn't leave the file
+            // with mixed line endings (which is what plain single-line edits used to do).
+            File.WriteAllText(Abs("crlf.txt"), "head\r\ntail");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "crlf.txt",
+                    "old_string", "tail", "new_string", "x\ny\nz")));
+            Assert.False(Harness.IsError(msgs[0]));
+            string after = File.ReadAllText(Abs("crlf.txt"));
+            Assert.Equal("head\r\nx\r\ny\r\nz", after);
+            Assert.DoesNotContain("\n", after.Replace("\r\n", "")); // every LF is part of a CRLF — no bare LFs
+        }
+
+        [Fact]
+        public void Edit_keeps_lf_endings_in_an_lf_file()
+        {
+            // No regression for the common LF case: a CRLF detection must not inject CRLFs into an
+            // LF file, and an LF old_string keeps matching.
+            File.WriteAllText(Abs("lf.txt"), "a\nb\nc\nd");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "lf.txt",
+                    "old_string", "b\nc", "new_string", "B\nC")));
+            Assert.False(Harness.IsError(msgs[0]));
+            string after = File.ReadAllText(Abs("lf.txt"));
+            Assert.Equal("a\nB\nC\nd", after);
+            Assert.DoesNotContain("\r", after);
+        }
+
+        [Fact]
+        public void Edit_matches_lf_old_string_spanning_a_chunk_boundary_in_crlf_file()
+        {
+            // Combine the two hard cases: a CRLF file, an LF-authored multi-line old_string, AND a
+            // match whose internal CRLF straddles the 64K read boundary. This exercises the carry
+            // buffer using the post-normalization (CRLF-expanded) old_string length.
+            const int chunk = 64 * 1024;          // EditChunkChars
+            string filler = string.Concat(System.Linq.Enumerable.Repeat("ab\r\n", 16383)); // 65532 chars
+            string prefix = filler + "c";         // 65533 chars: the marker's '\r' lands at index 65535
+            File.WriteAllText(Abs("span.txt"), prefix + "AA\r\nBB" + "tail");
+            Assert.True(prefix.Length + 2 == chunk - 1); // '\r' is the last char of chunk 1
+
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "edit", Harness.Args("path", "span.txt",
+                    "old_string", "AA\nBB", "new_string", "CC")));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal(1, (int)msgs[0]["result"]["structuredContent"]["replacements"]);
+            Assert.Equal(prefix + "CC" + "tail", File.ReadAllText(Abs("span.txt")));
+        }
+
         // ---- search ----
 
         [Fact]


### PR DESCRIPTION
## Problem

`files__edit` could not edit a multi-line span in any file with CRLF line endings, failing with `old_string not found in file`. Single-line edits to the same files worked. This is why editing the XP font fix in `ChatTranscriptControl.cs` only succeeded one line at a time.

Root cause is an asymmetry between the read tools and the edit tool:

- The read tools normalize line endings to LF before the caller sees them — numbered/whole-file reads go through `SplitLines` (`text.Replace("\r\n", "\n").Replace('\r', '\n')`), and ranged reads + `search` go through `StreamReader.ReadLine()`, which strips terminators. So an `old_string` copied out of a read is **LF-only**, even when the file on disk is **CRLF**.
- `Edit` matched byte-exact with `StringComparison.Ordinal` against the **raw** (CRLF) file content. An LF-only multi-line `old_string` therefore never matched. A single-line `old_string` has no embedded terminator, so it always matched — the exact asymmetry observed.

(The `\r$` regex probe that might have caught this can't: `search` reads via `ReadLine`, which removes the `\r` before the regex runs.)

## Fix

`Edit` now sniffs the file's dominant newline from the first read chunk and translates `old_string` **and** `new_string` to it before matching. The carry-buffer length (`keep`) is recomputed from the post-normalization `old_string` so chunk-boundary matches keep working. Normalizing `new_string` too means edits no longer inject bare LFs into a CRLF file (the mixed-ending side effect plain single-line edits used to cause).

## Tests

Adds to `FilesToolsTests`:
- `Edit_matches_lf_old_string_against_crlf_file` — the core regression.
- `Edit_normalizes_new_string_newlines_to_a_crlf_file` — `new_string` LFs become CRLF; asserts no bare LF survives.
- `Edit_keeps_lf_endings_in_an_lf_file` — no regression; CRLF detection must not inject `\r` into an LF file.
- `Edit_matches_lf_old_string_spanning_a_chunk_boundary_in_crlf_file` — LF `old_string` whose internal CRLF straddles the 64K read boundary.

## Scope / relationship to #67

Touches only `servers/FilesMcpServer/FilesTools.cs` and its test file — disjoint from #67 (which touches `GxPT/Controls/ChatTranscriptControl.cs`, the `.csproj`, `AssemblyInfo.cs`, and the setup project). No overlap, so the two merge in any order without conflict. This is a fix to the editing tool, not the app; #67 is an app/UI change.

## Not verified here

Built on a Linux container with no .NET toolchain (project targets net48), so I could not compile or run the suite. Please run `dotnet test tests/FilesMcpServer.Tests` (or build in VS) to confirm green.

Note: newline detection samples only the first 64K chunk. Real source files always have newlines there; a file whose first newline is past 64K falls back to LF (not asserted otherwise in the tests). Can switch to a head pre-sniff if you'd prefer to cover that edge.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7)_