### PR TITLE
Add agentic behavior guidance to tool-enabled system prompt

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -65,12 +65,14 @@ namespace GxPT.Tests.Mcp
 
             New(streamer, reg).RunTurn(new List<ChatMessage>(), "hello", new RecordingUi());
 
-            // first request: leading system message is the names manifest, history follows
+            // first request: agentic guidance leads, then the names manifest, then history
             var msgs = streamer.SeenMessages[0];
             Assert.Equal("system", msgs[0].Role);
-            Assert.Contains("reveal_tools", msgs[0].Content);   // manifest instructs reveal-before-call
-            Assert.Contains("files__read", msgs[0].Content);     // and lists tool names
-            Assert.Equal("user", msgs[1].Role);
+            Assert.Contains("operating as an agent", msgs[0].Content); // agentic behavior guidance
+            Assert.Equal("system", msgs[1].Role);
+            Assert.Contains("reveal_tools", msgs[1].Content);   // manifest instructs reveal-before-call
+            Assert.Contains("files__read", msgs[1].Content);     // and lists tool names
+            Assert.Equal("user", msgs[2].Role);
             // exposed tools always lead with reveal_tools
             Assert.Equal("reveal_tools", (string)streamer.SeenTools[0][0]["function"]["name"]);
         }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -37,8 +37,8 @@ namespace GxPT
             + "yourself.\n\n"
             + "When a tool call is denied or cancelled, treat it as a refusal of that specific "
             + "call in that specific moment, not a permanent ban on the tool. You may try the same "
-            + "tool again later with adjusted arguments, additional context, or once the situation "
-            + "changes; explain why it is needed if that helps.\n\n"
+            + "tool again later with adjusted arguments or once the situation changes; explain why "
+            + "it is needed if that helps.\n\n"
             + "Do not list or describe your tools or capabilities unless the user asks. Reply to "
             + "greetings and casual messages naturally and briefly, and bring up what you can do "
             + "only when it is relevant to the user's request.";

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -26,6 +26,23 @@ namespace GxPT
         // references it.
         internal const string DeniedResultText = "[Call denied by user.]";
 
+        // Agentic behavior guidance, prepended as a system message on tool-enabled turns only
+        // (this orchestrator runs solely when at least one tool is available). Kept short to
+        // limit token cost. Reinforces three things: act through the tools, treat a denial as
+        // scoped to that one call rather than a permanent ban, and don't volunteer a rundown of
+        // tools/capabilities unasked.
+        internal const string AgentSystemPrompt =
+            "You are operating as an agent with access to tools. Use them proactively to "
+            + "accomplish the user's request instead of asking the user to do what you can do "
+            + "yourself.\n\n"
+            + "When a tool call is denied or cancelled, treat it as a refusal of that specific "
+            + "call in that specific moment, not a permanent ban on the tool. You may try the same "
+            + "tool again later with adjusted arguments, additional context, or once the situation "
+            + "changes; explain why it is needed if that helps.\n\n"
+            + "Do not list or describe your tools or capabilities unless the user asks. Reply to "
+            + "greetings and casual messages naturally and briefly, and bring up what you can do "
+            + "only when it is relevant to the user's request.";
+
         private readonly IChatStreamer _streamer;
         private readonly McpToolRegistry _registry;
         private readonly IToolApprovalPolicy _approval;
@@ -132,6 +149,7 @@ namespace GxPT
                 // The names manifest rides as an extra system message in front of history; it is not
                 // persisted (rebuilt each request from the live catalog).
                 List<ChatMessage> requestMessages = new List<ChatMessage>();
+                requestMessages.Add(new ChatMessage("system", AgentSystemPrompt));
                 if (!string.IsNullOrEmpty(manifest))
                     requestMessages.Add(new ChatMessage("system", manifest));
                 // Build the sent messages from history, optionally transformed (e.g. attachments

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -37,8 +37,7 @@ namespace GxPT
             + "yourself.\n\n"
             + "When a tool call is denied or cancelled, treat it as a refusal of that specific "
             + "call in that specific moment, not a permanent ban on the tool. You may try the same "
-            + "tool again later with adjusted arguments or once the situation changes; explain why "
-            + "it is needed if that helps.\n\n"
+            + "tool again later with adjusted arguments or once the situation changes.\n\n"
             + "Do not list or describe your tools or capabilities unless the user asks. Reply to "
             + "greetings and casual messages naturally and briefly, and bring up what you can do "
             + "only when it is relevant to the user's request.";


### PR DESCRIPTION
## Summary

Adds a concise system message that steers agentic behavior, injected **only when at least one tool is enabled**. The tool-call orchestrator (`McpChatOrchestrator.RunTurn`) only runs when the registry reports `HasTools` (gated at `MainForm.cs`), so tool-less turns are completely unaffected — no extra tokens are spent when there are no tools.

## What it addresses

1. **Denied tool calls aren't permanent.** The key fix: when a tool call is denied/cancelled, the model should treat it as a refusal of *that specific call in that moment*, not a permanent ban on the tool. It may retry later with adjusted arguments, more context, or once the situation changes. This pairs with the existing `[Call denied by user.]` tool-result the model already receives on denial.
2. **No unprompted capability dumps.** The model shouldn't list/describe its tools or capabilities unless asked — a "hello" should get a natural, brief reply, not a rundown of everything it can do.
3. **General agentic framing** — act through the tools rather than asking the user to do what it can do itself.

## The prompt text

```
You are operating as an agent with access to tools. Use them proactively to
accomplish the user's request instead of asking the user to do what you can do
yourself.

When a tool call is denied or cancelled, treat it as a refusal of that specific
call in that specific moment, not a permanent ban on the tool. You may try the
same tool again later with adjusted arguments, additional context, or once the
situation changes; explain why it is needed if that helps.

Do not list or describe your tools or capabilities unless the user asks. Reply
to greetings and casual messages naturally and briefly, and bring up what you
can do only when it is relevant to the user's request.
```

It is prepended ahead of the existing `reveal_tools` names-manifest system message.

## Changes

- `McpChatOrchestrator.cs`: new `AgentSystemPrompt` constant; injected as a leading `system` message in the request loop.
- `McpChatOrchestratorTests.cs`: updated `Passes_manifest_system_message_and_tools_to_streamer` for the new leading-message order and added an assertion for the agentic guidance.

## Notes

The wording is easy to tweak — it's a single constant. The .NET 3.5 project has no build tooling in the cloud container, so this wasn't compiled locally; the change is small and isolated. Happy to adjust tone/length or fold it into the existing manifest message instead of a separate message if you'd prefer.

https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK)_