### PR TITLE
feat: agentic-loop logging coverage (host side)

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1767,6 +1767,11 @@ namespace GxPT
                 }
                 catch (Exception ex)
                 {
+                    // The turn worker crashed (e.g. in EnsureWorkingDir / BuildMessagesForModel /
+                    // RunTurn). The user sees ex.Message in the transcript, but log the full exception
+                    // (type + stack) too — otherwise a worker crash leaves no trace in the log.
+                    try { LoggerSink.Instance.Log("mcp", "turn worker failed: " + ex); }
+                    catch { }
                     string msg = ex.Message;
                     BeginInvoke((MethodInvoker)delegate
                     { FinalizeToolSend(ctx, renderTimer, sbLock, segs, msg); });

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Mcp35.Client;
 using Mcp35.Core.Diagnostics;
@@ -82,10 +83,18 @@ namespace GxPT
         {
             if (history == null) throw new ArgumentNullException("history");
 
+            // Short id so a turn's lines can be followed in the log even when tabs run concurrently
+            // (the ThreadPool thread id is reused across turns and can't be relied on for this).
+            string turnId = Guid.NewGuid().ToString("N").Substring(0, 6);
+            _log.Log("mcp", "[turn " + turnId + "] start: model=" + _model + ", history=" + history.Count
+                + " msg(s), maxIterations=" + _maxIterations);
+
             for (int iter = 0; iter < _maxIterations; iter++)
             {
                 IList<JObject> tools = _registry != null ? _registry.ExposedFunctionDefs() : null;
                 string manifest = _registry != null ? _registry.NamesManifestSystemMessage() : null;
+                _log.Log("mcp", "[turn " + turnId + "] iteration " + (iter + 1) + "/" + _maxIterations
+                    + ": requesting model with " + (tools != null ? tools.Count : 0) + " exposed tool(s)");
 
                 // The names manifest rides as an extra system message in front of history; it is not
                 // persisted (rebuilt each request from the live catalog).
@@ -116,13 +125,23 @@ namespace GxPT
                 if (errored)
                 {
                     // A streaming/transport error already failed this request; surface and stop.
+                    _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
+                        + ": stream error: " + (errMessage ?? "(none)"));
                     if (ui != null) ui.OnError(errMessage);
                     return;
                 }
 
+                _log.Log("mcp", "[turn " + turnId + "] response: finish_reason="
+                    + (asm.FinishReason ?? "(none)")
+                    + ", toolCalls=" + (asm.ProducedToolCalls ? asm.Calls.Count : 0)
+                    + ", textLen=" + (asm.Text != null ? asm.Text.Length : 0)
+                    + (asm.Truncated ? " [TRUNCATED: model output cut off by length]" : ""));
+
                 if (!asm.ProducedToolCalls)
                 {
                     history.Add(new ChatMessage("assistant", asm.Text));
+                    _log.Log("mcp", "[turn " + turnId + "] complete: final answer after " + (iter + 1)
+                        + " iteration(s), " + (asm.Text != null ? asm.Text.Length : 0) + " chars");
                     if (ui != null) ui.Complete();
                     return;
                 }
@@ -140,7 +159,7 @@ namespace GxPT
                     if (ui != null) ui.OnToolCall(call.Name, call.ArgumentsJson);
 
                     bool isError;
-                    string result = ExecuteCall(call, out isError);
+                    string result = ExecuteCall(call, turnId, out isError);
 
                     if (ui != null) ui.OnToolResult(call.Name, result, isError);
                     ChatMessage toolMsg = new ChatMessage("tool", result);
@@ -151,6 +170,8 @@ namespace GxPT
             }
 
             // Bounded: hitting the cap returns a note rather than looping unbounded.
+            _log.Log("mcp", "[turn " + turnId + "] stopped: hit max iterations (" + _maxIterations
+                + ") with tool calls still pending; returning [Tool-call limit reached]");
             history.Add(new ChatMessage("assistant", "[Tool-call limit reached.]"));
             if (ui != null) ui.Complete();
         }
@@ -158,18 +179,24 @@ namespace GxPT
         // Executes one tool call, returning the text to feed back as the tool message content.
         // Failures are returned as content (not thrown) so the model can recover; isError flags the
         // UI marker. reveal_tools is handled locally without an MCP round-trip.
