### PR TITLE
Add "Open Recent Work Dir" to the File menu

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\GxPT\Services\Mcp\DefaultServerConnector.cs" Link="Linked\Mcp\DefaultServerConnector.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
+    <Compile Include="..\GxPT\Services\RecentWorkDirs.cs" Link="Linked\RecentWorkDirs.cs" />
   </ItemGroup>
 
   <!-- MCP library sources (Core + Client) linked in so the host's Services/Mcp/ code (registry,

--- a/GxPT.Tests/RecentWorkDirsTests.cs
+++ b/GxPT.Tests/RecentWorkDirsTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class RecentWorkDirsTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _file;
+
+        public RecentWorkDirsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_recentdirs_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+            _file = Path.Combine(_root, "recent-workdirs.json");
+            RecentWorkDirs.FilePathOverride = _file;
+        }
+
+        public void Dispose()
+        {
+            RecentWorkDirs.FilePathOverride = null;
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void Get_OnMissingFile_ReturnsEmpty()
+        {
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void Add_ThenGet_ReturnsThePath()
+        {
+            RecentWorkDirs.Add(_root);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Single(list);
+            Assert.Equal(_root, list[0]);
+        }
+
+        [Fact]
+        public void Add_MostRecentFirst()
+        {
+            string a = Path.Combine(_root, "a"); Directory.CreateDirectory(a);
+            string b = Path.Combine(_root, "b"); Directory.CreateDirectory(b);
+            RecentWorkDirs.Add(a);
+            RecentWorkDirs.Add(b);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(2, list.Count);
+            Assert.Equal(b, list[0]);
+            Assert.Equal(a, list[1]);
+        }
+
+        [Fact]
+        public void Add_DeduplicatesCaseInsensitiveAndTrailingSlash_MovesToFront()
+        {
+            string a = Path.Combine(_root, "a"); Directory.CreateDirectory(a);
+            string b = Path.Combine(_root, "b"); Directory.CreateDirectory(b);
+            RecentWorkDirs.Add(a);
+            RecentWorkDirs.Add(b);
+            // Re-add 'a' with a trailing slash and upper-cased — must collapse to one entry, now first.
+            RecentWorkDirs.Add(a.ToUpperInvariant() + Path.DirectorySeparatorChar);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(2, list.Count);
+            Assert.Equal(a, list[0], StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(b, list[1], StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Add_CapsAtFiveAndDropsOldest()
+        {
+            string[] dirs = new string[7];
+            for (int i = 0; i < 7; i++)
+            {
+                dirs[i] = Path.Combine(_root, "d" + i);
+                Directory.CreateDirectory(dirs[i]);
+                RecentWorkDirs.Add(dirs[i]);
+            }
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(RecentWorkDirs.MaxEntries, list.Count);
+            Assert.Equal(dirs[6], list[0]); // newest first
+            Assert.Equal(dirs[2], list[4]); // d0, d1 dropped
+        }
+
+        [Fact]
+        public void Add_NullOrEmpty_IsIgnored()
+        {
+            RecentWorkDirs.Add(null);
+            RecentWorkDirs.Add("");
+            RecentWorkDirs.Add("   ");
+            Assert.Empty(RecentWorkDirs.Get());
+        }
+
+        [Fact]
+        public void List_RoundTripsAcrossCalls()
+        {
+            RecentWorkDirs.Add(_root);
+            // A second independent Get reads back from disk.
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Single(list);
+            Assert.Equal(_root, list[0]);
+        }
+    }
+}

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -34,6 +34,7 @@
             this.miSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.miNewConversation = new System.Windows.Forms.ToolStripMenuItem();
+            this.miOpenRecentWorkDir = new System.Windows.Forms.ToolStripMenuItem();
             this.miCloseConversation = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.miImport = new System.Windows.Forms.ToolStripMenuItem();
@@ -106,6 +107,7 @@
             this.miSettings,
             this.toolStripSeparator2,
             this.miNewConversation,
+            this.miOpenRecentWorkDir,
             this.miCloseConversation,
             this.toolStripSeparator4,
             this.miImport,
@@ -138,9 +140,15 @@
             this.miNewConversation.Size = new System.Drawing.Size(221, 22);
             this.miNewConversation.Text = "&New Conversation";
             this.miNewConversation.Click += new System.EventHandler(this.miNewConversation_Click);
-            // 
+            //
+            // miOpenRecentWorkDir
+            //
+            this.miOpenRecentWorkDir.Name = "miOpenRecentWorkDir";
+            this.miOpenRecentWorkDir.Size = new System.Drawing.Size(221, 22);
+            this.miOpenRecentWorkDir.Text = "Open Recent Work &Dir";
+            //
             // miCloseConversation
-            // 
+            //
             this.miCloseConversation.Name = "miCloseConversation";
             this.miCloseConversation.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
             this.miCloseConversation.Size = new System.Drawing.Size(221, 22);
@@ -569,6 +577,7 @@
         private System.Windows.Forms.Label lblNoApiKey;
         private System.Windows.Forms.LinkLabel lnkOpenSettings;
         private System.Windows.Forms.ToolStripMenuItem miNewConversation;
+        private System.Windows.Forms.ToolStripMenuItem miOpenRecentWorkDir;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabPage1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -140,15 +140,15 @@
             this.miNewConversation.Size = new System.Drawing.Size(221, 22);
             this.miNewConversation.Text = "&New Conversation";
             this.miNewConversation.Click += new System.EventHandler(this.miNewConversation_Click);
-            //
+            // 
             // miOpenRecentWorkDir
-            //
+            // 
             this.miOpenRecentWorkDir.Name = "miOpenRecentWorkDir";
             this.miOpenRecentWorkDir.Size = new System.Drawing.Size(221, 22);
             this.miOpenRecentWorkDir.Text = "Open Recent Work &Dir";
-            //
+            // 
             // miCloseConversation
-            //
+            // 
             this.miCloseConversation.Name = "miCloseConversation";
             this.miCloseConversation.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
             this.miCloseConversation.Size = new System.Drawing.Size(221, 22);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -524,6 +524,15 @@ namespace GxPT
                 }
             }
             catch { }
+            try
+            {
+                if (this.miFile != null)
+                {
+                    this.miFile.DropDownOpening -= miFile_DropDownOpening;
+                    this.miFile.DropDownOpening += miFile_DropDownOpening;
+                }
+            }
+            catch { }
 
             try
             {
@@ -711,6 +720,7 @@ namespace GxPT
                 if (!string.IsNullOrEmpty(ctx.WorkingDir)) dlg.SelectedPath = ctx.WorkingDir;
                 if (dlg.ShowDialog(this) != DialogResult.OK) return;
                 ctx.WorkingDir = dlg.SelectedPath;
+                RecentWorkDirs.Add(ctx.WorkingDir);
             }
             // Setting a folder re-shows the strip, so a prior dismissal no longer applies.
             if (ctx.Conversation != null) ctx.Conversation.WorkspaceStripDismissed = false;
@@ -732,12 +742,31 @@ namespace GxPT
             SyncMcpWorkingDirFromActiveTab();
         }
 
