### PR TITLE
Redesign landing page in classic early-2000s style

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,53 @@
+/* GxPT landing page — shared release lookup (ES5, no dependencies).
+   Loaded on every page. One unauthenticated call to the GitHub Releases API
+   populates, where present on the page:
+     - the Download button's target (#download-btn) -> newest .msi
+     - the download note's version (#download-note)
+     - the sidebar "Latest release" widget version (#latest-ver)
+   Release assets are uploaded manually, so the very latest tag may not have its
+   installer yet; we walk back to the most recent release that does. On any
+   failure every element keeps its static fallback. */
+(function () {
+  var btn = document.getElementById('download-btn');
+  var note = document.getElementById('download-note');
+  var latest = document.getElementById('latest-ver');
+  var baseNote = 'Windows XP or later · .NET Framework 3.5';
+
+  function findMsi(release) {
+    var assets = (release && release.assets) || [];
+    for (var i = 0; i < assets.length; i++) {
+      if (/\.msi$/i.test(assets[i].name) && assets[i].browser_download_url) {
+        return assets[i];
+      }
+    }
+    return null;
+  }
+
+  function apply(release, msi) {
+    // Normalize the tag's leading "v" so we never produce "vv0.15.0".
+    var tag = release.tag_name ? String(release.tag_name).replace(/^v/i, '') : '';
+    if (btn) { btn.setAttribute('data-href', msi.browser_download_url); }
+    if (note && tag) { note.innerHTML = baseNote + ' · GxPT v' + tag; }
+    if (latest && tag) { latest.innerHTML = 'GxPT v' + tag; }
+  }
+
+  try {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://api.github.com/repos/imclerran/GxPT/releases?per_page=20', true);
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState !== 4) return;
+      if (xhr.status < 200 || xhr.status >= 300) return; // keep fallbacks
+      try {
+        var releases = JSON.parse(xhr.responseText);
+        if (!releases || !releases.length) return;
+        for (var i = 0; i < releases.length; i++) {
+          if (releases[i].draft) continue;
+          var msi = findMsi(releases[i]);
+          if (msi) { apply(releases[i], msi); return; }
+        }
+        // No release carries an .msi yet — leave buttons on the releases page.
+      } catch (e) { /* keep fallbacks */ }
+    };
+    xhr.send();
+  } catch (e) { /* keep fallbacks */ }
+})();

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>GxPT — FAQ</title>
+  <meta name="description" content="Frequently asked questions about GxPT, the native agentic chatbot client and coding agent for Windows XP." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="site">
+
+    <div class="banner">
+      <a href="index.html"><h1>GxPT</h1></a>
+      <p class="slogan">Windows XP goes agentic!</p>
+    </div>
+
+    <div class="layout">
+      <div class="sidebar">
+        <div class="navbox">
+          <div class="navhead">Navigation</div>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="screenshots.html">Screenshots</a></li>
+            <li><a href="faq.html" class="current">FAQ</a></li>
+            <li><a href="https://github.com/imclerran/GxPT">GitHub</a></li>
+          </ul>
+        </div>
+        <div class="sidenote">
+          <b>Latest release</b><br>
+          <span class="ver" id="latest-ver">GxPT</span><br>
+          <a href="https://github.com/imclerran/GxPT/releases/latest">What's new &raquo;</a>
+        </div>
+      </div>
+
+      <div class="main">
+        <h2 class="bar">Frequently Asked Questions</h2>
+        <dl class="faq">
+          <dt>Does it really run on Windows XP?</dt>
+          <dd>Yes. GxPT is a native Windows application targeting .NET Framework 3.5, so it
+            runs on Windows XP and every version of Windows since.</dd>
+
+          <dt>What do I need to run it?</dt>
+          <dd>Windows XP or later and the .NET Framework 3.5 runtime. You'll also need an
+            <a href="https://openrouter.ai">OpenRouter.ai</a> API key to talk to AI models.</dd>
+
+          <dt>Which AI models are supported?</dt>
+          <dd>A huge range of frontier and open models through the OpenRouter.ai API &mdash;
+            you choose which model to use per conversation.</dd>
+
+          <dt>Is my data private?</dt>
+          <dd>Conversations are stored locally on your machine. You can enforce Zero Data
+            Retention (ZDR) on a per-conversation basis so prompts aren't retained upstream.</dd>
+
+          <dt>What is MCP, and what can GxPT do with it?</dt>
+          <dd>The Model Context Protocol lets GxPT call external tools: agentic coding
+            (file, git, and shell operations), web search, and GitHub access. The agent
+            chains these tool calls autonomously until your task is done.</dd>
+
+          <dt>Is it safe to let the agent run tools?</dt>
+          <dd>Every tool call is gated by an in-app approval prompt, and file, git, and
+            command tools stay confined to the working folder you choose.</dd>
+
+          <dt>How much does it cost?</dt>
+          <dd>GxPT itself is free and open source. You pay only for the AI usage billed
+            through your own OpenRouter.ai account.</dd>
+
+          <dt>Where do I report bugs or request features?</dt>
+          <dd>On the <a href="https://github.com/imclerran/GxPT">GitHub repository</a>.</dd>
+        </dl>
+      </div>
+    </div>
+
+    <div class="footer">
+      &copy; 2026 GxPT &middot; <a href="https://github.com/imclerran/GxPT">View on GitHub</a><br>
+      Best viewed at 1024&times;768 &middot; Made for Windows XP
+    </div>
+
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,6 +49,13 @@
           </p>
         </div>
 
