### PR TITLE
Centralize the default model catalog; refresh defaults for new installs (default Sonnet 4.6)

### DIFF
--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -375,22 +375,9 @@
             this.cmbModel.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.cmbModel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbModel.FormattingEnabled = true;
-            this.cmbModel.Items.AddRange(new object[] {
-            "anthropic/claude-opus-4.8",
-            "anthropic/claude-sonnet-4.6",
-            "anthropic/claude-haiku-4.5",
-            "google/gemini-pro-latest",
-            "google/gemini-3.5-flash",
-            "google/gemma-4-31b-it",
-            "openai/gpt-5.4",
-            "openai/gpt-5.1-codex-mini",
-            "openai/gpt-chat-latest",
-            "openai/gpt-5.4-mini",
-            "openai/gpt-4o",
-            "deepseek/deepseek-v4-pro",
-            "deepseek/deepseek-v4-flash",
-            "moonshotai/kimi-k2.6",
-            "qwen/qwen3.7-max"});
+            // Items are populated at runtime by MainForm.PopulateModelsFromSettings (from the user's
+            // settings, or ModelDefaults on a fresh install) - not hardcoded here, so the default
+            // catalog lives in one place.
             this.cmbModel.Location = new System.Drawing.Point(0, 0);
             this.cmbModel.Margin = new System.Windows.Forms.Padding(0);
             this.cmbModel.Name = "cmbModel";

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -376,12 +376,21 @@
             this.cmbModel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbModel.FormattingEnabled = true;
             this.cmbModel.Items.AddRange(new object[] {
-            "anthropic/claude-3.7-sonnet",
-            "anthropic/claude-sonnet-4",
-            "google/gemini-2.5-flash",
-            "google/gemini-2.5-pro",
+            "anthropic/claude-opus-4.8",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-haiku-4.5",
+            "google/gemini-pro-latest",
+            "google/gemini-3.5-flash",
+            "google/gemma-4-31b-it",
+            "openai/gpt-5.4",
+            "openai/gpt-5.1-codex-mini",
+            "openai/gpt-chat-latest",
+            "openai/gpt-5.4-mini",
             "openai/gpt-4o",
-            "openai/gpt-5"});
+            "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash",
+            "moonshotai/kimi-k2.6",
+            "qwen/qwen3.7-max"});
             this.cmbModel.Location = new System.Drawing.Point(0, 0);
             this.cmbModel.Margin = new System.Windows.Forms.Padding(0);
             this.cmbModel.Name = "cmbModel";

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -886,11 +886,11 @@ namespace GxPT
             {
                 string m = (cmbModel != null ? cmbModel.Text : null) ?? string.Empty;
                 m = m.Trim();
-                return string.IsNullOrEmpty(m) ? "openai/gpt-4o" : m;
+                return string.IsNullOrEmpty(m) ? ModelDefaults.DefaultModel : m;
             }
             catch
             {
-                return "openai/gpt-4o";
+                return ModelDefaults.DefaultModel;
             }
         }
 
@@ -1929,7 +1929,12 @@ namespace GxPT
                 var list = AppSettings.GetList("models");
                 string def = AppSettings.GetString("default_model");
 
-                if (list != null && list.Count > 0 && this.cmbModel != null)
+                // Fresh install (no models configured yet): fall back to the shared default catalog so
+                // the combo is never empty and matches what the Settings seed will write.
+                if (list == null || list.Count == 0) list = ModelDefaults.ModelList();
+                if (string.IsNullOrEmpty(def)) def = ModelDefaults.DefaultModel;
+
+                if (this.cmbModel != null)
                 {
                     // Preserve the active tab's chosen model if possible
                     string currentTabModel = null;
@@ -2427,7 +2432,7 @@ namespace GxPT
                 if (list != null && list.Count > 0) return list[0];
             }
             catch { }
-            return "openai/gpt-4o";
+            return ModelDefaults.DefaultModel;
         }
 
         // Sync the model combo box to the active tab's SelectedModel

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -188,24 +188,16 @@ namespace GxPT
             var sb = new StringBuilder();
             sb.AppendLine("{");
             sb.AppendLine("  \"openrouter_api_key\": \"\",");
