### PR TITLE
Add MSBuild MCP server (build tool per MSBuild version + devenv solution builds)

### DIFF
--- a/GxPT.Setup/GxPT.Setup.vdproj
+++ b/GxPT.Setup/GxPT.Setup.vdproj
@@ -15,8 +15,20 @@
     {
         "Entry"
         {
+        "MsmKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_233A41B509EE377D3539F831E7F0C67D"
         "OwnerKey" = "8:_7E3A6FA0A21D2C2AFAC5DA8698579058"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_233A41B509EE377D3539F831E7F0C67D"
+        "OwnerKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -94,6 +106,12 @@
         "Entry"
         {
         "MsmKey" = "8:_5EAF61B5A6C4B6FDBAF6DE42BC48BF23"
+        "OwnerKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_5EAF61B5A6C4B6FDBAF6DE42BC48BF23"
         "OwnerKey" = "8:_FFFB44874122465591E1DC6C44D1245E"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -113,6 +131,12 @@
         {
         "MsmKey" = "8:_7E3A6FA0A21D2C2AFAC5DA8698579058"
         "OwnerKey" = "8:_BE2F8CF3074242349ACC88C25F47CD77"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_7E3A6FA0A21D2C2AFAC5DA8698579058"
+        "OwnerKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -221,6 +245,12 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_E0499EB368C445EBB017CB750C98F6FD"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1523,6 +1553,34 @@
         }
         "ProjectOutput"
         {
+            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_10650E4BA14F4EB39F7DB44C8656F217"
+            {
+            "SourcePath" = "8:..\\servers\\MSBuildMcpServer\\obj\\Release\\MSBuildMcpServer.exe"
+            "TargetName" = "8:"
+            "Tag" = "8:"
+            "Folder" = "8:_A249DCF40CCD4A129F140A8AAEBBA6B7"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            "ProjectOutputGroupRegister" = "3:1"
+            "OutputConfiguration" = "8:"
+            "OutputGroupCanonicalName" = "8:Built"
+            "OutputProjectGuid" = "8:{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}"
+            "ShowKeyOutput" = "11:TRUE"
+                "ExcludeFilters"
+                {
+                }
+            }
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_BE2F8CF3074242349ACC88C25F47CD77"
             {
             "SourcePath" = "8:..\\servers\\WebSearchMcpServer\\obj\\Release\\WebSearchMcpServer.exe"

--- a/GxPT.Tests/Mcp/McpConfigTests.cs
+++ b/GxPT.Tests/Mcp/McpConfigTests.cs
@@ -113,7 +113,7 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Builtins_cover_the_four_servers_with_toggles_and_env()
+        public void Builtins_cover_the_five_servers_with_toggles_and_env()
         {
             var o = new McpConfig.BuiltInOptions
             {
@@ -121,6 +121,7 @@ namespace GxPT.Tests.Mcp
                 FilesEnabled = true,
                 GitEnabled = false,
                 CommandEnabled = true,
+                MsBuildEnabled = true,
                 WebSearchKey = "tav_key",
                 CurlPath = "C:\\curl.exe",
                 GitPath = "git",
@@ -130,7 +131,7 @@ namespace GxPT.Tests.Mcp
             var specs = McpConfig.BuiltInSpecs(o);
             var byName = specs.ToDictionary(s => s.Name);
 
-            Assert.Equal(4, specs.Count);
+            Assert.Equal(5, specs.Count);
             Assert.True(specs.All(s => s.BuiltIn && s.Kind == McpTransportKind.Stdio));
 
             var web = byName["web"];
@@ -149,6 +150,13 @@ namespace GxPT.Tests.Mcp
 
             Assert.Equal("cmd.exe", byName["command"].Env[McpConfig.EnvCmdShell]);
             Assert.True(byName["command"].WorkdirScoped);
+
+            // msbuild — workdir-scoped, engines discovered (no extra env baked in).
+            var msbuild = byName["msbuild"];
+            Assert.True(msbuild.Enabled);
+            Assert.True(msbuild.WorkdirScoped);
+            Assert.Equal(Path.Combine("C:\\app\\servers", "MSBuildMcpServer.exe"), msbuild.Command);
+            Assert.Empty(msbuild.Env);
         }
     }
 }

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -57,6 +57,12 @@ namespace GxPT.Tests.Mcp
             Assert.Equal(ToolTier.Destructive, build.Tier);
             Assert.Equal(RememberScope.Argument, build.Scope);
             Assert.Equal("project", build.ScopeArgPath);
+
+            // devenv solution builds are likewise Destructive, but scoped on the 'solution' argument.
+            var sln = c.Classify("msbuild__build_solution_2022", null, true);
+            Assert.Equal(ToolTier.Destructive, sln.Tier);
+            Assert.Equal(RememberScope.Argument, sln.Scope);
+            Assert.Equal("solution", sln.ScopeArgPath);
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -50,6 +50,13 @@ namespace GxPT.Tests.Mcp
             var extract = c.Classify("web__extract", null, true);
             Assert.Equal(ToolTier.ReadOnly, extract.Tier);
             Assert.Equal(RememberScope.Tool, extract.Scope);
+
+            // MSBuild tools are named per discovered engine, so they're matched by the msbuild__ prefix
+            // (not a static table entry) and gated as Destructive, argument-scoped on the project built.
+            var build = c.Classify("msbuild__build_17_0", null, true);
+            Assert.Equal(ToolTier.Destructive, build.Tier);
+            Assert.Equal(RememberScope.Argument, build.Scope);
+            Assert.Equal("project", build.ScopeArgPath);
         }
 
         [Fact]

--- a/GxPT.sln
+++ b/GxPT.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitMcpServer", "servers\Git
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandMcpServer", "servers\CommandMcpServer\CommandMcpServer.csproj", "{8B1149E6-9C3E-4860-A946-95989D4FD4D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildMcpServer", "servers\MSBuildMcpServer\MSBuildMcpServer.csproj", "{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B1149E6-9C3E-4860-A946-95989D4FD4D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2657,8 +2657,12 @@ namespace GxPT
         {
             header = null; body = string.Empty; language = "text"; added = -1; removed = -1;
 
-            // MSBuild tools are named per discovered engine (msbuild__build_4_0, msbuild__build_17_0, ...),
-            // so they can't be cased in the switch below; render them from the name + args here.
+            // MSBuild tools are named per discovered engine/IDE (msbuild__build_4_0,
+            // msbuild__build_solution_2022, ...), so they can't be cased in the switch below; render them
+            // from the name + args here. Solution (devenv) builds are checked first - the more specific
+            // prefix - then the per-engine MSBuild builds.
+            if (name != null && name.StartsWith("msbuild__build_solution_", StringComparison.Ordinal))
+                return BuildDevenvRecord(name, args, out header, out body, out language);
             if (name != null && name.StartsWith("msbuild__build_", StringComparison.Ordinal))
                 return BuildMsBuildRecord(name, args, out header, out body, out language);
 
@@ -2942,6 +2946,48 @@ namespace GxPT
             if (props != null)
                 foreach (var kv in props)
                     lines.Add("property: " + kv.Key + "=" + (kv.Value != null ? kv.Value.ToString() : string.Empty));
+            body = string.Join("\n", lines.ToArray());
+            return true;
+        }
+
+        // Renders a devenv solution-build call (msbuild__build_solution_<year>) into a transcript record:
+        // a header like "Built MyApp.sln (Release · Visual Studio 2022)" with the options as a body. The
+        // VS year comes from the tool-name suffix (build_solution_2022 -> 2022).
+        private static bool BuildDevenvRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language)
+        {
+            header = null; body = string.Empty; language = "text";
+
+            string year = name.Substring("msbuild__build_solution_".Length);
+            string solution = Str(args, "solution");
+            string solutionLabel = solution.Length > 0
+                ? System.IO.Path.GetFileName(solution.Replace('\\', '/')) : "solution";
+
+            // Verb from the action (Rebuild/Clean/Deploy), defaulting to "Built".
+            string action = Str(args, "action");
+            string verb = "Built";
+            switch (action.ToLowerInvariant())
+            {
+                case "rebuild": verb = "Rebuilt"; break;
+                case "clean": verb = "Cleaned"; break;
+                case "deploy": verb = "Deployed"; break;
+            }
+
+            // Parenthetical: configuration (default Release), then "Visual Studio <year>".
+            var bits = new List<string>();
+            string config = Str(args, "configuration");
+            if (config.Length == 0) config = "Release";
+            string platform = Str(args, "platform");
+            bits.Add(platform.Length > 0 ? config + "|" + platform : config);
+            bits.Add("Visual Studio " + year);
+            header = verb + " " + solutionLabel + " (" + string.Join(" · ", bits.ToArray()) + ")";
+
+            // Body: the build options, for the collapsible record.
+            var lines = new List<string>();
+            if (solution.Length > 0) lines.Add("solution: " + solution);
+            if (action.Length > 0) lines.Add("action: " + action);
+            lines.Add("configuration: " + (platform.Length > 0 ? config + "|" + platform : config));
+            string project = Str(args, "project");
+            if (project.Length > 0) lines.Add("project: " + project);
             body = string.Join("\n", lines.ToArray());
             return true;
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1019,6 +1019,10 @@ namespace GxPT
                 // server whose tools could only return "git not found".
                 opts.GitEnabled = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
                 opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled", false);
+                // MSBuild defaults ON when at least one MSBuild engine is found, OFF when none is, and is
+                // force-disabled when none is present regardless of the stored setting — so we never launch
+                // an MSBuild server whose tools would be an empty set.
+                opts.MsBuildEnabled = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled", true);
                 opts.WebSearchKey = AppSettings.GetString("mcp_websearch_key");
                 opts.CurlPath = curlPath;
                 // Server exes: dev builds deploy them to a 'mcp-servers' subfolder (AfterBuild copy);
@@ -2652,6 +2656,12 @@ namespace GxPT
         private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language, out int added, out int removed)
         {
             header = null; body = string.Empty; language = "text"; added = -1; removed = -1;
+
+            // MSBuild tools are named per discovered engine (msbuild__build_4_0, msbuild__build_17_0, ...),
+            // so they can't be cased in the switch below; render them from the name + args here.
+            if (name != null && name.StartsWith("msbuild__build_", StringComparison.Ordinal))
+                return BuildMsBuildRecord(name, args, out header, out body, out language);
+
             switch (name)
             {
                 case "files__edit":
@@ -2887,6 +2897,53 @@ namespace GxPT
                 return sb.ToString();
             }
             catch { return string.Empty; }
+        }
+
+        // Renders an MSBuild build-tool call (msbuild__build_<ver>) into a transcript record: a one-line
+        // header like "Built MyApp.sln (Release · MSBuild 17.0 x64)" with the build options as a
+        // collapsible body. The engine version comes from the tool-name suffix (build_17_0 -> 17.0).
+        private static bool BuildMsBuildRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language)
+        {
+            header = null; body = string.Empty; language = "text";
+
+            string ver = name.Substring("msbuild__build_".Length).Replace('_', '.');
+            string project = Str(args, "project");
+            string projectLabel = project.Length > 0
+                ? System.IO.Path.GetFileName(project.Replace('\\', '/')) : "solution";
+
+            // Verb from the requested targets (Clean/Rebuild/Restore), defaulting to "Built".
+            string targets = JoinPaths(args, "targets");
+            string verb = "Built";
+            switch (targets.ToLowerInvariant())
+            {
+                case "clean": verb = "Cleaned"; break;
+                case "rebuild": verb = "Rebuilt"; break;
+                case "restore": verb = "Restored"; break;
+            }
+
+            // Parenthetical: configuration, then "MSBuild <ver>[ <bitness>]".
+            var bits = new List<string>();
+            string config = Str(args, "configuration");
+            if (config.Length > 0) bits.Add(config);
+            string engine = "MSBuild " + ver;
+            string bitness = Str(args, "bitness");
+            if (bitness.Length > 0) engine += " " + bitness;
+            bits.Add(engine);
+            header = verb + " " + projectLabel + " (" + string.Join(" · ", bits.ToArray()) + ")";
+
+            // Body: the build options, for the collapsible record (omitted when there's nothing extra).
+            var lines = new List<string>();
+            if (project.Length > 0) lines.Add("project: " + project);
+            if (targets.Length > 0) lines.Add("targets: " + targets);
+            if (config.Length > 0) lines.Add("configuration: " + config);
+            string platform = Str(args, "platform");
+            if (platform.Length > 0) lines.Add("platform: " + platform);
+            var props = args["properties"] as Newtonsoft.Json.Linq.JObject;
+            if (props != null)
+                foreach (var kv in props)
+                    lines.Add("property: " + kv.Key + "=" + (kv.Value != null ? kv.Value.ToString() : string.Empty));
+            body = string.Join("\n", lines.ToArray());
+            return true;
         }
 
         private void RebuildTranscriptAsync(TabManager.ChatTabContext ctx, Conversation convo)

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -58,6 +58,7 @@
             this.cmbColor = new System.Windows.Forms.ComboBox();
             this.tabMcp = new System.Windows.Forms.TabPage();
             this.tblMcp = new System.Windows.Forms.TableLayoutPanel();
+            this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpWeb = new System.Windows.Forms.CheckBox();
             this.txtWebSearchKey = new System.Windows.Forms.TextBox();
             this.chkMcpGithub = new System.Windows.Forms.CheckBox();
@@ -78,6 +79,7 @@
             this.tabJson.SuspendLayout();
             this.tabMcp.SuspendLayout();
             this.tblMcp.SuspendLayout();
+            this.tblMcpKeyless.SuspendLayout();
             this.SuspendLayout();
             // 
             // flowLayoutPanel1
@@ -428,33 +430,41 @@
             this.tblMcp.Controls.Add(this.txtWebSearchKey, 1, 0);
             this.tblMcp.Controls.Add(this.chkMcpGithub, 0, 1);
             this.tblMcp.Controls.Add(this.txtGithubPat, 1, 1);
-            this.tblMcp.Controls.Add(this.chkMcpFiles, 0, 2);
-            this.tblMcp.Controls.Add(this.chkMcpCommand, 0, 3);
-            this.tblMcp.Controls.Add(this.chkMcpGit, 0, 4);
-            this.tblMcp.Controls.Add(this.chkMcpMsBuild, 0, 5);
-            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 6);
-            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 7);
+            // The four key-free servers sit in a compact grid rather than one full-width row each.
+            this.tblMcp.Controls.Add(this.tblMcpKeyless, 0, 2);
+            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 3);
+            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 4);
             this.tblMcp.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcp.Location = new System.Drawing.Point(3, 3);
             this.tblMcp.Name = "tblMcp";