+        <div class="section">
+          <h2 class="bar">Screenshot</h2>
+          <img class="shot" src="assets/GxPT-light.png" alt="GxPT running in light mode on Windows XP" />
+          <p class="shot-cap">GxPT &mdash; Light Mode on Windows XP &middot;
+            <a href="screenshots.html">See more screenshots &raquo;</a></p>
+        </div>
+
         <div class="section" id="download">
           <h2 class="bar">Download</h2>
           <div class="dlbox">
@@ -58,13 +65,6 @@
             <a class="dl-alt" href="https://github.com/imclerran/GxPT/releases">All releases</a>
             <p class="dl-note" id="download-note">Windows XP or later &middot; .NET Framework 3.5</p>
           </div>
-        </div>
-
-        <div class="section">
-          <h2 class="bar">Screenshot</h2>
-          <img class="shot" src="assets/GxPT-light.png" alt="GxPT running in light mode on Windows XP" />
-          <p class="shot-cap">GxPT &mdash; Light Mode on Windows XP &middot;
-            <a href="screenshots.html">See more screenshots &raquo;</a></p>
         </div>
 
         <div class="section">

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,181 +5,88 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>GxPT — Windows XP goes agentic!</title>
   <meta name="description" content="GxPT is a native chatbot client and coding agent for Windows XP, with agentic workflows, MCP tool calling, Markdown rendering, and per-conversation privacy controls." />
-  <!-- Genuine XP.css (vendored), then our page-specific overlay -->
-  <link rel="stylesheet" href="vendor/xp.css/XP.css" />
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="theme-silver">
-  <div class="page">
+<body>
+  <div class="site">
 