-        private string ExecuteCall(ToolCall call, out bool isError)
+        private string ExecuteCall(ToolCall call, string turnId, out bool isError)
         {
             isError = false;
 
             if (_registry != null && _registry.IsRevealTools(call.Name))
-                return _registry.Reveal(ParseRevealNames(call.ArgumentsJson));
+            {
+                string[] names = ParseRevealNames(call.ArgumentsJson);
+                _log.Log("mcp", "[turn " + turnId + "] reveal_tools: " + names.Length + " name(s)");
+                return _registry.Reveal(names);
+            }
 
             McpServerConnection conn;
             string toolName;
             if (_registry == null || !_registry.TryResolve(call.Name, WorkingDir, out conn, out toolName))
             {
                 isError = true;
+                _log.Log("mcp", "[turn " + turnId + "] unresolved tool '" + call.Name + "' (workdir="
+                    + (string.IsNullOrEmpty(WorkingDir) ? "(none)" : WorkingDir) + ")");
                 return "[Unknown tool: " + call.Name + "]";
             }
 
@@ -177,36 +204,57 @@ namespace GxPT
             if (!TryParseArgs(call.ArgumentsJson, out args))
             {
                 isError = true;
+                _log.Log("mcp", "[turn " + turnId + "] invalid arguments for '" + call.Name
+                    + "' (not valid JSON)");
                 return "[Invalid tool arguments: not valid JSON.]";
             }
+
+            // Logged before the approval check: if the next line for this call is far behind in
+            // wall-clock time but reports a small tool 'ms', the gap was the user's approval prompt.
+            _log.Log("mcp", "[turn " + turnId + "] dispatch '" + call.Name + "' (args "
+                + (call.ArgumentsJson != null ? call.ArgumentsJson.Length : 0) + " bytes)");
 
             ApprovalDecision decision = _approval.Check(call.Name, args);
             if (decision == ApprovalDecision.Deny)
             {
                 isError = true;
+                _log.Log("mcp", "[turn " + turnId + "] '" + call.Name + "' denied by approval policy");
                 return "[Call denied by user.]";
             }
 
+            Stopwatch sw = Stopwatch.StartNew();
             try
             {
                 CallToolResult res = conn.CallTool(toolName, args, _callTimeoutMs);
+                sw.Stop();
                 isError = (res != null && res.IsError);
-                return FormatResult(res);
+                string formatted = FormatResult(res);
+                _log.Log("mcp", "[turn " + turnId + "] '" + call.Name + "' -> "
+                    + (isError ? "isError" : "ok") + " (" + (formatted != null ? formatted.Length : 0)
+                    + " chars, " + sw.ElapsedMilliseconds + "ms)");
+                return formatted;
             }
             catch (McpTransportException ex)
             {
-                _log.Log("mcp", "transport fault calling '" + call.Name + "': " + ex.Message);
+                sw.Stop();
+                _log.Log("mcp", "[turn " + turnId + "] transport fault calling '" + call.Name + "' after "
+                    + sw.ElapsedMilliseconds + "ms: " + ex.Message);
                 isError = true;
                 return "[Server unavailable.]";
             }
             catch (McpTimeoutException ex)
             {
-                _log.Log("mcp", "timeout calling '" + call.Name + "': " + ex.Message);
+                sw.Stop();
+                _log.Log("mcp", "[turn " + turnId + "] timeout calling '" + call.Name + "' after "
+                    + sw.ElapsedMilliseconds + "ms: " + ex.Message);
                 isError = true;
                 return "[Tool timed out.]";
             }
             catch (McpException ex)
             {
+                sw.Stop();
+                _log.Log("mcp", "[turn " + turnId + "] tool error calling '" + call.Name + "' after "
+                    + sw.ElapsedMilliseconds + "ms: " + ex.Message);
                 isError = true;
                 return "[Tool error: " + ex.Message + "]";
             }

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -216,6 +216,8 @@ namespace GxPT
             {
                 // Tag the connection with its workdir so tool calls resolve to the right folder.
                 _registry.AddConnection(conn, workdir);
+                _log.Log("mcp", "server '" + spec.Name + "' ready"
+                    + (string.IsNullOrEmpty(workdir) ? " (eager)" : " (workdir=" + workdir + ")"));
                 return conn;
             }
 


### PR DESCRIPTION
## Why

The host-side tool loop was largely silent. After the streamer logged `curl exit=0 chunks=N`, nothing recorded what the orchestrator did next — so a stall (e.g. hitting the iteration cap) or a tool failure left no trace in `gxpt.log`. This adds coverage at the loop's decision points.

All changes are **app-side** and go through the existing `ILogSink` seam (`LoggerSink` → `Logger`). **No `Mcp35.*` library changes** — the library stays standalone; anything it logs already uses its injected sink.

## What

**`McpChatOrchestrator`**
- A short per-turn id (`[turn xxxxxx]`) on every line, so concurrent tabs can be followed in an interleaved log (ThreadPool thread ids are reused and unreliable for this).
- Logs: turn start; each iteration (with exposed-tool count); a response summary (`finish_reason`, tool-call count, text length, and `TRUNCATED` when `finish_reason == "length"`); final-answer completion; and the **max-iterations cap** — previously the silent `[Tool-call limit reached]` path, which was the exact undiagnosable stall symptom.
- `ExecuteCall` now logs every outcome that was previously invisible: `reveal_tools`, unresolved tool (with workdir), invalid arguments, **approval deny**, and each call's result (`ok`/`isError`, size, `ms`). The generic `McpException` path is now logged too (only transport/timeout were before).
- A `dispatch` line precedes the approval check. If the next line for that call is far behind in wall-clock time but reports a small tool `ms`, the gap was a user **approval-prompt wait** rather than a slow tool — disambiguating two stall shapes without touching the approval policy.

**`MainForm`** — the turn-worker `catch` now logs the full exception (type + stack) via `LoggerSink`, not just the transient UI message. A worker crash in `EnsureWorkingDir`/`BuildMessagesForModel`/`RunTurn` previously left no log trace.

**`McpHost`** — logs a server `ready` line on successful connect (failures were already logged), bounding connection setup so a slow/hung launch is visible.

## Notes

- Logging is opt-in (off unless `GXPT_LOG`/`enable_logging`), so this detail only appears when someone is actively debugging.
- No behavior change: only `_log.Log(...)` calls were added. The orchestrator tests pass `null` (→ `NullLogSink`), so they're unaffected; assertions are on `ui`/`history`/`streamer`, none of which changed.
- Did not alter existing log categories (app-side `_log.Log("mcp", …)` still renders as `mcp:mcp` through `LoggerSink`). Happy to normalize category naming in a follow-up if you want.

## Scope vs other PRs

Off `main`; touches only the three GxPT files. Independent of #69 (multiline search), #70 (teardown), and #67 (XP fonts).

## Not verified here

No .NET toolchain in this environment (net48) — couldn't compile/run. Please build in VS / run the test suite to confirm green.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7)_