-            this.tblMcp.RowCount = 8;
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowCount = 5;
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcp.SetColumnSpan(this.tblMcpKeyless, 2);
             this.tblMcp.SetColumnSpan(this.lblMcpCustom, 2);
             this.tblMcp.SetColumnSpan(this.rtbMcpJson, 2);
-            // Git's label carries a parenthetical, so let it span both columns rather than widen
-            // column 0 (which would squeeze the web/GitHub credential fields on rows 0-1).
-            this.tblMcp.SetColumnSpan(this.chkMcpGit, 2);
-            // MSBuild's label also carries a parenthetical; span both columns for the same reason.
-            this.tblMcp.SetColumnSpan(this.chkMcpMsBuild, 2);
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
+            //
+            // tblMcpKeyless
+            //
+            this.tblMcpKeyless.AutoSize = true;
+            this.tblMcpKeyless.ColumnCount = 2;
+            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcpKeyless.Controls.Add(this.chkMcpFiles, 0, 0);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpCommand, 1, 0);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 0, 1);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 1, 1);
+            this.tblMcpKeyless.Margin = new System.Windows.Forms.Padding(0);
+            this.tblMcpKeyless.Name = "tblMcpKeyless";
+            this.tblMcpKeyless.RowCount = 2;
+            this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpKeyless.TabIndex = 4;
             //
             // chkMcpWeb
             //
@@ -507,7 +517,7 @@
             this.chkMcpGit.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.chkMcpGit.Name = "chkMcpGit";
             this.chkMcpGit.TabIndex = 6;
-            this.chkMcpGit.Text = "Git  (optional - finer-grained, per-operation permissions than running git via Command)";
+            this.chkMcpGit.Text = "Git";
             this.chkMcpGit.UseVisualStyleBackColor = true;
             //
             // chkMcpCommand
@@ -597,6 +607,8 @@
             this.tabMcp.PerformLayout();
             this.tblMcp.ResumeLayout(false);
             this.tblMcp.PerformLayout();
+            this.tblMcpKeyless.ResumeLayout(false);
+            this.tblMcpKeyless.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -633,6 +645,7 @@
         private System.Windows.Forms.ComboBox cmbColor;
         private System.Windows.Forms.TabPage tabMcp;
         private System.Windows.Forms.TableLayoutPanel tblMcp;
+        private System.Windows.Forms.TableLayoutPanel tblMcpKeyless;
         private System.Windows.Forms.CheckBox chkMcpWeb;
         private System.Windows.Forms.TextBox txtWebSearchKey;
         private System.Windows.Forms.CheckBox chkMcpGithub;

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -527,7 +527,7 @@
             this.chkMcpMsBuild.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.chkMcpMsBuild.Name = "chkMcpMsBuild";
             this.chkMcpMsBuild.TabIndex = 7;
-            this.chkMcpMsBuild.Text = "MSBuild  (build .NET projects/solutions; surfaces each installed MSBuild version as a tool)";
+            this.chkMcpMsBuild.Text = "MSBuild";
             this.chkMcpMsBuild.UseVisualStyleBackColor = true;
             //
             // lblMcpCustom

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -430,7 +430,7 @@
             this.tblMcp.Controls.Add(this.txtWebSearchKey, 1, 0);
             this.tblMcp.Controls.Add(this.chkMcpGithub, 0, 1);
             this.tblMcp.Controls.Add(this.txtGithubPat, 1, 1);
-            // The four key-free servers sit in a compact grid rather than one full-width row each.
+            // The four key-free servers share one row, side by side.
             this.tblMcp.Controls.Add(this.tblMcpKeyless, 0, 2);
             this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 3);
             this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 4);
@@ -452,17 +452,18 @@
             // tblMcpKeyless
             //
             this.tblMcpKeyless.AutoSize = true;
-            this.tblMcpKeyless.ColumnCount = 2;
+            this.tblMcpKeyless.ColumnCount = 4;
+            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.Controls.Add(this.chkMcpFiles, 0, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpCommand, 1, 0);
-            this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 0, 1);
-            this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 1, 1);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 2, 0);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 3, 0);
             this.tblMcpKeyless.Margin = new System.Windows.Forms.Padding(0);
             this.tblMcpKeyless.Name = "tblMcpKeyless";
-            this.tblMcpKeyless.RowCount = 2;
-            this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpKeyless.RowCount = 1;
             this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcpKeyless.TabIndex = 4;
             //

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -65,6 +65,7 @@
             this.chkMcpFiles = new System.Windows.Forms.CheckBox();
             this.chkMcpGit = new System.Windows.Forms.CheckBox();
             this.chkMcpCommand = new System.Windows.Forms.CheckBox();
+            this.chkMcpMsBuild = new System.Windows.Forms.CheckBox();
             this.lblMcpCustom = new System.Windows.Forms.Label();
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
@@ -430,12 +431,14 @@
             this.tblMcp.Controls.Add(this.chkMcpFiles, 0, 2);
             this.tblMcp.Controls.Add(this.chkMcpCommand, 0, 3);
             this.tblMcp.Controls.Add(this.chkMcpGit, 0, 4);
-            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 5);
-            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 6);
+            this.tblMcp.Controls.Add(this.chkMcpMsBuild, 0, 5);
+            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 6);
+            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 7);
             this.tblMcp.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcp.Location = new System.Drawing.Point(3, 3);
             this.tblMcp.Name = "tblMcp";
-            this.tblMcp.RowCount = 7;
+            this.tblMcp.RowCount = 8;
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -448,6 +451,8 @@
             // Git's label carries a parenthetical, so let it span both columns rather than widen
             // column 0 (which would squeeze the web/GitHub credential fields on rows 0-1).
             this.tblMcp.SetColumnSpan(this.chkMcpGit, 2);
+            // MSBuild's label also carries a parenthetical; span both columns for the same reason.
+            this.tblMcp.SetColumnSpan(this.chkMcpMsBuild, 2);
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
             //
@@ -515,12 +520,22 @@
             this.chkMcpCommand.Text = "Command";
             this.chkMcpCommand.UseVisualStyleBackColor = true;
             //
+            // chkMcpMsBuild
+            //
+            this.chkMcpMsBuild.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpMsBuild.AutoSize = true;
+            this.chkMcpMsBuild.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpMsBuild.Name = "chkMcpMsBuild";
+            this.chkMcpMsBuild.TabIndex = 7;
+            this.chkMcpMsBuild.Text = "MSBuild  (build .NET projects/solutions; surfaces each installed MSBuild version as a tool)";
+            this.chkMcpMsBuild.UseVisualStyleBackColor = true;
+            //
             // lblMcpCustom
             //
             this.lblMcpCustom.AutoSize = true;
             this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
             this.lblMcpCustom.Name = "lblMcpCustom";
-            this.lblMcpCustom.TabIndex = 7;
+            this.lblMcpCustom.TabIndex = 8;
             this.lblMcpCustom.Text = "Custom servers (mcp.json):";
             //
             // rtbMcpJson
@@ -625,6 +640,7 @@
         private System.Windows.Forms.CheckBox chkMcpFiles;
         private System.Windows.Forms.CheckBox chkMcpGit;
         private System.Windows.Forms.CheckBox chkMcpCommand;
+        private System.Windows.Forms.CheckBox chkMcpMsBuild;
         private System.Windows.Forms.Label lblMcpCustom;
         private System.Windows.Forms.RichTextBox rtbMcpJson;
     }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1183,6 +1183,9 @@ namespace GxPT
             // disabled below) when git isn't on PATH.
             this.chkMcpGit.Checked = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
             this.chkMcpCommand.Checked = s.mcp_command_enabled;
+            // MSBuild, like Git, defaults ON when a build engine is found and the user hasn't chosen
+            // otherwise; OFF (and disabled below) when no MSBuild is present.
+            this.chkMcpMsBuild.Checked = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled", true);
             this.chkMcpGithub.Checked = s.mcp_github_enabled;
             this.txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
             this.txtGithubPat.Text = s.mcp_github_pat != null ? s.mcp_github_pat : string.Empty;
@@ -1196,6 +1199,7 @@ namespace GxPT
             target.mcp_files_enabled = this.chkMcpFiles.Checked;
             target.mcp_git_enabled = this.chkMcpGit.Checked;
             target.mcp_command_enabled = this.chkMcpCommand.Checked;
+            target.mcp_msbuild_enabled = this.chkMcpMsBuild.Checked;
             target.mcp_github_enabled = this.chkMcpGithub.Checked;
             target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
             target.mcp_github_pat = this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : string.Empty;
@@ -1222,6 +1226,18 @@ namespace GxPT
                 this._mcpTip.SetToolTip(this.chkMcpGit, gitInstalled
                     ? string.Empty
                     : "Git was not found on your PATH. Install Git to enable these tools.");
