### PR TITLE
fix: refreshable tool-call cap with in-transcript continue + graceful wrap-up

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -128,7 +128,33 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Hitting_iteration_cap_returns_a_note()
+        public void Hitting_iteration_cap_wraps_up_with_a_model_message()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            for (int i = 0; i < 3; i++) streamer.Turns.Add(Chunks.OneToolCall("c" + i, "files__read", "{}"));
+            // The tool-less wrap-up call (after the cap) gets this text.
+            streamer.Fallback = delegate(int i) { return Chunks.Text("Summary; how should I proceed?"); };
+
+            // cap 3, no ContinuationDecider => wrap up rather than dead-end.
+            var orch = new McpChatOrchestrator(streamer, reg, null, "m", null, 3, 1000);
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            orch.RunTurn(history, "loop forever", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(4, streamer.Calls);                       // 3 tool iterations + 1 tool-less wrap-up
+            Assert.Null(streamer.SeenTools[3]);                    // wrap-up offers no tools
+            Assert.Equal("assistant", history[history.Count - 1].Role);
+            Assert.Equal("Summary; how should I proceed?", history[history.Count - 1].Content);
+            Assert.Contains("how should I proceed", ui.Text.ToString());
+        }
+
+        [Fact]
+        public void Continuing_at_the_cap_grants_another_budget()
         {
             RegistryFakeTransport ft;
             var reg = RegistryWith(out ft, "files", new ToolDef("read"));
@@ -137,16 +163,57 @@ namespace GxPT.Tests.Mcp
             var streamer = new ScriptedStreamer();
             streamer.Fallback = delegate(int i) { return Chunks.OneToolCall("c" + i, "files__read", "{}"); };
 
-            var orch = new McpChatOrchestrator(streamer, reg, null, "m", null, 3, 1000);
+            var orch = new McpChatOrchestrator(streamer, reg, null, "m", null, 2, 1000);
+            int asked = 0;
+            orch.ContinuationDecider = delegate(int n) { asked++; return asked == 1; }; // continue once, then stop
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.Equal(2, asked);            // asked at the first cap (granted) and the refreshed cap (stopped)
+            Assert.Equal(5, streamer.Calls);   // (2 + 2) tool iterations + 1 wrap-up
+            Assert.True(ui.Completed);
+        }
+
+        [Fact]
+        public void Empty_response_is_retried_once_then_proceeds()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("ok"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new ChatCompletionChunk[0]);                     // empty: no text, no tool calls
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));  // retry yields a tool call
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.Equal(3, streamer.Calls);   // empty + retry(tool call) + final
+            Assert.Equal(new[] { "files__read" }, ui.ToolCalls.ToArray());
+            Assert.Equal("done", ui.Text.ToString());
+            Assert.True(ui.Completed);
+        }
+
+        [Fact]
+        public void Empty_response_twice_surfaces_a_notice()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new ChatCompletionChunk[0]);
+            streamer.Turns.Add(new ChatCompletionChunk[0]);
+
             var history = new List<ChatMessage>();
             var ui = new RecordingUi();
-            orch.RunTurn(history, "loop forever", ui);
+            New(streamer, reg).RunTurn(history, "go", ui);
 
             Assert.True(ui.Completed);
-            Assert.Equal(3, streamer.Calls);
-            Assert.Equal("[Tool-call limit reached.]", history[history.Count - 1].Content);
-            // user + 3*(assistant+tool) + note
-            Assert.Equal(1 + 6 + 1, history.Count);
+            Assert.Equal(2, streamer.Calls);   // initial + one retry, then surface
+            Assert.Contains("empty response", history[history.Count - 1].Content.ToLowerInvariant());
+            Assert.Contains("empty response", ui.Text.ToString().ToLowerInvariant());
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -148,6 +148,12 @@ namespace GxPT.Tests.Mcp
             Assert.True(ui.Completed);
             Assert.Equal(4, streamer.Calls);                       // 3 tool iterations + 1 tool-less wrap-up
             Assert.Null(streamer.SeenTools[3]);                    // wrap-up offers no tools
