### PR TITLE
Reclassify web__extract as ReadOnly (auto-allow, no approval prompt)

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -46,6 +46,10 @@ namespace GxPT.Tests.Mcp
             var push = c.Classify("git__push", null, true);
             Assert.Equal(ToolTier.Destructive, push.Tier);
             Assert.Equal(RememberScope.None, push.Scope);
+
+            var extract = c.Classify("web__extract", null, true);
+            Assert.Equal(ToolTier.ReadOnly, extract.Tier);
+            Assert.Equal(RememberScope.Tool, extract.Scope);
         }
 
         [Fact]
@@ -72,11 +76,11 @@ namespace GxPT.Tests.Mcp
             var store = new InMemoryApprovalStore();
             var pol = Policy(prompt, store);
 
-            // web__extract is Tool-scope and gated (not auto-allowed), so it prompts the first time.
-            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__extract", Args("{\"urls\":[\"x\"]}")));
+            // git__commit is Tool-scope and gated (not auto-allowed), so it prompts the first time.
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("git__commit", Args("{\"message\":\"x\"}")));
             Assert.Equal(1, prompt.Calls);
             // second call: remembered, no prompt
-            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__extract", Args("{\"urls\":[\"y\"]}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("git__commit", Args("{\"message\":\"y\"}")));
             Assert.Equal(1, prompt.Calls);
         }
 
@@ -85,18 +89,19 @@ namespace GxPT.Tests.Mcp
         {
             var prompt = new ScriptedPrompt { Next = ApprovalChoice.AllowOnce };
             var pol = Policy(prompt, new InMemoryApprovalStore());
-            pol.Check("web__extract", Args("{\"urls\":[\"x\"]}"));
-            pol.Check("web__extract", Args("{\"urls\":[\"y\"]}"));
+            pol.Check("git__commit", Args("{\"message\":\"x\"}"));
+            pol.Check("git__commit", Args("{\"message\":\"y\"}"));
             Assert.Equal(2, prompt.Calls); // prompted both times
         }
 
         [Fact]
         public void Auto_allowed_read_only_tools_never_prompt()
         {
-            // The read-only built-ins (and web__search) are always allowed without a prompt.
+            // The read-only built-ins (and web__search / web__extract) are always allowed without a prompt.
             var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
             var pol = Policy(prompt, new InMemoryApprovalStore());
             Assert.Equal(ApprovalDecision.Allow, pol.Check("web__search", Args("{\"query\":\"x\"}")));
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("web__extract", Args("{\"urls\":[\"x\"]}")));
             Assert.Equal(ApprovalDecision.Allow, pol.Check("files__read", Args("{\"path\":\"a\"}")));
             Assert.Equal(ApprovalDecision.Allow, pol.Check("git__status", Args("{}")));
             Assert.Equal(0, prompt.Calls);

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -26,8 +26,8 @@ namespace GxPT
         }
 
         // Tools that never require approval (always allowed, no prompt): the read-only built-ins, which