+            }
+            catch { }
+
+            // MSBuild requires an MSBuild engine on the system; if none is found, the toggle is disabled.
+            bool msbuildInstalled = MsBuildProbe.IsInstalled();
+            this.chkMcpMsBuild.Enabled = msbuildInstalled;
+            if (!msbuildInstalled) this.chkMcpMsBuild.Checked = false;
+            try
+            {
+                this._mcpTip.SetToolTip(this.chkMcpMsBuild, msbuildInstalled
+                    ? string.Empty
+                    : "No MSBuild was found on this system. Install the .NET Framework or Visual Studio/Build Tools to enable these tools.");
             }
             catch { }
         }
@@ -1300,6 +1316,7 @@ namespace GxPT
             public bool mcp_files_enabled { get; set; }
             public bool mcp_git_enabled { get; set; }
             public bool mcp_command_enabled { get; set; }
+            public bool mcp_msbuild_enabled { get; set; }
             public bool mcp_github_enabled { get; set; }
             public string mcp_websearch_key { get; set; }
             public string mcp_github_pat { get; set; }

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -339,6 +339,7 @@
       <McpServerFiles Include="..\servers\GitMcpServer\bin\$(Configuration)\**\*.*" Exclude="..\servers\GitMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\GitMcpServer\bin\$(Configuration)\**\*.xml" />
       <McpServerFiles Include="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.*" Exclude="..\servers\CommandMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\CommandMcpServer\bin\$(Configuration)\**\*.xml" />
       <McpServerFiles Include="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.*" Exclude="..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\WebSearchMcpServer\bin\$(Configuration)\**\*.xml" />
+      <McpServerFiles Include="..\servers\MSBuildMcpServer\bin\$(Configuration)\**\*.*" Exclude="..\servers\MSBuildMcpServer\bin\$(Configuration)\**\*.pdb;..\servers\MSBuildMcpServer\bin\$(Configuration)\**\*.xml" />
     </ItemGroup>
     <Copy SourceFiles="@(McpServerFiles)" DestinationFiles="@(McpServerFiles->'$(OutDir)mcp-servers\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" ContinueOnError="true" />
   </Target>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -141,6 +141,7 @@
     <Compile Include="Services\Mcp\McpServerSpec.cs" />
     <Compile Include="Services\Mcp\McpConfig.cs" />
     <Compile Include="Services\Mcp\GitProbe.cs" />
+    <Compile Include="Services\Mcp\MsBuildProbe.cs" />
     <Compile Include="Services\Mcp\IServerConnector.cs" />
     <Compile Include="Services\Mcp\McpHost.cs" />
     <Compile Include="Services\Mcp\DefaultServerConnector.cs" />

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -19,6 +19,7 @@ namespace GxPT
         public const string FilesName = "files";
         public const string GitName = "git";
         public const string CommandName = "command";
+        public const string MsBuildName = "msbuild";
         public const string GitHubName = "github";
         public const string GitHubUrl = "https://api.githubcopilot.com/mcp/";
 
@@ -48,6 +49,7 @@ namespace GxPT
             public bool FilesEnabled { get; set; }
             public bool GitEnabled { get; set; }
             public bool CommandEnabled { get; set; }
+            public bool MsBuildEnabled { get; set; }
 
             public string WebSearchKey { get; set; }   // GXPT_WEB_SEARCH_KEY (web)
             public string CurlPath { get; set; }        // GXPT_CURL_PATH (web)
@@ -101,6 +103,10 @@ namespace GxPT
             McpServerSpec cmd = NewBuiltIn(CommandName, "CommandMcpServer.exe", o.ServerDir, true, o.CommandEnabled);
             if (!string.IsNullOrEmpty(o.CmdShell)) cmd.Env[EnvCmdShell] = o.CmdShell;
             list.Add(cmd);
+
+            // msbuild — discovers installed MSBuild versions and builds the project at GXPT_WORKDIR.
+            // No extra env beyond the working directory: engines are discovered, not configured.
+            list.Add(NewBuiltIn(MsBuildName, "MSBuildMcpServer.exe", o.ServerDir, true, o.MsBuildEnabled));
 
             return list;
         }

--- a/GxPT/Services/Mcp/MsBuildProbe.cs
+++ b/GxPT/Services/Mcp/MsBuildProbe.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+
+namespace GxPT
+{
+    // Detects whether any MSBuild engine is available to the host (and therefore to the MSBuild MCP
+    // server, which discovers engines the same way). Used to default the MSBuild toggle ON when a
+    // build engine exists and OFF when none does, and to avoid launching a server that would expose
+    // no build tools.
+    //
+    // This is a cheap boolean probe (well-known path checks only); the server itself does the full
+    // version/bitness enumeration. The result is cached for the process — installed toolsets don't
+    // appear mid-session in practice (Invalidate() is provided for completeness).
+    internal static class MsBuildProbe
+    {
+        private static readonly object _lock = new object();
+        private static bool _done;
+        private static bool _installed;
+
+        public static bool IsInstalled()
+        {
+            lock (_lock)
+            {
+                if (_done) return _installed;
+                _installed = Probe();
+                _done = true;
+                return _installed;
+            }
+        }
+
+        public static void Invalidate()
+        {
+            lock (_lock) { _done = false; }
+        }
+
+        private static bool Probe()
+        {
+            try
+            {
+                // .NET Framework MSBuild (bundled from Windows XP onward) — the common case.
+                string windir = Environment.GetEnvironmentVariable("WINDIR");
+                if (string.IsNullOrEmpty(windir)) windir = Environment.GetEnvironmentVariable("SystemRoot");
+                if (!string.IsNullOrEmpty(windir))
+                {
+                    string[] subs = new string[] { "v2.0.50727", "v3.5", "v4.0.30319" };
+                    string[] roots = new string[] { "Framework", "Framework64" };
+                    foreach (string root in roots)
+                        foreach (string sub in subs)
+                            if (FileExists(Path.Combine(Path.Combine(Path.Combine(Path.Combine(windir, "Microsoft.NET"), root), sub), "MSBuild.exe")))
+                                return true;
+                }
+
+                string pf = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+                if (string.IsNullOrEmpty(pf)) pf = Environment.GetEnvironmentVariable("ProgramFiles");
+                if (!string.IsNullOrEmpty(pf))
+                {
+                    // Standalone MSBuild (VS2013/2015).
+                    string[] vers = new string[] { "12.0", "14.0" };
+                    foreach (string v in vers)
+                        if (FileExists(Path.Combine(Path.Combine(Path.Combine(Path.Combine(pf, "MSBuild"), v), "Bin"), "MSBuild.exe")))
+                            return true;
+
+                    // VS2017+ : vswhere's presence implies a VS installer; the server enumerates the rest.
+                    if (FileExists(Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio"), "Installer"), "vswhere.exe")))
+                        return true;
+                }
+
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool FileExists(string path)
+        {
+            try { return !string.IsNullOrEmpty(path) && File.Exists(path); }
+            catch { return false; }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -229,6 +229,7 @@ namespace GxPT
             s[McpConfig.FilesName] = true;
             s[McpConfig.GitName] = true;
             s[McpConfig.CommandName] = true;
+            s[McpConfig.MsBuildName] = true;
             // GitHub is a first-party-managed HTTP server but a third-party tool surface; classify
             // its tools via annotations (not the hardcoded table).
             return s;

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -63,6 +63,13 @@ namespace GxPT
                 ToolPolicy fp;
                 if (_firstParty.TryGetValue(functionName, out fp))
                     return new ToolPolicy(fp.Tier, fp.Scope, fp.ScopeArgPath);
+                // The MSBuild server surfaces one build tool per installed engine, so its tool names are
+                // discovered at runtime (msbuild__build_4_0, msbuild__build_17_0, ...) and can't be listed
+                // in the static table. A build runs arbitrary build logic (targets, Exec tasks, pre/post
+                // build events), so it is Destructive and argument-scoped on the project being built -
+                // "always allow building this project/solution", never a blanket "always allow MSBuild".
+                if (functionName.StartsWith(McpConfig.MsBuildName + "__", StringComparison.Ordinal))
+                    return new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "project");
                 // First-party but not in the table (shouldn't happen) -> conservative Write/Tool.
                 return new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
             }

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -63,13 +63,18 @@ namespace GxPT
                 ToolPolicy fp;
                 if (_firstParty.TryGetValue(functionName, out fp))
                     return new ToolPolicy(fp.Tier, fp.Scope, fp.ScopeArgPath);
-                // The MSBuild server surfaces one build tool per installed engine, so its tool names are
-                // discovered at runtime (msbuild__build_4_0, msbuild__build_17_0, ...) and can't be listed
-                // in the static table. A build runs arbitrary build logic (targets, Exec tasks, pre/post
-                // build events), so it is Destructive and argument-scoped on the project being built -
-                // "always allow building this project/solution", never a blanket "always allow MSBuild".
+                // The MSBuild server surfaces build tools per installed engine/IDE, so its tool names are
+                // discovered at runtime (msbuild__build_4_0, msbuild__build_solution_2022, ...) and can't
+                // be listed in the static table. A build runs arbitrary build logic (targets, Exec tasks,
+                // pre/post build events), so it is Destructive and argument-scoped on the project/solution
+                // being built - "always allow building this one", never a blanket "always allow MSBuild".
+                // devenv solution builds scope on the 'solution' arg; MSBuild engine builds on 'project'.
                 if (functionName.StartsWith(McpConfig.MsBuildName + "__", StringComparison.Ordinal))
-                    return new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "project");
+                {
+                    string scopeArg = functionName.IndexOf("build_solution", StringComparison.Ordinal) >= 0
+                        ? "solution" : "project";
+                    return new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, scopeArg);
+                }
                 // First-party but not in the table (shouldn't happen) -> conservative Write/Tool.
                 return new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
             }

--- a/servers/MSBuildMcpServer/ArgvQuoter.cs
+++ b/servers/MSBuildMcpServer/ArgvQuoter.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace MSBuildMcpServer
+{
+    /// <summary>
+    /// Quotes a list of discrete argument tokens into a single Windows command line that the
+    /// CRT / CommandLineToArgvW will parse back into exactly those tokens. This keeps model-supplied
+    /// values (project paths, property values, platforms like "Any CPU") from being misread as
+    /// switches or split into extra arguments — no value is ever concatenated raw (servers-spec §4).
+    ///
+    /// Rules (the standard MSVC argv quoting algorithm):
+    ///  - a token with no space/tab/quote is emitted as-is;
+    ///  - otherwise it is wrapped in double quotes;
+    ///  - backslashes are doubled only when they precede a quote (or the closing quote);
+    ///  - embedded quotes are backslash-escaped.
+    /// </summary>
+    internal static class ArgvQuoter
+    {
+        public static string Join(IList<string> tokens)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                AppendToken(sb, tokens[i] ?? string.Empty);
+            }
+            return sb.ToString();
+        }
+
+        private static void AppendToken(StringBuilder sb, string token)
+        {
+            if (token.Length > 0 && token.IndexOfAny(NeedsQuote) < 0)
+            {
+                sb.Append(token); // safe to emit bare
+                return;
+            }
+
+            sb.Append('"');
+            int backslashes = 0;
+            for (int i = 0; i < token.Length; i++)
+            {
+                char c = token[i];
+                if (c == '\\')
+                {
+                    backslashes++;
+                }
+                else if (c == '"')
+                {
+                    // Double the run of backslashes, then escape the quote.
+                    sb.Append('\\', backslashes * 2 + 1);
+                    sb.Append('"');
+                    backslashes = 0;
+                }
+                else
+                {
+                    if (backslashes > 0) { sb.Append('\\', backslashes); backslashes = 0; }
+                    sb.Append(c);
+                }
+            }
+            // Backslashes immediately before the closing quote must be doubled.
+            if (backslashes > 0) sb.Append('\\', backslashes * 2);
+            sb.Append('"');
+        }
+
+        private static readonly char[] NeedsQuote = new char[] { ' ', '\t', '"' };
+    }
+}

