### PR TITLE
Widen page to 1280px and clamp the home hero; drop the "why XP" paragraph

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,11 +43,6 @@
             agentic coding and web search via the Model Context Protocol (MCP), with
             per-conversation privacy controls.
           </p>
-          <p>
-            Why build this for Windows XP in 2026? Because the machines still run, and the
-            era of Luna deserves a modern AI client too. GxPT targets .NET Framework 3.5 so
-            it runs natively on XP and every Windows since.
-          </p>
         </div>
 
         <div class="section">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -18,9 +18,10 @@ body {
   color: #000;
 }
 
-/* Centered fixed-width column — the classic "fits 1024x768" layout. */
+/* Centered column — caps on wide screens, shrinks to fit narrower ones. */
 .site {
-  width: 780px;
+  width: auto;
+  max-width: 1280px;
   margin: 0 auto;
   background: #ffffff;
   border-left: 1px solid #2d3a4d;
@@ -173,8 +174,10 @@ ul.features li {
   line-height: 1.5;
 }
 
-/* ---- Screenshot (home hero) ---- */
-.shot { display: block; width: 100%; border: 1px solid #8a93a3; margin: 4px 0 6px; }
+/* ---- Screenshot (home hero) ----
+   Cap the hero at the width it would fill in the narrower 960px layout
+   (~762px of main content) and center it, so it doesn't blow up on wide screens. */
+.shot { display: block; width: 100%; max-width: 762px; border: 1px solid #8a93a3; margin: 4px auto 6px; }
 .shot-cap { font-size: 11px; color: #555; margin: 0 0 8px; text-align: center; }
 
 /* ---- Screenshots gallery (float grid) ---- */


### PR DESCRIPTION
## Summary

Follow-up tweaks to the landing page (the screenshots from #80 are already on main):

- **Removed** the "why build this for Windows XP in 2026?" paragraph from the Home welcome section.
- **Widened the page** from a fixed `780px` to a responsive **`max-width: 1280px`** (centered; shrinks to fit narrower screens instead of overflowing).
- **Clamped the home hero screenshot** to `max-width: 762px` (the width it fills in the 960px layout) and centered it, so it doesn't stretch full-width on wide screens.

## Verification
Rendered Home at 1920×1080 (Playwright/Chromium): page caps at 1280px centered with desktop margins; hero renders at exactly 762px, centered in its section.

https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS

---
_Generated by [Claude Code](https://claude.ai/code/session_013EwbNTo29mY1ELS6n7G7qS)_