### PR TITLE
Reset ZDR and working dir when last tab is recycled

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -742,6 +742,29 @@ namespace GxPT
             SyncMcpWorkingDirFromActiveTab();
         }
 
+        // Reset the per-tab workspace + ZDR *views* to a blank-slate state when the last tab is closed
+        // and reused as a fresh conversation. The recycle path already swaps in a new Conversation (with
+        // its ZDR and working-dir state cleared), but the tab-level WorkingDir field, the workspace strip,
+        // and the ZDR checkbox are derived views that must be re-synced or they keep the closed tab's
+        // state. No PersistWorkingDir here: the fresh conversation's WorkingDir is already null and the
+        // blank tab shouldn't be saved.
+        internal void ResetRecycledTabWorkspaceState(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            // Working folder: drop the tab's folder and return the strip to its "no folder" state, shown
+            // like a brand-new tab (the fresh conversation isn't dismissed).
+            ctx.WorkingDir = null;
+            if (ctx.WorkspaceStrip != null)
+            {
+                ctx.WorkspaceStrip.SetWorkingDir(null);
+                ctx.WorkspaceStrip.Visible = true;
+            }
+            SyncMcpWorkingDirFromActiveTab(); // release the closed folder's scoped MCP servers
+            // ZDR: the new conversation is unlatched and not per-tab ZDR, so re-sync the checkbox view
+            // (it reverts to the global default's checked/disabled state).
+            SyncZdrCheckboxFromActiveTab();
+        }
+
         // Opens a fresh conversation tab whose working folder is preset to 'dir'. Mirrors the
         // load flow (create tab -> set working dir -> persist -> adopt onto strip + MCP host),
         // and (via ApplyLoadedWorkingDir) bumps 'dir' to the top of the recent list.

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -275,6 +275,11 @@ namespace GxPT
                         catch { }
                         // re-hook name event for the fresh conversation on this reused tab
                         HookNameGenerated(ctx);
+                        // The fresh conversation cleared its ZDR + working-dir state, but the per-tab
+                        // ZDR checkbox and workspace strip are views that must be re-synced so the
+                        // recycled tab starts as a true blank slate.
+                        try { _mainForm.ResetRecycledTabWorkspaceState(ctx); }
+                        catch { }
                         page.Text = "New Conversation";
                         _mainForm.UpdateWindowTitle();
                     }


### PR DESCRIPTION
## Summary

When the last open conversation tab is closed, GxPT recycles it into a fresh blank conversation. The recycle path swapped in a new `Conversation` and re-synced the model combo, but left two conversation-derived **views** stale, so the "new" tab wasn't a true blank slate:

- **ZDR checkbox** (`chkZdrTab`) kept the closed conversation's `Checked`/`Enabled` state, because `SyncZdrCheckboxFromActiveTab()` was never called on this path.
- **Working directory**: the tab-level `ctx.WorkingDir` field was never cleared, so the workspace strip still showed the old folder and the scoped MCP servers stayed bound to it (the fresh conversation's null `WorkingDir` was shadowed by the stale tab field).

## Changes

- `GxPT/Forms/MainForm.cs`: add `internal ResetRecycledTabWorkspaceState(ctx)` — clears `ctx.WorkingDir`, returns the workspace strip to its visible "no folder" state, releases the closed folder's scoped MCP servers via `SyncMcpWorkingDirFromActiveTab()`, and re-syncs the ZDR checkbox (`Checked` + `Enabled`) via `SyncZdrCheckboxFromActiveTab()`.
- `GxPT/Managers/TabManager.cs`: the recycle branch of `CloseConversationTab` now calls `_mainForm.ResetRecycledTabWorkspaceState(ctx)`, mirroring the existing `_mainForm.*` resync calls already on that path.

Both sync methods read from `GetActiveContext()`, which is exactly the recycled (and only remaining) tab.

## Testing

- `GxPT.csproj` builds clean (only the pre-existing, unrelated `RecentWorkDirs.FilePathOverride` warning).
- Manual GUI click-through of the close-last-tab flow not yet performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)