--- a/servers/MSBuildMcpServer/MSBuildMcpServer.csproj
+++ b/servers/MSBuildMcpServer/MSBuildMcpServer.csproj
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C7E1B2A4-3D5F-4A6B-8E9C-1F2A3B4C5D6E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MSBuildMcpServer</RootNamespace>
+    <AssemblyName>MSBuildMcpServer</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\Mcp35.Core\lib\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="MsBuildConfig.cs" />
+    <Compile Include="MsBuildDiscovery.cs" />
+    <Compile Include="MsBuildTools.cs" />
+    <Compile Include="ArgvQuoter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mcp35.Server\Mcp35.Server.csproj">
+      <Project>{DCA697A6-1B4C-430C-BC45-134CB5F90072}</Project>
+      <Name>Mcp35.Server</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Mcp35.Core\Mcp35.Core.csproj">
+      <Project>{667AC466-F30B-4CDB-BEC9-7A139A709AA9}</Project>
+      <Name>Mcp35.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/servers/MSBuildMcpServer/MsBuildConfig.cs
+++ b/servers/MSBuildMcpServer/MsBuildConfig.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+
+namespace MSBuildMcpServer
+{
+    /// <summary>
+    /// Startup config from the environment (servers-spec §1), read once. Builds run from
+    /// GXPT_WORKDIR (the conversation's project folder); MSBuild executables are discovered on the
+    /// system, not configured, so there is no extra env var beyond the working directory.
+    /// </summary>
+    internal sealed class MsBuildConfig
+    {
+        public readonly string WorkDir;
+
+        private MsBuildConfig(string workDir)
+        {
+            WorkDir = workDir;
+        }
+
+        public static MsBuildConfig FromEnvironment(ILogSink log)
+        {
+            string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
+            if (string.IsNullOrEmpty(workDir)) workDir = Directory.GetCurrentDirectory();
+
+            if (log != null) log.Log("msbuild", "workdir=" + workDir);
+            return new MsBuildConfig(workDir);
+        }
+    }
+}

--- a/servers/MSBuildMcpServer/MsBuildDiscovery.cs
+++ b/servers/MSBuildMcpServer/MsBuildDiscovery.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace MSBuildMcpServer
+{
+    /// <summary>
+    /// One discovered MSBuild version. A version may ship a 32-bit engine, a 64-bit engine, or both;
+    /// <see cref="X86Path"/>/<see cref="X64Path"/> is null when that bitness isn't present. The engine
+    /// bitness is the bitness of the MSBuild *process* — the architecture of the build *output* is
+    /// controlled by the project's Platform/PlatformTarget, not by which engine runs.
+    /// </summary>
+    internal sealed class MsBuildInstall
+    {
+        public string Version;   // "2.0", "4.0", "17.0" — the MSBuild/toolset version
+        public string Label;     // human label, e.g. "MSBuild 4.0 (.NET Framework)"
+        public string X86Path;   // 32-bit MSBuild.exe, or null
+        public string X64Path;   // 64-bit MSBuild.exe, or null
+
+        public bool HasBoth { get { return !string.IsNullOrEmpty(X86Path) && !string.IsNullOrEmpty(X64Path); } }
+
+        // The engine to use for a requested bitness; falls back to whichever exists.
+        public string PathForBitness(string bitness)
+        {
+            bool wantX64 = string.Equals(bitness, "x64", StringComparison.OrdinalIgnoreCase);
+            bool wantX86 = string.Equals(bitness, "x86", StringComparison.OrdinalIgnoreCase);
+            if (wantX64 && !string.IsNullOrEmpty(X64Path)) return X64Path;
+            if (wantX86 && !string.IsNullOrEmpty(X86Path)) return X86Path;
+            // Default: prefer the 64-bit engine when present (only true on a 64-bit OS), else 32-bit.
+            return !string.IsNullOrEmpty(X64Path) ? X64Path : X86Path;
+        }
+    }
+
+    /// <summary>
+    /// Probes the system for installed MSBuild engines. Covers the whole XP-32 → Win11-64 range:
+    ///   - .NET Framework MSBuild bundled with the OS (v2.0/v3.5/v4.0, under %WINDIR%\Microsoft.NET);
+    ///   - standalone MSBuild from VS2013/2015 (12.0/14.0, under %ProgramFiles(x86)%\MSBuild);
+    ///   - VS2017+ toolsets (15/16/17) located via vswhere.exe, with a directory-probe fallback.
+    /// Every probe is defensive: any failure for one source simply yields no entry for it, never an
+    /// exception (a server must not crash during startup discovery).
+    /// </summary>
+    internal static class MsBuildDiscovery
+    {
+        public static IList<MsBuildInstall> Discover(ILogSink log)
+        {
+            // Keyed by version so the same toolset found via two routes collapses to one entry.
+            Dictionary<string, MsBuildInstall> byVersion =
+                new Dictionary<string, MsBuildInstall>(StringComparer.OrdinalIgnoreCase);
+
+            try { DiscoverFramework(byVersion); } catch (Exception ex) { Note(log, "framework probe failed: " + ex.Message); }
+            try { DiscoverStandalone(byVersion); } catch (Exception ex) { Note(log, "standalone probe failed: " + ex.Message); }
+            try { DiscoverViaVsWhere(byVersion, log); } catch (Exception ex) { Note(log, "vswhere probe failed: " + ex.Message); }
+            try { DiscoverVsFallback(byVersion); } catch (Exception ex) { Note(log, "vs fallback probe failed: " + ex.Message); }
+
+            List<MsBuildInstall> result = new List<MsBuildInstall>(byVersion.Values);
+            result.Sort(delegate(MsBuildInstall a, MsBuildInstall b) { return CompareVersion(a.Version, b.Version); });
+            return result;
+        }
+
+        // ---- .NET Framework MSBuild (bundled; present from Windows XP onward) ----
+
+        private static void DiscoverFramework(IDictionary<string, MsBuildInstall> into)
+        {
+            string windir = Environment.GetEnvironmentVariable("WINDIR");
+            if (string.IsNullOrEmpty(windir)) windir = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrEmpty(windir)) return;
+
+            // (framework subdir, toolset version)
+            string[][] table = new string[][]
+            {
+                new string[] { "v2.0.50727", "2.0" },
+                new string[] { "v3.5",       "3.5" },
+                new string[] { "v4.0.30319", "4.0" },
+            };
+
+            foreach (string[] row in table)
+            {
+                string sub = row[0], ver = row[1];
+                string x86 = Path.Combine(Path.Combine(Path.Combine(windir, "Microsoft.NET"), "Framework"), Path.Combine(sub, "MSBuild.exe"));
+                string x64 = Path.Combine(Path.Combine(Path.Combine(windir, "Microsoft.NET"), "Framework64"), Path.Combine(sub, "MSBuild.exe"));
+                AddPaths(into, ver, "MSBuild " + ver + " (.NET Framework)", Exists(x86) ? x86 : null, Exists(x64) ? x64 : null);
+            }
+        }
+
+        // ---- Standalone MSBuild from VS2013 (12.0) / VS2015 (14.0) ----
+
+        private static void DiscoverStandalone(IDictionary<string, MsBuildInstall> into)
+        {
+            string pf = ProgramFilesX86();
+            if (string.IsNullOrEmpty(pf)) return;
+
+            string[][] table = new string[][]
+            {
+                new string[] { "12.0", "Visual Studio 2013" },
+                new string[] { "14.0", "Visual Studio 2015" },
+            };
+
+            foreach (string[] row in table)
+            {
+                string ver = row[0], vs = row[1];
+                string bin = Path.Combine(Path.Combine(Path.Combine(pf, "MSBuild"), ver), "Bin");
+                string x86 = Path.Combine(bin, "MSBuild.exe");
+                string x64 = Path.Combine(Path.Combine(bin, "amd64"), "MSBuild.exe");
+                AddPaths(into, ver, "MSBuild " + ver + " (" + vs + ")", Exists(x86) ? x86 : null, Exists(x64) ? x64 : null);
+            }
+        }
+
+        // ---- VS2017+ via vswhere.exe (the supported discovery route for 15.0/Current toolsets) ----
+
+        private static void DiscoverViaVsWhere(IDictionary<string, MsBuildInstall> into, ILogSink log)
+        {
+            string pf = ProgramFilesX86();
+            if (string.IsNullOrEmpty(pf)) return;
+            string vswhere = Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio"), "Installer"), "vswhere.exe");
+            if (!Exists(vswhere)) return;
+
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = vswhere;
+            // JSON is the cleanest machine-readable form and Newtonsoft is already referenced.
+            req.Arguments = "-products * -requires Microsoft.Component.MSBuild -format json -utf8";
+            req.WorkingDirectory = pf;
+            req.TimeoutMs = 15000;
+
+            ProcessResult res = new ProcessRunner(null).Run(req);
+            if (res.TimedOut || res.ExitCode != 0 || string.IsNullOrEmpty(res.StdOut)) return;
+
+            JArray arr;
+            try { arr = JArray.Parse(res.StdOut); }
+            catch { return; }
+
+            foreach (JToken tok in arr)
+            {
+                JObject o = tok as JObject;
+                if (o == null) continue;
+                string installPath = (string)o["installationPath"];
+                string installVer = (string)o["installationVersion"];
+                if (string.IsNullOrEmpty(installPath)) continue;
+
+                int major = MajorOf(installVer);
+                if (major <= 0) continue;
+                string ver = major + ".0";                 // 15.0 / 16.0 / 17.0
+
+                // VS2017 lays MSBuild under MSBuild\15.0; VS2019/2022 under MSBuild\Current.
+                string x86 = FirstExisting(
+                    Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "Current"), Path.Combine("Bin", "MSBuild.exe")),
+                    Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "15.0"), Path.Combine("Bin", "MSBuild.exe")));
+                string x64 = FirstExisting(
+                    Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "Current"), Path.Combine(Path.Combine("Bin", "amd64"), "MSBuild.exe")),
+                    Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "15.0"), Path.Combine(Path.Combine("Bin", "amd64"), "MSBuild.exe")));
+
+                AddPaths(into, ver, "MSBuild " + ver + " (" + VsName(major) + ")", x86, x64);
+            }
+        }
+
+        // ---- Fallback when vswhere is absent: probe the well-known VS2017/2019/2022 install roots ----
+
+        private static void DiscoverVsFallback(IDictionary<string, MsBuildInstall> into)
+        {
+            string pf = ProgramFilesX86();
+            if (string.IsNullOrEmpty(pf)) return;
+
+            // (year folder, toolset version, MSBuild subfolder)
+            string[][] years = new string[][]
+            {
+                new string[] { "2017", "15.0", "15.0" },
+                new string[] { "2019", "16.0", "Current" },
+                new string[] { "2022", "17.0", "Current" },
+            };
+            string[] editions = new string[] { "Enterprise", "Professional", "Community", "BuildTools", "Preview" };
+
+            foreach (string[] y in years)
+            {
+                string year = y[0], ver = y[1], sub = y[2];
+                if (into.ContainsKey(ver)) continue; // vswhere already found this toolset
+                foreach (string ed in editions)
+                {
+                    string bin = Path.Combine(Path.Combine(Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio"), year), ed), "MSBuild"), Path.Combine(sub, "Bin"));
+                    string x86 = Path.Combine(bin, "MSBuild.exe");
+                    string x64 = Path.Combine(Path.Combine(bin, "amd64"), "MSBuild.exe");
+                    if (Exists(x86) || Exists(x64))
+                    {
+                        AddPaths(into, ver, "MSBuild " + ver + " (Visual Studio " + year + ")", Exists(x86) ? x86 : null, Exists(x64) ? x64 : null);
+                        break; // first edition found wins for this year
+                    }
+                }
+            }
+        }
+
+        // ---- helpers ----
+
+        private static void AddPaths(IDictionary<string, MsBuildInstall> into, string ver, string label, string x86, string x64)
+        {
+            if (string.IsNullOrEmpty(x86) && string.IsNullOrEmpty(x64)) return;
+            MsBuildInstall existing;
+            if (into.TryGetValue(ver, out existing))
+            {
+                if (string.IsNullOrEmpty(existing.X86Path)) existing.X86Path = x86;
+                if (string.IsNullOrEmpty(existing.X64Path)) existing.X64Path = x64;
+                return;
+            }
+            into[ver] = new MsBuildInstall { Version = ver, Label = label, X86Path = x86, X64Path = x64 };
+        }
+
+        private static string ProgramFilesX86()
+        {
+            string pf = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+            if (string.IsNullOrEmpty(pf)) pf = Environment.GetEnvironmentVariable("ProgramFiles");
+            return pf;
+        }
+
+        private static bool Exists(string path)
+        {
+            try { return !string.IsNullOrEmpty(path) && File.Exists(path); }
+            catch { return false; }
+        }
+
+        private static string FirstExisting(string a, string b)
+        {
+            if (Exists(a)) return a;
+            if (Exists(b)) return b;
+            return null;
+        }
+
+        private static int MajorOf(string version)
+        {
+            if (string.IsNullOrEmpty(version)) return 0;
+            int dot = version.IndexOf('.');
+            string head = dot > 0 ? version.Substring(0, dot) : version;
+            int n;
+            return int.TryParse(head, out n) ? n : 0;
+        }
+
+        private static string VsName(int major)
+        {
+            switch (major)
+            {
+                case 15: return "Visual Studio 2017";
+                case 16: return "Visual Studio 2019";
+                case 17: return "Visual Studio 2022";
+                default: return "Visual Studio";
+            }
+        }
+
+        // Numeric, dotted-version comparison ("4.0" < "12.0" < "17.0"), not lexicographic.
+        private static int CompareVersion(string a, string b)
+        {
+            int am = MajorOf(a), bm = MajorOf(b);
+            if (am != bm) return am.CompareTo(bm);
+            return string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void Note(ILogSink log, string msg)
+        {
+            if (log != null) log.Log("msbuild", msg);
+        }
+    }
+}

--- a/servers/MSBuildMcpServer/MsBuildDiscovery.cs
+++ b/servers/MSBuildMcpServer/MsBuildDiscovery.cs
@@ -35,6 +35,18 @@ namespace MSBuildMcpServer
     }
 
     /// <summary>