+            // The wrap-up instruction must be a trailing user turn, not a system message: Anthropic
+            // hoists in-array system messages out of position, leaving nothing for the model to answer.
+            var wrapMsgs = streamer.SeenMessages[3];
+            var lastSent = wrapMsgs[wrapMsgs.Count - 1];
+            Assert.Equal("user", lastSent.Role);
+            Assert.Contains("maximum number of tool calls", lastSent.Content);
             Assert.Equal("assistant", history[history.Count - 1].Role);
             Assert.Equal("Summary; how should I proceed?", history[history.Count - 1].Content);
             Assert.Contains("how should I proceed", ui.Text.ToString());

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -236,9 +236,9 @@ namespace GxPT
             _tierBadge.ForeColor = Color.DarkGoldenrod;
 
             _previewLabel.Text = "Details:";
-            _preview.Text = "The assistant has run " + iterationsSoFar + " tool iterations this turn and "
-                + "reached the limit.\r\n\r\nChoose Continue to let it keep working (a fresh batch), or "
-                + "Stop to have it summarize progress and ask how you'd like to proceed.";
+            _preview.Text = "The agent has been working for a long time. Do you want to continue?\r\n\r\n"
+                + "Choose Continue to let it keep working, or Stop to have it summarize progress and "
+                + "ask how you'd like to proceed.";
             _diffPanel.Visible = false;
             _preview.Visible = true;
             this.Height = 150;

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -23,6 +23,7 @@ namespace GxPT
         private readonly FlowLayoutPanel _buttons;
 
         private Action<ApprovalChoice> _onChoose;
+        private Action<bool> _onContinue;   // set instead of _onChoose for the iteration-cap prompt
 
         // Supplies the active workspace root so an edit approval can show a few lines of real file
         // context around the change. Set by the host (MainForm); null disables context (bare diff).
@@ -222,10 +223,40 @@ namespace GxPT
             this.SendToBack();
         }
 
+        // Iteration-cap confirmation, reusing this docked panel so it reads like the tool-approval
+        // prompt. callback(true) => grant another batch, callback(false) => stop (wrap up). Marshalled
+        // onto the UI thread by TranscriptContinuationPrompt; the click signals the blocked worker.
+        public void ShowContinuation(int iterationsSoFar, Action<bool> callback)
+        {
+            _onChoose = null;
+            _onContinue = callback;
+
+            _header.Text = "Tool-call limit reached";
+            _tierBadge.Text = "Paused after " + iterationsSoFar + " tool iteration(s) this turn";
+            _tierBadge.ForeColor = Color.DarkGoldenrod;
+
+            _previewLabel.Text = "Details:";
+            _preview.Text = "The assistant has run " + iterationsSoFar + " tool iterations this turn and "
+                + "reached the limit.\r\n\r\nChoose Continue to let it keep working (a fresh batch), or "
+                + "Stop to have it summarize progress and ask how you'd like to proceed.";
+            _diffPanel.Visible = false;
+            _preview.Visible = true;
+            this.Height = 150;
+
+            _buttons.Controls.Clear();
+            // Added first => rightmost in the RightToLeft flow.
+            AddContinuationButton("Stop", false, false);
+            AddContinuationButton("Continue", true, true);
+
+            this.Visible = true;
+            this.SendToBack();
+        }
+
         public void HidePanel()
         {
             this.Visible = false;
             _onChoose = null;
+            _onContinue = null;
         }
 
         // If the panel is torn down (e.g. its tab is closed) while a call still awaits a decision,
@@ -240,6 +271,16 @@ namespace GxPT
                 if (cb != null)
                 {
                     try { cb(ApprovalChoice.Deny); }
+                    catch { }
+                }
+
+                // A pending continuation prompt resolves to "stop" so the blocked worker is released
+                // (wraps up) rather than left waiting forever.
+                Action<bool> cc = _onContinue;
+                _onContinue = null;
+                if (cc != null)
+                {
+                    try { cc(false); }
                     catch { }
                 }
             }
@@ -280,6 +321,22 @@ namespace GxPT
                 Action<ApprovalChoice> cb = _onChoose;
                 HidePanel();
                 if (cb != null) cb(choice);
