### PR TITLE
Render tool-call records on the outcome, not the request (don't show denied edits as applied)

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2821,7 +2821,7 @@ namespace GxPT
                 };
                 // Outcome of each tool call (by id) so a denied call renders as "denied" instead of as
                 // an applied record. Tool messages aren't shown directly, but their content is the
-                // result the orchestrator recorded (McpMarkers.DeniedResult on denial).
+                // result the orchestrator recorded (McpChatOrchestrator.DeniedResultText on denial).
                 var toolResultById = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal);
                 foreach (var rm in convo.History)
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1741,17 +1741,16 @@ namespace GxPT
                             cur.Text.Append(t);
                         }
                     };
-                    // Rendered on the call's RESULT (not the request), so a denied call shows as
-                    // "denied" instead of an applied edit/diff. argsJson is threaded through for
-                    // files__edit etc., which render a collapsible record instead of the generic
-                    // "using" marker; register the record (it has its own lock) before taking sbLock.
-                    // Live keys are per-call GUIDs (ephemeral — the reloaded view re-derives under the
-                    // persisted call id). Consecutive calls share one block.
-                    Action<string, string, string, bool> onToolActivity = delegate(string name, string argsJson, string resultText, bool isError)
+                    // Tool activity renders in two beats: an immediate "using <tool>" placeholder on the
+                    // call (live feedback while it runs / the approval gate waits), replaced by the
+                    // outcome marker on the result. So a denied call ends as "denied: <tool>" and an
+                    // approved edit ends as its collapsible record — never an unapproved diff. The
+                    // placeholder sits at the tail of the tool block (calls are serial and no model text
+                    // streams between a call and its result), so we truncate back to it and append.
+                    LiveSeg pendingToolSeg = null;
+                    int pendingToolStart = 0;
+                    Action<string> onToolCall = delegate(string name)
                     {
-                        string marker = McpMarkers.IsDenied(resultText)
-                            ? McpMarkers.Denied(name)
-                            : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
                         lock (sbLock)
                         {
                             LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
@@ -1761,7 +1760,41 @@ namespace GxPT
                                 segs.Add(cur);
                             }
                             if (cur.Text.Length > 0) cur.Text.Append("\r\n");
-                            cur.Text.Append(marker);
+                            pendingToolSeg = cur;
+                            pendingToolStart = cur.Text.Length;
+                            cur.Text.Append(McpMarkers.Call(name));
+                        }
+                    };
+                    // argsJson is threaded through for files__edit etc., which render a collapsible
+                    // record instead of the generic "using" marker; register the record (it has its own
+                    // lock) before taking sbLock. Live keys are per-call GUIDs (ephemeral — the reloaded
+                    // view re-derives under the persisted call id).
+                    Action<string, string, string, bool> onToolResult = delegate(string name, string argsJson, string resultText, bool isError)
+                    {
+                        string marker = McpMarkers.IsDenied(resultText)
+                            ? McpMarkers.Denied(name)
+                            : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
+                        lock (sbLock)
+                        {
+                            if (pendingToolSeg != null)
+                            {
+                                // Replace the placeholder (at the tail) with the outcome marker.
+                                if (pendingToolStart <= pendingToolSeg.Text.Length)
+                                    pendingToolSeg.Text.Length = pendingToolStart;
+                                pendingToolSeg.Text.Append(marker);
+                                pendingToolSeg = null;
+                            }
+                            else
+                            {
+                                LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
+                                if (cur == null || cur.Role != MessageRole.Tool)
+                                {
+                                    cur = new LiveSeg(MessageRole.Tool);
+                                    segs.Add(cur);
+                                }
+                                if (cur.Text.Length > 0) cur.Text.Append("\r\n");
+                                cur.Text.Append(marker);
+                            }
                         }
                     };
                     Action onComplete = delegate
@@ -1776,7 +1809,7 @@ namespace GxPT
                         { FinalizeToolSend(ctx, renderTimer, sbLock, segs, e2); });
                     };
 
-                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolActivity, onComplete, onErr));
+                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolCall, onToolResult, onComplete, onErr));
                 }
                 catch (Exception ex)
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1741,13 +1741,17 @@ namespace GxPT
                             cur.Text.Append(t);
                         }
                     };
