### PR TITLE
fix: JsonRpcPeer reports a clean shutdown as a transport fault

### DIFF
--- a/src/Mcp35.Core/Rpc/JsonRpcPeer.cs
+++ b/src/Mcp35.Core/Rpc/JsonRpcPeer.cs
@@ -195,20 +195,34 @@ namespace Mcp35.Core.Rpc
 
         private void OnChannelFaulted(Exception ex)
         {
+            lock (_gate)
+            {
+                // Idempotent: ignore a second fault, and ignore a late fault raised while/after we
+                // tear down (disposing the channel can trip its reader's EOF -> Faulted). Without this
+                // a clean shutdown would be reported as, and logged as, a transport fault.
+                if (_faulted || _disposed) return;
+                _faulted = true;
+                _faultEx = ex;
+            }
+            FailPending(ex);
+            _log.Log("mcp", "Transport faulted: " + (ex == null ? "(unknown)" : ex.Message));
+        }
+
+        // Wake every caller parked in SendRequest with the given reason so none hangs. Used by both
+        // a real channel fault and intentional disposal.
+        private void FailPending(Exception reason)
+        {
             List<PendingCall> toFault;
             lock (_gate)
             {
-                _faulted = true;
-                _faultEx = ex;
                 toFault = new List<PendingCall>(_pending.Values);
                 _pending.Clear();
             }
             for (int i = 0; i < toFault.Count; i++)
             {
-                toFault[i].Fault = ex;
+                toFault[i].Fault = reason;
                 toFault[i].Done.Set();
             }
-            _log.Log("mcp", "Transport faulted: " + (ex == null ? "(unknown)" : ex.Message));
         }
 
         private void RaiseInbound(string method, JToken prms, bool isRequest, RequestId id, JObject raw)
@@ -282,11 +296,21 @@ namespace Mcp35.Core.Rpc
                 if (_disposed) return;
                 _disposed = true;
             }
+
+            // Stop inbound callbacks first: disposing the channel can trip its reader's EOF and raise
+            // Faulted, which would otherwise re-enter OnChannelFaulted and log a spurious fault during
+            // an intentional shutdown. Unsubscribing also prevents any late message/fault from running
+            // after we are gone.
+            _channel.MessageReceived -= OnMessage;
+            _channel.Faulted -= OnChannelFaulted;
+
             try { _channel.Dispose(); }
             catch (Exception ex) { _log.Log("mcp", "Channel dispose threw: " + ex.Message); }
 
-            // Fault any callers still blocked in SendRequest so none hang.
-            OnChannelFaulted(_faultEx ?? new ObjectDisposedException("JsonRpcPeer"));
+            // Unblock any callers still parked in SendRequest. This is an intentional shutdown, not a
+            // transport fault, so report it as a disposal rather than synthesizing a fault (which used
+            // to surface as the misleading "Transport faulted: Cannot access a disposed object").
+            FailPending(new McpTransportException("Transport disposed."));
         }
 
         private static JToken IdToToken(RequestId id)

--- a/tests/Mcp35.Core.Tests/JsonRpcPeerTests.cs
+++ b/tests/Mcp35.Core.Tests/JsonRpcPeerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Mcp35.Core.Diagnostics;
 using Mcp35.Core.Errors;
 using Mcp35.Core.Rpc;
 using Newtonsoft.Json.Linq;
@@ -156,6 +157,85 @@ namespace Mcp35.Core.Tests
 
                 Assert.True(t.Join(2000));
                 Assert.IsType<McpTransportException>(caught);