+            };
+            _buttons.Controls.Add(b);
+            if (defaultFocus) { try { b.Select(); } catch { } }
+        }
+
+        private void AddContinuationButton(string text, bool cont, bool defaultFocus)
+        {
+            Button b = new Button();
+            b.Text = text;
+            b.AutoSize = true;
+            b.Margin = new Padding(4, 4, 4, 4);
+            b.Click += delegate
+            {
+                Action<bool> cb = _onContinue;
+                HidePanel();
+                if (cb != null) cb(cont);
             };
             _buttons.Controls.Add(b);
             if (defaultFocus) { try { b.Select(); } catch { } }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1703,6 +1703,15 @@ namespace GxPT
                                                        model, LoggerSink.Instance);
                     orch.WorkingDir = ctx.WorkingDir;
                     orch.Zdr = zdr ? true : (bool?)null;
+                    // At the tool-call cap, confirm in-transcript (like a tool-approval prompt) whether
+                    // to continue: Continue grants another batch, Stop has the model wrap up and ask how
+                    // to proceed. Needs this tab's panel to host the prompt; without one the orchestrator
+                    // wraps up by default.
+                    if (ctx.ApprovalPanel != null)
+                    {
+                        var contPrompt = new TranscriptContinuationPrompt(this, delegate { return ctx.ApprovalPanel; });
+                        orch.ContinuationDecider = delegate(int n) { return contPrompt.Ask(n); };
+                    }
                     orch.RequestMessageTransform = delegate(IList<ChatMessage> h)
                     {
                         List<ChatMessage> asList = h as List<ChatMessage>;

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Services\Mcp\ToolApprovalPolicy.cs" />
     <Compile Include="Services\Mcp\ApprovalStore.cs" />
     <Compile Include="Services\Mcp\TranscriptApprovalPrompt.cs" />
+    <Compile Include="Services\Mcp\TranscriptContinuationPrompt.cs" />
     <Compile Include="Controls\ToolApprovalPanel.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -248,7 +248,12 @@ namespace GxPT
             IList<ChatMessage> contextMessages = RequestMessageTransform != null
                 ? RequestMessageTransform(history) : history;
             requestMessages.AddRange(contextMessages);
-            requestMessages.Add(new ChatMessage("system",
+            // Sent as a user message, not system: Anthropic (via OpenRouter) hoists in-array system
+            // messages to the top-level system parameter, which would leave the conversation ending
+            // on a tool result and the model with nothing in-position to answer (it replies with a
+            // near-empty acknowledgment). A trailing user turn keeps the instruction in place so the
+            // model actually summarizes.
+            requestMessages.Add(new ChatMessage("user",
                 "You have reached the maximum number of tool calls allowed for this turn. Do not "
                 + "request any more tools now. Briefly summarize what you have done so far and what "
                 + "still remains, then ask the user how they would like to proceed."));

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -18,7 +18,7 @@ namespace GxPT
     // tiered policy) and called at the one right point.
     internal sealed class McpChatOrchestrator
     {
-        public const int DefaultMaxIterations = 8;
+        public const int DefaultMaxIterations = 25;
         public const int DefaultCallTimeoutMs = 60000;
 
         private readonly IChatStreamer _streamer;
@@ -41,6 +41,13 @@ namespace GxPT
         // Zero data retention for every request in this turn. When true, emits provider.zdr=true so
         // OpenRouter routes only to zero-retention endpoints. Null/false leaves routing unconstrained.
         public bool? Zdr { get; set; }
+
+        // Called when a turn exhausts its iteration budget with tool calls still pending. The argument
+        // is the number of model iterations completed so far. Return true to grant another full budget
+        // (the user chose to keep going), false to wrap up. Null => wrap up. The host wires this to an
+        // in-transcript confirmation similar to the tool-approval prompt; it blocks the turn until the
+        // user answers, which is correct (the user is present).
+        public Func<int, bool> ContinuationDecider { get; set; }
 
         // The working directory of the conversation running this turn. Resolution of workdir-scoped
         // tools (files/git/command) is routed to the server bound to THIS folder, so concurrent turns
@@ -89,11 +96,32 @@ namespace GxPT
             _log.Log("mcp", "[turn " + turnId + "] start: model=" + _model + ", history=" + history.Count
                 + " msg(s), maxIterations=" + _maxIterations);
 
-            for (int iter = 0; iter < _maxIterations; iter++)
+            // The cap is a budget rather than a fixed loop bound so the user can grant another batch
+            // when it's reached (ContinuationDecider) instead of dead-ending the turn.
+            int budget = _maxIterations;
+            for (int iter = 0; ; iter++)
             {
+                if (iter >= budget)
+                {
+                    bool cont = (ContinuationDecider != null) && ContinuationDecider(iter);
+                    if (cont)
+                    {
+                        budget += _maxIterations;
+                        _log.Log("mcp", "[turn " + turnId + "] iteration cap reached at " + iter
+                            + "; user chose to continue (budget now " + budget + ")");
+                    }
+                    else
+                    {
+                        _log.Log("mcp", "[turn " + turnId + "] iteration cap reached at " + iter
+                            + "; wrapping up");
+                        RunCapWrapUp(history, ui, turnId);
+                        return;
+                    }
+                }
+
                 IList<JObject> tools = _registry != null ? _registry.ExposedFunctionDefs() : null;
                 string manifest = _registry != null ? _registry.NamesManifestSystemMessage() : null;
-                _log.Log("mcp", "[turn " + turnId + "] iteration " + (iter + 1) + "/" + _maxIterations
+                _log.Log("mcp", "[turn " + turnId + "] iteration " + (iter + 1) + "/" + budget
                     + ": requesting model with " + (tools != null ? tools.Count : 0) + " exposed tool(s)");
 
                 // The names manifest rides as an extra system message in front of history; it is not
@@ -107,41 +135,50 @@ namespace GxPT
                     ? RequestMessageTransform(history) : history;
                 requestMessages.AddRange(contextMessages);
 
-                ClientProperties props = new ClientProperties();
-                props.Stream = true;
-                props.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
-                props.Zdr = Zdr;
-
-                Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
-                ToolCallAssembler asm = new ToolCallAssembler(textSink);
-                bool errored = false;
-                string errMessage = null;
-
-                _streamer.StreamChat(_model, requestMessages, tools, props,
-                    asm.OnChunk,
-                    delegate(string err) { errored = true; errMessage = err; });
-                asm.Finish();
-
+                bool errored;
+                string errMessage;
+                ToolCallAssembler asm = StreamOnce(requestMessages, tools, ui, out errored, out errMessage);
                 if (errored)
                 {
-                    // A streaming/transport error already failed this request; surface and stop.
                     _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
                         + ": stream error: " + (errMessage ?? "(none)"));
                     if (ui != null) ui.OnError(errMessage);
                     return;
                 }
+                LogResponse(turnId, iter, asm);
 
-                _log.Log("mcp", "[turn " + turnId + "] response: finish_reason="
-                    + (asm.FinishReason ?? "(none)")
-                    + ", toolCalls=" + (asm.ProducedToolCalls ? asm.Calls.Count : 0)
-                    + ", textLen=" + (asm.Text != null ? asm.Text.Length : 0)
-                    + (asm.Truncated ? " [TRUNCATED: model output cut off by length]" : ""));
+                // Degenerate response (no tool calls AND no text, but no error): some providers emit an
+                // empty completion on a transient hiccup. Retry the same request once before giving up.
+                if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
+                {
+                    _log.Log("mcp", "[turn " + turnId + "] empty response (no tool calls, no text); retrying once");
+                    asm = StreamOnce(requestMessages, tools, ui, out errored, out errMessage);
+                    if (errored)
+                    {
+                        _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
+                            + " (retry): stream error: " + (errMessage ?? "(none)"));
+                        if (ui != null) ui.OnError(errMessage);
+                        return;
+                    }
+                    LogResponse(turnId, iter, asm);
+                }
 
                 if (!asm.ProducedToolCalls)
                 {
+                    if (IsEmptyText(asm.Text))
+                    {
+                        // Still empty after a retry: surface a clear, resumable notice rather than
+                        // completing with a silent empty bubble.
+                        string emptyNotice = "The model returned an empty response. Please try again.";
+                        history.Add(new ChatMessage("assistant", emptyNotice));
+                        _log.Log("mcp", "[turn " + turnId + "] still empty after retry; surfaced notice");
+                        if (ui != null) { ui.AppendTextDelta(emptyNotice); ui.Complete(); }
+                        return;
+                    }
+
                     history.Add(new ChatMessage("assistant", asm.Text));
                     _log.Log("mcp", "[turn " + turnId + "] complete: final answer after " + (iter + 1)
-                        + " iteration(s), " + (asm.Text != null ? asm.Text.Length : 0) + " chars");
+                        + " iteration(s), " + asm.Text.Length + " chars");
                     if (ui != null) ui.Complete();
                     return;
                 }
@@ -168,12 +205,81 @@ namespace GxPT
                 }
                 // Loop: re-call the model with the tool results in context.
             }
+        }
 
