### PR TITLE
Add vertical spacing between download buttons when they wrap

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -150,6 +150,11 @@ h2.bar {
   background: #f4f6f9;
   padding: 14px;
   text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
 }
 .dl-btn {
   display: inline-block;
@@ -172,7 +177,6 @@ h2.bar {
   display: inline-block;
   font-size: 11px;
   padding: 6px 12px;
-  margin-left: 6px;
   color: #1a3358;
   text-decoration: none;
   background: #e3e7ee;
@@ -181,7 +185,7 @@ h2.bar {
   vertical-align: middle;
 }
 .dl-alt:hover { background: #eef1f6; }
-.dl-note { font-size: 11px; color: #555; margin: 12px 0 0; }
+.dl-note { font-size: 11px; color: #555; margin: 4px 0 0; flex-basis: 100%; }
 
 /* ---- Features list ---- */
 ul.features { margin: 0; padding: 0; list-style: none; }


### PR DESCRIPTION
## Summary
On the download page, when the viewport narrows and the **All releases** button wraps below the **Download Installer** button, there was no vertical spacing between them.

`.dlbox` previously laid out its children as `inline-block` with only a horizontal `margin-left` on `.dl-alt`, so a wrapped button sat flush against the one above it.

## Changes (`docs/styles.css`)
- `.dlbox` → centered `flex` container with `flex-wrap: wrap` and `gap: 8px`, so spacing applies both side-by-side and when wrapped.
- `.dl-alt` → removed the now-redundant `margin-left: 6px` (the `gap` handles it).
- `.dl-note` → added `flex-basis: 100%` so the requirements note stays on its own row below the buttons; top margin reduced to `4px` (the `8px` gap restores the original ~12px spacing).

`text-align: center` is retained so the note text stays centered.

## Note
This uses flexbox `gap`, which works in modern browsers but not very old IE/XP-era browsers. The buttons still render and stack correctly there — they just fall back to default spacing without the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)