+            }
+        }
+
+        [Fact]
+        public void Dispose_while_request_in_flight_unblocks_caller()
+        {
+            var ch = new LoopbackChannel(); // no responder => request would hang
+            var peer = new JsonRpcPeer(ch, null);
+            peer.Start();
+
+            Exception caught = null;
+            var t = new Thread(delegate ()
+            {
+                try { peer.SendRequest("hang", null, 5000); }
+                catch (Exception ex) { caught = ex; }
+            });
+            t.Start();
+
+            Assert.True(ch.SendSignaled.WaitOne(2000)); // the request is on the wire
+            peer.Dispose();
+
+            Assert.True(t.Join(2000)); // disposal must wake the parked caller, not let it hang
+            Assert.IsType<McpTransportException>(caught);
+        }
+
+        [Fact]
+        public void Dispose_does_not_report_a_transport_fault()
+        {
+            // A clean shutdown must not be logged as a fault. This used to surface as
+            // "Transport faulted: Cannot access a disposed object. Object name: 'JsonRpcPeer'".
+            var log = new RecordingLog();
+            var ch = new LoopbackChannel();
+            var peer = new JsonRpcPeer(ch, log);
+            peer.Start();
+            peer.Dispose();
+
+            string all = string.Join("\n", log.Messages);
+            Assert.DoesNotContain("Transport faulted", all);
+            Assert.DoesNotContain("disposed object", all); // no synthesized ObjectDisposedException
+        }
+
+        [Fact]
+        public void Real_channel_fault_is_reported_exactly_once()
+        {
+            // Genuine faults are still surfaced — and idempotently (a second/late fault is ignored).
+            var log = new RecordingLog();
+            var ch = new LoopbackChannel();
+            using (var peer = new JsonRpcPeer(ch, log))
+            {
+                peer.Start();
+                ch.Fault(new Exception("boom"));
+                ch.Fault(new Exception("boom-again")); // ignored: already faulted
+            }
+            Assert.Equal(1, log.Messages.FindAll(delegate (string m) { return m.Contains("Transport faulted"); }).Count);
+        }
+
+        [Fact]
+        public void Late_channel_callbacks_after_dispose_are_ignored()
+        {
+            // The reader thread can deliver a final message or fault after teardown; once disposed the
+            // peer has unsubscribed, so these are no-ops — no throw, no spurious fault log.
+            var log = new RecordingLog();
+            var ch = new LoopbackChannel();
+            var peer = new JsonRpcPeer(ch, log);
+            peer.Start();
+            peer.Dispose();
+
+            ch.Fault(new Exception("late fault"));
+            ch.Deliver("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}");
+
+            Assert.DoesNotContain("Transport faulted", string.Join("\n", log.Messages));
+        }
+
+        private sealed class RecordingLog : ILogSink
+        {
+            public readonly List<string> Messages = new List<string>();
+            public void Log(string category, string message)
+            {
+                lock (Messages) { Messages.Add(category + ": " + message); }
             }
         }
     }


### PR DESCRIPTION
## Symptom

Every teardown logged:

```
Transport faulted: Cannot access a disposed object.
Object name: 'JsonRpcPeer'.
```

## Cause

It's self-inflicted, not a thread race. `JsonRpcPeer.Dispose()` woke parked callers by calling `OnChannelFaulted(_faultEx ?? new ObjectDisposedException("JsonRpcPeer"))`. `OnChannelFaulted` logs `"Transport faulted: " + ex.Message`, so a clean shutdown was routed through the fault path and logged with that synthesized `ObjectDisposedException` message. Two related weaknesses:

- Disposing the channel can trip its reader's EOF → `Faulted`, which re-enters `OnChannelFaulted` (double processing / double log, and `_faultEx` overwrite).
- No guard against a late inbound message/fault arriving after `Dispose`.

## Fix

- `Dispose()` now **unsubscribes** the channel's `MessageReceived`/`Faulted` handlers before disposing it (so EOF-driven faults and late messages can't re-enter), then wakes parked callers via a new `FailPending(...)` with a clear `McpTransportException("Transport disposed.")` — no synthesized fault.
- `OnChannelFaulted` is **idempotent**: a second or post-dispose fault returns early, so a genuine fault logs exactly once and a clean shutdown logs nothing.
- Extracted `FailPending()` shared by the fault and dispose paths.

Behavior preserved: parked `SendRequest` callers are still unblocked on dispose; post-dispose `SendRequest` still throws `McpTransportException`; `IsConnected` still false after dispose.

## Tests (`JsonRpcPeerTests`)

- `Dispose_while_request_in_flight_unblocks_caller`
- `Dispose_does_not_report_a_transport_fault` (asserts no `Transport faulted` / `disposed object` in the log)
- `Real_channel_fault_is_reported_exactly_once` (genuine fault still surfaced, idempotent)
- `Late_channel_callbacks_after_dispose_are_ignored`

## Scope

Builds on `main`; touches only `src/Mcp35.Core/Rpc/JsonRpcPeer.cs` and its test. Independent of #69 (multiline search) and #67 (XP fonts).

## Honest caveat re: the loop stalls

This removes the misleading teardown log and hardens disposal, but I do **not** have evidence it fixes the "loop stalls until re-prompt" behavior — see the timeline analysis in the PR discussion. The disposed-peer log only appears during the teardown/reconnect cluster, which in the captured logs occurs *after* an already-idle gap, so it reads as a symptom of the recycle, not the cause of the stall. Stall root-cause needs host-side tool-loop logs.

## Not verified here

No .NET toolchain in this environment (net48) — couldn't compile/run. Please run `dotnet test tests/Mcp35.Core.Tests` (or build in VS) to confirm green.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7)_