-            // Bounded: hitting the cap returns a note rather than looping unbounded.
-            _log.Log("mcp", "[turn " + turnId + "] stopped: hit max iterations (" + _maxIterations
-                + ") with tool calls still pending; returning [Tool-call limit reached]");
-            history.Add(new ChatMessage("assistant", "[Tool-call limit reached.]"));
+        // One streamed model request into a fresh assembler. Shared by the main loop, the
+        // empty-response retry, and (with tools = null) the cap wrap-up.
+        private ToolCallAssembler StreamOnce(IList<ChatMessage> requestMessages, IList<JObject> tools,
+                                             IToolLoopUi ui, out bool errored, out string errMessage)
+        {
+            ClientProperties props = new ClientProperties();
+            props.Stream = true;
+            props.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
+            props.Zdr = Zdr;
+
+            Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
+            ToolCallAssembler asm = new ToolCallAssembler(textSink);
+            bool err = false;
+            string emsg = null;
+            _streamer.StreamChat(_model, requestMessages, tools, props,
+                asm.OnChunk,
+                delegate(string e) { err = true; emsg = e; });
+            asm.Finish();
+            errored = err;
+            errMessage = emsg;
+            return asm;
+        }
+
+        private void LogResponse(string turnId, int iter, ToolCallAssembler asm)
+        {
+            _log.Log("mcp", "[turn " + turnId + "] iteration " + (iter + 1) + " response: finish_reason="
+                + (asm.FinishReason ?? "(none)")
+                + ", toolCalls=" + (asm.ProducedToolCalls ? asm.Calls.Count : 0)
+                + ", textLen=" + (asm.Text != null ? asm.Text.Length : 0)
+                + (asm.Truncated ? " [TRUNCATED: model output cut off by length]" : ""));
+        }
+
+        // Cap reached and not continued: one final tool-less model call asking it to summarize and
+        // ask how to proceed, so the turn ends with a readable assistant message rather than a
+        // cryptic dead-end. The user can simply reply to keep going (a fresh budget next turn).
+        private void RunCapWrapUp(IList<ChatMessage> history, IToolLoopUi ui, string turnId)
+        {
+            List<ChatMessage> requestMessages = new List<ChatMessage>();
+            IList<ChatMessage> contextMessages = RequestMessageTransform != null
+                ? RequestMessageTransform(history) : history;
+            requestMessages.AddRange(contextMessages);
+            requestMessages.Add(new ChatMessage("system",
+                "You have reached the maximum number of tool calls allowed for this turn. Do not "
+                + "request any more tools now. Briefly summarize what you have done so far and what "
+                + "still remains, then ask the user how they would like to proceed."));
+
+            // No tools offered, so the model must answer with text.
+            bool errored;
+            string errMessage;
+            ToolCallAssembler asm = StreamOnce(requestMessages, null, ui, out errored, out errMessage);
+
+            string text;
+            if (errored || IsEmptyText(asm.Text))
+            {
+                if (errored)
+                    _log.Log("mcp", "[turn " + turnId + "] wrap-up stream error: " + (errMessage ?? "(none)"));
+                text = "I've reached the tool-call limit for this turn. Let me know how you'd like to proceed.";
+                // StreamOnce streamed nothing usable, so emit the fallback to the UI ourselves.
+                if (ui != null) ui.AppendTextDelta(text);
+            }
+            else
+            {
+                text = asm.Text;
+                _log.Log("mcp", "[turn " + turnId + "] wrap-up complete (" + text.Length + " chars)");
+            }
+
+            history.Add(new ChatMessage("assistant", text));
             if (ui != null) ui.Complete();
+        }
+
+        private static bool IsEmptyText(string s)
+        {
+            return s == null || s.Trim().Length == 0;
         }
 
         // Executes one tool call, returning the text to feed back as the tool message content.