+    /// One discovered Visual Studio IDE (devenv.com), keyed by VS year. devenv builds whole solutions
+    /// — including project types MSBuild can't, notably .vdproj setup/deployment projects. Only *full*
+    /// VS installs ship devenv (Build Tools SKUs do not), so this set can be smaller than the MSBuild set.
+    /// </summary>
+    internal sealed class DevenvInstall
+    {
+        public string Year;    // "2008", "2015", "2022"
+        public string Label;   // "Visual Studio 2022"
+        public string Path;    // full path to devenv.com
+    }
+
+    /// <summary>
     /// Probes the system for installed MSBuild engines. Covers the whole XP-32 → Win11-64 range:
     ///   - .NET Framework MSBuild bundled with the OS (v2.0/v3.5/v4.0, under %WINDIR%\Microsoft.NET);
     ///   - standalone MSBuild from VS2013/2015 (12.0/14.0, under %ProgramFiles(x86)%\MSBuild);
@@ -112,24 +124,8 @@ namespace MSBuildMcpServer
 
         private static void DiscoverViaVsWhere(IDictionary<string, MsBuildInstall> into, ILogSink log)
         {
-            string pf = ProgramFilesX86();
-            if (string.IsNullOrEmpty(pf)) return;
-            string vswhere = Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio"), "Installer"), "vswhere.exe");
-            if (!Exists(vswhere)) return;
-
-            ProcessRequest req = new ProcessRequest();
-            req.FileName = vswhere;
-            // JSON is the cleanest machine-readable form and Newtonsoft is already referenced.
-            req.Arguments = "-products * -requires Microsoft.Component.MSBuild -format json -utf8";
-            req.WorkingDirectory = pf;
-            req.TimeoutMs = 15000;
-
-            ProcessResult res = new ProcessRunner(null).Run(req);
-            if (res.TimedOut || res.ExitCode != 0 || string.IsNullOrEmpty(res.StdOut)) return;
-
-            JArray arr;
-            try { arr = JArray.Parse(res.StdOut); }
-            catch { return; }
+            JArray arr = QueryVsWhere(log);
+            if (arr == null) return;
 
             foreach (JToken tok in arr)
             {
@@ -151,8 +147,44 @@ namespace MSBuildMcpServer
                     Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "Current"), Path.Combine(Path.Combine("Bin", "amd64"), "MSBuild.exe")),
                     Path.Combine(Path.Combine(Path.Combine(installPath, "MSBuild"), "15.0"), Path.Combine(Path.Combine("Bin", "amd64"), "MSBuild.exe")));
 
+                // Build Tools SKUs are included here too (they ship MSBuild under the same layout);
+                // the file-existence check is the real gate. Only devenv discovery excludes them.
                 AddPaths(into, ver, "MSBuild " + ver + " (" + VsName(major) + ")", x86, x64);
             }
+        }
+
+        // vswhere is run at most once per process; both the MSBuild and devenv probes share the result.
+        private static bool _vsWhereDone;
+        private static JArray _vsWhereCache;
+
+        private static JArray QueryVsWhere(ILogSink log)
+        {
+            if (_vsWhereDone) return _vsWhereCache;
+            _vsWhereDone = true;
+            try
+            {
+                string pf = ProgramFilesX86();
+                if (string.IsNullOrEmpty(pf)) return null;
+                string vswhere = Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio"), "Installer"), "vswhere.exe");
+                if (!Exists(vswhere)) return null;
+
+                ProcessRequest req = new ProcessRequest();
+                req.FileName = vswhere;
+                // All products; JSON is the cleanest machine-readable form (Newtonsoft is referenced).
+                req.Arguments = "-products * -format json -utf8";
+                req.WorkingDirectory = pf;
+                req.TimeoutMs = 15000;
+
+                ProcessResult res = new ProcessRunner(null).Run(req);
+                if (res.TimedOut || res.ExitCode != 0 || string.IsNullOrEmpty(res.StdOut)) return null;
+                _vsWhereCache = JArray.Parse(res.StdOut);
+            }
+            catch (Exception ex)
+            {
+                Note(log, "vswhere query failed: " + ex.Message);
+                _vsWhereCache = null;
+            }
+            return _vsWhereCache;
         }
 
         // ---- Fallback when vswhere is absent: probe the well-known VS2017/2019/2022 install roots ----
@@ -186,6 +218,86 @@ namespace MSBuildMcpServer
                         break; // first edition found wins for this year
                     }
                 }
+            }
+        }
+
+        // ---- devenv.com (Visual Studio IDE) discovery ----
+
+        public static IList<DevenvInstall> DiscoverDevenv(ILogSink log)
+        {
+            Dictionary<string, DevenvInstall> byYear =
+                new Dictionary<string, DevenvInstall>(StringComparer.OrdinalIgnoreCase);
+
+            try { DevenvLegacy(byYear); } catch (Exception ex) { Note(log, "devenv legacy probe failed: " + ex.Message); }
+            try { DevenvViaVsWhere(byYear, log); } catch (Exception ex) { Note(log, "devenv vswhere probe failed: " + ex.Message); }
+
+            List<DevenvInstall> result = new List<DevenvInstall>(byYear.Values);
+            result.Sort(delegate(DevenvInstall a, DevenvInstall b) { return string.Compare(a.Year, b.Year, StringComparison.OrdinalIgnoreCase); });
+            return result;
+        }
+
+        // VS2008-2015: devenv.com under %ProgramFiles(x86)%\Microsoft Visual Studio <ver>\Common7\IDE.
+        private static void DevenvLegacy(IDictionary<string, DevenvInstall> into)
+        {
+            string pf = ProgramFilesX86();
+            if (string.IsNullOrEmpty(pf)) return;
+
+            // (version folder, VS year)
+            string[][] table = new string[][]
+            {
+                new string[] { "9.0",  "2008" },
+                new string[] { "10.0", "2010" },
+                new string[] { "11.0", "2012" },
+                new string[] { "12.0", "2013" },
+                new string[] { "14.0", "2015" },
+            };
+            foreach (string[] row in table)
+            {
+                string verDir = row[0], year = row[1];
+                string devenv = Path.Combine(Path.Combine(Path.Combine(Path.Combine(pf, "Microsoft Visual Studio " + verDir), "Common7"), "IDE"), "devenv.com");
+                AddDevenv(into, year, devenv);
+            }
+        }
+
+        // VS2017+: devenv.com at <installationPath>\Common7\IDE (full installs only; Build Tools lacks it).
+        private static void DevenvViaVsWhere(IDictionary<string, DevenvInstall> into, ILogSink log)
+        {
+            JArray arr = QueryVsWhere(log);
+            if (arr == null) return;
+
+            foreach (JToken tok in arr)
+            {
+                JObject o = tok as JObject;
+                if (o == null) continue;
+                string installPath = (string)o["installationPath"];
+                string installVer = (string)o["installationVersion"];
+                if (string.IsNullOrEmpty(installPath)) continue;
+                string year = YearOfMajor(MajorOf(installVer));
+                if (year == null) continue;
+                string devenv = Path.Combine(Path.Combine(Path.Combine(installPath, "Common7"), "IDE"), "devenv.com");
+                AddDevenv(into, year, devenv);
+            }
+        }
+
+        private static void AddDevenv(IDictionary<string, DevenvInstall> into, string year, string devenvPath)
+        {
+            if (into.ContainsKey(year) || !Exists(devenvPath)) return;
+            into[year] = new DevenvInstall { Year = year, Label = "Visual Studio " + year, Path = devenvPath };
+        }
+
+        private static string YearOfMajor(int major)
+        {
+            switch (major)
+            {
+                case 9: return "2008";
+                case 10: return "2010";
+                case 11: return "2012";
+                case 12: return "2013";
+                case 14: return "2015";
+                case 15: return "2017";
+                case 16: return "2019";
+                case 17: return "2022";
+                default: return null;
             }
         }
 

--- a/servers/MSBuildMcpServer/MsBuildTools.cs
+++ b/servers/MSBuildMcpServer/MsBuildTools.cs
@@ -38,6 +38,17 @@ namespace MSBuildMcpServer
                 server.AddTool(toolName, BuildDescription(inst), BuildSchema(inst),
                     delegate(ToolCallContext ctx) { return Run(config, runner, inst, ctx); });
             }
+
+            // devenv.com (full Visual Studio) builds whole solutions, including project types MSBuild
+            // can't — notably .vdproj setup/deployment projects. One build_solution_<year> tool per IDE.
+            IList<DevenvInstall> ides = MsBuildDiscovery.DiscoverDevenv(new StdErrLogSink());
+            foreach (DevenvInstall ide in ides)
+            {
+                DevenvInstall vs = ide; // capture a per-iteration copy for the closure
+                string toolName = "build_solution_" + vs.Year;
+                server.AddTool(toolName, BuildDevenvDescription(vs), BuildDevenvSchema(),
+                    delegate(ToolCallContext ctx) { return RunDevenv(config, runner, vs, ctx); });
+            }
         }
 
         private static string BuildDescription(MsBuildInstall inst)