-                    // argsJson is threaded through for files__edit etc., which render a collapsible
-                    // record instead of the generic "using" marker. Register the record (it has its own
-                    // lock) before taking sbLock. Live keys are per-call GUIDs (ephemeral — the reloaded
-                    // view re-derives under the persisted call id). Consecutive calls share one block.
-                    Action<string, string> onToolCall = delegate(string name, string argsJson)
+                    // Rendered on the call's RESULT (not the request), so a denied call shows as
+                    // "denied" instead of an applied edit/diff. argsJson is threaded through for
+                    // files__edit etc., which render a collapsible record instead of the generic
+                    // "using" marker; register the record (it has its own lock) before taking sbLock.
+                    // Live keys are per-call GUIDs (ephemeral — the reloaded view re-derives under the
+                    // persisted call id). Consecutive calls share one block.
+                    Action<string, string, string, bool> onToolActivity = delegate(string name, string argsJson, string resultText, bool isError)
                     {
-                        string marker = EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
+                        string marker = McpMarkers.IsDenied(resultText)
+                            ? McpMarkers.Denied(name)
+                            : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
                         lock (sbLock)
                         {
                             LiveSeg cur = (segs.Count > 0) ? segs[segs.Count - 1] : null;
@@ -1772,7 +1776,7 @@ namespace GxPT
                         { FinalizeToolSend(ctx, renderTimer, sbLock, segs, e2); });
                     };
 
-                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolCall, onComplete, onErr));
+                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolActivity, onComplete, onErr));
                 }
                 catch (Exception ex)
                 {
@@ -2782,6 +2786,16 @@ namespace GxPT
                     }
                     pendingTools = null;
                 };
+                // Outcome of each tool call (by id) so a denied call renders as "denied" instead of as
+                // an applied record. Tool messages aren't shown directly, but their content is the
+                // result the orchestrator recorded (McpMarkers.DeniedResult on denial).
+                var toolResultById = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal);
+                foreach (var rm in convo.History)
+                {
+                    if (rm == null) continue;
+                    if (string.Equals(rm.Role, "tool", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(rm.ToolCallId))
+                        toolResultById[rm.ToolCallId] = rm.Content;
+                }
                 int hi = -1;
                 foreach (var m in convo.History)
                 {
@@ -2817,8 +2831,18 @@ namespace GxPT
                             var tc = m.ToolCalls[ti];
                             if (tc == null) continue;
                             if (pendingTools.Length > 0) pendingTools.Append("\r\n");
-                            string key = !string.IsNullOrEmpty(tc.Id) ? tc.Id : ("edit" + ti);
-                            pendingTools.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
+                            string res;
+                            bool denied = !string.IsNullOrEmpty(tc.Id)
+                                && toolResultById.TryGetValue(tc.Id, out res) && McpMarkers.IsDenied(res);
+                            if (denied)
+                            {
+                                pendingTools.Append(McpMarkers.Denied(tc.Name));
+                            }
+                            else
+                            {
+                                string key = !string.IsNullOrEmpty(tc.Id) ? tc.Id : ("edit" + ti);
+                                pendingTools.Append(EditDiffMarkerOrCall(ctx.Transcript, tc.Name, tc.ArgumentsJson, key));
+                            }
                         }
                     }
                 }

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -26,14 +26,12 @@ namespace GxPT
             return MarkdownParser.EditDiffSentinel(key);
         }
 
-        // The tool-result content the orchestrator returns when the user denies a call. Centralized
-        // so the transcript can recognize a denied call (live and on reload) and render it as denied
-        // rather than as an applied edit/diff.
-        public const string DeniedResult = "[Call denied by user.]";
-
+        // True when a tool result is the orchestrator's "denied by user" sentinel, so the transcript
+        // renders the call as denied (live and on reload) rather than as an applied edit/diff. The
+        // sentinel lives on McpChatOrchestrator (which the test project links; this file does not).
         public static bool IsDenied(string resultText)
         {
-            return string.Equals(resultText, DeniedResult, StringComparison.Ordinal);
+            return string.Equals(resultText, McpChatOrchestrator.DeniedResultText, StringComparison.Ordinal);
         }
 
         // Shown in place of the edit/diff record when a call was denied, so a denied edit reads as

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -46,27 +46,29 @@ namespace GxPT
 
     // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can render a tool-call
     // turn as a chrome-less "tool activity" message plus a separate answer bubble: model text ->
-    // appendText, each completed tool call -> onToolActivity (its own message), Complete/OnError
-    // finalize.
+    // appendText, tool calls -> onToolCall/onToolResult, Complete/OnError finalize.
     //