-    <!-- Hero window -->
-    <section class="window hero-window">
-      <div class="title-bar">
-        <div class="title-bar-text">GxPT</div>
-        <div class="title-bar-controls">
-          <button aria-label="Minimize"></button>
-          <button aria-label="Maximize"></button>
-          <button aria-label="Close"></button>
-        </div>
-      </div>
-      <div class="window-body hero">
-        <h1>GxPT</h1>
-        <p class="tagline">Windows XP goes agentic!</p>
-        <p class="lead">
-          A native chatbot client and coding agent for Windows XP. GxPT brings agentic
-          workflows to the era of Luna and Aero &mdash; autonomously chaining tools for
-          agentic coding and web search via the Model Context Protocol (MCP), with
-          per-conversation privacy controls.
-        </p>
-      </div>
-    </section>
-
-    <!-- Download window -->
-    <section class="window download-window">
-      <div class="title-bar">
-        <div class="title-bar-text">Download GxPT</div>
-        <div class="title-bar-controls">
-          <button aria-label="Close"></button>
-        </div>
-      </div>
-      <div class="window-body">
-        <p class="dl-intro">Get the latest installer for Windows XP or later.</p>
-        <div class="dl-actions">
-          <button id="download-btn" class="dl-primary" type="button"
-                  onclick="window.location.href=this.dataset.href"
-                  data-href="https://github.com/imclerran/GxPT/releases/latest">
-            Download Installer (.msi)
-          </button>
-          <button type="button"
-                  onclick="window.location.href='https://github.com/imclerran/GxPT/releases'">
-            All releases
-          </button>
-        </div>
-        <p class="download-note" id="download-note">
-          Windows XP or later &middot; .NET Framework 3.5
-        </p>
-      </div>
-    </section>
-
-    <!-- Primary screenshot -->
-    <section class="window shot-window">
-      <div class="title-bar">
-        <div class="title-bar-text">GxPT &mdash; Light Mode</div>
-        <div class="title-bar-controls">
-          <button aria-label="Minimize"></button>
-          <button aria-label="Maximize"></button>
-          <button aria-label="Close"></button>
-        </div>
-      </div>
-      <div class="window-body shot-body">
-        <img class="shot" src="assets/GxPT-light.png" alt="GxPT running in light mode on Windows XP" />
-      </div>
-    </section>
-
-    <!-- Features window -->
-    <section class="window">
-      <div class="title-bar">
-        <div class="title-bar-text">Features</div>
-        <div class="title-bar-controls">
-          <button aria-label="Minimize"></button>
-          <button aria-label="Maximize"></button>
-          <button aria-label="Close"></button>
-        </div>
-      </div>
-      <div class="window-body">
-        <ul class="features">
-          <li><b>Agentic Workflows</b> &mdash; autonomously chains tool calls until your task is done: agentic coding (file/git/shell), web search, and GitHub access via MCP.</li>
-          <li><b>Tool Approval &amp; Sandboxing</b> &mdash; every tool call is gated by an in-app approval prompt; file/git/command tools stay confined to the working folder you choose.</li>
-          <li><b>Markdown &amp; Syntax Highlighting</b> &mdash; rich Markdown rendering plus code highlighting for 50+ languages.</li>
-          <li><b>Privacy &amp; Local Storage</b> &mdash; conversations stored locally; enforce Zero Data Retention (ZDR) per conversation.</li>
-          <li><b>Frontier Model Support</b> &mdash; a huge range of AI models through the OpenRouter.ai API.</li>
-          <li><b>Legacy Compatibility</b> &mdash; runs on Windows XP and .NET 3.5.</li>
-        </ul>
-      </div>
-    </section>
-
-    <!-- Secondary screenshots -->
-    <div class="shots-grid">
-      <section class="window shot-window">
-        <div class="title-bar">
-          <div class="title-bar-text">Dark Mode</div>
-          <div class="title-bar-controls">
-            <button aria-label="Close"></button>
-          </div>
-        </div>
-        <div class="window-body shot-body">
-          <img class="shot" src="assets/GxPT-dark.png" alt="GxPT running in dark mode" />
-        </div>
-      </section>
-      <section class="window shot-window">
-        <div class="title-bar">
-          <div class="title-bar-text">Windows 7</div>
-          <div class="title-bar-controls">
-            <button aria-label="Close"></button>
-          </div>
-        </div>
-        <div class="window-body shot-body">
-          <img class="shot" src="assets/GxPT-win7.png" alt="GxPT running on Windows 7" />
-        </div>
-      </section>
+    <div class="banner">
+      <a href="index.html"><h1>GxPT</h1></a>
+      <p class="slogan">Windows XP goes agentic!</p>
     </div>
 