--- a/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // Bridges the orchestrator's synchronous iteration-cap decision (called on the tool-loop worker
+    // thread) to the docked ToolApprovalPanel on the UI thread, reusing the same blocking pattern as
+    // TranscriptApprovalPrompt. Ask blocks the worker until the user clicks Continue/Stop; the turn
+    // pauses at the cap, which is correct — the user is present and choosing whether to keep going.
+    internal sealed class TranscriptContinuationPrompt
+    {
+        private readonly Control _uiMarshal;          // any control on the UI thread (the form)
+        private readonly Func<ToolApprovalPanel> _getPanel;
+
+        public TranscriptContinuationPrompt(Control uiMarshal, Func<ToolApprovalPanel> getPanel)
+        {
+            _uiMarshal = uiMarshal;
+            _getPanel = getPanel;
+        }
+
+        // Returns true to continue (grant another budget), false to stop (wrap up). Defaults to false
+        // if the UI is unavailable (e.g. the tab is closing) so the turn still ends cleanly.
+        public bool Ask(int iterationsSoFar)
+        {
+            if (_uiMarshal == null || _getPanel == null) return false;
+
+            bool[] result = { false };
+            using (ManualResetEvent done = new ManualResetEvent(false))
+            {
+                try
+                {
+                    _uiMarshal.BeginInvoke((MethodInvoker)delegate
+                    {
+                        ToolApprovalPanel panel = _getPanel();
+                        if (panel == null) { done.Set(); return; }
+                        panel.ShowContinuation(iterationsSoFar, delegate(bool cont)
+                        {
+                            result[0] = cont;
+                            done.Set();
+                        });
+                    });
+                }
+                catch
+                {
+                    return false; // UI gone (e.g. closing) -> stop and wrap up
+                }
+
+                done.WaitOne();
+            }
+            return result[0];
+        }
+    }
+}


