### PR TITLE
Size the approval prompt to its content: collapse short prompts, grow when buttons wrap

### DIFF
--- a/GxPT/Controls/DiffPreviewPanel.cs
+++ b/GxPT/Controls/DiffPreviewPanel.cs
@@ -71,6 +71,26 @@ namespace GxPT
             catch { this.AutoScrollMinSize = Size.Empty; }
         }
 
+        // Natural pixel height of the current content (optional header + body + padding), measured
+        // independently of the control's own bounds so the host can size the approval panel to fit.
+        // Uses an offscreen Graphics so it is valid even before the panel is shown.
+        public int GetPreferredContentHeight()
+        {
+            int oneLine = (_monoFont != null ? _monoFont.Height : 14);
+            if (_monoFont == null || string.IsNullOrEmpty(_body)) return HeaderHeight + oneLine + Pad;
+            try
+            {
+                using (var bmp = new Bitmap(1, 1))
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, _language, _monoFont, _dark);
+                    Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
+                    return HeaderHeight + Math.Max(_monoFont.Height, content.Height) + Pad;
+                }
+            }
+            catch { return HeaderHeight + oneLine + Pad; }
+        }
+
         protected override void OnPaint(PaintEventArgs e)
         {
             base.OnPaint(e);

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -31,9 +31,15 @@ namespace GxPT
 
         // The details area (diff/preview) is sized to its content between these bounds: short prompts
         // (e.g. a one-line command) collapse instead of leaving a tall empty box, while long content
-        // is capped here and scrolls. See ComputePanelHeight.
+        // is capped here and scrolls. See LayoutToContent.
         private const int MinDetailsHeight = 24;
         private const int MaxDetailsHeight = 200;
+
+        // Clamped content height for the current prompt; the panel height is rebuilt from this plus
+        // the (possibly multi-row) button strip whenever the panel resizes. Re-entrancy guard stops
+        // the height we set from recursing through OnSizeChanged.
+        private int _detailsHeight = MinDetailsHeight;
+        private bool _inLayoutToContent;
 
         public ToolApprovalPanel()
         {
@@ -226,8 +232,10 @@ namespace GxPT
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
 
-            // Size to fit the content (buttons built above so their height is counted).
-            this.Height = ComputePanelHeight(handled);
+            // Size to fit the content (buttons built above so their height is counted, including any
+            // wrapping at the current width).
+            _detailsHeight = ClampedDetailsHeight(handled);
+            LayoutToContent();
 
             this.Visible = true;
             // Keep this Bottom-docked panel BEHIND the Fill transcript in z-order. WinForms fills the
@@ -261,7 +269,8 @@ namespace GxPT
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
 
-            this.Height = ComputePanelHeight(false);
+            _detailsHeight = ClampedDetailsHeight(false);
+            LayoutToContent();
 
             this.Visible = true;
             this.SendToBack();
@@ -274,23 +283,55 @@ namespace GxPT
             _onContinue = null;
         }
 
-        // Total panel height that makes the Fill details control exactly fit its content, clamped to
-        // [Min,Max]. The chrome rows (header/tier/label) are their fixed docked heights; the button
-        // strip is measured after it's populated. The leftover docked space (the Fill control) then
-        // equals the clamped content height — so short prompts collapse and long ones cap + scroll.
-        private int ComputePanelHeight(bool handled)
+        // The clamped natural height of the current details control's content, in [Min,Max].
+        private int ClampedDetailsHeight(bool handled)
         {
             int detailsContent = handled
                 ? _diffPanel.GetPreferredContentHeight()
                 : MeasurePreviewContentHeight();
-            int detailsH = Math.Max(MinDetailsHeight, Math.Min(MaxDetailsHeight, detailsContent));
+            return Math.Max(MinDetailsHeight, Math.Min(MaxDetailsHeight, detailsContent));
+        }
 
-            int chrome = _header.Height + _tierBadge.Height + _previewLabel.Height;
-            int buttonsH = _buttons.PreferredSize.Height;
-            if (buttonsH < 28) buttonsH = 34; // guard against a not-yet-measured strip
-            const int border = 2; // FixedSingle: 1px top + 1px bottom
+        // Rebuild the panel height so the Fill details control keeps its clamped content height even
+        // as the button strip wraps to more rows on a narrow window: the panel grows to fit the taller
+        // strip instead of squeezing (and clipping) the details. Capped so it can't swallow the
+        // transcript above it; past the cap the details give way and scroll. Recomputed on every
+        // resize because button wrapping depends on the current width.
+        private void LayoutToContent()
+        {
+            if (_inLayoutToContent) return;
+            _inLayoutToContent = true;
+            try
+            {
+                int avail = this.ClientSize.Width - this.Padding.Horizontal;
+                if (avail < 1) avail = (this.Parent != null ? this.Parent.ClientSize.Width : 400) - this.Padding.Horizontal;
+                if (avail < 1) avail = 400;
 
-            return this.Padding.Top + this.Padding.Bottom + chrome + detailsH + buttonsH + border;
+                // GetPreferredSize at the real width includes any row wrapping of the buttons.
+                int buttonsH = _buttons.GetPreferredSize(new Size(avail, 0)).Height;
+                if (buttonsH < 28) buttonsH = 34; // guard against a not-yet-measured strip
+
+                int chrome = _header.Height + _tierBadge.Height + _previewLabel.Height;
+                const int border = 2; // FixedSingle: 1px top + 1px bottom
+                int target = this.Padding.Top + this.Padding.Bottom + chrome + _detailsHeight + buttonsH + border;
+
+                // Don't let the docked panel grow tall enough to bury the transcript above it.
+                if (this.Parent != null)
+                {
+                    int cap = this.Parent.ClientSize.Height - 64;
+                    if (cap > 120 && target > cap) target = cap;
+                }
+
+                if (this.Height != target) this.Height = target;
+            }
+            finally { _inLayoutToContent = false; }
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            // Width changes (parent resize) can re-wrap the buttons; keep the panel tall enough.
+            if (this.Visible) LayoutToContent();
         }
 
         // Approximate wrapped height of the raw-JSON preview text at the current width. Best-effort:

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -29,6 +29,12 @@ namespace GxPT
         // context around the change. Set by the host (MainForm); null disables context (bare diff).
         public Func<string> WorkingDirProvider;
 
+        // The details area (diff/preview) is sized to its content between these bounds: short prompts
+        // (e.g. a one-line command) collapse instead of leaving a tall empty box, while long content
+        // is capped here and scrolls. See ComputePanelHeight.
+        private const int MinDetailsHeight = 24;
+        private const int MaxDetailsHeight = 200;
+
         public ToolApprovalPanel()
         {
             this.Dock = DockStyle.Bottom;
@@ -205,7 +211,6 @@ namespace GxPT
             {
                 _preview.Visible = false;
                 _diffPanel.Visible = true;
-                this.Height = 260;
             }
             else
             {
@@ -213,7 +218,6 @@ namespace GxPT
                 _previewLabel.Text = "Details:";
                 _diffPanel.Visible = false;
                 _preview.Visible = true;
-                this.Height = 150;
             }
 
             _buttons.Controls.Clear();
@@ -221,6 +225,9 @@ namespace GxPT
             AddButton("Deny", ApprovalChoice.Deny, tier == ToolTier.Destructive);
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
+
+            // Size to fit the content (buttons built above so their height is counted).
+            this.Height = ComputePanelHeight(handled);
 
             this.Visible = true;
             // Keep this Bottom-docked panel BEHIND the Fill transcript in z-order. WinForms fills the
@@ -248,12 +255,13 @@ namespace GxPT
                 + "ask how you'd like to proceed.";
             _diffPanel.Visible = false;
             _preview.Visible = true;
-            this.Height = 150;
 
             _buttons.Controls.Clear();
             // Added first => rightmost in the RightToLeft flow.
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
+
+            this.Height = ComputePanelHeight(false);
 
             this.Visible = true;
             this.SendToBack();
@@ -264,6 +272,38 @@ namespace GxPT
             this.Visible = false;
             _onChoose = null;
             _onContinue = null;
+        }
+
+        // Total panel height that makes the Fill details control exactly fit its content, clamped to
+        // [Min,Max]. The chrome rows (header/tier/label) are their fixed docked heights; the button
+        // strip is measured after it's populated. The leftover docked space (the Fill control) then
+        // equals the clamped content height — so short prompts collapse and long ones cap + scroll.
+        private int ComputePanelHeight(bool handled)
+        {
+            int detailsContent = handled
+                ? _diffPanel.GetPreferredContentHeight()
+                : MeasurePreviewContentHeight();
+            int detailsH = Math.Max(MinDetailsHeight, Math.Min(MaxDetailsHeight, detailsContent));
+
+            int chrome = _header.Height + _tierBadge.Height + _previewLabel.Height;
+            int buttonsH = _buttons.PreferredSize.Height;
+            if (buttonsH < 28) buttonsH = 34; // guard against a not-yet-measured strip
+            const int border = 2; // FixedSingle: 1px top + 1px bottom
+
+            return this.Padding.Top + this.Padding.Bottom + chrome + detailsH + buttonsH + border;
+        }
+
+        // Approximate wrapped height of the raw-JSON preview text at the current width. Best-effort:
+        // the TextBox scrolls if we under-shoot, and the caller clamps the result anyway.
+        private int MeasurePreviewContentHeight()
+        {
+            string text = _preview.Text != null ? _preview.Text : string.Empty;
+            if (text.Length == 0) return MinDetailsHeight;
+            int width = this.ClientSize.Width - this.Padding.Horizontal;
+            if (width < 50 && this.Parent != null) width = this.Parent.ClientSize.Width - this.Padding.Horizontal;
+            if (width < 50) width = 400;
+            Size sz = TextRenderer.MeasureText(text, _preview.Font, new Size(width, int.MaxValue), TextFormatFlags.WordBreak);
+            return sz.Height + 8;
         }
 
         // If the panel is torn down (e.g. its tab is closed) while a call still awaits a decision,


### PR DESCRIPTION
## Why

Two related sizing problems with the tool-approval panel:

1. Many prompts were vertically much taller than their content needed — e.g. a one-line `command__run` (`rem`) left a large empty details box, because the panel used fixed heights (260 for diff/command previews, 150 for the raw-JSON preview).
2. After the button strip became a wrapping auto-size strip (#76), narrowing the window wrapped the buttons onto extra rows, which grew the strip *upward* into the fixed panel height and **squeezed/clipped the details** — a multi-line diff just gained scrollbars, but a single-line diff got cut off entirely.

## What

Size the panel to its content instead of using fixed heights:

- Measure the details' natural height and **clamp it** between `MinDetailsHeight = 24` and `MaxDetailsHeight = 200`.
- Build the panel height as `padding + chrome (header/tier/label) + clamped-details + button-strip`, so the `Dock=Fill` details control lands exactly on its clamped height. Short content collapses; long content caps and scrolls.
- **Measure the button strip at the actual current width** (`GetPreferredSize`), so row wrapping is counted, and **grow the whole panel** to keep the details at their content height rather than squeezing them.
- **Recompute on resize** (`OnSizeChanged`, re-entrancy guarded) since button wrapping depends on width.
- **Cap** the panel at the parent height minus a small margin so the docked panel can't bury the transcript; past the cap the details give way and scroll.

Details:
- `DiffPreviewPanel` gains a handle-independent `GetPreferredContentHeight()` (offscreen `Graphics`, valid before the panel is shown).
- The raw-JSON preview is measured with `TextRenderer` (best-effort; the `TextBox` scrolls if under-shot, and the result is clamped anyway).
- Same sizing applied to the iteration-cap continuation prompt.

## Notes

- Builds on #76 (the auto-sized button strip).
- The diff-content measurement is width-independent (no-wrap), so it's stable across resizes; the raw-JSON preview height is computed at show time.
- No automated coverage — these are WinForms controls. **Please verify in Visual Studio:** a one-line command should be compact; a long diff should cap (~200px) and scroll; and narrowing the window until the buttons wrap should grow the panel rather than clip the diff. The `Min`/`Max`/cap constants are easy to tune.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7