@@ -179,6 +190,150 @@ namespace MSBuildMcpServer
 
             args.Add("/nologo");
             return args;
+        }
+
+        // ---- devenv.com (Visual Studio IDE) build — handles whole solutions incl. .vdproj ----
+
+        private static string BuildDevenvDescription(DevenvInstall vs)
+        {
+            return "Build an entire solution with " + vs.Label + " (devenv.com). Unlike the MSBuild "
+                + "tools, this drives the Visual Studio IDE, so it builds EVERY project type in the "
+                + "solution - including Visual Studio setup/deployment (.vdproj) projects, which MSBuild "
+                + "cannot build. If 'solution' is omitted, the lone .sln in the working directory is used. "
+                + "'configuration' defaults to Release.";
+        }
+
+        private static JObject BuildDevenvSchema()
+        {
+            return SchemaBuilder.Object()
+                .Str("solution", false, "Path to the .sln (relative to the working directory, or absolute). Omit to use the lone .sln in the working directory.")
+                .Raw("action", EnumSchema("What to do: Build (default), Rebuild, Clean, or Deploy.", new string[] { "Build", "Rebuild", "Clean", "Deploy" }), false)
+                .Str("configuration", false, "Solution configuration name, e.g. Debug or Release. Default: Release.")
+                .Str("platform", false, "Solution platform, e.g. \"Any CPU\", x86. Combined with configuration as \"Config|Platform\".")
+                .Str("project", false, "Build only this project within the solution (devenv /Project).")
+                .Str("project_config", false, "Project-specific configuration for the single-project build (devenv /ProjectConfig).")
+                .Int("timeout_ms", false, "Kill the build after this many milliseconds (default 600000, max 1800000).")
+                .Build();
+        }
+
+        private static CallToolResult RunDevenv(MsBuildConfig config, ProcessRunner runner, DevenvInstall vs, ToolCallContext ctx)
+        {
+            JObject a = ctx.Arguments;
+            string solutionFull, solutionRel, resolveError;
+            if (!ResolveSolution(config.WorkDir, a.Value<string>("solution"), out solutionFull, out solutionRel, out resolveError))
+                return ToolResults.Error(resolveError);
+
+            int timeout = IntArg(a, "timeout_ms", DefaultTimeoutMs, 1000, MaxTimeoutMs);
+            List<string> args = BuildDevenvArgs(a, solutionFull);
+
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = vs.Path;
+            req.Arguments = ArgvQuoter.Join(args);
+            req.WorkingDirectory = config.WorkDir;
+            req.TimeoutMs = timeout;
+
+            ProcessResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return ToolResults.Error("Visual Studio (devenv.com) could not be launched (" + vs.Path + ").");
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("failed to run devenv: " + ex.Message);
+            }
+
+            bool outTrunc, errTrunc;
+            JObject outp = new JObject();
+            outp["ide"] = vs.Label;
+            outp["solution"] = solutionRel;
+            outp["action"] = ActionName(a);
+            outp["exitCode"] = result.ExitCode;
+            outp["succeeded"] = (!result.TimedOut && result.ExitCode == 0);
+            outp["timedOut"] = result.TimedOut;
+            outp["stdout"] = Cap(result.StdOut, out outTrunc);
+            outp["stderr"] = Cap(result.StdErr, out errTrunc);
+            if (outTrunc || errTrunc) outp["truncated"] = true;
+            return ToolResults.Json(outp);
+        }
+
+        // Build the devenv argument token list:
+        //   <solution> /Build|/Rebuild|/Clean|/Deploy "<Config>[|<Platform>]" [/Project p [/ProjectConfig pc]]
+        // Pure (operates on the parsed arguments only) so it is unit-testable.
+        internal static List<string> BuildDevenvArgs(JObject a, string solutionFull)
+        {
+            List<string> args = new List<string>();
+            args.Add(solutionFull);
+            args.Add(ActionSwitch(a.Value<string>("action")));
+
+            // devenv requires a solution configuration name for Build/Rebuild/Clean/Deploy.
+            string config = a.Value<string>("configuration");
+            if (string.IsNullOrEmpty(config)) config = "Release";
+            string platform = a.Value<string>("platform");
+            args.Add(string.IsNullOrEmpty(platform) ? config : (config + "|" + platform));
+
+            string project = a.Value<string>("project");
+            if (!string.IsNullOrEmpty(project)) { args.Add("/Project"); args.Add(project); }
+            string projectConfig = a.Value<string>("project_config");
+            if (!string.IsNullOrEmpty(projectConfig)) { args.Add("/ProjectConfig"); args.Add(projectConfig); }
+            return args;
+        }
+
+        private static string ActionSwitch(string action)
+        {
+            if (string.IsNullOrEmpty(action)) return "/Build";
+            switch (action.ToLowerInvariant())
+            {
+                case "rebuild": return "/Rebuild";
+                case "clean": return "/Clean";
+                case "deploy": return "/Deploy";
+                default: return "/Build";
+            }
+        }
+
+        private static string ActionName(JObject a)
+        {
+            string s = a.Value<string>("action");
+            if (string.IsNullOrEmpty(s)) return "Build";
+            switch (s.ToLowerInvariant())
+            {
+                case "rebuild": return "Rebuild";
+                case "clean": return "Clean";
+                case "deploy": return "Deploy";
+                default: return "Build";
+            }
+        }
+
+        // Resolve the .sln to build via devenv. Provided path is validated; otherwise a lone .sln in the
+        // working directory is used.
+        internal static bool ResolveSolution(string workDir, string solution, out string full, out string rel, out string error)
+        {
+            full = null; rel = null; error = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(solution))
+                {
+                    string candidate = Path.IsPathRooted(solution) ? solution : Path.Combine(workDir, solution);
+                    candidate = Path.GetFullPath(candidate);
+                    if (!File.Exists(candidate)) { error = "solution not found: " + solution; return false; }
+                    full = candidate; rel = solution; return true;
+                }
+                string picked = PickSingle(workDir, ".sln");
+                if (picked == null)
+                {
+                    error = "no 'solution' given and could not find a single .sln in the working directory; specify 'solution'.";
+                    return false;
+                }
+                full = Path.GetFullPath(picked); rel = Path.GetFileName(picked); return true;
+            }
+            catch (Exception ex)
+            {
+                error = "failed to resolve solution: " + ex.Message;
+                return false;
+            }
         }
 
         // Resolve the project/solution to build. Returns the full path to run and a workdir-relative

