### PR TITLE
Fix cmd.exe quote stripping issue with quoted paths and arguments

### DIFF
--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -45,7 +45,15 @@ namespace CommandMcpServer
             req.FileName = config.Shell;
             // Hand the command to the shell as written; the shell (not this server) parses it.
             // The host already showed the user this exact string at the approval gate.
-            req.Arguments = "/c " + command;
+            //
+            // Wrap as: cmd.exe /s /c "<command>". The /S flag plus a single outer quote pair makes
+            // cmd strip exactly those outer quotes and pass everything between them through verbatim.
+            // Without it, bare `cmd /c <command>` hits cmd's legacy quoting rule: when the line
+            // starts with a quote and carries more than one quoted token (e.g. a quoted program path
+            // AND a quoted argument), cmd strips the FIRST and LAST quote of the whole line,
+            // corrupting it (the "quote stripping" failure on commands like
+            // `"C:\Program Files\...\ssh-keygen.exe" -f "C:\path" -N ""`).
+            req.Arguments = "/s /c \"" + command + "\"";
             req.WorkingDirectory = config.WorkDir;
             req.TimeoutMs = timeout;
 

--- a/tests/CommandMcpServer.Tests/CommandToolsTests.cs
+++ b/tests/CommandMcpServer.Tests/CommandToolsTests.cs
@@ -37,10 +37,10 @@ namespace CommandMcpServer.Tests
                 : Harness.NewCommandServerWithShell("/bin/sh", _work);
         }
 
-        // The Command server prepends the shell's own switch: on Windows it uses "/c", which cmd
-        // wants; for /bin/sh the server still passes "/c <command>", so on non-Windows we phrase
-        // commands that tolerate that. To keep the suite portable we only assert on Windows-shaped
-        // behavior when running on Windows, and use a sh-friendly form otherwise.
+        // The Command server invokes the shell as `<shell> /s /c "<command>"` so cmd strips just the
+        // outer quote pair and runs the command verbatim (see CommandTools). For /bin/sh that switch
+        // shape is meaningless, so on non-Windows we skip the exec-based asserts and run them only on
+        // Windows, where cmd /c is the real target.
 
         [Fact]
         public void Lists_the_run_tool()
@@ -110,6 +110,29 @@ namespace CommandMcpServer.Tests
             JObject s = Harness.Structured(msgs[0]);
             Assert.Equal(0, (int)s["exitCode"]);
             Assert.Contains("abc", (string)s["stdout"]);
+        }
+
+        [Fact]
+        public void Leading_quoted_path_with_a_quoted_arg_is_not_mangled()
+        {
+            if (!IsWindows) return;
+            // Regression for cmd.exe's quote-stripping quirk. A command that BEGINS with a quoted
+            // path AND carries a further quoted token (>2 quotes) makes bare `cmd /c <line>` strip
+            // the first+last quote of the whole line, corrupting it. The server wraps the command as
+            // `cmd /s /c "<line>"`, which preserves it verbatim. The space in the directory forces
+            // the leading quote to matter (so the bug can't hide behind cmd's two-quotes-only
+            // preservation rule). On the old code this command failed with a nonzero exit.
+            string subdir = Path.Combine(_work, "sub dir");
+            Directory.CreateDirectory(subdir);
+            string bat = Path.Combine(subdir, "say.bat");
+            File.WriteAllText(bat, "@echo off\r\n@echo got=[%~1]\r\n");
+
+            string command = "\"" + bat + "\" \"hello world\"";
+            var msgs = Harness.Exchange(NewServer(),
+                Harness.ToolsCall(1, "run", Harness.Args("command", command)));
+            JObject s = Harness.Structured(msgs[0]);
+            Assert.Equal(0, (int)s["exitCode"]);
+            Assert.Contains("got=[hello world]", (string)s["stdout"]);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Fixed a critical bug in the Command MCP Server where cmd.exe's legacy quote-stripping behavior would corrupt commands that begin with a quoted path and contain additional quoted arguments. The fix wraps shell commands with the `/s /c` flags and outer quotes to preserve the command verbatim.

## Changes
- **CommandTools.cs**: Modified the shell invocation from `cmd /c <command>` to `cmd /s /c "<command>"`. The `/s` flag combined with outer quotes ensures cmd.exe strips only the outer quote pair and passes the command through verbatim, preventing corruption of commands with multiple quoted tokens.

- **CommandToolsTests.cs**: 
  - Updated comment to clarify the new shell invocation behavior and explain why assertions are Windows-specific
  - Added regression test `Leading_quoted_path_with_a_quoted_arg_is_not_mangled()` that verifies commands with quoted paths containing spaces and quoted arguments are executed correctly

## Implementation Details
The issue occurred because cmd.exe has a legacy quoting rule: when a command line starts with a quote and contains more than one quoted token (e.g., a quoted program path AND a quoted argument), cmd strips the first and last quote of the entire line, corrupting the command.

By using `cmd /s /c "<command>"`, the `/s` flag tells cmd to treat the content between the outer quotes literally, stripping only those outer quotes and passing everything else through unchanged. This preserves the integrity of commands like `"C:\Program Files\...\ssh-keygen.exe" -f "C:\path" -N ""`.

The test specifically validates this fix by creating a batch file in a directory with spaces and invoking it with a quoted argument, which would fail under the old behavior.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7