-        // are high-frequency and don't modify anything. Tools that write, delete, run commands, push, or
-        // fetch arbitrary pages (web__extract) deliberately stay gated.
+        // are high-frequency and don't modify anything. Tools that write, delete, run commands, or push
+        // deliberately stay gated.
         private static readonly Dictionary<string, bool> _autoAllow = BuildAutoAllowSet();
         private static Dictionary<string, bool> BuildAutoAllowSet()
         {
@@ -40,6 +40,7 @@ namespace GxPT
             s["git__log"] = true;
             s["git__fetch"] = true; // updates remote-tracking refs only; no working-tree change
             s["web__search"] = true;
+            s["web__extract"] = true; // only fetches and returns page content; no state change
             return s;
         }
 

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -51,7 +51,8 @@ namespace GxPT
             t["git__cherry_pick"] = new ToolPolicy(ToolTier.Destructive, RememberScope.None, null);
             t["command__run"] = new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "command");
             t["web__search"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
-            t["web__extract"] = new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
+            // extract only fetches and returns page content (no state change) -> ReadOnly/auto-allow.
+            t["web__extract"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             return t;
         }
 

--- a/docs/mcp35-approval-spec.md
+++ b/docs/mcp35-approval-spec.md
@@ -92,7 +92,7 @@ public interface IToolClassifier {
    | `git__push`, `git__pull`, `git__checkout`, `git__restore`, `git__merge`, `git__rebase`, `git__reset`, `git__rm`, `git__cherry_pick` | Destructive | None |
    | `command__run` | Destructive | **Argument(`command`)** |
    | `web__search` | ReadOnly | Tool |
-   | `web__extract` | Write | Tool |
+   | `web__extract` | ReadOnly | Tool |
 3. **Third-party → annotations** (advisory): `destructiveHint:true` →
    Destructive/None; `readOnlyHint:true` → ReadOnly/Tool; otherwise → Write/Tool.
    We can't infer a third-party server's argument semantics, so third-party

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -149,11 +149,11 @@ architecture §3).
 | Tool | Approval | Schema (required *) | Behavior |
 |------|----------|---------------------|----------|
 | `search` (→ `web__search`) | ReadOnly | `query*`, `max_results?` (default 5, cap 20), `topic?`, `search_depth?`, `chunks_per_source?`, `include_answer?`, `include_raw_content?`, `time_range?`, `start_date?`, `end_date?`, `country?`, `include_domains?`, `exclude_domains?` | `POST /search`; condensed results + optional answer. |
-| `extract` (→ `web__extract`) | **Write (confirm each call)** | `urls*` (string or array), `extract_depth?`, `format?`, `include_images?` | `POST /extract`; fetch and return full page content for the given URLs. |
+| `extract` (→ `web__extract`) | ReadOnly | `urls*` (string or array), `extract_depth?`, `format?`, `include_images?` | `POST /extract`; fetch and return full page content for the given URLs. |
 
-`extract` is gated as **Write** (not ReadOnly): it fetches arbitrary external
-pages — more network/token cost, and it pulls in whatever content the page
-serves — so each call is confirmed (`mcp35-approval-spec.md`).
+`extract` is classified **ReadOnly** (auto-allowed, like `web__search`): it only
+fetches and returns page content for URLs the model already has, without changing
+any local or remote state (`mcp35-approval-spec.md`).
 
 - Auth: `Authorization: Bearer <GXPT_WEB_SEARCH_KEY>`, passed to curl via a
   **`-K` config file**, never the command line (same discipline as

--- a/servers/WebSearchMcpServer/WebSearchTools.cs
+++ b/servers/WebSearchMcpServer/WebSearchTools.cs
@@ -7,8 +7,8 @@ namespace WebSearchMcpServer
 {
     /// <summary>
     /// The web server's two tools over the Tavily API:
-    ///   web__search  (ReadOnly)    — query the web, condensed results + optional answer.
-    ///   web__extract (Write/confirm) — fetch and return full page content for given URLs.
+    ///   web__search  (ReadOnly) — query the web, condensed results + optional answer.
+    ///   web__extract (ReadOnly) — fetch and return full page content for given URLs.
     /// Request builders and response condensers are pure functions (unit-tested directly); the
     /// handlers add the network call. Failures are Error values; the API key never appears in output.
     /// See servers-spec §3.


### PR DESCRIPTION
## Summary

Changes the `web__extract` tool classification from **Write** to **ReadOnly** so the agent can call it without an approval prompt, the same way `web__search` is handled.

`web__extract` only fetches and returns page content for URLs the model already has — it doesn't change any local or remote state — so gating it behind a per-call confirmation added friction without a real safety benefit.

## Changes

- **`ToolClassifier.cs`** — `web__extract` is now `ToolTier.ReadOnly` (was `ToolTier.Write`).
- **`ToolApprovalPolicy.cs`** — added `web__extract` to the `_autoAllow` set. This is what actually makes the tool callable without a prompt; the tier change alone is not sufficient.
- **Docs** — updated `mcp35-approval-spec.md` and `mcp35-servers-spec.md` classification tables/notes to ReadOnly.
- **`WebSearchTools.cs`** — corrected the tool doc comment.

## Tests

- The two approval tests that used `web__extract` as a gated Tool-scope example now use `git__commit` (still Write/Tool, still gated) so they keep testing prompt-then-remember and allow-once behavior.
- `Auto_allowed_read_only_tools_never_prompt` now also asserts `web__extract` is allowed with zero prompts.
- `First_party_table_is_authoritative` now asserts `web__extract` classifies as `ReadOnly` / `Tool`.

Note: `dotnet` is not available in this environment, so the tests were not executed here — they run via `dotnet test` on the Windows CI runner.

https://claude.ai/code/session_01HQczMNA19mWUrzxDuhZbq6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQczMNA19mWUrzxDuhZbq6)_