-    // The tool record is rendered on the RESULT, not the call: OnToolCall fires before the approval
-    // gate, so rendering there would show an edit/diff (and persist it) even when the user denies the
-    // call. We stash the arguments at call time and emit the record once the outcome is known, so the
-    // transcript reflects what actually happened (applied / denied / errored).
+    // Tool activity renders in two beats: OnToolCall shows an immediate "using <tool>" placeholder so
+    // there's live feedback while the call runs (and the approval gate waits); OnToolResult replaces
+    // that placeholder once the outcome is known, so the transcript reflects what actually happened
+    // (applied record / denied / errored) rather than the unapproved request. Arguments are stashed at
+    // call time since OnToolResult doesn't carry them.
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
-        // (functionName, argumentsJson, resultText, isError) — emitted once a call's outcome is known.
-        private readonly Action<string, string, string, bool> _onToolActivity;
+        private readonly Action<string> _onToolCall;                         // (functionName) -> show placeholder
+        private readonly Action<string, string, string, bool> _onToolResult; // (fn, argsJson, resultText, isError) -> replace
         private readonly Action _complete;
         private readonly Action<string> _error;
 
         private string _pendingArgs; // arguments of the in-flight call, awaiting its result
 
-        public DelegateToolLoopUi(Action<string> appendText, Action<string, string, string, bool> onToolActivity, Action complete, Action<string> error)
+        public DelegateToolLoopUi(Action<string> appendText, Action<string> onToolCall,
+                                  Action<string, string, string, bool> onToolResult, Action complete, Action<string> error)
         {
             _appendText = appendText;
-            _onToolActivity = onToolActivity;
+            _onToolCall = onToolCall;
+            _onToolResult = onToolResult;
             _complete = complete;
             _error = error;
         }
@@ -78,13 +80,14 @@ namespace GxPT
 
         public void OnToolCall(string functionName, string argumentsJson)
         {
-            // Defer rendering until the result: calls are serial, so a single pending slot suffices.
+            // Stash args for the result; show the placeholder now. Calls are serial, so one slot fits.
             _pendingArgs = argumentsJson;
+            if (_onToolCall != null) _onToolCall(functionName);
         }
 
         public void OnToolResult(string functionName, string resultText, bool isError)
         {
-            if (_onToolActivity != null) _onToolActivity(functionName, _pendingArgs, resultText, isError);
+            if (_onToolResult != null) _onToolResult(functionName, _pendingArgs, resultText, isError);
             _pendingArgs = null;
         }
 

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -25,23 +25,48 @@ namespace GxPT
         {
             return MarkdownParser.EditDiffSentinel(key);
         }
+
+        // The tool-result content the orchestrator returns when the user denies a call. Centralized
+        // so the transcript can recognize a denied call (live and on reload) and render it as denied
+        // rather than as an applied edit/diff.
+        public const string DeniedResult = "[Call denied by user.]";
+
+        public static bool IsDenied(string resultText)
+        {
+            return string.Equals(resultText, DeniedResult, StringComparison.Ordinal);
+        }
+
+        // Shown in place of the edit/diff record when a call was denied, so a denied edit reads as
+        // "denied" instead of looking like it was applied.
+        public static string Denied(string functionName)
+        {
+            return "denied: " + Display(functionName);
+        }
     }
 
     // Adapts the orchestrator's IToolLoopUi to simple delegates so MainForm can render a tool-call
     // turn as a chrome-less "tool activity" message plus a separate answer bubble: model text ->
-    // appendText, each tool call -> onToolCall (its own message), Complete/OnError finalize. Tool
-    // results are never shown (the model summarizes them).
+    // appendText, each completed tool call -> onToolActivity (its own message), Complete/OnError
+    // finalize.
+    //
+    // The tool record is rendered on the RESULT, not the call: OnToolCall fires before the approval
+    // gate, so rendering there would show an edit/diff (and persist it) even when the user denies the
+    // call. We stash the arguments at call time and emit the record once the outcome is known, so the
+    // transcript reflects what actually happened (applied / denied / errored).
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
-        private readonly Action<string, string> _onToolCall; // (functionName, argumentsJson)
+        // (functionName, argumentsJson, resultText, isError) — emitted once a call's outcome is known.
+        private readonly Action<string, string, string, bool> _onToolActivity;
         private readonly Action _complete;
         private readonly Action<string> _error;
 
