### PR TITLE
Add 404.html to redirect lowercase /gxpt URLs to canonical /GxPT

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex">
+  <title>Redirecting...</title>
+  <script>
+    (function () {
+      var path = window.location.pathname;
+      // If the first path segment is some case-variant of "GxPT" (but not the
+      // canonical casing), normalize it and redirect to the correct URL.
+      var m = path.match(/^\/([^\/]+)(\/.*)?$/);
+      if (m && m[1].toLowerCase() === 'gxpt' && m[1] !== 'GxPT') {
+        var rest = m[2] || '';
+        window.location.replace('/GxPT' + rest + window.location.search + window.location.hash);
+      }
+    })();
+  </script>
+</head>
+<body>
+  <p>Redirecting to <a href="/GxPT/">/GxPT/</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

GitHub Pages serves project sites under a case-sensitive path matching the repository name, so `imclerran.com/GxPT` works but `imclerran.com/gxpt` returns a 404. This adds a `docs/404.html` that catches case-variant requests and redirects them to the canonical `/GxPT` URL.

## How it works

GitHub Pages serves the site's `404.html` when a path within the pages site cannot be found. Based on observed GitHub behavior, a request for a case-variant of the repo name (e.g. `/gxpt`) is still routed into this site, where the custom `404.html` runs a small script that:

- Inspects the first path segment of the URL.
- If it is a case-insensitive match for `gxpt` but not the canonical `GxPT`, it rewrites the segment to `GxPT`.
- Preserves any sub-path, query string, and hash fragment.
- Issues a client-side `location.replace` so the wrong-case entry does not stay in browser history.

The page is marked `noindex` so search engines do not index the redirect stub.

## Verification

After this is merged and Pages redeploys, please verify by visiting:

- `imclerran.com/gxpt` (should redirect to `imclerran.com/GxPT/`)
- `imclerran.com/GXPT` (should redirect to `imclerran.com/GxPT/`)
- `imclerran.com/gxpt/download.html` (should redirect to `imclerran.com/GxPT/download.html`)

## Notes / caveats

The redirect relies on GitHub routing a case-variant first path segment into this pages site so that `404.html` is served. This is well-documented community behavior but is not an explicit guarantee in the official docs, so the verification step above is worth doing. If it does not behave as expected, the alternative robust fixes are renaming the repo to lowercase (`gxpt`) or serving the site from a custom subdomain.