--- a/servers/MSBuildMcpServer/MsBuildTools.cs
+++ b/servers/MSBuildMcpServer/MsBuildTools.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace MSBuildMcpServer
+{
+    /// <summary>
+    /// Registers one build tool per discovered MSBuild version (servers-spec §4 — this server builds
+    /// command lines, so it owns argv escaping). Each tool (e.g. build_4_0 → msbuild__build_4_0) runs
+    /// a specific MSBuild engine against a project/solution under GXPT_WORKDIR and returns the engine's
+    /// output and exit code verbatim. MSBuild runs arbitrary build logic (targets, Exec tasks, pre/post
+    /// build events), so the host gates these tools as Destructive — the server's job is only to
+    /// construct and run the invocation safely.
+    /// </summary>
+    internal static class MsBuildTools
+    {
+        private const int DefaultTimeoutMs = 600000;   // 10 min — builds can be slow
+        private const int MaxTimeoutMs = 1800000;      // 30 min hard cap
+        private const int OutputCap = 100000;          // chars per stream
+
+        private static readonly string[] ProjectExtensions =
+            new string[] { ".sln", ".csproj", ".vbproj", ".fsproj", ".vcxproj", ".proj" };
+
+        public static void Register(McpServer server, MsBuildConfig config)
+        {
+            ProcessRunner runner = new ProcessRunner(null);
+            // Discovery diagnostics go to stderr (never stdout — that carries the JSON-RPC stream).
+            IList<MsBuildInstall> installs = MsBuildDiscovery.Discover(new StdErrLogSink());
+
+            foreach (MsBuildInstall install in installs)
+            {
+                MsBuildInstall inst = install; // capture a per-iteration copy for the closure
+                string toolName = "build_" + inst.Version.Replace('.', '_');
+                server.AddTool(toolName, BuildDescription(inst), BuildSchema(inst),
+                    delegate(ToolCallContext ctx) { return Run(config, runner, inst, ctx); });
+            }
+        }
+
+        private static string BuildDescription(MsBuildInstall inst)
+        {
+            string d = "Build a project or solution with " + inst.Label + ". Runs MSBuild in the "
+                + "conversation's working directory and returns its full output and exit code. If "
+                + "'project' is omitted, the lone .sln (or lone project file) in the working directory "
+                + "is built.";
+            if (inst.HasBoth)
+                d += " 'bitness' selects the 32- or 64-bit MSBuild engine (default x64); this is the "
+                   + "build process bitness, NOT the output architecture - use the 'platform' property "
+                   + "to control the built binary's architecture.";
+            return d;
+        }
+
+        private static JObject BuildSchema(MsBuildInstall inst)
+        {
+            SchemaBuilder sb = SchemaBuilder.Object()
+                .Str("project", false, "Path to a .sln/.csproj/.*proj (relative to the working directory, or absolute). Omit to build the lone solution/project in the working directory.")
+                .Arr("targets", "string", false, "MSBuild targets to run, e.g. [\"Build\"], [\"Rebuild\"], [\"Clean\"], [\"Restore\"]. Default: the project's default target (Build).")
+                .Str("configuration", false, "Build configuration, e.g. Debug or Release (/p:Configuration=).")
+                .Str("platform", false, "Build/output platform, e.g. \"Any CPU\", x86, x64 (/p:Platform=). Controls the produced binary's architecture.")
+                .Raw("properties", PropertiesSchema(), false)
+                .Raw("verbosity", EnumSchema("MSBuild output verbosity (/v:). Default minimal.", new string[] { "quiet", "minimal", "normal", "detailed", "diagnostic" }), false)
+                .Int("max_cpu_count", false, "Parallel build worker count (/m:N). Omit for MSBuild's single-process default.")
+                .Int("timeout_ms", false, "Kill the build after this many milliseconds (default 600000, max 1800000).");
+
+            if (inst.HasBoth)
+                sb.Raw("bitness", EnumSchema("Which MSBuild engine (process bitness) to run; default x64.", new string[] { "x86", "x64" }), false);
+
+            return sb.Build();
+        }
+
+        private static JObject PropertiesSchema()
+        {
+            JObject p = new JObject();
+            p["type"] = "object";
+            p["description"] = "Additional MSBuild properties as name/value pairs, each passed as /p:Name=Value.";
+            JObject add = new JObject();
+            add["type"] = "string";
+            p["additionalProperties"] = add;
+            return p;
+        }
+
+        private static JObject EnumSchema(string description, string[] values)
+        {
+            JObject p = new JObject();
+            p["type"] = "string";
+            p["description"] = description;
+            JArray e = new JArray();
+            for (int i = 0; i < values.Length; i++) e.Add(values[i]);
+            p["enum"] = e;
+            return p;
+        }
+
+        private static CallToolResult Run(MsBuildConfig config, ProcessRunner runner, MsBuildInstall inst, ToolCallContext ctx)
+        {
+            string projectFull, projectRel, resolveError;
+            if (!ResolveProject(config.WorkDir, ctx.Arguments.Value<string>("project"), out projectFull, out projectRel, out resolveError))
+                return ToolResults.Error(resolveError);
+
+            JObject a = ctx.Arguments;
+            string bitness = a.Value<string>("bitness");
+            string exe = inst.PathForBitness(bitness);
+            if (string.IsNullOrEmpty(exe))
+                return ToolResults.Error("MSBuild " + inst.Version + " engine not found.");
+            string engine = string.Equals(exe, inst.X64Path, StringComparison.OrdinalIgnoreCase) ? "x64" : "x86";
+
+            int timeout = IntArg(a, "timeout_ms", DefaultTimeoutMs, 1000, MaxTimeoutMs);
+
+            List<string> args = BuildArgs(a, projectFull);
+
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = exe;
+            req.Arguments = ArgvQuoter.Join(args);   // discrete tokens, quoted once (servers-spec §4)
+            req.WorkingDirectory = config.WorkDir;
+            req.TimeoutMs = timeout;
+
+            ProcessResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return ToolResults.Error("MSBuild could not be launched (" + exe + "). The engine may have been uninstalled.");
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("failed to run MSBuild: " + ex.Message);
+            }
+
+            bool outTrunc, errTrunc;
+            JObject outp = new JObject();
+            outp["version"] = inst.Version;
+            outp["engine"] = engine;
+            outp["project"] = projectRel;
+            outp["exitCode"] = result.ExitCode;
+            outp["succeeded"] = (!result.TimedOut && result.ExitCode == 0);
+            outp["timedOut"] = result.TimedOut;
+            outp["stdout"] = Cap(result.StdOut, out outTrunc);
+            outp["stderr"] = Cap(result.StdErr, out errTrunc);
+            if (outTrunc || errTrunc) outp["truncated"] = true;
+            return ToolResults.Json(outp);
+        }
+
+        // Build the MSBuild argument token list. The project comes first; everything else is a switch.
+        // Pure (operates on the parsed arguments only) so it is unit-testable without the MCP runtime.
+        internal static List<string> BuildArgs(JObject a, string projectFull)
+        {
+            List<string> args = new List<string>();
+            args.Add(projectFull);
+
+            List<string> targets = StrArrayArg(a, "targets");
+            if (targets.Count > 0) args.Add("/t:" + string.Join(";", targets.ToArray()));
+
+            string config = a.Value<string>("configuration");
+            if (!string.IsNullOrEmpty(config)) args.Add("/p:Configuration=" + config);
+
+            string platform = a.Value<string>("platform");
+            if (!string.IsNullOrEmpty(platform)) args.Add("/p:Platform=" + platform);
+
+            JObject props = a["properties"] as JObject;
+            if (props != null)
+            {
+                foreach (KeyValuePair<string, JToken> kv in props)
+                {
+                    if (string.IsNullOrEmpty(kv.Key)) continue;
+                    string val = kv.Value != null ? kv.Value.ToString() : string.Empty;
+                    args.Add("/p:" + kv.Key + "=" + val);
+                }
+            }
+
+            string verbosity = a.Value<string>("verbosity");
+            args.Add("/v:" + (string.IsNullOrEmpty(verbosity) ? "minimal" : verbosity));
+
+            int cpu = IntArg(a, "max_cpu_count", 0, 0, 1024);
+            if (cpu > 0) args.Add("/m:" + cpu.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            args.Add("/nologo");
+            return args;
+        }
+
+        // Resolve the project/solution to build. Returns the full path to run and a workdir-relative
+        // (or original) form for display. Auto-discovers a lone solution/project when none is given.
+        internal static bool ResolveProject(string workDir, string project, out string full, out string rel, out string error)
+        {
+            full = null; rel = null; error = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(project))
+                {
+                    string candidate = Path.IsPathRooted(project) ? project : Path.Combine(workDir, project);
+                    candidate = Path.GetFullPath(candidate);
+                    if (!File.Exists(candidate)) { error = "project not found: " + project; return false; }
+                    full = candidate;
+                    rel = project;
+                    return true;
+                }
+
+                // No project given: prefer a single .sln, else a single project file, in the workdir root.
+                string picked = PickSingle(workDir, ".sln");
+                if (picked == null) picked = PickSingleProject(workDir);
+                if (picked == null)
+                {
+                    error = "no 'project' given and could not find a single .sln or project file in the working directory; specify 'project'.";
+                    return false;
+                }
+                full = Path.GetFullPath(picked);
+                rel = Path.GetFileName(picked);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = "failed to resolve project: " + ex.Message;
+                return false;
+            }
+        }
+
+        private static string PickSingle(string dir, string ext)
+        {
+            string[] hits = Directory.GetFiles(dir, "*" + ext);
+            return hits.Length == 1 ? hits[0] : null;
+        }
+
+        private static string PickSingleProject(string dir)
+        {
+            List<string> hits = new List<string>();
+            for (int i = 1; i < ProjectExtensions.Length; i++) // skip .sln (index 0)
+                hits.AddRange(Directory.GetFiles(dir, "*" + ProjectExtensions[i]));
+            return hits.Count == 1 ? hits[0] : null;
+        }
+
+        // ---- argument helpers (mirroring the other first-party servers) ----
+
+        private static int IntArg(JObject a, string name, int fallback, int min, int max)
+        {
+            JToken t = a[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        // Read a string[] argument; also accepts a lone string for convenience. Skips null/empty.
+        private static List<string> StrArrayArg(JObject a, string name)
+        {
+            List<string> result = new List<string>();
+            JToken t = a[name];
+            if (t == null) return result;
+            if (t.Type == JTokenType.Array)
+            {
+                foreach (JToken item in (JArray)t)
+                {
+                    if (item == null || item.Type == JTokenType.Null) continue;
+                    string s;
+                    try { s = item.Value<string>(); }
+                    catch { continue; }
+                    if (!string.IsNullOrEmpty(s)) result.Add(s);
+                }
+            }
+            else if (t.Type == JTokenType.String)
+            {
+                string s = t.Value<string>();
+                if (!string.IsNullOrEmpty(s)) result.Add(s);
+            }
+            return result;
+        }
+
+        private static string Cap(string s, out bool truncated)
+        {
+            truncated = false;
+            if (s == null) return string.Empty;
+            if (s.Length <= OutputCap) return s;
+            truncated = true;
+            return s.Substring(0, OutputCap);
+        }
+    }
+}

--- a/servers/MSBuildMcpServer/Program.cs
+++ b/servers/MSBuildMcpServer/Program.cs
@@ -1,0 +1,29 @@
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+
+namespace MSBuildMcpServer
+{
+    /// <summary>
+    /// First-party MSBuild MCP server: discovers the MSBuild versions installed on the system
+    /// (XP-era .NET Framework 2.0/3.5/4.0 through Visual Studio 2017+/MSBuild 17) and surfaces
+    /// each version as its own build tool. The standard five lines around a dynamically-built tool
+    /// set (servers-spec §1); the tool list is still static for the life of the process (discovery
+    /// runs once at startup, listChanged=false).
+    /// </summary>
+    internal static class Program
+    {
+        private static int Main()
+        {
+            StdErrLogSink log = new StdErrLogSink();
+
+            Implementation info = new Implementation();
+            info.Name = "msbuild";
+            info.Version = "1.0";
+
+            McpServer server = new McpServer(info, log);
+            MsBuildTools.Register(server, MsBuildConfig.FromEnvironment(log));
+            server.Run(); // blocks until stdin EOF
+            return 0;
+        }
+    }
+}

--- a/servers/MSBuildMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/MSBuildMcpServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("MSBuildMcpServer")]
+[assembly: AssemblyDescription("First-party MCP server: discovers installed MSBuild versions and builds projects/solutions, capturing output.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Mcp35")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("c7e1b2a4-3d5f-4a6b-8e9c-1f2a3b4c5d6e")]
+
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/tests/MSBuildMcpServer.Tests/ArgvQuoterTests.cs
+++ b/tests/MSBuildMcpServer.Tests/ArgvQuoterTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using MSBuildMcpServer;
+using Xunit;
+
+namespace MSBuildMcpServer.Tests
+{
+    /// <summary>
+    /// Pure tests for the Windows argv quoter — the security core that keeps model-supplied values
+    /// (project paths, property values, a "Any CPU" platform) from injecting extra tokens or flags.
+    /// </summary>
+    public class ArgvQuoterTests
+    {
+        private static string Join(params string[] tokens)
+        {
+            return ArgvQuoter.Join(new List<string>(tokens));
+        }
+
+        [Fact]
+        public void Simple_tokens_are_unquoted()
+        {
+            Assert.Equal("MyApp.sln /t:Build /nologo", Join("MyApp.sln", "/t:Build", "/nologo"));
+        }
+
+        [Fact]
+        public void Property_value_with_spaces_is_quoted()
+        {
+            // /p:Platform=Any CPU contains a space → wrapped so MSBuild sees one token.
+            Assert.Equal("\"/p:Platform=Any CPU\"", Join("/p:Platform=Any CPU"));
+        }
+
+        [Fact]
+        public void Path_with_spaces_is_quoted()
+        {
+            Assert.Equal("\"C:\\My Projects\\App.csproj\"", Join("C:\\My Projects\\App.csproj"));
+        }
+
+        [Fact]
+        public void Trailing_backslashes_before_closing_quote_are_doubled()
+        {
+            Assert.Equal("\"a b\\\\\"", Join("a b\\"));
+        }
+
+        [Fact]
+        public void Backslash_not_before_quote_is_left_alone()
+        {
+            Assert.Equal("C:\\repo\\src", Join("C:\\repo\\src"));
+        }
+    }
+}

--- a/tests/MSBuildMcpServer.Tests/BuildArgsTests.cs
+++ b/tests/MSBuildMcpServer.Tests/BuildArgsTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using MSBuildMcpServer;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace MSBuildMcpServer.Tests
+{
+    /// <summary>
+    /// Tests MSBuild command-line construction: the parsed arguments map to the right /t:, /p:, /v:,
+    /// and /m: switches, the project leads, and /nologo + a default verbosity are always present.
+    /// </summary>
+    public class BuildArgsTests
+    {
+        private static List<string> Build(string json)
+        {
+            return MsBuildTools.BuildArgs(JObject.Parse(json), "App.sln");
+        }
+
+        [Fact]
+        public void Defaults_emit_project_minimal_verbosity_and_nologo()
+        {
+            Assert.Equal(new[] { "App.sln", "/v:minimal", "/nologo" }, Build("{}").ToArray());
+        }
+
+        [Fact]
+        public void Targets_array_joins_with_semicolons()
+        {
+            List<string> a = Build("{\"targets\":[\"Clean\",\"Build\"]}");
+            Assert.Contains("/t:Clean;Build", a);
+        }
+
+        [Fact]
+        public void Targets_accepts_a_lone_string()
+        {
+            List<string> a = Build("{\"targets\":\"Rebuild\"}");
+            Assert.Contains("/t:Rebuild", a);
+        }
+
+        [Fact]
+        public void Configuration_and_platform_become_properties()
+        {
+            List<string> a = Build("{\"configuration\":\"Release\",\"platform\":\"Any CPU\"}");
+            Assert.Contains("/p:Configuration=Release", a);
+            Assert.Contains("/p:Platform=Any CPU", a);
+        }
+
+        [Fact]
+        public void Extra_properties_are_passed_through()
+        {
+            List<string> a = Build("{\"properties\":{\"DefineConstants\":\"TRACE\",\"WarningLevel\":\"4\"}}");
+            Assert.Contains("/p:DefineConstants=TRACE", a);
+            Assert.Contains("/p:WarningLevel=4", a);
+        }
+
+        [Fact]
+        public void Verbosity_overrides_the_default()
+        {
+            List<string> a = Build("{\"verbosity\":\"detailed\"}");
+            Assert.Contains("/v:detailed", a);
+            Assert.DoesNotContain("/v:minimal", a);
+        }
+
+        [Fact]
+        public void Max_cpu_count_emits_parallel_switch()
+        {
+            Assert.Contains("/m:4", Build("{\"max_cpu_count\":4}"));
+        }
+
+        [Fact]
+        public void Zero_or_missing_cpu_count_omits_parallel_switch()
+        {
+            Assert.DoesNotContain("/m:0", Build("{\"max_cpu_count\":0}"));
+            foreach (string t in Build("{}")) Assert.False(t.StartsWith("/m"));
+        }
+    }
+}