-        public DelegateToolLoopUi(Action<string> appendText, Action<string, string> onToolCall, Action complete, Action<string> error)
+        private string _pendingArgs; // arguments of the in-flight call, awaiting its result
+
+        public DelegateToolLoopUi(Action<string> appendText, Action<string, string, string, bool> onToolActivity, Action complete, Action<string> error)
         {
             _appendText = appendText;
-            _onToolCall = onToolCall;
+            _onToolActivity = onToolActivity;
             _complete = complete;
             _error = error;
         }
@@ -53,12 +78,14 @@ namespace GxPT
 
         public void OnToolCall(string functionName, string argumentsJson)
         {
-            if (_onToolCall != null) _onToolCall(functionName, argumentsJson);
+            // Defer rendering until the result: calls are serial, so a single pending slot suffices.
+            _pendingArgs = argumentsJson;
         }
 
         public void OnToolResult(string functionName, string resultText, bool isError)
         {
-            // Results are not rendered — the model incorporates them into its next message.
+            if (_onToolActivity != null) _onToolActivity(functionName, _pendingArgs, resultText, isError);
+            _pendingArgs = null;
         }
 
         public void OnError(string message)

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -21,6 +21,11 @@ namespace GxPT
         public const int DefaultMaxIterations = 25;
         public const int DefaultCallTimeoutMs = 60000;
 
+        // Tool-result content returned when the user denies a call. Lives here (this file is linked
+        // into the test project) so the transcript renderer can recognize a denied call; McpMarkers
+        // references it.
+        internal const string DeniedResultText = "[Call denied by user.]";
+
         private readonly IChatStreamer _streamer;
         private readonly McpToolRegistry _registry;
         private readonly IToolApprovalPolicy _approval;
@@ -330,7 +335,7 @@ namespace GxPT
             {
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] '" + call.Name + "' denied by approval policy");
-                return McpMarkers.DeniedResult;
+                return DeniedResultText;
             }
 
             Stopwatch sw = Stopwatch.StartNew();

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -330,7 +330,7 @@ namespace GxPT
             {
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] '" + call.Name + "' denied by approval policy");
-                return "[Call denied by user.]";
+                return McpMarkers.DeniedResult;
             }
 
             Stopwatch sw = Stopwatch.StartNew();


### PR DESCRIPTION
## Why

Tool-call records — notably the `files__edit` diff and the `command__run` command line — were drawn at `OnToolCall` time, which fires **before** the approval gate in `ExecuteCall`. So an edit showed in the transcript as "edited xyz" *with its diff* before it was ever approved, and it **stayed even when denied**:

- `OnToolResult` was a no-op, so denial never reconciled the live record.
- The reload path re-derived the record purely from the persisted `tool_calls`, never consulting the tool result — so a denied edit still rendered as applied after reopening the conversation.

## What

Render tool activity in **two beats**, keyed on the outcome:

- **`OnToolCall`** appends an immediate `using <tool>` placeholder, so there's live feedback while the call runs and while the approval gate waits.
- **`OnToolResult`** replaces that placeholder in place with the final marker: the collapsible record on success, or `denied: <tool>` on denial — never an unapproved diff.

Because calls are serial and no model text streams between a call and its result, the placeholder is always at the tail of the tool block; the result handler truncates the segment back to the placeholder's start and appends the outcome marker. `MaterializeLiveSegs` already re-renders a segment whose length changes, so the swap appears on the next render tick (or the final flush if the call resolved before any tick).

On **reload**, denied calls render as `denied: <tool>` too: the reload path builds a `tool-call id → result` map and recognizes the denial sentinel. The denial result string is centralized as `McpMarkers.DeniedResult` so the orchestrator and the transcript agree on it.

Non-denial outcomes (success, and other tool errors) render the record as before — this change only stops *unapproved/denied* actions from appearing as if they happened.

## Tests / verification

- No interface change (`IToolLoopUi` is unchanged; only `DelegateToolLoopUi`'s constructor shape changed, and only `MainForm` builds it). The existing orchestrator test that asserts the denial result string still holds — `McpMarkers.DeniedResult` is the same literal.
- WinForms rendering isn't covered by automated tests and I can't run it here. **Please verify in VS:** request an edit → a `using files / edit` marker appears immediately; **deny** it → it becomes `denied: files / edit` (no diff); **allow** it → it becomes the collapsible diff record; reopen the conversation → denied calls stay "denied", approved ones keep their record.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7