+            // Models come from the shared default catalog (ModelDefaults) so this seed, the strongly
+            // typed defaults, and the combo's fresh-install fallback can't drift apart.
             sb.AppendLine("  \"models\": [");
-            sb.AppendLine("    \"anthropic/claude-opus-4.8\",");
-            sb.AppendLine("    \"anthropic/claude-sonnet-4.6\",");
-            sb.AppendLine("    \"anthropic/claude-haiku-4.5\",");
-            sb.AppendLine("    \"google/gemini-pro-latest\",");
-            sb.AppendLine("    \"google/gemini-3.5-flash\",");
-            sb.AppendLine("    \"google/gemma-4-31b-it\",");
-            sb.AppendLine("    \"openai/gpt-5.4\",");
-            sb.AppendLine("    \"openai/gpt-5.1-codex-mini\",");
-            sb.AppendLine("    \"openai/gpt-chat-latest\",");
-            sb.AppendLine("    \"openai/gpt-5.4-mini\",");
-            sb.AppendLine("    \"openai/gpt-4o\",");
-            sb.AppendLine("    \"deepseek/deepseek-v4-pro\",");
-            sb.AppendLine("    \"deepseek/deepseek-v4-flash\",");
-            sb.AppendLine("    \"moonshotai/kimi-k2.6\",");
-            sb.AppendLine("    \"qwen/qwen3.7-max\"");
+            for (int i = 0; i < ModelDefaults.Models.Length; i++)
+            {
+                bool last = (i == ModelDefaults.Models.Length - 1);
+                sb.AppendLine("    \"" + ModelDefaults.Models[i] + "\"" + (last ? "" : ","));
+            }
             sb.AppendLine("  ],");
-            sb.AppendLine("  \"default_model\": \"anthropic/claude-sonnet-4.6\",");
+            sb.AppendLine("  \"default_model\": \"" + ModelDefaults.DefaultModel + "\",");
             sb.AppendLine("  \"theme\": \"light\",");
             // Default UI color theme
             sb.AppendLine("  \"color_theme\": \"blue\",");
