### PR TITLE
Reserve height for the diff panel's horizontal scrollbar so wide commands aren't clipped

### DIFF
--- a/GxPT/Controls/DiffPreviewPanel.cs
+++ b/GxPT/Controls/DiffPreviewPanel.cs
@@ -73,8 +73,11 @@ namespace GxPT
 
         // Natural pixel height of the current content (optional header + body + padding), measured
         // independently of the control's own bounds so the host can size the approval panel to fit.
-        // Uses an offscreen Graphics so it is valid even before the panel is shown.
-        public int GetPreferredContentHeight()
+        // Uses an offscreen Graphics so it is valid even before the panel is shown. When the content
+        // is wider than availableWidth (>0), it will get a horizontal scrollbar that eats vertical
+        // space, so room for that scrollbar is included — otherwise a single wide line (e.g. a long
+        // command) gets clipped behind the scrollbar. Pass availableWidth <= 0 to skip that.
+        public int GetPreferredContentHeight(int availableWidth)
         {
             int oneLine = (_monoFont != null ? _monoFont.Height : 14);
             if (_monoFont == null || string.IsNullOrEmpty(_body)) return HeaderHeight + oneLine + Pad;
@@ -85,7 +88,10 @@ namespace GxPT
                 {
                     var colored = SyntaxHighlightingRenderer.GetColoredSegments(_body, _language, _monoFont, _dark);
                     Size content = SyntaxHighlightingRenderer.MeasureColoredSegmentsNoWrap(g, colored);
-                    return HeaderHeight + Math.Max(_monoFont.Height, content.Height) + Pad;
+                    int h = HeaderHeight + Math.Max(_monoFont.Height, content.Height) + Pad;
+                    if (availableWidth > 0 && content.Width + 2 * Pad > availableWidth)
+                        h += SystemInformation.HorizontalScrollBarHeight;
+                    return h;
                 }
             }
             catch { return HeaderHeight + oneLine + Pad; }

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -36,9 +36,12 @@ namespace GxPT
         private const int MaxDetailsHeight = 200;
 
         // Clamped content height for the current prompt; the panel height is rebuilt from this plus
-        // the (possibly multi-row) button strip whenever the panel resizes. Re-entrancy guard stops
-        // the height we set from recursing through OnSizeChanged.
+        // the (possibly multi-row) button strip whenever the panel resizes. _handledDetails records
+        // whether the active prompt uses the diff panel (vs the raw preview) so the height can be
+        // re-measured at the new width on resize. Re-entrancy guard stops the height we set from
+        // recursing through OnSizeChanged.
         private int _detailsHeight = MinDetailsHeight;
+        private bool _handledDetails;
         private bool _inLayoutToContent;
 
         public ToolApprovalPanel()
@@ -233,8 +236,8 @@ namespace GxPT
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
 
             // Size to fit the content (buttons built above so their height is counted, including any
-            // wrapping at the current width).
-            _detailsHeight = ClampedDetailsHeight(handled);
+            // wrapping at the current width; LayoutToContent measures the details at the live width).
+            _handledDetails = handled;
             LayoutToContent();
 
             this.Visible = true;
@@ -269,7 +272,7 @@ namespace GxPT
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
 
-            _detailsHeight = ClampedDetailsHeight(false);
+            _handledDetails = false;
             LayoutToContent();
 
             this.Visible = true;
@@ -287,9 +290,22 @@ namespace GxPT
         private int ClampedDetailsHeight(bool handled)
         {
             int detailsContent = handled
-                ? _diffPanel.GetPreferredContentHeight()
+                ? _diffPanel.GetPreferredContentHeight(DiffAvailableWidth())
                 : MeasurePreviewContentHeight();
             return Math.Max(MinDetailsHeight, Math.Min(MaxDetailsHeight, detailsContent));
+        }
+
+        // Width the diff panel has for its content, used to predict whether a horizontal scrollbar
+        // will appear (so its height can be reserved). The diff panel fills this panel minus padding;
+        // prefer its actual width, with fallbacks for when it hasn't been laid out yet.
+        private int DiffAvailableWidth()
+        {
+            // The approval panel's own client width is authoritative and current (even mid-resize,
+            // when the Fill child's width may lag); the diff panel fills it minus padding.
+            int w = this.ClientSize.Width - this.Padding.Horizontal;
+            if (w <= 0 && _diffPanel != null) w = _diffPanel.ClientSize.Width;
+            if (w <= 0 && this.Parent != null) w = this.Parent.ClientSize.Width - this.Padding.Horizontal;
+            return w > 0 ? w : 400;
         }
 
         // Rebuild the panel height so the Fill details control keeps its clamped content height even
@@ -303,6 +319,10 @@ namespace GxPT
             _inLayoutToContent = true;
             try
             {
+                // Re-measure the details at the current width: a horizontal scrollbar (long command)
+                // appears/disappears as the panel widens or narrows, and that changes the height needed.
+                _detailsHeight = ClampedDetailsHeight(_handledDetails);
+
                 int avail = this.ClientSize.Width - this.Padding.Horizontal;
                 if (avail < 1) avail = (this.Parent != null ? this.Parent.ClientSize.Width : 400) - this.Padding.Horizontal;
                 if (avail < 1) avail = 400;


### PR DESCRIPTION
## Why

A very long single-line command (e.g. a big `powershell -Command "…"`) gets a **horizontal** scrollbar in the approval prompt's diff panel. But the panel was sized to just the line height, so the scrollbar ate into that height and **clipped the command text** behind it (see the report screenshot).

## What

The details area's preferred height now accounts for the horizontal scrollbar when the content is wider than the panel:

- `DiffPreviewPanel.GetPreferredContentHeight(int availableWidth)` — when `content.Width + 2*Pad > availableWidth` (i.e. a horizontal scrollbar will appear), it adds `SystemInformation.HorizontalScrollBarHeight` to the reported height. Pass `availableWidth <= 0` to skip.
- `ToolApprovalPanel` passes the diff panel's available width (`DiffAvailableWidth()`, derived from the panel's own authoritative client width) and now **re-measures the details height inside `LayoutToContent`** via a stored `_handledDetails` flag. So the reservation also tracks resizes — narrowing the window until a command overflows grows the panel instead of clipping it, and widening it back reclaims the space.

So a long command now shows its first line in full with the scrollbar beneath it, rather than the scrollbar slicing through the text.

## Notes

- Builds on the approval-panel sizing from #77 (already merged).
- Approval content is always small (a one-line command, or a diff with ±3 lines of context), so re-measuring on resize is cheap.
- No automated coverage — these are WinForms controls. **Please verify in VS:** trigger a `command__run` approval with a very long command → the command line should be fully visible above the horizontal scrollbar; resize narrower/wider and confirm the panel grows/shrinks accordingly.

https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7ZvGGFx1oR8SmTvMYKPk7)_