### PR TITLE
Show full conversation name in a hover tooltip when truncated

### DIFF
--- a/GxPT/Managers/SidebarManager.cs
+++ b/GxPT/Managers/SidebarManager.cs
@@ -344,6 +344,7 @@ namespace GxPT
                 _lvConversations.HideSelection = false;
                 _lvConversations.HeaderStyle = ColumnHeaderStyle.None;
                 _lvConversations.BorderStyle = BorderStyle.None;
+                _lvConversations.ShowItemToolTips = true;
                 _lvConversations.Dock = DockStyle.Left;
                 _lvConversations.Columns.Add("Conversation", 200, HorizontalAlignment.Left);
                 _lvConversations.MultiSelect = false;
@@ -733,6 +734,28 @@ namespace GxPT
                 // Make the column fill the ListView's client width to avoid right-side gaps
                 int target = Math.Max(20, _lvConversations.ClientSize.Width);
                 _lvConversations.Columns[0].Width = target;
+                UpdateSidebarTooltips();
+            }
+            catch { }
+        }
+
+        // Show a hover tooltip with the full conversation name, but only for items
+        // whose name is too long to fit and is therefore truncated with an ellipsis.
+        private void UpdateSidebarTooltips()
+        {
+            try
+            {
+                if (_lvConversations == null || _lvConversations.Columns.Count == 0) return;
+                // Available text width inside the column, leaving room for the
+                // padding/indent the ListView reserves on each row.
+                int available = _lvConversations.Columns[0].Width - 8;
+                foreach (ListViewItem lvi in _lvConversations.Items)
+                {
+                    if (lvi == null) continue;
+                    int textWidth = TextRenderer.MeasureText(lvi.Text, _lvConversations.Font).Width;
+                    string tip = (textWidth > available) ? lvi.Text : string.Empty;
+                    if (lvi.ToolTipText != tip) lvi.ToolTipText = tip;
+                }
             }
             catch { }
         }


### PR DESCRIPTION
## Summary

Long conversation names in the history sidebar get truncated with an ellipsis, which hides the full title. This adds a mouse-hover tooltip that shows the complete conversation name.

## Changes

- Enable `ShowItemToolTips` on the sidebar `ListView`.
- Add `UpdateSidebarTooltips()`, which sets each item's `ToolTipText` to its full name **only when the text is wider than the column** (i.e. actually truncated). Names that already fit get no tooltip, so tooltips don't pop up needlessly.
- Recompute tooltips whenever the column is resized (`ResizeSidebarColumn` already runs on refresh, resize, and font changes), so truncation state stays accurate as the sidebar width or font size changes.

## Notes

Uses only APIs available in the project's .NET Framework 3.5 target (`ListView.ShowItemToolTips`, `ListViewItem.ToolTipText`, `TextRenderer.MeasureText`). No build tooling is available in the cloud container, so this was not compiled locally; the change is isolated to `SidebarManager.cs`.

https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK)_