-    <p class="footer">
-      &copy; GxPT &middot;
-      <a href="https://github.com/imclerran/GxPT">View on GitHub</a>
-    </p>
+    <div class="layout">
+      <div class="sidebar">
+        <div class="navbox">
+          <div class="navhead">Navigation</div>
+          <ul>
+            <li><a href="index.html" class="current">Home</a></li>
+            <li><a href="screenshots.html">Screenshots</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="https://github.com/imclerran/GxPT">GitHub</a></li>
+          </ul>
+        </div>
+        <div class="sidenote">
+          <b>Latest release</b><br>
+          <span class="ver" id="latest-ver">GxPT</span><br>
+          <a href="https://github.com/imclerran/GxPT/releases/latest">What's new &raquo;</a>
+        </div>
+      </div>
+
+      <div class="main">
+        <div class="section">
+          <h2 class="bar">Welcome</h2>
+          <p>
+            A native chatbot client and coding agent for Windows XP. GxPT brings agentic
+            workflows to the era of Luna and Aero &mdash; autonomously chaining tools for
+            agentic coding and web search via the Model Context Protocol (MCP), with
+            per-conversation privacy controls.
+          </p>
+          <p>
+            Why build this for Windows XP in 2026? Because the machines still run, and the
+            era of Luna deserves a modern AI client too. GxPT targets .NET Framework 3.5 so
+            it runs natively on XP and every Windows since.
+          </p>
+        </div>
+
+        <div class="section" id="download">
+          <h2 class="bar">Download</h2>
+          <div class="dlbox">
+            <a class="dl-btn" id="download-btn"
+               href="https://github.com/imclerran/GxPT/releases/latest"
+               onclick="var h=this.getAttribute('data-href'); if(h){this.href=h;}">Download Installer (.msi)</a>
+            <a class="dl-alt" href="https://github.com/imclerran/GxPT/releases">All releases</a>
+            <p class="dl-note" id="download-note">Windows XP or later &middot; .NET Framework 3.5</p>
+          </div>
+        </div>
+
+        <div class="section">
+          <h2 class="bar">Screenshot</h2>
+          <img class="shot" src="assets/GxPT-light.png" alt="GxPT running in light mode on Windows XP" />
+          <p class="shot-cap">GxPT &mdash; Light Mode on Windows XP &middot;
+            <a href="screenshots.html">See more screenshots &raquo;</a></p>
+        </div>
+
+        <div class="section">
+          <h2 class="bar">Features</h2>
+          <ul class="features">
+            <li><b>Agentic Workflows</b> &mdash; autonomously chains tool calls until your task is done: agentic coding (file/git/shell), web search, and GitHub access via MCP.</li>
+            <li><b>Tool Approval &amp; Sandboxing</b> &mdash; every tool call is gated by an in-app approval prompt; file/git/command tools stay confined to the working folder you choose.</li>
+            <li><b>Markdown &amp; Syntax Highlighting</b> &mdash; rich Markdown rendering plus code highlighting for 50+ languages.</li>
+            <li><b>Privacy &amp; Local Storage</b> &mdash; conversations stored locally; enforce Zero Data Retention (ZDR) per conversation.</li>
+            <li><b>Frontier Model Support</b> &mdash; a huge range of AI models through the OpenRouter.ai API.</li>
+            <li><b>Legacy Compatibility</b> &mdash; runs on Windows XP and .NET 3.5.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      &copy; 2026 GxPT &middot; <a href="https://github.com/imclerran/GxPT">View on GitHub</a><br>
+      Best viewed at 1024&times;768 &middot; Made for Windows XP
+    </div>
 
   </div>