@@ -244,25 +236,8 @@ namespace GxPT
             return new SettingsData
             {
                 openrouter_api_key = "",
-                models = new List<string>
-                {
-                    "anthropic/claude-opus-4.8",
-                    "anthropic/claude-sonnet-4.6",
-                    "anthropic/claude-haiku-4.5",
-                    "google/gemini-pro-latest",
-                    "google/gemini-3.5-flash",
-                    "google/gemma-4-31b-it",
-                    "openai/gpt-5.4",
-                    "openai/gpt-5.1-codex-mini",
-                    "openai/gpt-chat-latest",
-                    "openai/gpt-5.4-mini",
-                    "openai/gpt-4o",
-                    "deepseek/deepseek-v4-pro",
-                    "deepseek/deepseek-v4-flash",
-                    "moonshotai/kimi-k2.6",
-                    "qwen/qwen3.7-max"
-                },
-                default_model = "anthropic/claude-sonnet-4.6",
+                models = ModelDefaults.ModelList(),
+                default_model = ModelDefaults.DefaultModel,
                 enable_logging = false,
                 font_size = GetChatDefaultFontSize(),
                 theme = "light",

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -189,14 +189,23 @@ namespace GxPT
             sb.AppendLine("{");
             sb.AppendLine("  \"openrouter_api_key\": \"\",");
             sb.AppendLine("  \"models\": [");
-            sb.AppendLine("    \"anthropic/claude-3.7-sonnet\",");
-            sb.AppendLine("    \"anthropic/claude-sonnet-4\",");
-            sb.AppendLine("    \"google/gemini-2.5-flash\",");
-            sb.AppendLine("    \"google/gemini-2.5-pro\",");
+            sb.AppendLine("    \"anthropic/claude-opus-4.8\",");
+            sb.AppendLine("    \"anthropic/claude-sonnet-4.6\",");
+            sb.AppendLine("    \"anthropic/claude-haiku-4.5\",");
+            sb.AppendLine("    \"google/gemini-pro-latest\",");
+            sb.AppendLine("    \"google/gemini-3.5-flash\",");
+            sb.AppendLine("    \"google/gemma-4-31b-it\",");
+            sb.AppendLine("    \"openai/gpt-5.4\",");
+            sb.AppendLine("    \"openai/gpt-5.1-codex-mini\",");
+            sb.AppendLine("    \"openai/gpt-chat-latest\",");
+            sb.AppendLine("    \"openai/gpt-5.4-mini\",");
             sb.AppendLine("    \"openai/gpt-4o\",");
-            sb.AppendLine("    \"openai/gpt-5-chat\"");
+            sb.AppendLine("    \"deepseek/deepseek-v4-pro\",");
+            sb.AppendLine("    \"deepseek/deepseek-v4-flash\",");
+            sb.AppendLine("    \"moonshotai/kimi-k2.6\",");
+            sb.AppendLine("    \"qwen/qwen3.7-max\"");
             sb.AppendLine("  ],");
-            sb.AppendLine("  \"default_model\": \"openai/gpt-4o\",");
+            sb.AppendLine("  \"default_model\": \"anthropic/claude-sonnet-4.6\",");
             sb.AppendLine("  \"theme\": \"light\",");
             // Default UI color theme
             sb.AppendLine("  \"color_theme\": \"blue\",");
@@ -237,14 +246,23 @@ namespace GxPT
                 openrouter_api_key = "",
                 models = new List<string>
                 {
-                    "anthropic/claude-3.7-sonnet",
-                    "anthropic/claude-sonnet-4",
-                    "google/gemini-2.5-flash",
-                    "google/gemini-2.5-pro",
+                    "anthropic/claude-opus-4.8",
+                    "anthropic/claude-sonnet-4.6",
+                    "anthropic/claude-haiku-4.5",
+                    "google/gemini-pro-latest",
+                    "google/gemini-3.5-flash",
+                    "google/gemma-4-31b-it",
+                    "openai/gpt-5.4",
+                    "openai/gpt-5.1-codex-mini",
+                    "openai/gpt-chat-latest",
+                    "openai/gpt-5.4-mini",
                     "openai/gpt-4o",
-                    "openai/gpt-5"
+                    "deepseek/deepseek-v4-pro",
+                    "deepseek/deepseek-v4-flash",
+                    "moonshotai/kimi-k2.6",
+                    "qwen/qwen3.7-max"
                 },
-                default_model = "openai/gpt-4o",
+                default_model = "anthropic/claude-sonnet-4.6",
                 enable_logging = false,
                 font_size = GetChatDefaultFontSize(),
                 theme = "light",

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Services\AppSettings.cs" />
     <Compile Include="Models\ChatModels.cs" />
     <Compile Include="Models\Conversation.cs" />
+    <Compile Include="Models\ModelDefaults.cs" />
     <Compile Include="Data\ConversationStore.cs" />
     <Compile Include="Forms\FileViewerForm.cs">
       <SubType>Form</SubType>

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -21,7 +21,7 @@ namespace GxPT
             "~anthropic/claude-sonnet-latest",
             "~anthropic/claude-haiku-latest",
             "~google/gemini-pro-latest",
-            "google/gemini-3.5-flash",
+            "~google/gemini-flash-latest",
             "google/gemma-4-31b-it",
             "openai/gpt-5.4",
             "openai/gpt-5.1-codex-mini",

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Single source of truth for the models shipped to NEW installs and the default selection.
+    // The seed settings.json (SettingsForm.BuildDefaultJson), the in-memory fallback
+    // (SettingsForm.BuildDefaultSettings), and the model dropdown's fresh-install fallback
+    // (MainForm.PopulateModelsFromSettings) all pull from here, so the list is defined once and the
+    // three can't drift apart. Existing users' configured models live in their own settings.json and
+    // are never overwritten by this.
+    internal static class ModelDefaults
+    {
+        // Selected by default on a fresh install. Must be one of Models below.
+        public const string DefaultModel = "anthropic/claude-sonnet-4.6";
+
+        // Default catalog, in display order (the model combo is sorted, so order is cosmetic there;
+        // it is preserved verbatim in the seeded settings.json).
+        public static readonly string[] Models = new string[]
+        {
+            "anthropic/claude-opus-4.8",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-haiku-4.5",
+            "google/gemini-pro-latest",
+            "google/gemini-3.5-flash",
+            "google/gemma-4-31b-it",
+            "openai/gpt-5.4",
+            "openai/gpt-5.1-codex-mini",
+            "openai/gpt-chat-latest",
+            "openai/gpt-5.4-mini",
+            "openai/gpt-4o",
+            "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash",
+            "moonshotai/kimi-k2.6",
+            "qwen/qwen3.7-max"
+        };
+
+        // Convenience copy as a List (callers that mutate or store a List).
+        public static List<string> ModelList()
+        {
+            return new List<string>(Models);
+        }
+    }
+}

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -11,16 +11,16 @@ namespace GxPT
     internal static class ModelDefaults
     {
         // Selected by default on a fresh install. Must be one of Models below.
-        public const string DefaultModel = "anthropic/claude-sonnet-4.6";
+        public const string DefaultModel = "~anthropic/claude-sonnet-latest";
 
         // Default catalog, in display order (the model combo is sorted, so order is cosmetic there;
         // it is preserved verbatim in the seeded settings.json).
         public static readonly string[] Models = new string[]
         {
-            "anthropic/claude-opus-4.8",
-            "anthropic/claude-sonnet-4.6",
-            "anthropic/claude-haiku-4.5",
-            "google/gemini-pro-latest",
+            "~anthropic/claude-opus-latest",
+            "~anthropic/claude-sonnet-latest",
+            "~anthropic/claude-haiku-latest",
+            "~google/gemini-pro-latest",
             "google/gemini-3.5-flash",
             "google/gemma-4-31b-it",
             "openai/gpt-5.4",


### PR DESCRIPTION
## Why

Some models in the shipped default set are no longer available on OpenRouter. Refresh the defaults for **new installs**, set the default model to `anthropic/claude-sonnet-4.6`, and — to stop this from being a three-places-to-edit problem — define the catalog in **one place**.

## New default model set

```
anthropic/claude-opus-4.8
anthropic/claude-sonnet-4.6   <- default_model
anthropic/claude-haiku-4.5
google/gemini-pro-latest
google/gemini-3.5-flash
google/gemma-4-31b-it
openai/gpt-5.4
openai/gpt-5.1-codex-mini
openai/gpt-chat-latest
openai/gpt-5.4-mini
openai/gpt-4o
deepseek/deepseek-v4-pro
deepseek/deepseek-v4-flash
moonshotai/kimi-k2.6
qwen/qwen3.7-max
```

## Single source of truth

New `Models/ModelDefaults.cs` holds `Models` (the catalog) and `DefaultModel`. Everything pulls from it, so the lists can't drift:

- **`SettingsForm.BuildDefaultJson`** loops `ModelDefaults.Models` to emit the seed `settings.json` array; `default_model` from `ModelDefaults.DefaultModel`.
- **`SettingsForm.BuildDefaultSettings`** uses `ModelDefaults.ModelList()` / `DefaultModel`.
- **The model combo** no longer hardcodes items in `MainForm.Designer.cs`; `PopulateModelsFromSettings` populates it from the user's settings, falling back to `ModelDefaults` when none are configured (fresh install). So the dropdown is never empty and always matches the seed.
- **`MainForm`'s default-model fallbacks** (`GetSelectedModel`, `GetConfiguredDefaultModel`) return `ModelDefaults.DefaultModel`.

Net: three duplicated lists removed (~55 lines deleted, ~23 added).

## Existing users are not affected

Defaults change for **new** installs only. The seed is written by `EnsureSettingsFileExists` **only when `settings.json` is absent**, and there is **no migration** — a current user's model list and chosen default are left exactly as they are.

## Notes

- `OpenRouterClient`'s low-level `openai/gpt-4o` fallback is intentionally left as a literal: that file is linked into the test project, which does not compile `ModelDefaults`, and `gpt-4o` is still a valid catalog entry. (No test-linked file references `ModelDefaults`, so the build stays green.)
- The model combo is `Sorted = true`, so the dropdown displays alphabetically; catalog order is preserved verbatim in the seeded `settings.json`.
- Out of scope (per discussion): the hardcoded conversation auto-title model (`google/gemma-4-26b-a4b-it` in `Conversation.cs`) is unchanged.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7