### PR DESCRIPTION
## Why

The host tool loop hard-stopped after 8 model↔tool iterations, appended a cryptic `[Tool-call limit reached.]` assistant message, and forced the user to re-prompt mid-task — the stalling behavior we've been chasing. (A turn ending because the model gave a final *text* answer is the model's choice and is left alone; this targets the cap and the silent-empty case.)

## What

**Cap → 25, and refreshable instead of a dead-end.**
- `DefaultMaxIterations` 8 → 25.
- The cap is now a budget. When it's reached with tool calls still pending, the orchestrator asks the host via a new `ContinuationDecider` hook:
  - **Continue** → `budget += 25`, the loop keeps going.
  - **Stop** (or no hook wired) → wrap up.
- `MainForm` wires the hook to an **in-transcript confirmation that reuses `ToolApprovalPanel`** (new `ShowContinuation`) via `TranscriptContinuationPrompt`, using the exact worker-blocking pattern as the tool-approval prompt (per your PS).

**Clean ending on Stop.** Instead of the dead-end note, the turn makes one final **tool-less** model call instructing it to summarize progress and ask how to proceed — so the turn ends with a readable assistant message. The user simply replying continues with a fresh budget next turn (so "reply to continue" naturally refreshes the cap).

**Empty/degenerate response hardening** (your other answer — "retry once, then surface"): if a turn yields no tool calls and empty text with no error, re-issue the same request once; if still empty, surface a clear notice instead of completing with a silent empty bubble.

## Tests (`McpChatOrchestratorTests`)
- `Hitting_iteration_cap_wraps_up_with_a_model_message` — cap now makes a tool-less wrap-up call (asserts no tools offered on it) and ends with the model's message (replaces the old "returns a note" test).
- `Continuing_at_the_cap_grants_another_budget` — decider returning true refreshes the budget; false wraps up.
- `Empty_response_is_retried_once_then_proceeds` and `Empty_response_twice_surfaces_a_notice`.

## ⚠️ Stacked on #71 + UI compile-untested
- **Base is `claude/agentic-loop-logging` (#71), not `main`** — this builds on #71's `turnId`/per-iteration logging in the orchestrator. **Merge #71 first;** GitHub will retarget this to `main` afterward.
- No .NET toolchain here (net48). The orchestrator logic is covered by the tests above (they pass `ContinuationDecider` directly, no WinForms). The **WinForms pieces** — `ToolApprovalPanel.ShowContinuation` and `TranscriptContinuationPrompt` — are written to the existing approval-prompt pattern but are **compile-untested**; please build in VS and click through Continue/Stop once.

## Landing order
#71 → this → then #69, #70, #67 as before (all still independent of these two).

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7)_