-
-  <script>
-    // Point the download button at the newest release that actually has an .msi asset.
-    // Release assets are uploaded manually, so the very latest tag may not have its
-    // installer yet — in that case we walk back to the most recent release that does.
-    // On any failure we keep the default target (the releases/latest page).
-    (function () {
-      var btn = document.getElementById('download-btn');
-      var note = document.getElementById('download-note');
-      var baseNote = 'Windows XP or later &middot; .NET Framework 3.5';
-
-      function findMsi(release) {
-        var assets = (release && release.assets) || [];
-        for (var i = 0; i < assets.length; i++) {
-          if (/\.msi$/i.test(assets[i].name) && assets[i].browser_download_url) {
-            return assets[i];
-          }
-        }
-        return null;
-      }
-
-      try {
-        var xhr = new XMLHttpRequest();
-        // List releases (newest first); scan for the first one carrying an .msi.
-        xhr.open('GET', 'https://api.github.com/repos/imclerran/GxPT/releases?per_page=20', true);
-        xhr.onreadystatechange = function () {
-          if (xhr.readyState !== 4) return;
-          if (xhr.status < 200 || xhr.status >= 300) return; // keep fallback
-          try {
-            var releases = JSON.parse(xhr.responseText);
-            if (!releases || !releases.length) return;
-            for (var i = 0; i < releases.length; i++) {
-              if (releases[i].draft) continue;
-              var msi = findMsi(releases[i]);
-              if (msi) {
-                btn.dataset.href = msi.browser_download_url;
-                // Label it "GxPT vX.Y.Z" so it's clearly the app version, not
-                // another prerequisite. Normalize the tag's leading "v" first.
-                var tag = releases[i].tag_name ? String(releases[i].tag_name).replace(/^v/i, '') : '';
-                var ver = tag ? (' &middot; GxPT v' + tag) : '';
-                note.innerHTML = baseNote + ver;
-                return;
-              }
-            }
-            // No release has an .msi yet — leave the button on the releases page.
-          } catch (e) { /* keep fallback */ }
-        };
-        xhr.send();
-      } catch (e) { /* keep fallback */ }
-    })();
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/docs/screenshots.html
+++ b/docs/screenshots.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>GxPT — Screenshots</title>
+  <meta name="description" content="Screenshots of GxPT, the native agentic chatbot client for Windows XP — light and dark themes, and running on Windows 7." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="site">
+
+    <div class="banner">
+      <a href="index.html"><h1>GxPT</h1></a>
+      <p class="slogan">Windows XP goes agentic!</p>
+    </div>
+
+    <div class="layout">
+      <div class="sidebar">
+        <div class="navbox">
+          <div class="navhead">Navigation</div>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="screenshots.html" class="current">Screenshots</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="https://github.com/imclerran/GxPT">GitHub</a></li>
+          </ul>
+        </div>
+        <div class="sidenote">
+          <b>Latest release</b><br>
+          <span class="ver" id="latest-ver">GxPT</span><br>
+          <a href="https://github.com/imclerran/GxPT/releases/latest">What's new &raquo;</a>
+        </div>
+      </div>
+
+      <div class="main">
+        <h2 class="bar">Screenshots</h2>
+        <p>GxPT running across themes and Windows versions. More to come as the app evolves.</p>
+
+        <div class="gallery">
+          <div class="tile">
+            <img src="assets/GxPT-light.png" alt="GxPT in light mode on Windows XP" />
+            <p class="cap">Light Mode &mdash; Windows XP</p>
+          </div>
+          <div class="tile right">
+            <img src="assets/GxPT-dark.png" alt="GxPT in dark mode" />
+            <p class="cap">Dark Mode</p>
+          </div>
+          <div style="clear:both"></div>
+          <div class="tile">
+            <img src="assets/GxPT-win7.png" alt="GxPT running on Windows 7" />
+            <p class="cap">Running on Windows 7</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      &copy; 2026 GxPT &middot; <a href="https://github.com/imclerran/GxPT">View on GitHub</a><br>
+      Best viewed at 1024&times;768 &middot; Made for Windows XP
+    </div>
+
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -147,6 +147,8 @@ h2.bar {
   text-shadow: 1px 1px 1px #234214;
 }
 .dl-btn:hover { background: #4f8a36; }
+/* Keep the primary button label white — outranks the generic .main a/:visited color. */
+.main a.dl-btn, .main a.dl-btn:visited { color: #fff; }
 .dl-alt {
   display: inline-block;
   font-size: 11px;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,118 +1,206 @@
-/* GxPT landing page — page-specific overlay on top of the vendored XP.css.
-   XP.css provides the authentic Luna window/title-bar/button chrome; everything
-   here is layout, wallpaper, hero typography, screenshot framing, and CTA sizing. */
+/* ============================================================================
+   GxPT landing page — classic early-2000s styling.
+   No build step, no framework: plain static HTML/CSS + a little ES5 JS.
+   Old-browser friendly: float-based layout (no flexbox), web-safe fonts, and
+   every CSS3 gradient carries a solid background-color fallback so nothing
+   renders as invisible text on period browsers. CSS3 niceties (rounded
+   corners, shadows) simply degrade to squared/flat on old browsers.
+   ========================================================================== */
 
-html, body {
+* { box-sizing: border-box; }
+
+body {
   margin: 0;
   padding: 0;
-  /* Plain neutral-gray desktop */
-  background: #9a9a9e;
-  min-height: 100vh;
-}
-
-/* ===== Silver Luna theme =====
-   Retints XP.css's default blue Luna chrome to the silver scheme. */
-/* Retint the window frame: XP.css draws the blue beveled border as a stack of
-   inset box-shadows, so we have to restate the whole stack in silver tones
-   (mirrors XP.css's blue stop structure, darkest on the bottom-right edge). */
-body.theme-silver .window {
-  box-shadow:
-    inset -1px -1px #4a4a5a, inset 1px 1px #d6d5e0,
-    inset -2px -2px #6f6e85, inset 2px 2px #b0afc0,
-    inset -3px -3px #8d8ca3, inset 3px 3px #c7c6d6,
-    0 6px 22px rgba(0, 0, 0, 0.45) !important;
-}
-body.theme-silver .title-bar {
-  /* Silver caption gradient (mirrors XP.css's blue stop structure) */
-  background: linear-gradient(180deg,
-    #ebebf2, #c7c6d6 8%, #a3a2b8 45%,
-    #8d8ca3 88%, #8d8ca3 93%, #9b9ab0 95%, #76758d 96%, #76758d) !important;
-  /* XP.css gives the caption blue top/left/right borders + a blue text shadow;
-     retint all of them to silver (bottom edge was already handled). */
-  border-top: 1px solid #d6d5e0;
-  border-left: 1px solid #d6d5e0;
-  border-right: 1px solid #8d8ca3;
-  border-bottom: 1px solid #6f6e85;
-  text-shadow: 1px 1px #6f6e85;
-}
-/* Desaturate the blue min/max glyphs to silver; Close stays red (correct for Silver Luna) */
-body.theme-silver .title-bar-controls button[aria-label="Minimize"],
-body.theme-silver .title-bar-controls button[aria-label="Maximize"] {
-  filter: grayscale(100%);
-}
-
-.page {
-  max-width: 880px;
-  margin: 0 auto;
-  padding: 32px 16px 56px;
-}
-
-/* Give each window some breathing room and a stronger drop shadow */
-.window {
-  margin: 0 0 24px;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45);
-}
-.shots-grid .window { margin-bottom: 0; }
-
-/* ---- hero ---- */
-.hero { text-align: center; padding: 20px 22px 22px; }
-.hero h1 {
-  margin: 2px 0 2px;
-  font-size: 40px;
-  letter-spacing: 1px;
-  color: #33343c;
-  text-shadow: 1px 1px 0 #fff;
-}
-.tagline {
-  margin: 0 0 12px;
-  font-size: 16px;
-  font-style: italic;
-  color: #44454e;
-}
-.hero p.lead {
-  margin: 10px auto 2px;
-  max-width: 620px;
-  line-height: 1.5;
-  font-size: 13px;
-}
-
-/* ---- download ---- */
-.download-window { max-width: 440px; margin-left: auto; margin-right: auto; }
-.dl-intro { margin: 2px 0 14px; }
-.dl-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-/* Enlarge XP.css's native buttons into proper call-to-action targets */
-.dl-actions button { min-height: 30px; padding: 4px 16px; font-size: 13px; }
-.dl-actions .dl-primary { font-weight: bold; padding: 6px 20px; }
-.download-note { font-size: 11px; color: #333; margin: 12px 0 2px; }
-
-/* ---- screenshots ---- */
-.shot-body { padding: 3px; background: #fff; }
-.shot { display: block; width: 100%; height: auto; }
-
-.shots-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 18px;
-  margin-bottom: 24px;
-}
-@media (max-width: 620px) { .shots-grid { grid-template-columns: 1fr; } }
-
-/* ---- features ---- */
-ul.features { margin: 4px 0; padding-left: 22px; line-height: 1.55; }
-ul.features li { margin-bottom: 6px; }
-ul.features b { color: #33343c; }
-
-/* ---- footer ---- */
-.footer {
-  text-align: center;
-  margin-top: 4px;
-  color: #2a2a30;
+  background: #4b5a70;
+  font-family: Verdana, Geneva, Arial, sans-serif;
   font-size: 12px;
-  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
+  color: #000;
 }
-.footer a { color: #2a2a30; }
+
+/* Centered fixed-width column — the classic "fits 1024x768" layout. */
+.site {
+  width: 780px;
+  margin: 0 auto;
+  background: #ffffff;
+  border-left: 1px solid #2d3a4d;
+  border-right: 1px solid #2d3a4d;
+}
+
+/* ---- Header banner (dark blue) ---- */
+.banner {
+  background: #21365c;                              /* fallback */
+  background: linear-gradient(180deg, #3a5d96, #21365c);
+  border-bottom: 3px solid #b0b8c4;
+  padding: 14px 16px;
+}
+.banner a { text-decoration: none; }
+.banner h1 {
+  margin: 0;
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  font-size: 30px;
+  color: #fff;
+  letter-spacing: 1px;
+  text-shadow: 1px 1px 2px #0c1626;
+}
+.banner .slogan {
+  margin: 2px 0 0;
+  font-size: 12px;
+  font-style: italic;
+  color: #cdd9ec;
+}
+
+/* ---- Layout: sidebar + main via floats ----
+   Faux-column background paints the sidebar stripe full height; old browsers
+   that ignore the gradient fall back to a white content area (nav still works). */
+.layout {
+  background: #ffffff;                              /* fallback */
+  background: linear-gradient(90deg,
+    #e7eaf0 0, #e7eaf0 158px, #aab3c2 158px, #aab3c2 159px, #fff 159px);
+}
+.layout:after { content: ""; display: block; clear: both; }  /* clearfix */
+
+.sidebar { float: left; width: 158px; }
+.main {
+  margin-left: 159px;
+  padding: 14px 18px 6px;
+  min-height: 360px;
+  border-left: 1px solid #aab3c2;
+}
+
+/* ---- Sidebar navigation box ---- */
+.navbox .navhead {
+  background: #2f4f86;                              /* fallback */
+  background: linear-gradient(180deg, #3a5d96, #2c4a7d);
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  padding: 4px 10px;
+  letter-spacing: 0.5px;
+}
+.navbox ul { list-style: none; margin: 0 0 14px; padding: 0; }
+.navbox li { border-bottom: 1px solid #d2d7e0; }
+.navbox a {
+  display: block;
+  padding: 6px 10px 6px 18px;
+  text-decoration: none;
+  color: #1a3358;
+  font-size: 11px;
+  font-weight: bold;
+}
+.navbox a:hover { background: #d3dae6; color: #0a4ea0; }
+.navbox a.current {
+  background: #fff;
+  border-left: 3px solid #3a5d96;
+  padding-left: 15px;
+}
+
+/* ---- "Latest release" widget ---- */
+.sidenote {
+  margin: 0 8px 14px;
+  padding: 8px;
+  background: #fffbe6;
+  border: 1px solid #d8c97a;
+  font-size: 10px;
+  color: #5a4d18;
+  line-height: 1.6;
+}
+.sidenote b { color: #4a3f12; }
+.sidenote .ver { font-weight: bold; }
+.sidenote a { color: #0000cc; }
+
+/* ---- Main content ---- */
+h2.bar {
+  background: #2f4f86;                              /* fallback */
+  background: linear-gradient(180deg, #3a5d96, #2c4a7d);
+  color: #fff;
+  font-size: 12px;
+  margin: 0 0 12px;
+  padding: 4px 8px;
+  border: 1px solid #21365c;
+  letter-spacing: 0.5px;
+}
+.main p { line-height: 1.55; margin: 0 0 12px; }
+.main a { color: #0000cc; }
+.main a:visited { color: #551a8b; }
+.section { margin-bottom: 22px; }
+
+/* ---- Download box ---- */
+.dlbox {
+  border: 1px solid #8a93a3;
+  background: #f4f6f9;
+  padding: 14px;
+  text-align: center;
+}
+.dl-btn {
+  display: inline-block;
+  font-family: Verdana, sans-serif;
+  font-size: 13px;
+  font-weight: bold;
+  color: #fff;
+  text-decoration: none;
+  padding: 7px 18px;
+  background: #3c7026;                              /* fallback */
+  background: linear-gradient(180deg, #5a9a3f, #3c7026);
+  border: 1px solid #2c5219;
+  border-radius: 3px;
+  text-shadow: 1px 1px 1px #234214;
+}
+.dl-btn:hover { background: #4f8a36; }
+.dl-alt {
+  display: inline-block;
+  font-size: 11px;
+  padding: 6px 12px;
+  margin-left: 6px;
+  color: #1a3358;
+  text-decoration: none;
+  background: #e3e7ee;
+  border: 1px solid #8a93a3;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+.dl-alt:hover { background: #eef1f6; }
+.dl-note { font-size: 11px; color: #555; margin: 12px 0 0; }
+
+/* ---- Features list ---- */
+ul.features { margin: 0; padding: 0; list-style: none; }
+ul.features li {
+  padding: 5px 5px 5px 22px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Crect x='2' y='2' width='8' height='8' fill='%233a5d96'/%3E%3C/svg%3E") no-repeat 2px 7px;
+  border-bottom: 1px dotted #c4c9d2;
+  line-height: 1.5;
+}
+
+/* ---- Screenshot (home hero) ---- */
+.shot { display: block; width: 100%; border: 1px solid #8a93a3; margin: 4px 0 6px; }
+.shot-cap { font-size: 11px; color: #555; margin: 0 0 8px; text-align: center; }
+
+/* ---- Screenshots gallery (float grid) ---- */
+.gallery { margin: 0; }
+.gallery:after { content: ""; display: block; clear: both; }
+.tile { float: left; width: 48%; margin: 0 0 16px; }
+.tile.right { float: right; }
+.tile img { display: block; width: 100%; border: 1px solid #8a93a3; background: #000; }
+.tile .cap { font-size: 11px; color: #444; margin: 4px 0 0; text-align: center; }
+
+/* ---- FAQ ---- */
+.faq dt {
+  font-weight: bold;
+  color: #1a3358;
+  margin: 14px 0 4px;
+  padding-left: 16px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Crect x='2' y='2' width='8' height='8' fill='%233a5d96'/%3E%3C/svg%3E") no-repeat 0 3px;
+}
+.faq dd { margin: 0 0 4px; line-height: 1.55; }
+
+/* ---- Footer ---- */
+.footer {
+  background: #e9ecf1;
+  border-top: 1px solid #8a93a3;
+  padding: 10px 18px;
+  font-size: 10px;
+  color: #666;
+  text-align: center;
+  line-height: 1.6;
+}
+.footer a { color: #0000cc; }


### PR DESCRIPTION
## Summary

Replaces the XP.css-themed single page with a **no-build, ES5-compatible, old-browser-friendly** static site in the classic early-2000s style (dark blue banner, left sidebar nav, web-safe Verdana type).

### Pages (trimmed nav: Home · Screenshots · FAQ · GitHub)
- **Home** — Welcome (with a short "why XP in 2026?" note), a single hero screenshot, Download, and Features.
- **Screenshots** — dedicated gallery; currently the 3 existing screenshots (light/dark/Win7). *To be revisited soon with new screenshots.*
- **FAQ** — common questions (XP support, requirements, privacy/ZDR, MCP, models, cost).

### Implementation notes
- **No build step / static only** — plain HTML/CSS + a little ES5 JS.
- **Old-browser friendly** — float-based layout (no flexbox); every CSS3 gradient carries a solid `background-color` fallback.
- **Shared `app.js`** does one GitHub Releases lookup to populate the download link, the download-note version, and the sidebar "Latest release" widget version, with static fallbacks on any failure. The widget's "What's new »" links to `/releases/latest`.
- Download button label forced white; Download section sits below the hero screenshot.
- The previously vendored `docs/vendor/xp.css/` is **no longer referenced** (left in place; can be removed in a follow-up).

## Verification
Rendered every page headless (Playwright/Chromium):
- Layout, sidebar faux-columns, and footer render correctly across Home/Screenshots/FAQ.
- With the Releases API mocked, the download note and the sidebar widget both show `GxPT v0.15.0`; with it blocked, both fall back gracefully.

https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS

---
_Generated by [Claude Code](https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS)_