--- a/tests/MSBuildMcpServer.Tests/DevenvArgsTests.cs
+++ b/tests/MSBuildMcpServer.Tests/DevenvArgsTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using MSBuildMcpServer;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace MSBuildMcpServer.Tests
+{
+    /// <summary>
+    /// Tests devenv.com command-line construction:
+    ///   &lt;solution&gt; /Build|/Rebuild|/Clean|/Deploy "Config[|Platform]" [/Project p [/ProjectConfig pc]]
+    /// devenv requires a solution-configuration name, so one is always emitted (default Release).
+    /// </summary>
+    public class DevenvArgsTests
+    {
+        private static List<string> Build(string json)
+        {
+            return MsBuildTools.BuildDevenvArgs(JObject.Parse(json), "App.sln");
+        }
+
+        [Fact]
+        public void Defaults_are_build_release()
+        {
+            Assert.Equal(new[] { "App.sln", "/Build", "Release" }, Build("{}").ToArray());
+        }
+
+        [Fact]
+        public void Action_maps_to_the_right_switch()
+        {
+            Assert.Contains("/Rebuild", Build("{\"action\":\"Rebuild\"}"));
+            Assert.Contains("/Clean", Build("{\"action\":\"Clean\"}"));
+            Assert.Contains("/Deploy", Build("{\"action\":\"Deploy\"}"));
+        }
+
+        [Fact]
+        public void Configuration_and_platform_combine_with_a_pipe()
+        {
+            Assert.Equal(new[] { "App.sln", "/Build", "Debug|x86" },
+                Build("{\"configuration\":\"Debug\",\"platform\":\"x86\"}").ToArray());
+        }
+
+        [Fact]
+        public void Single_project_adds_project_and_project_config_switches()
+        {
+            List<string> a = Build("{\"project\":\"Setup\",\"project_config\":\"Release\"}");
+            int i = a.IndexOf("/Project");
+            Assert.True(i >= 0);
+            Assert.Equal("Setup", a[i + 1]);
+            int j = a.IndexOf("/ProjectConfig");
+            Assert.True(j >= 0);
+            Assert.Equal("Release", a[j + 1]);
+        }
+    }
+}

--- a/tests/MSBuildMcpServer.Tests/MSBuildMcpServer.Tests.csproj
+++ b/tests/MSBuildMcpServer.Tests/MSBuildMcpServer.Tests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Tests for MSBuildMcpServer. Links Core + Server + the MSBuildMcpServer sources and exercises the
+    pure pieces: the Windows argv quoter and the MSBuild command-line construction (targets /
+    configuration / platform / properties -> /t:, /p: switches). Live engine discovery and process
+    execution are Windows/install specific and are not exercised here. Targets net48.
+
+    Program.Main is excluded (a second entry point would clash with the test host).
+    NOTE: intentionally NOT in GxPT.sln.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>MSBuildMcpServer.Tests</AssemblyName>
+    <RootNamespace>MSBuildMcpServer.Tests</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Mcp35.Core\**\*.cs"
+             Exclude="..\..\src\Mcp35.Core\Properties\**\*.cs;..\..\src\Mcp35.Core\obj\**\*.cs;..\..\src\Mcp35.Core\bin\**\*.cs"
+             Link="Linked\Core\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\src\Mcp35.Server\**\*.cs"
+             Exclude="..\..\src\Mcp35.Server\Properties\**\*.cs;..\..\src\Mcp35.Server\obj\**\*.cs;..\..\src\Mcp35.Server\bin\**\*.cs"
+             Link="Linked\Server\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\..\servers\MSBuildMcpServer\**\*.cs"
+             Exclude="..\..\servers\MSBuildMcpServer\Program.cs;..\..\servers\MSBuildMcpServer\Properties\**\*.cs;..\..\servers\MSBuildMcpServer\obj\**\*.cs;..\..\servers\MSBuildMcpServer\bin\**\*.cs"
+             Link="Linked\MSBuild\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MSBuildMcpServer.Tests/ResolveProjectTests.cs
+++ b/tests/MSBuildMcpServer.Tests/ResolveProjectTests.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using MSBuildMcpServer;
+using Xunit;
+
+namespace MSBuildMcpServer.Tests
+{
+    /// <summary>
+    /// Tests the project/solution resolution: an explicit path is honored (and validated), and when
+    /// none is given a lone .sln (or lone project file) in the working directory is auto-selected.
+    /// </summary>
+    public class ResolveProjectTests
+    {
+        private static string NewTempDir()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "gxpt-msbuild-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        [Fact]
+        public void Missing_explicit_project_is_an_error()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                string full, rel, err;
+                bool ok = MsBuildTools.ResolveProject(dir, "nope.csproj", out full, out rel, out err);
+                Assert.False(ok);
+                Assert.Contains("not found", err);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void A_lone_solution_is_auto_selected()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "App.sln"), "");
+                string full, rel, err;
+                bool ok = MsBuildTools.ResolveProject(dir, null, out full, out rel, out err);
+                Assert.True(ok, err);
+                Assert.Equal("App.sln", rel);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void A_lone_project_is_auto_selected_when_no_solution()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "App.csproj"), "");
+                string full, rel, err;
+                bool ok = MsBuildTools.ResolveProject(dir, null, out full, out rel, out err);
+                Assert.True(ok, err);
+                Assert.Equal("App.csproj", rel);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void Ambiguous_solutions_require_an_explicit_project()
+        {
+            string dir = NewTempDir();
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "One.sln"), "");
+                File.WriteAllText(Path.Combine(dir, "Two.sln"), "");
+                string full, rel, err;
+                bool ok = MsBuildTools.ResolveProject(dir, null, out full, out rel, out err);
+                Assert.False(ok);
+                Assert.Contains("specify 'project'", err);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A new first-party **MSBuild MCP server** that discovers the build toolchains installed on the machine and surfaces:
- **each MSBuild version as its own build tool** (e.g. `msbuild__build_4_0`, `msbuild__build_17_0`), and
- **each full Visual Studio install as a `devenv.com` solution-build tool** (e.g. `msbuild__build_solution_2022`) — so whole solutions, **including `.vdproj` setup/deployment projects that MSBuild cannot build**, are buildable from the agent.

Plus all the host-side wiring to launch, gate, render, and toggle it.

## The server — `servers/MSBuildMcpServer/`

A net35 console exe on the `Mcp35.Server` SDK (no `GxPT.*` refs), mirroring the existing servers.

**MSBuild discovery** (`MsBuildDiscovery`) covers the full XP-32 → Win11-64 range, every probe defensive:
- **.NET Framework MSBuild** (bundled): `v2.0` / `v3.5` / `v4.0` under `%WINDIR%\Microsoft.NET\Framework[64]`.
- **Standalone MSBuild**: `12.0` / `14.0` (VS2013/2015) under `%ProgramFiles(x86)%\MSBuild`.
- **VS2017+ toolsets** (15/16/17) via `vswhere.exe`, with a directory-probe fallback when vswhere is absent.

**MSBuild tools** (`MsBuildTools`) — one `build_` per discovered version. Schema: `project` (auto-discovers a lone `.sln`/project when omitted), `targets` (Build/Clean/Rebuild/Restore…), `configuration`, `platform`, `properties` (map), `verbosity`, `max_cpu_count`, `timeout_ms`, and `bitness` (only when both engines exist; default **x64**). The description distinguishes **`bitness` = engine process bitness** from **`platform` = output architecture**. Argv is built as discrete tokens and quoted once (`ArgvQuoter`), run through the SDK `ProcessRunner`; results return `{version, engine, project, exitCode, succeeded, timedOut, stdout, stderr}`.

### devenv.com solution builds (incl. `.vdproj`)

MSBuild can't build Visual Studio setup/deployment (`.vdproj`) projects — only the VS IDE can. So discovery also finds **`devenv.com` per *full* VS install** (VS2008–2015 via well-known `…\Common7\IDE` paths; VS2017+ via the **same `vswhere` query**, refactored to run at most once and shared with the MSBuild probe). Build Tools SKUs have no `devenv`, so they only get MSBuild tools.

Each install yields a **`build_solution_<year>`** tool running `devenv.com <sln> /Build|/Rebuild|/Clean|/Deploy "Config[|Platform]" [/Project p [/ProjectConfig pc]]`. Schema: `solution` (auto-discovers a lone `.sln`), `action`, `configuration` (default **Release** — devenv requires a solution-config name), `platform`, `project`, `project_config`, `timeout_ms`. It builds **every** project type in the solution, `.vdproj` included.

## Host integration

- **`McpConfig`** — `msbuild` server name + a workdir-scoped spec (`MSBuildMcpServer.exe`).
- **`MsBuildProbe`** — cheap host-side presence check; the toggle defaults **ON when an engine is found**, OFF (and disabled) when none is — mirroring Git&#39;s install-aware default.
- **`ToolClassifier`** — `msbuild__*` tools have dynamic names, so they&#39;re matched by prefix → **Destructive**, argument-scoped: MSBuild builds scope on **`project`**, devenv solution builds on **`solution`** (&#34;always allow building this one&#34;, never a blanket allow). Builds run arbitrary logic (targets, `Exec`, pre/post-build events, the whole IDE), hence Destructive.
- **`ToolApprovalPolicy`** — `msbuild` added to the first-party server set.
- **`MainForm.TryBuildToolRecord`** — custom transcript entries, e.g. **&#34;Built App.sln (Release · MSBuild 17.0 x64)&#34;** and **&#34;Built App.sln (Release · Visual Studio 2022)&#34;**, with the build options as a collapsible body.
- **`SettingsForm`** — an MSBuild enable toggle next to Git/Command (disabled with an explanatory tooltip when no engine is found).

## Build wiring

New project in `GxPT.sln`, an AfterBuild copy into `mcp-servers\`, registration in the setup deployment, and a sibling **test project** (`tests/MSBuildMcpServer.Tests`) covering argv quoting, MSBuild + devenv arg construction, and project/solution resolution, plus `msbuild__*` classification tests in `GxPT.Tests`. (The `McpConfig` built-ins test was also updated — there are now five built-in servers.)

## ⚠️ Unverified — needs a Windows build

This is a large, **Windows-only, .NET 3.5** change and this Linux container has **no MSBuild/VS**, so I could **not compile, run, or test the server end-to-end** — discovery only does anything on a real Windows install. Please build in VS on Windows and confirm:
- the solution builds and the new exe lands in `mcp-servers\`;
- discovery finds your toolsets/VS installs and each appears as a tool (MSBuild versions **and** `build_solution_<year>` for full VS);
- a build runs, the approval prompt scopes to the project/solution, and the transcript record renders;
- a `build_solution_<year>` call builds a solution containing a `.vdproj`.

I matched the existing server/host patterns closely to minimize breakage, but it ships unverified from my side. Happy to adjust naming, schema, or the discovery scope after you try it.

https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfxFKGLs7oJPpTcVLTgTHK)_