+        // Opens a fresh conversation tab whose working folder is preset to 'dir'. Mirrors the
+        // load flow (create tab -> set working dir -> persist -> adopt onto strip + MCP host),
+        // and (via ApplyLoadedWorkingDir) bumps 'dir' to the top of the recent list.
+        private void OpenNewTabWithWorkingDir(string dir)
+        {
+            if (_tabManager == null || string.IsNullOrEmpty(dir)) return;
+            TabManager.ChatTabContext ctx = _tabManager.CreateConversationTab();
+            if (ctx == null) return;
+            ctx.WorkingDir = dir;
+            if (ctx.Conversation != null)
+            {
+                ctx.Conversation.WorkingDir = dir;
+                ctx.Conversation.WorkspaceStripDismissed = false;
+            }
+            PersistWorkingDir(ctx);
+            ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
+        }
+
         // After a conversation is loaded into a tab, adopt its persisted working folder onto the tab
         // context + strip and (re)bind the MCP host to it.
         private void ApplyLoadedWorkingDir(TabManager.ChatTabContext ctx)
         {
             if (ctx == null) return;
             ctx.WorkingDir = (ctx.Conversation != null) ? ctx.Conversation.WorkingDir : null;
+            if (!string.IsNullOrEmpty(ctx.WorkingDir)) RecentWorkDirs.Add(ctx.WorkingDir);
             if (ctx.WorkspaceStrip != null)
             {
                 ctx.WorkspaceStrip.SetWorkingDir(ctx.WorkingDir);
@@ -2016,6 +2045,44 @@ namespace GxPT
         private void miNewConversation_Click(object sender, EventArgs e)
         {
             if (_tabManager != null) _tabManager.CreateConversationTab();
+        }
+
+        // Rebuilds the "Open Recent Work Dir" submenu each time the File menu opens. Lists each
+        // remembered dir (full path) that still exists; silently drops missing ones. Disables the
+        // parent when nothing valid remains.
+        private void PopulateRecentWorkDirsMenu()
+        {
+            if (miOpenRecentWorkDir == null) return;
+
+            for (int i = miOpenRecentWorkDir.DropDownItems.Count - 1; i >= 0; i--)
+            {
+                System.Windows.Forms.ToolStripItem old = miOpenRecentWorkDir.DropDownItems[i];
+                miOpenRecentWorkDir.DropDownItems.RemoveAt(i);
+                old.Dispose();
+            }
+
+            int added = 0;
+            List<string> dirs = RecentWorkDirs.Get();
+            foreach (string dir in dirs)
+            {
+                if (string.IsNullOrEmpty(dir)) continue;
+                try { if (!Directory.Exists(dir)) continue; }
+                catch { continue; }
+
+                string captured = dir; // avoid the closure capturing the loop variable
+                System.Windows.Forms.ToolStripMenuItem item =
+                    new System.Windows.Forms.ToolStripMenuItem(captured);
+                item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                miOpenRecentWorkDir.DropDownItems.Add(item);
+                added++;
+            }
+
+            miOpenRecentWorkDir.Enabled = added > 0;
+        }
+
+        private void miFile_DropDownOpening(object sender, EventArgs e)
+        {
+            PopulateRecentWorkDirsMenu();
         }
 
         // File > Close Conversation

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2066,13 +2066,24 @@ namespace GxPT
             foreach (string dir in dirs)
             {
                 if (string.IsNullOrEmpty(dir)) continue;
-                try { if (!Directory.Exists(dir)) continue; }
-                catch { continue; }
+
+                bool exists;
+                try { exists = Directory.Exists(dir); }
+                catch { exists = false; }
 
                 string captured = dir; // avoid the closure capturing the loop variable
                 System.Windows.Forms.ToolStripMenuItem item =
                     new System.Windows.Forms.ToolStripMenuItem(captured);
-                item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                if (exists)
+                {
+                    item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                }
+                else
+                {
+                    // Keep missing dirs visible but unselectable so the user can see them.
+                    item.Enabled = false;
+                    item.ToolTipText = "Folder not found";
+                }
                 miOpenRecentWorkDir.DropDownItems.Add(item);
                 added++;
             }

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -100,6 +100,7 @@
     </Compile>
     <Compile Include="Managers\ImportExportManager.cs" />
     <Compile Include="Services\AppSettings.cs" />
+    <Compile Include="Services\RecentWorkDirs.cs" />
     <Compile Include="Models\ChatModels.cs" />
     <Compile Include="Models\Conversation.cs" />
     <Compile Include="Models\ModelDefaults.cs" />

--- a/GxPT/Services/RecentWorkDirs.cs
+++ b/GxPT/Services/RecentWorkDirs.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace GxPT
+{
+    // Remembers the most-recently-used working directories (most-recent-first, capped),
+    // persisted to its own JSON file alongside settings.json. XP / .NET 3.5 compatible.
+    internal static class RecentWorkDirs
+    {
+        public const int MaxEntries = 5;
+
+        // Tests redirect IO here; null means use the default %APPDATA%\GxPT path.
+        internal static string FilePathOverride;
+
+        private static readonly object _gate = new object();
+
+        private static string FilePath
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(FilePathOverride)) return FilePathOverride;
+                return Path.Combine(AppSettings.SettingsDirectory, "recent-workdirs.json");
+            }
+        }
+
+        // Returns the stored list, most-recent-first. No existence filtering here.
+        public static List<string> Get()
+        {
+            lock (_gate)
+            {
+                return ReadLocked();
+            }
+        }
+
+        // Records 'path' as the most-recent entry: dedup (case-insensitive), move to front, cap.
+        public static void Add(string path)
+        {
+            if (string.IsNullOrEmpty(path) || path.Trim().Length == 0) return;
+
+            string norm = path.Trim();
+            try { norm = Path.GetFullPath(norm); }
+            catch { }
+            norm = norm.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (norm.Length == 0) return;
+
+            lock (_gate)
+            {
+                List<string> list = ReadLocked();
+                for (int i = list.Count - 1; i >= 0; i--)
+                {
+                    if (string.Equals(list[i], norm, StringComparison.OrdinalIgnoreCase))
+                        list.RemoveAt(i);
+                }
+                list.Insert(0, norm);
+                while (list.Count > MaxEntries) list.RemoveAt(list.Count - 1);
+                WriteLocked(list);
+            }
+        }
+
+        private static List<string> ReadLocked()
+        {
+            List<string> result = new List<string>();
+            try
+            {
+                string path = FilePath;
+                if (!File.Exists(path)) return result;
+                string text = File.ReadAllText(path, Encoding.UTF8);
+                if (string.IsNullOrEmpty(text)) return result;
+                JavaScriptSerializer ser = new JavaScriptSerializer();
+                object[] arr = ser.DeserializeObject(text) as object[];
+                if (arr != null)
+                {
+                    foreach (object item in arr)
+                    {
+                        if (item != null) result.Add(Convert.ToString(item));
+                    }
+                }
+            }
+            catch { }
+            return result;
+        }
+
+        private static void WriteLocked(List<string> list)
+        {
+            try
+            {
+                JavaScriptSerializer ser = new JavaScriptSerializer();
+                string json = ser.Serialize(list);
+                string path = FilePath;
+                string dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                FileSafe.WriteAllTextAtomic(path, json, new UTF8Encoding(false));
+            }
+            catch { }
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-03-recent-work-dirs.md
+++ b/docs/superpowers/plans/2026-06-03-recent-work-dirs.md
@@ -1,0 +1,478 @@
+# Open Recent Work Dir Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remember the last 5 working directories the user opened and add an "Open Recent Work Dir" File-menu submenu that opens each in a new conversation tab.
+
+**Architecture:** A new static `RecentWorkDirs` store persists the list (most-recent-first, capped at 5) to a dedicated `%APPDATA%\GxPT\recent-workdirs.json` file. `MainForm` records a directory whenever one becomes active (explicit pick or conversation load), and a dynamically-populated File-menu submenu opens a fresh tab for any still-existing recent dir.
+
+**Tech Stack:** C# 3.0 / .NET 3.5 (app assembly `GxPT`); WinForms; `JavaScriptSerializer` (System.Web.Extensions) for JSON; `FileSafe.WriteAllTextAtomic` for crash-safe writes. Tests are xUnit on `net48` via `dotnet test`, linking GxPT source files directly.
+
+**Constraints:**
+- `GxPT/Services/RecentWorkDirs.cs` compiles under **C# 3.0 / .NET 3.5** — no `var` issues (allowed), but no LINQ query niceties beyond what 3.5 supports, no string interpolation, no expression-bodied members.
+- The app's `internal` members are visible to the test project only because it **links the source file**; the new file must be added to `GxPT.Tests.csproj`.
+
+---
+
+### Task 1: `RecentWorkDirs` store (TDD)
+
+**Files:**
+- Create: `GxPT/Services/RecentWorkDirs.cs`
+- Modify: `GxPT.Tests/GxPT.Tests.csproj` (add a linked-source `<Compile Include>` after line 55)
+- Test: `GxPT.Tests/RecentWorkDirsTests.cs`
+
+- [ ] **Step 1: Create the store with the full implementation**
+
+Create `GxPT/Services/RecentWorkDirs.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace GxPT
+{
+    // Remembers the most-recently-used working directories (most-recent-first, capped),
+    // persisted to its own JSON file alongside settings.json. XP / .NET 3.5 compatible.
+    internal static class RecentWorkDirs
+    {
+        public const int MaxEntries = 5;
+
+        // Tests redirect IO here; null means use the default %APPDATA%\GxPT path.
+        internal static string FilePathOverride;
+
+        private static readonly object _gate = new object();
+
+        private static string FilePath
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(FilePathOverride)) return FilePathOverride;
+                return Path.Combine(AppSettings.SettingsDirectory, "recent-workdirs.json");
+            }
+        }
+
+        // Returns the stored list, most-recent-first. No existence filtering here.
+        public static List<string> Get()
+        {
+            lock (_gate)
+            {
+                return ReadLocked();
+            }
+        }
+
+        // Records 'path' as the most-recent entry: dedup (case-insensitive), move to front, cap.
+        public static void Add(string path)
+        {
+            if (string.IsNullOrEmpty(path) || path.Trim().Length == 0) return;
+
+            string norm = path.Trim();
+            try { norm = Path.GetFullPath(norm); }
+            catch { }
+            norm = norm.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (norm.Length == 0) return;
+
+            lock (_gate)
+            {
+                List<string> list = ReadLocked();
+                for (int i = list.Count - 1; i >= 0; i--)
+                {
+                    if (string.Equals(list[i], norm, StringComparison.OrdinalIgnoreCase))
+                        list.RemoveAt(i);
+                }
+                list.Insert(0, norm);
+                while (list.Count > MaxEntries) list.RemoveAt(list.Count - 1);
+                WriteLocked(list);
+            }
+        }
+
+        private static List<string> ReadLocked()
+        {
+            List<string> result = new List<string>();
+            try
+            {
+                string path = FilePath;
+                if (!File.Exists(path)) return result;
+                string text = File.ReadAllText(path, Encoding.UTF8);
+                if (string.IsNullOrEmpty(text)) return result;
+                JavaScriptSerializer ser = new JavaScriptSerializer();
+                object[] arr = ser.DeserializeObject(text) as object[];
+                if (arr != null)
+                {
+                    foreach (object item in arr)
+                    {
+                        if (item != null) result.Add(Convert.ToString(item));
+                    }
+                }
+            }
+            catch { }
+            return result;
+        }
+
+        private static void WriteLocked(List<string> list)
+        {
+            try
+            {
+                JavaScriptSerializer ser = new JavaScriptSerializer();
+                string json = ser.Serialize(list);
+                string path = FilePath;
+                string dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+                FileSafe.WriteAllTextAtomic(path, json, new UTF8Encoding(false));
+            }
+            catch { }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the store to the test project's linked sources**
+
+In `GxPT.Tests/GxPT.Tests.csproj`, after the `AppSettings.cs` line (line 55):
+
+```xml
+    <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
+    <Compile Include="..\GxPT\Services\RecentWorkDirs.cs" Link="Linked\RecentWorkDirs.cs" />
+```
+
+(`FileSafe.cs` is already linked at line 35, and `System.Web.Extensions` is already referenced at line 77, so `JavaScriptSerializer` resolves.)
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `GxPT.Tests/RecentWorkDirsTests.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class RecentWorkDirsTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _file;
+
+        public RecentWorkDirsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_recentdirs_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+            _file = Path.Combine(_root, "recent-workdirs.json");
+            RecentWorkDirs.FilePathOverride = _file;
+        }
+
+        public void Dispose()
+        {
+            RecentWorkDirs.FilePathOverride = null;
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void Get_OnMissingFile_ReturnsEmpty()
+        {
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void Add_ThenGet_ReturnsThePath()
+        {
+            RecentWorkDirs.Add(_root);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Single(list);
+            Assert.Equal(_root, list[0]);
+        }
+
+        [Fact]
+        public void Add_MostRecentFirst()
+        {
+            string a = Path.Combine(_root, "a"); Directory.CreateDirectory(a);
+            string b = Path.Combine(_root, "b"); Directory.CreateDirectory(b);
+            RecentWorkDirs.Add(a);
+            RecentWorkDirs.Add(b);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(2, list.Count);
+            Assert.Equal(b, list[0]);
+            Assert.Equal(a, list[1]);
+        }
+
+        [Fact]
+        public void Add_DeduplicatesCaseInsensitiveAndTrailingSlash_MovesToFront()
+        {
+            string a = Path.Combine(_root, "a"); Directory.CreateDirectory(a);
+            string b = Path.Combine(_root, "b"); Directory.CreateDirectory(b);
+            RecentWorkDirs.Add(a);
+            RecentWorkDirs.Add(b);
+            // Re-add 'a' with a trailing slash and upper-cased — must collapse to one entry, now first.
+            RecentWorkDirs.Add(a.ToUpperInvariant() + Path.DirectorySeparatorChar);
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(2, list.Count);
+            Assert.Equal(a, list[0], StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(b, list[1], StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Add_CapsAtFiveAndDropsOldest()
+        {
+            string[] dirs = new string[7];
+            for (int i = 0; i < 7; i++)
+            {
+                dirs[i] = Path.Combine(_root, "d" + i);
+                Directory.CreateDirectory(dirs[i]);
+                RecentWorkDirs.Add(dirs[i]);
+            }
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Equal(RecentWorkDirs.MaxEntries, list.Count);
+            Assert.Equal(dirs[6], list[0]); // newest first
+            Assert.Equal(dirs[2], list[4]); // d0, d1 dropped
+        }
+
+        [Fact]
+        public void Add_NullOrEmpty_IsIgnored()
+        {
+            RecentWorkDirs.Add(null);
+            RecentWorkDirs.Add("");
+            RecentWorkDirs.Add("   ");
+            Assert.Empty(RecentWorkDirs.Get());
+        }
+
+        [Fact]
+        public void List_RoundTripsAcrossCalls()
+        {
+            RecentWorkDirs.Add(_root);
+            // A second independent Get reads back from disk.
+            List<string> list = RecentWorkDirs.Get();
+            Assert.Single(list);
+            Assert.Equal(_root, list[0]);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test GxPT.Tests/GxPT.Tests.csproj --filter "FullyQualifiedName~RecentWorkDirsTests"`
+Expected: PASS, 7 tests passed.
+
+(Because the implementation is created in Step 1, these pass on first run. If any fail, fix `RecentWorkDirs.cs` before continuing — do not edit the tests to match a bug.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GxPT/Services/RecentWorkDirs.cs GxPT.Tests/GxPT.Tests.csproj GxPT.Tests/RecentWorkDirsTests.cs
+git commit -m "Add RecentWorkDirs store with tests"
+```
+
+---
+
+### Task 2: Add the "Open Recent Work Dir" menu item to the designer
+
+**Files:**
+- Modify: `GxPT/Forms/MainForm.Designer.cs` (instantiation ~line 36; `DropDownItems` list ~line 108; item config block ~after line 140; field declaration ~line 571)
+
+- [ ] **Step 1: Instantiate the menu item**
+
+In `MainForm.Designer.cs`, after the `miNewConversation` instantiation (line 36):
+
+```csharp
+            this.miNewConversation = new System.Windows.Forms.ToolStripMenuItem();
+            this.miOpenRecentWorkDir = new System.Windows.Forms.ToolStripMenuItem();
+```
+
+- [ ] **Step 2: Add it to the File menu's DropDownItems**
+
+In the `miFile.DropDownItems.AddRange(...)` array, insert after `this.miNewConversation,` (line 108):
+
+```csharp
+            this.miNewConversation,
+            this.miOpenRecentWorkDir,
+            this.miCloseConversation,
+```
+
+- [ ] **Step 3: Configure the item**
+
+After the `miNewConversation` configuration block (immediately after line 140, `this.miNewConversation.Click += ...`):
+
+```csharp
+            // 
+            // miOpenRecentWorkDir
+            // 
+            this.miOpenRecentWorkDir.Name = "miOpenRecentWorkDir";
+            this.miOpenRecentWorkDir.Size = new System.Drawing.Size(221, 22);
+            this.miOpenRecentWorkDir.Text = "Open Recent Work &Dir";
+```
+
+(No `Click` handler — this is a parent menu populated dynamically. Its children are rebuilt when the File menu opens, in Task 3.)
+
+- [ ] **Step 4: Declare the field**
+
+After the `miNewConversation` field declaration (line 571):
+
+```csharp
+        private System.Windows.Forms.ToolStripMenuItem miNewConversation;
+        private System.Windows.Forms.ToolStripMenuItem miOpenRecentWorkDir;
+```
+
+- [ ] **Step 5: Build the app to verify the designer compiles**
+
+Run: `msbuild GxPT/GxPT.csproj /p:Configuration=Debug /v:m` (or build `GxPT.sln` in VS2008).
+Expected: Build succeeds. (If `msbuild` for .NET 3.5 is unavailable in this environment, this is verified during the manual run in Task 3 Step 6.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add GxPT/Forms/MainForm.Designer.cs
+git commit -m "Add Open Recent Work Dir menu item to File menu"
+```
+
+---
+
+### Task 3: Wire capture, dynamic population, and tab opening in MainForm
+
+**Files:**
+- Modify: `GxPT/Forms/MainForm.cs` (`SetWorkingFolderForContext` ~line 713; `ApplyLoadedWorkingDir` ~line 737; add new methods; wire `miFile.DropDownOpening`)
+
+- [ ] **Step 1: Record the dir when the user explicitly picks a folder**
+
+In `SetWorkingFolderForContext` (MainForm.cs), after `ctx.WorkingDir = dlg.SelectedPath;` (line 713, inside the `using` block):
+
+```csharp
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+                ctx.WorkingDir = dlg.SelectedPath;
+                RecentWorkDirs.Add(ctx.WorkingDir);
+```
+
+- [ ] **Step 2: Record the dir when a loaded conversation's working dir is adopted**
+
+In `ApplyLoadedWorkingDir` (MainForm.cs ~line 740), after `ctx.WorkingDir` is assigned from the conversation:
+
+```csharp
+            ctx.WorkingDir = (ctx.Conversation != null) ? ctx.Conversation.WorkingDir : null;
+            if (!string.IsNullOrEmpty(ctx.WorkingDir)) RecentWorkDirs.Add(ctx.WorkingDir);
+```
+
+- [ ] **Step 3: Add the tab-opening helper**
+
+Add this method to `MainForm.cs` (place it next to `SetWorkingFolderForContext`, e.g. after `ClearWorkingFolderForContext` ~line 733):
+
+```csharp
+        // Opens a fresh conversation tab whose working folder is preset to 'dir'. Mirrors the
+        // load flow (create tab -> set working dir -> persist -> adopt onto strip + MCP host),
+        // and bumps 'dir' to the top of the recent list.
+        private void OpenNewTabWithWorkingDir(string dir)
+        {
+            if (_tabManager == null || string.IsNullOrEmpty(dir)) return;
+            TabManager.ChatTabContext ctx = _tabManager.CreateConversationTab();
+            if (ctx == null) return;
+            ctx.WorkingDir = dir;
+            if (ctx.Conversation != null)
+            {
+                ctx.Conversation.WorkingDir = dir;
+                ctx.Conversation.WorkspaceStripDismissed = false;
+            }
+            PersistWorkingDir(ctx);
+            ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
+        }
+```
+
+(Note: `ApplyLoadedWorkingDir` already calls `RecentWorkDirs.Add` per Step 2, so opening a recent dir naturally bumps it to the front — no duplicate add needed here.)
+
+- [ ] **Step 4: Add the submenu population handler**
+
+Add this method to `MainForm.cs` (near the other menu handlers, e.g. after `miNewConversation_Click` ~line 2019):
+
+```csharp
+        // Rebuilds the "Open Recent Work Dir" submenu each time the File menu opens. Lists each
+        // remembered dir (full path) that still exists; silently drops missing ones. Disables the
+        // parent when nothing valid remains.
+        private void PopulateRecentWorkDirsMenu()
+        {
+            if (miOpenRecentWorkDir == null) return;
+
+            // Dispose and clear any previously-built child items.
+            for (int i = miOpenRecentWorkDir.DropDownItems.Count - 1; i >= 0; i--)
+            {
+                System.Windows.Forms.ToolStripItem old = miOpenRecentWorkDir.DropDownItems[i];
+                miOpenRecentWorkDir.DropDownItems.RemoveAt(i);
+                old.Dispose();
+            }
+
+            int added = 0;
+            List<string> dirs = RecentWorkDirs.Get();
+            foreach (string dir in dirs)
+            {
+                if (string.IsNullOrEmpty(dir)) continue;
+                try { if (!System.IO.Directory.Exists(dir)) continue; }
+                catch { continue; }
+
+                string captured = dir; // avoid closure capturing the loop variable
+                System.Windows.Forms.ToolStripMenuItem item =
+                    new System.Windows.Forms.ToolStripMenuItem(captured);
+                item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                miOpenRecentWorkDir.DropDownItems.Add(item);
+                added++;
+            }
+
+            miOpenRecentWorkDir.Enabled = added > 0;
+        }
+```
+
+(`List<string>` requires `using System.Collections.Generic;` — already present in MainForm.cs; verify and add if missing.)
+
+- [ ] **Step 5: Wire the File menu's DropDownOpening event**
+
+In `MainForm.cs`, find the form constructor or an init method where other event handlers are wired (search for an existing `this.miFile` reference or the constructor after `InitializeComponent()`), and add:
+
+```csharp
+            this.miFile.DropDownOpening += new EventHandler(this.miFile_DropDownOpening);
+```
+
+Then add the handler near `PopulateRecentWorkDirsMenu`:
+
+```csharp
+        private void miFile_DropDownOpening(object sender, EventArgs e)
+        {
+            PopulateRecentWorkDirsMenu();
+        }
+```
+
+If no suitable post-`InitializeComponent()` location exists, wire it inside `MainForm.Designer.cs` instead, in the `miFile` configuration block (after line 118), matching the designer style:
+
+```csharp
+            this.miFile.DropDownOpening += new System.EventHandler(this.miFile_DropDownOpening);
+```
+
+- [ ] **Step 6: Build and manually verify**
+
+Build `GxPT.sln` (VS2008 or msbuild v3.5) and run `GxPT.exe`. Verify:
+1. With no recents yet, **File ▸ Open Recent Work Dir** is grayed out (disabled).
+2. Set a working folder on a conversation (workspace strip "Set working folder", or the existing menu/route), then reopen File — the dir now appears under the submenu as a full path.
+3. Click the entry → a new tab opens with the workspace strip showing that folder.
+4. Set 6+ different folders → only the latest 5 appear, newest first; re-selecting an existing one moves it to the top without duplicating.
+5. Delete one of the remembered folders on disk, reopen the menu → it no longer appears.
+
+Run the unit suite to confirm nothing regressed:
+Run: `dotnet test GxPT.Tests/GxPT.Tests.csproj`
+Expected: PASS (all tests, including the 7 new ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add GxPT/Forms/MainForm.cs GxPT/Forms/MainForm.Designer.cs
+git commit -m "Wire Open Recent Work Dir: capture, populate, and open in new tab"
+```
+
+---
+
+## Notes for the implementer
+
+- **Order matters:** Task 1 (store) before Task 3 (which calls `RecentWorkDirs.Add`/`Get`). Task 2 (field + designer) before Task 3 Step 5 references `miOpenRecentWorkDir` / `miFile`.
+- **C# 3.0 constraint** applies to `GxPT/Services/RecentWorkDirs.cs` and all `MainForm` edits (the `GxPT` assembly is .NET 3.5). `delegate(object s, EventArgs e) { ... }` anonymous methods are valid in C# 3.0; lambdas would also compile but anonymous-method syntax matches what the designer/codebase tends to use — either is fine.
+- **Do not** add `RecentWorkDirs.Add` inside `OpenNewTabWithWorkingDir` separately; it would double-add (harmless due to dedup, but redundant). `ApplyLoadedWorkingDir` covers it.
+- If `msbuild` for the net35 app isn't runnable in the worker's environment, the designer/MainForm build is validated during the Task 3 Step 6 manual run; flag this rather than skipping verification silently.

--- a/docs/superpowers/plans/2026-06-03-recent-work-dirs.md
+++ b/docs/superpowers/plans/2026-06-03-recent-work-dirs.md
@@ -389,8 +389,8 @@ Add this method to `MainForm.cs` (near the other menu handlers, e.g. after `miNe
 
 ```csharp
         // Rebuilds the "Open Recent Work Dir" submenu each time the File menu opens. Lists each
-        // remembered dir (full path) that still exists; silently drops missing ones. Disables the
-        // parent when nothing valid remains.
+        // remembered dir (full path); missing dirs are shown disabled (grayed, "Folder not found"
+        // tooltip) rather than dropped. Disables the parent only when there are no entries at all.
         private void PopulateRecentWorkDirsMenu()
         {
             if (miOpenRecentWorkDir == null) return;
@@ -408,13 +408,24 @@ Add this method to `MainForm.cs` (near the other menu handlers, e.g. after `miNe
             foreach (string dir in dirs)
             {
                 if (string.IsNullOrEmpty(dir)) continue;
-                try { if (!System.IO.Directory.Exists(dir)) continue; }
-                catch { continue; }
+
+                bool exists;
+                try { exists = System.IO.Directory.Exists(dir); }
+                catch { exists = false; }
 
                 string captured = dir; // avoid closure capturing the loop variable
                 System.Windows.Forms.ToolStripMenuItem item =
                     new System.Windows.Forms.ToolStripMenuItem(captured);
-                item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                if (exists)
+                {
+                    item.Click += delegate(object s, EventArgs e) { OpenNewTabWithWorkingDir(captured); };
+                }
+                else
+                {
+                    // Keep missing dirs visible but unselectable so the user can see them.
+                    item.Enabled = false;
+                    item.ToolTipText = "Folder not found";
+                }
                 miOpenRecentWorkDir.DropDownItems.Add(item);
                 added++;
             }
@@ -455,7 +466,7 @@ Build `GxPT.sln` (VS2008 or msbuild v3.5) and run `GxPT.exe`. Verify:
 2. Set a working folder on a conversation (workspace strip "Set working folder", or the existing menu/route), then reopen File — the dir now appears under the submenu as a full path.
 3. Click the entry → a new tab opens with the workspace strip showing that folder.
 4. Set 6+ different folders → only the latest 5 appear, newest first; re-selecting an existing one moves it to the top without duplicating.
-5. Delete one of the remembered folders on disk, reopen the menu → it no longer appears.
+5. Delete one of the remembered folders on disk, reopen the menu → it still appears but is grayed/disabled (tooltip "Folder not found").
 
 Run the unit suite to confirm nothing regressed:
 Run: `dotnet test GxPT.Tests/GxPT.Tests.csproj`

--- a/docs/superpowers/specs/2026-06-03-recent-work-dirs-design.md
+++ b/docs/superpowers/specs/2026-06-03-recent-work-dirs-design.md
@@ -14,9 +14,9 @@ working folder.
 
 - **Capture point:** A directory is recorded as "recent" both when the user explicitly
   picks a folder *and* whenever a loaded conversation's working dir becomes active.
-- **Stale dirs:** Directories that no longer exist on disk are silently dropped when the
-  submenu is built. Stored entries are left untouched (a dir that reappears can show up
-  again).
+- **Stale dirs:** Directories that no longer exist on disk are shown but **disabled**
+  (grayed, unclickable, with a "Folder not found" tooltip) when the submenu is built.
+  Stored entries are left untouched (a dir that reappears becomes clickable again).
 - **Label:** Each entry shows the **full path**.
 - **Storage location:** A dedicated JSON file, **not** `settings.json`.
 - **Cap:** 5 entries, most-recent-first.
@@ -81,14 +81,15 @@ Handle the File menu's `DropDownOpening` (wire `miFile.DropDownOpening` in the f
 designer) to rebuild the submenu each time it is shown:
 
 - Clear existing child items (disposing them).
-- For each path from `RecentWorkDirs.Get()` where `Directory.Exists(path)` is true, add a
-  child `ToolStripMenuItem` whose `Text` is the full path and whose `Click` calls
-  `OpenNewTabWithWorkingDir(path)`. Capture `path` in a local to avoid the closure-capture
-  pitfall.
-- If no valid entries remain, set `miOpenRecentWorkDir.Enabled = false`; otherwise
-  `Enabled = true`.
+- For each path from `RecentWorkDirs.Get()`, add a child `ToolStripMenuItem` whose `Text`
+  is the full path. If `Directory.Exists(path)` is true, wire its `Click` to
+  `OpenNewTabWithWorkingDir(path)` (capture `path` in a local to avoid the closure-capture
+  pitfall). If the path is missing, leave it **disabled** (`item.Enabled = false`) with a
+  "Folder not found" tooltip — visible but unselectable.
+- If there are no remembered entries at all, set `miOpenRecentWorkDir.Enabled = false`;
+  otherwise `Enabled = true` (so the submenu opens to show the entries, grayed ones included).
 
-Rebuilding on every open keeps the list current and naturally drops stale dirs without a
+Rebuilding on every open keeps the list current and reflects stale dirs without a
 separate refresh mechanism.
 
 ### 5. Opening helper — `GxPT/Forms/MainForm.cs`
@@ -115,9 +116,9 @@ conversation opened with a saved working folder.
 
 1. User sets / loads / opens-recent a working dir → `RecentWorkDirs.Add(dir)` →
    `recent-workdirs.json` updated.
-2. User opens the File menu → `DropDownOpening` → `RecentWorkDirs.Get()` → filter by
-   `Directory.Exists` → submenu rebuilt.
-3. User clicks an entry → `OpenNewTabWithWorkingDir(path)` → new tab with working dir set,
+2. User opens the File menu → `DropDownOpening` → `RecentWorkDirs.Get()` → submenu rebuilt,
+   each entry enabled/disabled by `Directory.Exists`.
+3. User clicks an enabled entry → `OpenNewTabWithWorkingDir(path)` → new tab with working dir set,
    workspace strip shown, MCP bound, and the dir bumped to the top of the recents.
 
 ## Error handling

--- a/docs/superpowers/specs/2026-06-03-recent-work-dirs-design.md
+++ b/docs/superpowers/specs/2026-06-03-recent-work-dirs-design.md
@@ -1,0 +1,151 @@
+# Design: "Open Recent Work Dir" File-menu feature
+
+**Date:** 2026-06-03
+**Status:** Approved (design)
+
+## Summary
+
+Remember the last 5 working directories the user has opened in GxPT and expose them
+through a new **Open Recent Work Dir** submenu in the File menu. Selecting an entry
+opens a brand-new conversation tab with that directory preset as the conversation's
+working folder.
+
+## Decisions
+
+- **Capture point:** A directory is recorded as "recent" both when the user explicitly
+  picks a folder *and* whenever a loaded conversation's working dir becomes active.
+- **Stale dirs:** Directories that no longer exist on disk are silently dropped when the
+  submenu is built. Stored entries are left untouched (a dir that reappears can show up
+  again).
+- **Label:** Each entry shows the **full path**.
+- **Storage location:** A dedicated JSON file, **not** `settings.json`.
+- **Cap:** 5 entries, most-recent-first.
+
+## Components
+
+### 1. `RecentWorkDirs` store — new file `GxPT/Services/RecentWorkDirs.cs`
+
+A static class that owns the recent-dirs list and its persistence. XP / .NET 3.5
+compatible: uses `System.Web.Script.Serialization.JavaScriptSerializer` (matching
+`AppSettings`) and `FileSafe.WriteAllTextAtomic` for safe writes.
+
+- **File path:** `%APPDATA%\GxPT\recent-workdirs.json`, built from
+  `AppSettings.SettingsDirectory`. The file holds a JSON array of strings, ordered
+  most-recent-first, e.g. `["C:\\a","C:\\b"]`.
+- **Testability:** an `internal static string FilePathOverride` lets tests redirect IO
+  to a temp file. When null, the default `%APPDATA%` path is used.
+- **Constant:** `MaxEntries = 5`.
+
+Public surface:
+
+- `static List<string> Get()` — reads the file and returns the stored list
+  (most-recent-first). Returns an empty list on any error or missing file. Performs **no**
+  existence filtering — that is the menu builder's job.
+- `static void Add(string path)` — records `path` as the most recent:
+  1. Ignore null/empty/whitespace.
+  2. Normalize: `Path.GetFullPath` (best effort) and trim a trailing
+     directory separator so `C:\a` and `C:\a\` collapse.
+  3. Remove any existing case-insensitive duplicate (`StringComparer.OrdinalIgnoreCase`,
+     appropriate for Windows paths).
+  4. Insert at index 0.
+  5. Trim to `MaxEntries`.
+  6. Write atomically.
+
+  Read-modify-write is wrapped in a simple `lock` for parity with `AppSettings`'
+  thread-safety posture (the naming/UI threads can both touch working dirs).
+
+The core list transform (dedup + move-to-front + cap) is simple enough to be covered by
+exercising `Add`/`Get` round-trips against a temp file; no separate pure helper is
+required.
+
+### 2. Capture wiring — `GxPT/Forms/MainForm.cs`
+
+Call `RecentWorkDirs.Add(dir)` at the points where a working dir becomes active:
+
+- `SetWorkingFolderForContext` (~line 713) — after `ctx.WorkingDir = dlg.SelectedPath;`,
+  add the chosen folder.
+- `ApplyLoadedWorkingDir` (~line 737) — after adopting the conversation's working dir,
+  add it when non-empty.
+- `OpenNewTabWithWorkingDir` (new, below) — adds the dir so re-opening a recent moves it
+  back to the top.
+
+### 3. Menu item — `GxPT/Forms/MainForm.Designer.cs`
+
+Add a `ToolStripMenuItem miOpenRecentWorkDir` ("Open Recent Work &Dir") to
+`miFile.DropDownItems`, positioned immediately after `miNewConversation`. It is a parent
+menu whose children are built dynamically.
+
+### 4. Dynamic population — `GxPT/Forms/MainForm.cs`
+
+Handle the File menu's `DropDownOpening` (wire `miFile.DropDownOpening` in the form ctor /
+designer) to rebuild the submenu each time it is shown:
+
+- Clear existing child items (disposing them).
+- For each path from `RecentWorkDirs.Get()` where `Directory.Exists(path)` is true, add a
+  child `ToolStripMenuItem` whose `Text` is the full path and whose `Click` calls
+  `OpenNewTabWithWorkingDir(path)`. Capture `path` in a local to avoid the closure-capture
+  pitfall.
+- If no valid entries remain, set `miOpenRecentWorkDir.Enabled = false`; otherwise
+  `Enabled = true`.
+
+Rebuilding on every open keeps the list current and naturally drops stale dirs without a
+separate refresh mechanism.
+
+### 5. Opening helper — `GxPT/Forms/MainForm.cs`
+
+```
+private void OpenNewTabWithWorkingDir(string dir)
+{
+    if (_tabManager == null) return;
+    var ctx = _tabManager.CreateConversationTab();
+    if (ctx == null) return;
+    ctx.WorkingDir = dir;
+    if (ctx.Conversation != null) ctx.Conversation.WorkingDir = dir;
+    PersistWorkingDir(ctx);
+    ApplyLoadedWorkingDir(ctx);   // shows the workspace strip + binds MCP host
+    RecentWorkDirs.Add(dir);
+}
+```
+
+This mirrors the existing load flow (`CreateConversationTab` → set working dir →
+`PersistWorkingDir` → `ApplyLoadedWorkingDir`), so the new tab behaves exactly like a
+conversation opened with a saved working folder.
+
+## Data flow
+
+1. User sets / loads / opens-recent a working dir → `RecentWorkDirs.Add(dir)` →
+   `recent-workdirs.json` updated.
+2. User opens the File menu → `DropDownOpening` → `RecentWorkDirs.Get()` → filter by
+   `Directory.Exists` → submenu rebuilt.
+3. User clicks an entry → `OpenNewTabWithWorkingDir(path)` → new tab with working dir set,
+   workspace strip shown, MCP bound, and the dir bumped to the top of the recents.
+
+## Error handling
+
+- All file IO in `RecentWorkDirs` is wrapped in try/catch; failures degrade to an empty
+  list / no-op (consistent with `AppSettings` and `PersistWorkingDir`).
+- Closure capture in the dynamic menu uses a per-item local to avoid every item opening
+  the last directory.
+
+## Testing
+
+`GxPT.Tests/RecentWorkDirsTests.cs` (xUnit), using `FilePathOverride` pointed at a temp
+file (cleaned up via `IDisposable`, matching `FileSafeTests`):
+
+- `Add` then `Get` returns the path.
+- Adding a duplicate (including a different-case / trailing-slash variant) does not create
+  a second entry and moves it to the front.
+- Most-recent-first ordering after several adds.
+- The list is capped at 5; the oldest entry falls off.
+- `Get` on a missing file returns an empty list.
+- A persisted file round-trips across separate `Get` calls (serialization works).
+
+Menu wiring and tab opening are verified manually (WinForms UI is not unit-tested in this
+project).
+
+## Out of scope (YAGNI)
+
+- Pinning / favorites.
+- A "clear recent" command.
+- Configurable entry count.
+- Per-directory metadata (last-used time, project name, etc.).


### PR DESCRIPTION
@
## Summary

Adds an **Open Recent Work Dir** submenu to the File menu that remembers the last 5 working directories and opens any of them in a new conversation tab with the workspace folder preset.

- New `RecentWorkDirs` store (`GxPT/Services/RecentWorkDirs.cs`) persists the list to its own `%APPDATA%\GxPT\recent-workdirs.json` (most-recent-first, capped at 5, case-insensitive dedup, crash-safe atomic write).
- A directory is recorded both when the user explicitly picks a working folder **and** when a saved conversation with a working dir is loaded.
- The submenu rebuilds on each File-menu open: entries show the **full path**; missing dirs are shown **disabled** (grayed, "Folder not found" tooltip) rather than dropped; the parent is grayed only when there are no entries at all.
- Selecting an entry opens a fresh tab via `OpenNewTabWithWorkingDir`, mirroring the existing load flow (workspace strip shown, MCP bound), and bumps the dir to the top of the list.

## Implementation notes

- Targets .NET 3.5 / C# 3.0 (the GxPT app), following existing patterns (`AppSettings`/`FileSafe` for persistence, the idempotent `-=`/`+=` wiring in `HookEvents`).
- The VS2008 project uses an explicit `<Compile Include>` list, so the new file is registered in both `GxPT.csproj` (app) and `GxPT.Tests.csproj` (linked source).

## Testing

- 7 new xUnit tests for `RecentWorkDirs` (dedup, ordering, cap, missing-file, round-trip); full suite green (156/156) via `dotnet test`.
- The .NET 3.5 app build (designer + MainForm wiring) and the menu UI behavior are verified manually in VS2008 — not buildable in CI here.

Design spec and implementation plan: `docs/superpowers/specs/2026-06-03-recent-work-dirs-design.md`, `docs/superpowers/plans/2026-06-03-recent-work-dirs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@