### PR TITLE
Fix button panel layout to prevent clipping on window resize

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -68,10 +68,17 @@ namespace GxPT
 
             _buttons = new FlowLayoutPanel();
             _buttons.Dock = DockStyle.Bottom;
-            _buttons.Height = 34;
             _buttons.FlowDirection = FlowDirection.RightToLeft;
-            _buttons.WrapContents = false;
-            _buttons.AutoScroll = true;
+            // Wrap onto extra rows when the window is too narrow to fit every button on one line, and
+            // AutoSize so the strip grows upward (shrinking the preview above) to keep them all
+            // visible. The old fixed-height, no-wrap, AutoScroll setup let a horizontal scrollbar
+            // appear on resize and slice the buttons' bottoms off — and the scroll offset persisted,
+            // so they stayed cut off after the resize.
+            _buttons.WrapContents = true;
+            _buttons.AutoScroll = false;
+            _buttons.AutoSize = true;
+            _buttons.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _buttons.MinimumSize = new Size(0, 34);
 
             // Order added (Fill must be added before docked siblings to lay out correctly):
             this.Controls.Add(_diffPanel);


### PR DESCRIPTION
## Summary
Fixed the ToolApprovalPanel button layout to properly handle window resizing by switching from a fixed-height, non-wrapping layout with horizontal scrolling to a dynamic, wrapping layout that grows vertically as needed.

## Key Changes
- Removed fixed height constraint (`_buttons.Height = 34`) to allow dynamic sizing
- Enabled `WrapContents` to allow buttons to wrap onto multiple rows when space is constrained
- Disabled `AutoScroll` to prevent horizontal scrollbars that could clip button content
- Enabled `AutoSize` with `GrowAndShrink` mode to allow the panel to expand vertically
- Added `MinimumSize` constraint to maintain a minimum height of 34 pixels

## Implementation Details
The previous implementation had a critical flaw: when the window was resized to be too narrow for all buttons to fit on one line, a horizontal scrollbar would appear and slice off the bottoms of the buttons. Additionally, the scroll offset would persist after resizing, leaving buttons permanently cut off.

The new approach allows buttons to wrap naturally onto additional rows, and the button panel grows upward (shrinking the preview panel above) to keep all buttons visible. This provides a better user experience during window resizing without losing access to any controls.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7