### PR TITLE
Recommended models: refresh from the shipped catalog + update banner

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2162,7 +2162,7 @@ namespace GxPT
 
                 _modelUpdateBanner = new System.Windows.Forms.Panel();
                 _modelUpdateBanner.AutoSize = true;
-                _modelUpdateBanner.Dock = DockStyle.Bottom;
+                _modelUpdateBanner.Dock = DockStyle.Top;
                 _modelUpdateBanner.Padding = new Padding(6, 4, 6, 4);
                 _modelUpdateBanner.BackColor = Color.FromArgb(252, 246, 220); // cream / warning
                 _modelUpdateBanner.Visible = false;
@@ -2202,9 +2202,11 @@ namespace GxPT
                 flow.Controls.Add(dismiss);
                 _modelUpdateBanner.Controls.Add(flow);
 
-                // Host in pnlBottom; SendToBack keeps the input box bottom-most so the banner sits above it.
+                // Host in pnlBottom. The input box (and other banners) are docked Bottom, so docking this
+                // Top pins it to the top of pnlBottom - i.e. the bottom of the transcript, directly above
+                // the input area - regardless of child add order. BringToFront so the Top dock wins.
                 this.pnlBottom.Controls.Add(_modelUpdateBanner);
-                _modelUpdateBanner.SendToBack();
+                _modelUpdateBanner.BringToFront();
 
                 // Let the input-height math account for this banner's footprint, like the other banners.
                 if (_inputManager != null) _inputManager.SetModelUpdateBanner(_modelUpdateBanner);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2151,49 +2151,63 @@ namespace GxPT
             if (_tabManager != null) _tabManager.CloseActiveConversationTab();
         }
 
-        // Build the cream notice strip and dock it at the top of the chat area (inside Panel2, above the
-        // transcript and input). Styling mirrors WorkspaceContextStrip - fixed, un-themed system chrome.
+        // Build the cream notice strip and dock it at the bottom of the chat area (in pnlBottom, just
+        // above the input - the same slot as the API-key banner). Styling mirrors WorkspaceContextStrip;
+        // the font size is matched to the rest of the UI (ThemeManager scales the API-key banner the same way).
         private void InitModelUpdateBanner()
         {
             try
             {
-                if (this.splitContainer1 == null) return;
+                if (this.pnlBottom == null) return;
 
                 _modelUpdateBanner = new System.Windows.Forms.Panel();
-                _modelUpdateBanner.Dock = DockStyle.Top;
-                _modelUpdateBanner.Height = 26;
-                _modelUpdateBanner.Padding = new Padding(8, 0, 8, 0);
+                _modelUpdateBanner.AutoSize = true;
+                _modelUpdateBanner.Dock = DockStyle.Bottom;
+                _modelUpdateBanner.Padding = new Padding(6, 4, 6, 4);
                 _modelUpdateBanner.BackColor = Color.FromArgb(252, 246, 220); // cream / warning
                 _modelUpdateBanner.Visible = false;
 
-                var links = new FlowLayoutPanel();
-                links.Dock = DockStyle.Right;
-                links.FlowDirection = FlowDirection.LeftToRight;
-                links.WrapContents = false;
-                links.AutoSize = true;
-                links.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-                links.Margin = new Padding(0);
+                // The default control font is noticeably small; match the configured chat font size so this
+                // reads like the rest of the UI (and the API-key banner, which ThemeManager scales likewise).
+                try
+                {
+                    double fs = AppSettings.GetDouble("font_size", 0);
+                    float size = (fs > 0) ? (float)Math.Max(6, Math.Min(48, fs)) : 9f;
+                    _modelUpdateBanner.Font = new Font(_modelUpdateBanner.Font.FontFamily, size, _modelUpdateBanner.Font.Style);
+                }
+                catch { }
+
+                var flow = new FlowLayoutPanel();
+                flow.AutoSize = true;
+                flow.Dock = DockStyle.Fill;
+                flow.FlowDirection = FlowDirection.LeftToRight;
+                flow.WrapContents = false;
+                flow.Margin = new Padding(0);
+
+                var text = new Label();
+                text.AutoSize = true;
+                text.TextAlign = ContentAlignment.MiddleLeft;
+                text.ForeColor = Color.FromArgb(55, 55, 55);
+                text.Margin = new Padding(3, 0, 3, 0);
+                text.Anchor = AnchorStyles.None; // vertically centered in the flow row
+                text.Text = "Updated recommended models are available.";
 
                 var review = MakeBannerLink("Review in Settings");
                 review.LinkClicked += delegate { OnModelBannerReview(); };
                 var dismiss = MakeBannerLink("Dismiss");
                 dismiss.LinkClicked += delegate { OnModelBannerDismiss(); };
-                links.Controls.Add(review);
-                links.Controls.Add(dismiss);
 
-                var text = new Label();
-                text.Dock = DockStyle.Fill;
-                text.AutoEllipsis = true;
-                text.TextAlign = ContentAlignment.MiddleLeft;
-                text.ForeColor = Color.FromArgb(55, 55, 55);
-                text.Text = "Updated recommended models are available.";
+                flow.Controls.Add(text);
+                flow.Controls.Add(review);
+                flow.Controls.Add(dismiss);
+                _modelUpdateBanner.Controls.Add(flow);
 
-                // Fill first, edge-docked links after (matches the working docking order elsewhere).
-                _modelUpdateBanner.Controls.Add(text);
-                _modelUpdateBanner.Controls.Add(links);
+                // Host in pnlBottom; SendToBack keeps the input box bottom-most so the banner sits above it.
+                this.pnlBottom.Controls.Add(_modelUpdateBanner);
+                _modelUpdateBanner.SendToBack();
 
-                this.splitContainer1.Panel2.Controls.Add(_modelUpdateBanner);
-                _modelUpdateBanner.BringToFront(); // Top dock sits above the Fill tab control
+                // Let the input-height math account for this banner's footprint, like the other banners.
+                if (_inputManager != null) _inputManager.SetModelUpdateBanner(_modelUpdateBanner);
             }
             catch { }
         }
@@ -2208,8 +2222,8 @@ namespace GxPT
             lnk.ActiveLinkColor = Color.FromArgb(0, 90, 158);
             lnk.VisitedLinkColor = Color.FromArgb(0, 90, 158);
             lnk.LinkBehavior = LinkBehavior.HoverUnderline;
-            lnk.Margin = new Padding(12, 0, 0, 0);
-            lnk.Anchor = AnchorStyles.None; // vertically centered in the flow panel
+            lnk.Margin = new Padding(12, 0, 3, 0);
+            lnk.Anchor = AnchorStyles.None; // vertically centered in the flow row
             return lnk;
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -40,6 +40,11 @@ namespace GxPT
 
         private bool _syncingModelCombo; // avoid event feedback loops when syncing combo text
 
+        // Slim cream notice at the top of the chat area, shown when the shipped recommended model list
+        // has changed since the user last acknowledged it. Built programmatically (see
+        // InitModelUpdateBanner); persists until the user reviews settings or dismisses it.
+        private System.Windows.Forms.Panel _modelUpdateBanner;
+
         // Helper DTO for background-parsed messages
         private sealed class ParsedMessage
         {
@@ -67,9 +72,14 @@ namespace GxPT
                 this.lnkOpenSettings.LinkClicked += lnkOpenSettings_LinkClicked;
             if (this.pnlApiKeyBanner != null)
                 this.pnlApiKeyBanner.Resize += (s, e) => LayoutApiKeyBanner();
+
+            // Build the "updated recommended models" banner (hidden until Load decides whether to show it).
+            InitModelUpdateBanner();
+
             this.Load += (s, e) =>
             {
                 UpdateApiKeyBanner();
+                MaybeShowModelUpdateBanner();
                 try { RestoreOpenTabsOnStartup(); }
                 catch { }
                 // After restoring tabs, if no API key is configured, open the API Keys Help tab and focus it
@@ -2139,6 +2149,102 @@ namespace GxPT
         private void closeConversationToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (_tabManager != null) _tabManager.CloseActiveConversationTab();
+        }
+
+        // Build the cream notice strip and dock it at the top of the chat area (inside Panel2, above the
+        // transcript and input). Styling mirrors WorkspaceContextStrip - fixed, un-themed system chrome.
+        private void InitModelUpdateBanner()
+        {
+            try
+            {
+                if (this.splitContainer1 == null) return;
+
+                _modelUpdateBanner = new System.Windows.Forms.Panel();
+                _modelUpdateBanner.Dock = DockStyle.Top;
+                _modelUpdateBanner.Height = 26;
+                _modelUpdateBanner.Padding = new Padding(8, 0, 8, 0);
+                _modelUpdateBanner.BackColor = Color.FromArgb(252, 246, 220); // cream / warning
+                _modelUpdateBanner.Visible = false;
+
+                var links = new FlowLayoutPanel();
+                links.Dock = DockStyle.Right;
+                links.FlowDirection = FlowDirection.LeftToRight;
+                links.WrapContents = false;
+                links.AutoSize = true;
+                links.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+                links.Margin = new Padding(0);
+
+                var review = MakeBannerLink("Review in Settings");
+                review.LinkClicked += delegate { OnModelBannerReview(); };
+                var dismiss = MakeBannerLink("Dismiss");
+                dismiss.LinkClicked += delegate { OnModelBannerDismiss(); };
+                links.Controls.Add(review);
+                links.Controls.Add(dismiss);
+
+                var text = new Label();
+                text.Dock = DockStyle.Fill;
+                text.AutoEllipsis = true;
+                text.TextAlign = ContentAlignment.MiddleLeft;
+                text.ForeColor = Color.FromArgb(55, 55, 55);
+                text.Text = "Updated recommended models are available.";
+
+                // Fill first, edge-docked links after (matches the working docking order elsewhere).
+                _modelUpdateBanner.Controls.Add(text);
+                _modelUpdateBanner.Controls.Add(links);
+
+                this.splitContainer1.Panel2.Controls.Add(_modelUpdateBanner);
+                _modelUpdateBanner.BringToFront(); // Top dock sits above the Fill tab control
+            }
+            catch { }
+        }
+
+        private static LinkLabel MakeBannerLink(string text)
+        {
+            var lnk = new LinkLabel();
+            lnk.AutoSize = true;
+            lnk.Text = text;
+            lnk.TextAlign = ContentAlignment.MiddleLeft;
+            lnk.LinkColor = Color.FromArgb(0, 90, 158);
+            lnk.ActiveLinkColor = Color.FromArgb(0, 90, 158);
+            lnk.VisitedLinkColor = Color.FromArgb(0, 90, 158);
+            lnk.LinkBehavior = LinkBehavior.HoverUnderline;
+            lnk.Margin = new Padding(12, 0, 0, 0);
+            lnk.Anchor = AnchorStyles.None; // vertically centered in the flow panel
+            return lnk;
+        }
+
+        // Show the banner when the shipped recommended list differs from what the user last acknowledged
+        // (or has never acknowledged one). The acknowledged fingerprint is only written when the user acts
+        // (reviews or dismisses), so the banner persists across launches until then.
+        private void MaybeShowModelUpdateBanner()
+        {
+            try
+            {
+                if (_modelUpdateBanner == null) return;
+                string seen = AppSettings.GetString("recommended_hash_seen");
+                string current = ModelDefaults.RecommendedHash();
+                bool show = string.IsNullOrEmpty(seen) || !string.Equals(seen, current, StringComparison.Ordinal);
+                _modelUpdateBanner.Visible = show;
+            }
+            catch { }
+        }
+
+        private void MarkRecommendedSeen()
+        {
+            try { AppSettings.SetString("recommended_hash_seen", ModelDefaults.RecommendedHash()); }
+            catch { }
+            if (_modelUpdateBanner != null) _modelUpdateBanner.Visible = false;
+        }
+
+        private void OnModelBannerDismiss()
+        {
+            MarkRecommendedSeen();
+        }
+
+        private void OnModelBannerReview()
+        {
+            MarkRecommendedSeen();
+            miSettings_Click(this, EventArgs.Empty);
         }
 
         // Center the label and link vertically within the banner panel

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -42,8 +42,8 @@
             this.lblFontSize = new System.Windows.Forms.Label();
             this.lblEnableLogging = new System.Windows.Forms.Label();
             this.txtApiKey = new System.Windows.Forms.TextBox();
-            this.txtModels = new System.Windows.Forms.TextBox();
             this.pnlModelsRow = new System.Windows.Forms.Panel();
+            this.txtModels = new System.Windows.Forms.TextBox();
             this.pnlModelsRight = new System.Windows.Forms.Panel();
             this.grpRecommended = new System.Windows.Forms.GroupBox();
             this.btnAddRecommended = new System.Windows.Forms.Button();
@@ -56,6 +56,8 @@
             this.chkEnableLogging = new System.Windows.Forms.CheckBox();
             this.lblProviderDataCollection = new System.Windows.Forms.Label();
             this.chkZdr = new System.Windows.Forms.CheckBox();
+            this.lblColor = new System.Windows.Forms.Label();
+            this.cmbColor = new System.Windows.Forms.ComboBox();
             this.lblMemoryEnabled = new System.Windows.Forms.Label();
             this.chkMemoryEnabled = new System.Windows.Forms.CheckBox();
             this.lblMemoryMaxLines = new System.Windows.Forms.Label();
@@ -63,18 +65,16 @@
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabVisual = new System.Windows.Forms.TabPage();
             this.tabJson = new System.Windows.Forms.TabPage();
-            this.lblColor = new System.Windows.Forms.Label();
-            this.cmbColor = new System.Windows.Forms.ComboBox();
             this.tabMcp = new System.Windows.Forms.TabPage();
             this.tblMcp = new System.Windows.Forms.TableLayoutPanel();
-            this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpWeb = new System.Windows.Forms.CheckBox();
             this.txtWebSearchKey = new System.Windows.Forms.TextBox();
             this.chkMcpGithub = new System.Windows.Forms.CheckBox();
             this.txtGithubPat = new System.Windows.Forms.TextBox();
+            this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpFiles = new System.Windows.Forms.CheckBox();
-            this.chkMcpGit = new System.Windows.Forms.CheckBox();
             this.chkMcpCommand = new System.Windows.Forms.CheckBox();
+            this.chkMcpGit = new System.Windows.Forms.CheckBox();
             this.chkMcpMsBuild = new System.Windows.Forms.CheckBox();
             this.lblMcpCustom = new System.Windows.Forms.Label();
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
@@ -101,7 +101,7 @@
             this.flowLayoutPanel1.Controls.Add(this.btnSave);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 389);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 437);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(604, 23);
             this.flowLayoutPanel1.TabIndex = 0;
@@ -178,7 +178,7 @@
             this.tblSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblSettings.Size = new System.Drawing.Size(590, 357);
+            this.tblSettings.Size = new System.Drawing.Size(590, 405);
             this.tblSettings.TabIndex = 2;
             // 
             // lblApiKey
@@ -196,7 +196,7 @@
             // 
             this.lblModels.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblModels.AutoSize = true;
-            this.lblModels.Location = new System.Drawing.Point(83, 6);
+            this.lblModels.Location = new System.Drawing.Point(83, 32);
             this.lblModels.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
             this.lblModels.Name = "lblModels";
             this.lblModels.Size = new System.Drawing.Size(41, 13);
@@ -217,7 +217,7 @@
             // 
             this.lblTheme.AutoSize = true;
             this.lblTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblTheme.Location = new System.Drawing.Point(3, 202);
+            this.lblTheme.Location = new System.Drawing.Point(3, 198);
             this.lblTheme.Name = "lblTheme";
             this.lblTheme.Size = new System.Drawing.Size(121, 27);
             this.lblTheme.TabIndex = 10;
@@ -228,7 +228,7 @@
             // 
             this.lblTranscriptMaxWidth.AutoSize = true;
             this.lblTranscriptMaxWidth.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblTranscriptMaxWidth.Location = new System.Drawing.Point(3, 256);
+            this.lblTranscriptMaxWidth.Location = new System.Drawing.Point(3, 252);
             this.lblTranscriptMaxWidth.Name = "lblTranscriptMaxWidth";
             this.lblTranscriptMaxWidth.Size = new System.Drawing.Size(121, 26);
             this.lblTranscriptMaxWidth.TabIndex = 12;
@@ -239,7 +239,7 @@
             // 
             this.lblMessageMaxWidth.AutoSize = true;
             this.lblMessageMaxWidth.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblMessageMaxWidth.Location = new System.Drawing.Point(3, 282);
+            this.lblMessageMaxWidth.Location = new System.Drawing.Point(3, 278);
             this.lblMessageMaxWidth.Name = "lblMessageMaxWidth";
             this.lblMessageMaxWidth.Size = new System.Drawing.Size(121, 26);
             this.lblMessageMaxWidth.TabIndex = 14;
@@ -250,7 +250,7 @@
             // 
             this.lblFontSize.AutoSize = true;
             this.lblFontSize.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblFontSize.Location = new System.Drawing.Point(3, 308);
+            this.lblFontSize.Location = new System.Drawing.Point(3, 304);
             this.lblFontSize.Name = "lblFontSize";
             this.lblFontSize.Size = new System.Drawing.Size(121, 26);
             this.lblFontSize.TabIndex = 8;
@@ -260,7 +260,7 @@
             // lblEnableLogging
             // 
             this.lblEnableLogging.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblEnableLogging.Location = new System.Drawing.Point(3, 334);
+            this.lblEnableLogging.Location = new System.Drawing.Point(3, 382);
             this.lblEnableLogging.Name = "lblEnableLogging";
             this.lblEnableLogging.Size = new System.Drawing.Size(121, 23);
             this.lblEnableLogging.TabIndex = 3;
@@ -271,72 +271,74 @@
             // 
             this.txtApiKey.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
                         | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtApiKey.Location = new System.Drawing.Point(130, 3);
+            this.txtApiKey.Location = new System.Drawing.Point(127, 3);
+            this.txtApiKey.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.txtApiKey.Name = "txtApiKey";
-            this.txtApiKey.Size = new System.Drawing.Size(457, 20);
+            this.txtApiKey.Size = new System.Drawing.Size(463, 20);
             this.txtApiKey.TabIndex = 7;
             // 
-            // txtModels
-            //
-            this.txtModels.AcceptsReturn = true;
-            this.txtModels.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtModels.Multiline = true;
-            this.txtModels.Name = "txtModels";
-            this.txtModels.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtModels.TabIndex = 6;
-            //
             // pnlModelsRow
-            //
-            // Hosts the models textbox (fills the left space) with pnlModelsRight docked to its right.
-            // txtModels is added first so it fills the area the right-docked panel leaves.
+            // 
             this.pnlModelsRow.Controls.Add(this.txtModels);
             this.pnlModelsRow.Controls.Add(this.pnlModelsRight);
             this.pnlModelsRow.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlModelsRow.Location = new System.Drawing.Point(127, 26);
             this.pnlModelsRow.Margin = new System.Windows.Forms.Padding(0);
             this.pnlModelsRow.Name = "pnlModelsRow";
+            this.pnlModelsRow.Size = new System.Drawing.Size(463, 122);
             this.pnlModelsRow.TabIndex = 20;
-            //
+            // 
+            // txtModels
+            // 
+            this.txtModels.AcceptsReturn = true;
+            this.txtModels.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtModels.Location = new System.Drawing.Point(0, 0);
+            this.txtModels.Multiline = true;
+            this.txtModels.Name = "txtModels";
+            this.txtModels.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtModels.Size = new System.Drawing.Size(274, 122);
+            this.txtModels.TabIndex = 6;
+            // 
             // pnlModelsRight
-            //
-            // Thin right column hosting the group docked to its top, so the group collapses to its own
-            // height instead of stretching to the full row height (the space below it stays empty).
+            // 
             this.pnlModelsRight.Controls.Add(this.grpRecommended);
             this.pnlModelsRight.Dock = System.Windows.Forms.DockStyle.Right;
-            // Left padding insets the (top-docked) group, leaving a gap between it and the textbox.
-            this.pnlModelsRight.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            this.pnlModelsRight.Location = new System.Drawing.Point(274, 0);
             this.pnlModelsRight.Name = "pnlModelsRight";
-            this.pnlModelsRight.Size = new System.Drawing.Size(189, 116);
+            this.pnlModelsRight.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            this.pnlModelsRight.Size = new System.Drawing.Size(189, 122);
             this.pnlModelsRight.TabIndex = 20;
-            //
+            // 
             // grpRecommended
-            //
+            // 
             this.grpRecommended.Controls.Add(this.btnAddRecommended);
             this.grpRecommended.Controls.Add(this.btnReplaceRecommended);
             this.grpRecommended.Dock = System.Windows.Forms.DockStyle.Top;
+            this.grpRecommended.Location = new System.Drawing.Point(4, 0);
             this.grpRecommended.Name = "grpRecommended";
-            this.grpRecommended.Size = new System.Drawing.Size(181, 96);
+            this.grpRecommended.Size = new System.Drawing.Size(185, 96);
             this.grpRecommended.TabIndex = 21;
             this.grpRecommended.TabStop = false;
             this.grpRecommended.Text = "Recommended models";
-            //
+            // 
             // btnAddRecommended
-            //
+            // 
             this.btnAddRecommended.Location = new System.Drawing.Point(13, 26);
             this.btnAddRecommended.Name = "btnAddRecommended";
             this.btnAddRecommended.Size = new System.Drawing.Size(150, 26);
             this.btnAddRecommended.TabIndex = 0;
             this.btnAddRecommended.Text = "Add to list";
             this.btnAddRecommended.UseVisualStyleBackColor = true;
-            //
+            // 
             // btnReplaceRecommended
-            //
+            // 
             this.btnReplaceRecommended.Location = new System.Drawing.Point(13, 60);
             this.btnReplaceRecommended.Name = "btnReplaceRecommended";
             this.btnReplaceRecommended.Size = new System.Drawing.Size(150, 26);
             this.btnReplaceRecommended.TabIndex = 1;
             this.btnReplaceRecommended.Text = "Replace list...";
             this.btnReplaceRecommended.UseVisualStyleBackColor = true;
-            //
+            // 
             // cmbDefaultModel
             // 
             this.cmbDefaultModel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -351,7 +353,7 @@
             // cmbTheme
             // 
             this.cmbTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbTheme.Location = new System.Drawing.Point(130, 205);
+            this.cmbTheme.Location = new System.Drawing.Point(130, 201);
             this.cmbTheme.Name = "cmbTheme";
             this.cmbTheme.Size = new System.Drawing.Size(120, 21);
             this.cmbTheme.TabIndex = 11;
@@ -363,7 +365,7 @@
             0,
             0,
             0});
-            this.nudTranscriptMaxWidth.Location = new System.Drawing.Point(130, 259);
+            this.nudTranscriptMaxWidth.Location = new System.Drawing.Point(130, 255);
             this.nudTranscriptMaxWidth.Maximum = new decimal(new int[] {
             1900,
             0,
@@ -390,7 +392,7 @@
             0,
             0,
             0});
-            this.nudMessageMaxWidth.Location = new System.Drawing.Point(130, 285);
+            this.nudMessageMaxWidth.Location = new System.Drawing.Point(130, 281);
             this.nudMessageMaxWidth.Minimum = new decimal(new int[] {
             50,
             0,
@@ -408,7 +410,7 @@
             // nudFontSize
             // 
             this.nudFontSize.DecimalPlaces = 2;
-            this.nudFontSize.Location = new System.Drawing.Point(130, 311);
+            this.nudFontSize.Location = new System.Drawing.Point(130, 307);
             this.nudFontSize.Name = "nudFontSize";
             this.nudFontSize.Size = new System.Drawing.Size(120, 20);
             this.nudFontSize.TabIndex = 9;
@@ -417,51 +419,97 @@
             // 
             this.chkEnableLogging.AutoSize = true;
             this.chkEnableLogging.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkEnableLogging.Location = new System.Drawing.Point(130, 340);
+            this.chkEnableLogging.Location = new System.Drawing.Point(130, 388);
             this.chkEnableLogging.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
             this.chkEnableLogging.Name = "chkEnableLogging";
             this.chkEnableLogging.Size = new System.Drawing.Size(457, 14);
             this.chkEnableLogging.TabIndex = 4;
             this.chkEnableLogging.UseVisualStyleBackColor = true;
-            //
+            // 
+            // lblProviderDataCollection
+            // 
+            this.lblProviderDataCollection.AutoSize = true;
+            this.lblProviderDataCollection.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblProviderDataCollection.Location = new System.Drawing.Point(3, 175);
+            this.lblProviderDataCollection.Name = "lblProviderDataCollection";
+            this.lblProviderDataCollection.Size = new System.Drawing.Size(121, 23);
+            this.lblProviderDataCollection.TabIndex = 16;
+            this.lblProviderDataCollection.Text = "Zero Data Retention";
+            this.lblProviderDataCollection.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // chkZdr
+            // 
+            this.chkZdr.AutoSize = true;
+            this.chkZdr.Dock = System.Windows.Forms.DockStyle.Left;
+            this.chkZdr.Location = new System.Drawing.Point(130, 178);
+            this.chkZdr.Name = "chkZdr";
+            this.chkZdr.Size = new System.Drawing.Size(299, 17);
+            this.chkZdr.TabIndex = 17;
+            this.chkZdr.Text = "Default new conversations to zero-retention providers only";
+            this.chkZdr.UseVisualStyleBackColor = true;
+            // 
+            // lblColor
+            // 
+            this.lblColor.AutoSize = true;
+            this.lblColor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblColor.Location = new System.Drawing.Point(3, 225);
+            this.lblColor.Name = "lblColor";
+            this.lblColor.Size = new System.Drawing.Size(121, 27);
+            this.lblColor.TabIndex = 18;
+            this.lblColor.Text = "Chat Color";
+            this.lblColor.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // cmbColor
+            // 
+            this.cmbColor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbColor.FormattingEnabled = true;
+            this.cmbColor.Location = new System.Drawing.Point(130, 228);
+            this.cmbColor.Name = "cmbColor";
+            this.cmbColor.Size = new System.Drawing.Size(121, 21);
+            this.cmbColor.TabIndex = 19;
+            // 
             // lblMemoryEnabled
-            //
+            // 
             this.lblMemoryEnabled.AutoSize = true;
             this.lblMemoryEnabled.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblMemoryEnabled.Location = new System.Drawing.Point(3, 330);
             this.lblMemoryEnabled.Name = "lblMemoryEnabled";
-            this.lblMemoryEnabled.Size = new System.Drawing.Size(121, 23);
+            this.lblMemoryEnabled.Size = new System.Drawing.Size(121, 26);
             this.lblMemoryEnabled.TabIndex = 20;
             this.lblMemoryEnabled.Text = "Memory";
             this.lblMemoryEnabled.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            //
+            // 
             // chkMemoryEnabled
-            //
+            // 
             this.chkMemoryEnabled.AutoSize = true;
             this.chkMemoryEnabled.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkMemoryEnabled.Location = new System.Drawing.Point(130, 336);
             this.chkMemoryEnabled.Margin = new System.Windows.Forms.Padding(3, 6, 3, 3);
             this.chkMemoryEnabled.Name = "chkMemoryEnabled";
-            this.chkMemoryEnabled.Size = new System.Drawing.Size(457, 14);
+            this.chkMemoryEnabled.Size = new System.Drawing.Size(457, 17);
             this.chkMemoryEnabled.TabIndex = 21;
             this.chkMemoryEnabled.Text = "Remember facts about my workspaces (persistent project memory)";
             this.chkMemoryEnabled.UseVisualStyleBackColor = true;
-            //
+            // 
             // lblMemoryMaxLines
-            //
+            // 
             this.lblMemoryMaxLines.AutoSize = true;
             this.lblMemoryMaxLines.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblMemoryMaxLines.Location = new System.Drawing.Point(3, 356);
             this.lblMemoryMaxLines.Name = "lblMemoryMaxLines";
             this.lblMemoryMaxLines.Size = new System.Drawing.Size(121, 26);
             this.lblMemoryMaxLines.TabIndex = 22;
             this.lblMemoryMaxLines.Text = "Memory size limit";
             this.lblMemoryMaxLines.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            //
+            // 
             // nudMemoryMaxLines
-            //
+            // 
             this.nudMemoryMaxLines.Increment = new decimal(new int[] {
             5,
             0,
             0,
             0});
+            this.nudMemoryMaxLines.Location = new System.Drawing.Point(130, 359);
             this.nudMemoryMaxLines.Maximum = new decimal(new int[] {
             500,
             0,
@@ -480,28 +528,6 @@
             0,
             0,
             0});
-            //
-            // lblProviderDataCollection
-            // 
-            this.lblProviderDataCollection.AutoSize = true;
-            this.lblProviderDataCollection.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblProviderDataCollection.Location = new System.Drawing.Point(3, 175);
-            this.lblProviderDataCollection.Name = "lblProviderDataCollection";
-            this.lblProviderDataCollection.Size = new System.Drawing.Size(121, 27);
-            this.lblProviderDataCollection.TabIndex = 16;
-            this.lblProviderDataCollection.Text = "Zero Data Retention";
-            this.lblProviderDataCollection.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            //
-            // chkZdr
-            //
-            this.chkZdr.AutoSize = true;
-            this.chkZdr.Dock = System.Windows.Forms.DockStyle.Left;
-            this.chkZdr.Location = new System.Drawing.Point(130, 178);
-            this.chkZdr.Name = "chkZdr";
-            this.chkZdr.Size = new System.Drawing.Size(300, 21);
-            this.chkZdr.TabIndex = 17;
-            this.chkZdr.Text = "Default new conversations to zero-retention providers only";
-            this.chkZdr.UseVisualStyleBackColor = true;
             // 
             // tabControl1
             // 
@@ -512,7 +538,7 @@
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(604, 389);
+            this.tabControl1.Size = new System.Drawing.Size(604, 437);
             this.tabControl1.TabIndex = 3;
             // 
             // tabVisual
@@ -521,7 +547,7 @@
             this.tabVisual.Location = new System.Drawing.Point(4, 22);
             this.tabVisual.Name = "tabVisual";
             this.tabVisual.Padding = new System.Windows.Forms.Padding(3);
-            this.tabVisual.Size = new System.Drawing.Size(596, 363);
+            this.tabVisual.Size = new System.Drawing.Size(596, 411);
             this.tabVisual.TabIndex = 0;
             this.tabVisual.Text = "Visual";
             this.tabVisual.UseVisualStyleBackColor = true;
@@ -536,9 +562,9 @@
             this.tabJson.TabIndex = 1;
             this.tabJson.Text = "JSON";
             this.tabJson.UseVisualStyleBackColor = true;
-            //
+            // 
             // tabMcp
-            //
+            // 
             this.tabMcp.Controls.Add(this.tblMcp);
             this.tabMcp.Location = new System.Drawing.Point(4, 22);
             this.tabMcp.Name = "tabMcp";
@@ -547,9 +573,9 @@
             this.tabMcp.TabIndex = 2;
             this.tabMcp.Text = "Tools";
             this.tabMcp.UseVisualStyleBackColor = true;
-            //
+            // 
             // tblMcp
-            //
+            // 
             this.tblMcp.ColumnCount = 2;
             this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -557,7 +583,6 @@
             this.tblMcp.Controls.Add(this.txtWebSearchKey, 1, 0);
             this.tblMcp.Controls.Add(this.chkMcpGithub, 0, 1);
             this.tblMcp.Controls.Add(this.txtGithubPat, 1, 1);
-            // The four key-free servers share one row, side by side.
             this.tblMcp.Controls.Add(this.tblMcpKeyless, 0, 2);
             this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 3);
             this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 4);
@@ -570,16 +595,54 @@
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tblMcp.SetColumnSpan(this.tblMcpKeyless, 2);
-            this.tblMcp.SetColumnSpan(this.lblMcpCustom, 2);
-            this.tblMcp.SetColumnSpan(this.rtbMcpJson, 2);
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
-            //
+            // 
+            // chkMcpWeb
+            // 
+            this.chkMcpWeb.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpWeb.AutoSize = true;
+            this.chkMcpWeb.Location = new System.Drawing.Point(3, 4);
+            this.chkMcpWeb.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpWeb.Name = "chkMcpWeb";
+            this.chkMcpWeb.Size = new System.Drawing.Size(84, 17);
+            this.chkMcpWeb.TabIndex = 0;
+            this.chkMcpWeb.Text = "Web search";
+            this.chkMcpWeb.UseVisualStyleBackColor = true;
+            // 
+            // txtWebSearchKey
+            // 
+            this.txtWebSearchKey.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtWebSearchKey.Location = new System.Drawing.Point(93, 3);
+            this.txtWebSearchKey.Name = "txtWebSearchKey";
+            this.txtWebSearchKey.Size = new System.Drawing.Size(494, 20);
+            this.txtWebSearchKey.TabIndex = 1;
+            // 
+            // chkMcpGithub
+            // 
+            this.chkMcpGithub.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpGithub.AutoSize = true;
+            this.chkMcpGithub.Location = new System.Drawing.Point(3, 30);
+            this.chkMcpGithub.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpGithub.Name = "chkMcpGithub";
+            this.chkMcpGithub.Size = new System.Drawing.Size(59, 17);
+            this.chkMcpGithub.TabIndex = 2;
+            this.chkMcpGithub.Text = "GitHub";
+            this.chkMcpGithub.UseVisualStyleBackColor = true;
+            // 
+            // txtGithubPat
+            // 
+            this.txtGithubPat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtGithubPat.Location = new System.Drawing.Point(93, 29);
+            this.txtGithubPat.Name = "txtGithubPat";
+            this.txtGithubPat.Size = new System.Drawing.Size(494, 20);
+            this.txtGithubPat.TabIndex = 3;
+            // 
             // tblMcpKeyless
-            //
+            // 
             this.tblMcpKeyless.AutoSize = true;
             this.tblMcpKeyless.ColumnCount = 4;
+            this.tblMcp.SetColumnSpan(this.tblMcpKeyless, 2);
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
@@ -588,136 +651,94 @@
             this.tblMcpKeyless.Controls.Add(this.chkMcpCommand, 1, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 2, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 3, 0);
+            this.tblMcpKeyless.Location = new System.Drawing.Point(0, 52);
             this.tblMcpKeyless.Margin = new System.Windows.Forms.Padding(0);
             this.tblMcpKeyless.Name = "tblMcpKeyless";
             this.tblMcpKeyless.RowCount = 1;
             this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpKeyless.Size = new System.Drawing.Size(248, 25);
             this.tblMcpKeyless.TabIndex = 4;
-            //
-            // chkMcpWeb
-            //
-            this.chkMcpWeb.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.chkMcpWeb.AutoSize = true;
-            this.chkMcpWeb.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.chkMcpWeb.Name = "chkMcpWeb";
-            this.chkMcpWeb.TabIndex = 0;
-            this.chkMcpWeb.Text = "Web search";
-            this.chkMcpWeb.UseVisualStyleBackColor = true;
-            //
-            // txtWebSearchKey
-            //
-            this.txtWebSearchKey.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtWebSearchKey.Name = "txtWebSearchKey";
-            this.txtWebSearchKey.Size = new System.Drawing.Size(450, 20);
-            this.txtWebSearchKey.TabIndex = 1;
-            //
-            // chkMcpGithub
-            //
-            this.chkMcpGithub.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.chkMcpGithub.AutoSize = true;
-            this.chkMcpGithub.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.chkMcpGithub.Name = "chkMcpGithub";
-            this.chkMcpGithub.TabIndex = 2;
-            this.chkMcpGithub.Text = "GitHub";
-            this.chkMcpGithub.UseVisualStyleBackColor = true;
-            //
-            // txtGithubPat
-            //
-            this.txtGithubPat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtGithubPat.Name = "txtGithubPat";
-            this.txtGithubPat.Size = new System.Drawing.Size(450, 20);
-            this.txtGithubPat.TabIndex = 3;
-            //
+            // 
             // chkMcpFiles
-            //
+            // 
             this.chkMcpFiles.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkMcpFiles.AutoSize = true;
+            this.chkMcpFiles.Location = new System.Drawing.Point(3, 4);
             this.chkMcpFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.chkMcpFiles.Name = "chkMcpFiles";
+            this.chkMcpFiles.Size = new System.Drawing.Size(47, 17);
             this.chkMcpFiles.TabIndex = 4;
             this.chkMcpFiles.Text = "Files";
             this.chkMcpFiles.UseVisualStyleBackColor = true;
-            //
-            // chkMcpGit
-            //
-            this.chkMcpGit.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.chkMcpGit.AutoSize = true;
-            this.chkMcpGit.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.chkMcpGit.Name = "chkMcpGit";
-            this.chkMcpGit.TabIndex = 6;
-            this.chkMcpGit.Text = "Git";
-            this.chkMcpGit.UseVisualStyleBackColor = true;
-            //
+            // 
             // chkMcpCommand
-            //
+            // 
             this.chkMcpCommand.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkMcpCommand.AutoSize = true;
+            this.chkMcpCommand.Location = new System.Drawing.Point(56, 4);
             this.chkMcpCommand.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.chkMcpCommand.Name = "chkMcpCommand";
+            this.chkMcpCommand.Size = new System.Drawing.Size(73, 17);
             this.chkMcpCommand.TabIndex = 5;
             this.chkMcpCommand.Text = "Command";
             this.chkMcpCommand.UseVisualStyleBackColor = true;
-            //
+            // 
+            // chkMcpGit
+            // 
+            this.chkMcpGit.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpGit.AutoSize = true;
+            this.chkMcpGit.Location = new System.Drawing.Point(135, 4);
+            this.chkMcpGit.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpGit.Name = "chkMcpGit";
+            this.chkMcpGit.Size = new System.Drawing.Size(39, 17);
+            this.chkMcpGit.TabIndex = 6;
+            this.chkMcpGit.Text = "Git";
+            this.chkMcpGit.UseVisualStyleBackColor = true;
+            // 
             // chkMcpMsBuild
-            //
+            // 
             this.chkMcpMsBuild.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkMcpMsBuild.AutoSize = true;
+            this.chkMcpMsBuild.Location = new System.Drawing.Point(180, 4);
             this.chkMcpMsBuild.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.chkMcpMsBuild.Name = "chkMcpMsBuild";
+            this.chkMcpMsBuild.Size = new System.Drawing.Size(65, 17);
             this.chkMcpMsBuild.TabIndex = 7;
             this.chkMcpMsBuild.Text = "MSBuild";
             this.chkMcpMsBuild.UseVisualStyleBackColor = true;
-            //
+            // 
             // lblMcpCustom
-            //
+            // 
             this.lblMcpCustom.AutoSize = true;
+            this.tblMcp.SetColumnSpan(this.lblMcpCustom, 2);
+            this.lblMcpCustom.Location = new System.Drawing.Point(3, 85);
             this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
             this.lblMcpCustom.Name = "lblMcpCustom";
+            this.lblMcpCustom.Size = new System.Drawing.Size(133, 13);
             this.lblMcpCustom.TabIndex = 8;
             this.lblMcpCustom.Text = "Custom servers (mcp.json):";
-            //
+            // 
             // rtbMcpJson
-            //
+            // 
             this.rtbMcpJson.AcceptsTab = true;
             this.rtbMcpJson.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.tblMcp.SetColumnSpan(this.rtbMcpJson, 2);
             this.rtbMcpJson.DetectUrls = false;
             this.rtbMcpJson.Dock = System.Windows.Forms.DockStyle.Fill;
             this.rtbMcpJson.Font = new System.Drawing.Font("Consolas", 9F);
             this.rtbMcpJson.HideSelection = false;
+            this.rtbMcpJson.Location = new System.Drawing.Point(3, 104);
             this.rtbMcpJson.Name = "rtbMcpJson";
-            this.rtbMcpJson.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Both;
+            this.rtbMcpJson.Size = new System.Drawing.Size(584, 250);
             this.rtbMcpJson.TabIndex = 8;
             this.rtbMcpJson.Text = "";
             this.rtbMcpJson.WordWrap = false;
-            //
-            // lblColor
-            //
-            this.lblColor.AutoSize = true;
-            this.lblColor.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblColor.Location = new System.Drawing.Point(3, 229);
-            this.lblColor.Name = "lblColor";
-            this.lblColor.Size = new System.Drawing.Size(121, 27);
-            this.lblColor.TabIndex = 18;
-            this.lblColor.Text = "Chat Color";
-            this.lblColor.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // cmbColor
-            // 
-            this.cmbColor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbColor.FormattingEnabled = true;
-            this.cmbColor.Location = new System.Drawing.Point(130, 232);
-            this.cmbColor.Name = "cmbColor";
-            this.cmbColor.Size = new System.Drawing.Size(121, 21);
-            this.cmbColor.TabIndex = 19;
             // 
             // SettingsForm
             // 
             this.AcceptButton = this.btnSave;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            // Tall enough that the Percent-sized Models row gives the textbox / Recommended-models group
-            // room for both buttons (the memory-system rows had squeezed it). MinimumSize keeps it from
-            // being resized back down into clipping.
             this.ClientSize = new System.Drawing.Size(604, 460);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.flowLayoutPanel1);
@@ -727,12 +748,12 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
             this.flowLayoutPanel1.ResumeLayout(false);
-            this.grpRecommended.ResumeLayout(false);
-            this.pnlModelsRight.ResumeLayout(false);
-            this.pnlModelsRow.ResumeLayout(false);
-            this.pnlModelsRow.PerformLayout();
             this.tblSettings.ResumeLayout(false);
             this.tblSettings.PerformLayout();
+            this.pnlModelsRow.ResumeLayout(false);
+            this.pnlModelsRow.PerformLayout();
+            this.pnlModelsRight.ResumeLayout(false);
+            this.grpRecommended.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMessageMaxWidth)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudFontSize)).EndInit();
@@ -741,7 +762,6 @@
             this.tabVisual.ResumeLayout(false);
             this.tabJson.ResumeLayout(false);
             this.tabMcp.ResumeLayout(false);
-            this.tabMcp.PerformLayout();
             this.tblMcp.ResumeLayout(false);
             this.tblMcp.PerformLayout();
             this.tblMcpKeyless.ResumeLayout(false);

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -302,8 +302,10 @@
             // height instead of stretching to the full row height (the space below it stays empty).
             this.pnlModelsRight.Controls.Add(this.grpRecommended);
             this.pnlModelsRight.Dock = System.Windows.Forms.DockStyle.Right;
+            // Left padding insets the (top-docked) group, leaving a gap between it and the textbox.
+            this.pnlModelsRight.Padding = new System.Windows.Forms.Padding(8, 0, 0, 0);
             this.pnlModelsRight.Name = "pnlModelsRight";
-            this.pnlModelsRight.Size = new System.Drawing.Size(181, 116);
+            this.pnlModelsRight.Size = new System.Drawing.Size(189, 116);
             this.pnlModelsRight.TabIndex = 20;
             //
             // grpRecommended

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -43,7 +43,7 @@
             this.lblEnableLogging = new System.Windows.Forms.Label();
             this.txtApiKey = new System.Windows.Forms.TextBox();
             this.txtModels = new System.Windows.Forms.TextBox();
-            this.pnlModelsLeft = new System.Windows.Forms.Panel();
+            this.pnlModelsRow = new System.Windows.Forms.Panel();
             this.grpRecommended = new System.Windows.Forms.GroupBox();
             this.btnAddRecommended = new System.Windows.Forms.Button();
             this.btnReplaceRecommended = new System.Windows.Forms.Button();
@@ -79,7 +79,7 @@
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
             this.tblSettings.SuspendLayout();
-            this.pnlModelsLeft.SuspendLayout();
+            this.pnlModelsRow.SuspendLayout();
             this.grpRecommended.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMessageMaxWidth)).BeginInit();
@@ -134,13 +134,10 @@
             // tblSettings
             // 
             this.tblSettings.ColumnCount = 2;
-            // Fixed width on the label column so the "Recommended models" group fits beneath the Models
-            // label without forcing the column to auto-grow unpredictably. txtModels is anchored
-            // Left|Right (below) so it shrinks to fit the remaining space rather than clipping.
-            this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 175F));
+            this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblSettings.Controls.Add(this.lblApiKey, 0, 0);
-            this.tblSettings.Controls.Add(this.pnlModelsLeft, 0, 1);
+            this.tblSettings.Controls.Add(this.lblModels, 0, 1);
             this.tblSettings.Controls.Add(this.lblDefaultModel, 0, 2);
             this.tblSettings.Controls.Add(this.lblTheme, 0, 4);
             this.tblSettings.Controls.Add(this.lblTranscriptMaxWidth, 0, 6);
@@ -148,7 +145,7 @@
             this.tblSettings.Controls.Add(this.lblFontSize, 0, 8);
             this.tblSettings.Controls.Add(this.lblEnableLogging, 0, 11);
             this.tblSettings.Controls.Add(this.txtApiKey, 1, 0);
-            this.tblSettings.Controls.Add(this.txtModels, 1, 1);
+            this.tblSettings.Controls.Add(this.pnlModelsRow, 1, 1);
             this.tblSettings.Controls.Add(this.cmbDefaultModel, 1, 2);
             this.tblSettings.Controls.Add(this.cmbTheme, 1, 4);
             this.tblSettings.Controls.Add(this.nudTranscriptMaxWidth, 1, 6);
@@ -197,7 +194,7 @@
             // 
             this.lblModels.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblModels.AutoSize = true;
-            this.lblModels.Location = new System.Drawing.Point(126, 6);
+            this.lblModels.Location = new System.Drawing.Point(83, 6);
             this.lblModels.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
             this.lblModels.Name = "lblModels";
             this.lblModels.Size = new System.Drawing.Size(41, 13);
@@ -280,50 +277,49 @@
             // txtModels
             //
             this.txtModels.AcceptsReturn = true;
-            this.txtModels.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtModels.Location = new System.Drawing.Point(130, 29);
+            this.txtModels.Dock = System.Windows.Forms.DockStyle.Fill;
             this.txtModels.Multiline = true;
             this.txtModels.Name = "txtModels";
             this.txtModels.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtModels.Size = new System.Drawing.Size(457, 116);
             this.txtModels.TabIndex = 6;
             //
-            // pnlModelsLeft
+            // pnlModelsRow
             //
-            this.pnlModelsLeft.Controls.Add(this.lblModels);
-            this.pnlModelsLeft.Controls.Add(this.grpRecommended);
-            this.pnlModelsLeft.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlModelsLeft.Margin = new System.Windows.Forms.Padding(0);
-            this.pnlModelsLeft.Name = "pnlModelsLeft";
-            this.pnlModelsLeft.TabIndex = 20;
+            // Hosts the models textbox (fills the left space) with the "Recommended models" group docked
+            // to its right. txtModels is added first so it fills the area the right-docked group leaves.
+            this.pnlModelsRow.Controls.Add(this.txtModels);
+            this.pnlModelsRow.Controls.Add(this.grpRecommended);
+            this.pnlModelsRow.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlModelsRow.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlModelsRow.Name = "pnlModelsRow";
+            this.pnlModelsRow.TabIndex = 20;
             //
             // grpRecommended
             //
-            this.grpRecommended.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.grpRecommended.Controls.Add(this.btnAddRecommended);
             this.grpRecommended.Controls.Add(this.btnReplaceRecommended);
-            this.grpRecommended.Location = new System.Drawing.Point(4, 30);
+            this.grpRecommended.Dock = System.Windows.Forms.DockStyle.Right;
+            this.grpRecommended.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
             this.grpRecommended.Name = "grpRecommended";
-            this.grpRecommended.Size = new System.Drawing.Size(165, 86);
+            this.grpRecommended.Size = new System.Drawing.Size(178, 116);
             this.grpRecommended.TabIndex = 21;
             this.grpRecommended.TabStop = false;
             this.grpRecommended.Text = "Recommended models";
             //
             // btnAddRecommended
             //
-            this.btnAddRecommended.Location = new System.Drawing.Point(10, 22);
+            this.btnAddRecommended.Location = new System.Drawing.Point(13, 26);
             this.btnAddRecommended.Name = "btnAddRecommended";
-            this.btnAddRecommended.Size = new System.Drawing.Size(145, 25);
+            this.btnAddRecommended.Size = new System.Drawing.Size(150, 26);
             this.btnAddRecommended.TabIndex = 0;
             this.btnAddRecommended.Text = "Add to list";
             this.btnAddRecommended.UseVisualStyleBackColor = true;
             //
             // btnReplaceRecommended
             //
-            this.btnReplaceRecommended.Location = new System.Drawing.Point(10, 52);
+            this.btnReplaceRecommended.Location = new System.Drawing.Point(13, 60);
             this.btnReplaceRecommended.Name = "btnReplaceRecommended";
-            this.btnReplaceRecommended.Size = new System.Drawing.Size(145, 25);
+            this.btnReplaceRecommended.Size = new System.Drawing.Size(150, 26);
             this.btnReplaceRecommended.TabIndex = 1;
             this.btnReplaceRecommended.Text = "Replace list...";
             this.btnReplaceRecommended.UseVisualStyleBackColor = true;
@@ -715,8 +711,8 @@
             this.Text = "Settings";
             this.flowLayoutPanel1.ResumeLayout(false);
             this.grpRecommended.ResumeLayout(false);
-            this.pnlModelsLeft.ResumeLayout(false);
-            this.pnlModelsLeft.PerformLayout();
+            this.pnlModelsRow.ResumeLayout(false);
+            this.pnlModelsRow.PerformLayout();
             this.tblSettings.ResumeLayout(false);
             this.tblSettings.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).EndInit();
@@ -750,7 +746,7 @@
         private System.Windows.Forms.CheckBox chkEnableLogging;
         private System.Windows.Forms.ComboBox cmbDefaultModel;
         private System.Windows.Forms.TextBox txtModels;
-        private System.Windows.Forms.Panel pnlModelsLeft;
+        private System.Windows.Forms.Panel pnlModelsRow;
         private System.Windows.Forms.GroupBox grpRecommended;
         private System.Windows.Forms.Button btnAddRecommended;
         private System.Windows.Forms.Button btnReplaceRecommended;

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -303,7 +303,7 @@
             this.pnlModelsRight.Controls.Add(this.grpRecommended);
             this.pnlModelsRight.Dock = System.Windows.Forms.DockStyle.Right;
             // Left padding insets the (top-docked) group, leaving a gap between it and the textbox.
-            this.pnlModelsRight.Padding = new System.Windows.Forms.Padding(8, 0, 0, 0);
+            this.pnlModelsRight.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
             this.pnlModelsRight.Name = "pnlModelsRight";
             this.pnlModelsRight.Size = new System.Drawing.Size(189, 116);
             this.pnlModelsRight.TabIndex = 20;

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -44,6 +44,7 @@
             this.txtApiKey = new System.Windows.Forms.TextBox();
             this.txtModels = new System.Windows.Forms.TextBox();
             this.pnlModelsRow = new System.Windows.Forms.Panel();
+            this.pnlModelsRight = new System.Windows.Forms.Panel();
             this.grpRecommended = new System.Windows.Forms.GroupBox();
             this.btnAddRecommended = new System.Windows.Forms.Button();
             this.btnReplaceRecommended = new System.Windows.Forms.Button();
@@ -80,6 +81,7 @@
             this.flowLayoutPanel1.SuspendLayout();
             this.tblSettings.SuspendLayout();
             this.pnlModelsRow.SuspendLayout();
+            this.pnlModelsRight.SuspendLayout();
             this.grpRecommended.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMessageMaxWidth)).BeginInit();
@@ -285,23 +287,32 @@
             //
             // pnlModelsRow
             //
-            // Hosts the models textbox (fills the left space) with the "Recommended models" group docked
-            // to its right. txtModels is added first so it fills the area the right-docked group leaves.
+            // Hosts the models textbox (fills the left space) with pnlModelsRight docked to its right.
+            // txtModels is added first so it fills the area the right-docked panel leaves.
             this.pnlModelsRow.Controls.Add(this.txtModels);
-            this.pnlModelsRow.Controls.Add(this.grpRecommended);
+            this.pnlModelsRow.Controls.Add(this.pnlModelsRight);
             this.pnlModelsRow.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlModelsRow.Margin = new System.Windows.Forms.Padding(0);
             this.pnlModelsRow.Name = "pnlModelsRow";
             this.pnlModelsRow.TabIndex = 20;
             //
+            // pnlModelsRight
+            //
+            // Thin right column hosting the group docked to its top, so the group collapses to its own
+            // height instead of stretching to the full row height (the space below it stays empty).
+            this.pnlModelsRight.Controls.Add(this.grpRecommended);
+            this.pnlModelsRight.Dock = System.Windows.Forms.DockStyle.Right;
+            this.pnlModelsRight.Name = "pnlModelsRight";
+            this.pnlModelsRight.Size = new System.Drawing.Size(181, 116);
+            this.pnlModelsRight.TabIndex = 20;
+            //
             // grpRecommended
             //
             this.grpRecommended.Controls.Add(this.btnAddRecommended);
             this.grpRecommended.Controls.Add(this.btnReplaceRecommended);
-            this.grpRecommended.Dock = System.Windows.Forms.DockStyle.Right;
-            this.grpRecommended.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.grpRecommended.Dock = System.Windows.Forms.DockStyle.Top;
             this.grpRecommended.Name = "grpRecommended";
-            this.grpRecommended.Size = new System.Drawing.Size(178, 116);
+            this.grpRecommended.Size = new System.Drawing.Size(181, 96);
             this.grpRecommended.TabIndex = 21;
             this.grpRecommended.TabStop = false;
             this.grpRecommended.Text = "Recommended models";
@@ -715,6 +726,7 @@
             this.Text = "Settings";
             this.flowLayoutPanel1.ResumeLayout(false);
             this.grpRecommended.ResumeLayout(false);
+            this.pnlModelsRight.ResumeLayout(false);
             this.pnlModelsRow.ResumeLayout(false);
             this.pnlModelsRow.PerformLayout();
             this.tblSettings.ResumeLayout(false);
@@ -751,6 +763,7 @@
         private System.Windows.Forms.ComboBox cmbDefaultModel;
         private System.Windows.Forms.TextBox txtModels;
         private System.Windows.Forms.Panel pnlModelsRow;
+        private System.Windows.Forms.Panel pnlModelsRight;
         private System.Windows.Forms.GroupBox grpRecommended;
         private System.Windows.Forms.Button btnAddRecommended;
         private System.Windows.Forms.Button btnReplaceRecommended;

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -702,10 +702,14 @@
             this.AcceptButton = this.btnSave;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(604, 412);
+            // Tall enough that the Percent-sized Models row gives the textbox / Recommended-models group
+            // room for both buttons (the memory-system rows had squeezed it). MinimumSize keeps it from
+            // being resized back down into clipping.
+            this.ClientSize = new System.Drawing.Size(604, 460);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MinimumSize = new System.Drawing.Size(620, 498);
             this.Name = "SettingsForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -43,6 +43,10 @@
             this.lblEnableLogging = new System.Windows.Forms.Label();
             this.txtApiKey = new System.Windows.Forms.TextBox();
             this.txtModels = new System.Windows.Forms.TextBox();
+            this.pnlModelsLeft = new System.Windows.Forms.Panel();
+            this.grpRecommended = new System.Windows.Forms.GroupBox();
+            this.btnAddRecommended = new System.Windows.Forms.Button();
+            this.btnReplaceRecommended = new System.Windows.Forms.Button();
             this.cmbDefaultModel = new System.Windows.Forms.ComboBox();
             this.cmbTheme = new System.Windows.Forms.ComboBox();
             this.nudTranscriptMaxWidth = new System.Windows.Forms.NumericUpDown();
@@ -75,6 +79,8 @@
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
             this.tblSettings.SuspendLayout();
+            this.pnlModelsLeft.SuspendLayout();
+            this.grpRecommended.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMessageMaxWidth)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudFontSize)).BeginInit();
@@ -128,10 +134,13 @@
             // tblSettings
             // 
             this.tblSettings.ColumnCount = 2;
-            this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            // Fixed width on the label column so the "Recommended models" group fits beneath the Models
+            // label without forcing the column to auto-grow unpredictably. txtModels is anchored
+            // Left|Right (below) so it shrinks to fit the remaining space rather than clipping.
+            this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 175F));
             this.tblSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblSettings.Controls.Add(this.lblApiKey, 0, 0);
-            this.tblSettings.Controls.Add(this.lblModels, 0, 1);
+            this.tblSettings.Controls.Add(this.pnlModelsLeft, 0, 1);
             this.tblSettings.Controls.Add(this.lblDefaultModel, 0, 2);
             this.tblSettings.Controls.Add(this.lblTheme, 0, 4);
             this.tblSettings.Controls.Add(this.lblTranscriptMaxWidth, 0, 6);
@@ -188,7 +197,7 @@
             // 
             this.lblModels.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblModels.AutoSize = true;
-            this.lblModels.Location = new System.Drawing.Point(83, 32);
+            this.lblModels.Location = new System.Drawing.Point(126, 6);
             this.lblModels.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
             this.lblModels.Name = "lblModels";
             this.lblModels.Size = new System.Drawing.Size(41, 13);
@@ -269,15 +278,56 @@
             this.txtApiKey.TabIndex = 7;
             // 
             // txtModels
-            // 
+            //
             this.txtModels.AcceptsReturn = true;
+            this.txtModels.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
             this.txtModels.Location = new System.Drawing.Point(130, 29);
             this.txtModels.Multiline = true;
             this.txtModels.Name = "txtModels";
             this.txtModels.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.txtModels.Size = new System.Drawing.Size(457, 116);
             this.txtModels.TabIndex = 6;
-            // 
+            //
+            // pnlModelsLeft
+            //
+            this.pnlModelsLeft.Controls.Add(this.lblModels);
+            this.pnlModelsLeft.Controls.Add(this.grpRecommended);
+            this.pnlModelsLeft.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlModelsLeft.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlModelsLeft.Name = "pnlModelsLeft";
+            this.pnlModelsLeft.TabIndex = 20;
+            //
+            // grpRecommended
+            //
+            this.grpRecommended.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpRecommended.Controls.Add(this.btnAddRecommended);
+            this.grpRecommended.Controls.Add(this.btnReplaceRecommended);
+            this.grpRecommended.Location = new System.Drawing.Point(4, 30);
+            this.grpRecommended.Name = "grpRecommended";
+            this.grpRecommended.Size = new System.Drawing.Size(165, 86);
+            this.grpRecommended.TabIndex = 21;
+            this.grpRecommended.TabStop = false;
+            this.grpRecommended.Text = "Recommended models";
+            //
+            // btnAddRecommended
+            //
+            this.btnAddRecommended.Location = new System.Drawing.Point(10, 22);
+            this.btnAddRecommended.Name = "btnAddRecommended";
+            this.btnAddRecommended.Size = new System.Drawing.Size(145, 25);
+            this.btnAddRecommended.TabIndex = 0;
+            this.btnAddRecommended.Text = "Add to list";
+            this.btnAddRecommended.UseVisualStyleBackColor = true;
+            //
+            // btnReplaceRecommended
+            //
+            this.btnReplaceRecommended.Location = new System.Drawing.Point(10, 52);
+            this.btnReplaceRecommended.Name = "btnReplaceRecommended";
+            this.btnReplaceRecommended.Size = new System.Drawing.Size(145, 25);
+            this.btnReplaceRecommended.TabIndex = 1;
+            this.btnReplaceRecommended.Text = "Replace list...";
+            this.btnReplaceRecommended.UseVisualStyleBackColor = true;
+            //
             // cmbDefaultModel
             // 
             this.cmbDefaultModel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -664,6 +714,9 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.grpRecommended.ResumeLayout(false);
+            this.pnlModelsLeft.ResumeLayout(false);
+            this.pnlModelsLeft.PerformLayout();
             this.tblSettings.ResumeLayout(false);
             this.tblSettings.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudTranscriptMaxWidth)).EndInit();
@@ -697,6 +750,10 @@
         private System.Windows.Forms.CheckBox chkEnableLogging;
         private System.Windows.Forms.ComboBox cmbDefaultModel;
         private System.Windows.Forms.TextBox txtModels;
+        private System.Windows.Forms.Panel pnlModelsLeft;
+        private System.Windows.Forms.GroupBox grpRecommended;
+        private System.Windows.Forms.Button btnAddRecommended;
+        private System.Windows.Forms.Button btnReplaceRecommended;
         private System.Windows.Forms.TextBox txtApiKey;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabVisual;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -990,6 +990,10 @@ namespace GxPT
                 }
             }
             catch { }
+
+            // Load runs with _isSyncing set, which suppresses TxtModels_TextChanged, so set the
+            // recommended-models button states explicitly here.
+            UpdateRecommendedButtonStates();
         }
 
         private void CaptureVisualControlsToSettings(SettingsData target)
@@ -1101,14 +1105,10 @@ namespace GxPT
                 if (seen.Add(m)) { result.Add(m); added = true; }
             }
 
-            if (!added)
-            {
-                MessageBox.Show(this, "Your list already includes all of GxPT's recommended models.",
-                    "Recommended models", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
-            }
+            // The button is disabled when there's nothing to add, so this is just a guard.
+            if (!added) return;
 
-            // Setting Lines fires TxtModels_TextChanged, which refreshes the default-model combo.
+            // Setting Lines fires TxtModels_TextChanged, which refreshes the combo and button states.
             this.txtModels.Lines = result.ToArray();
         }
 
@@ -1124,6 +1124,53 @@ namespace GxPT
             if (answer != DialogResult.OK) return;
 
             this.txtModels.Lines = (string[])ModelDefaults.Models.Clone();
+        }
+
+        // Enable the recommended-models buttons based on how the current list compares to the shipped
+        // catalog (independent of the acknowledged-hash that drives the banner). "Add to list" is enabled
+        // whenever a recommended model is missing; "Replace list..." whenever the list isn't already
+        // exactly the recommended set/order - so it doubles as a "reset to default" even after the user
+        // applied the recommendations and then tweaked them.
+        private void UpdateRecommendedButtonStates()
+        {
+            try
+            {
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var current = new List<string>();
+                if (this.txtModels.Lines != null)
+                {
+                    foreach (var line in this.txtModels.Lines)
+                    {
+                        if (line == null) continue;
+                        var t = line.Trim();
+                        if (t.Length == 0) continue;
+                        if (seen.Add(t)) current.Add(t);
+                    }
+                }
+
+                bool anyMissing = false;
+                foreach (var m in ModelDefaults.Models)
+                {
+                    if (!seen.Contains(m)) { anyMissing = true; break; }
+                }
+
+                bool matchesRecommended = (current.Count == ModelDefaults.Models.Length);
+                if (matchesRecommended)
+                {
+                    for (int i = 0; i < current.Count; i++)
+                    {
+                        if (!string.Equals(current[i], ModelDefaults.Models[i], StringComparison.OrdinalIgnoreCase))
+                        {
+                            matchesRecommended = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (this.btnAddRecommended != null) this.btnAddRecommended.Enabled = anyMissing;
+                if (this.btnReplaceRecommended != null) this.btnReplaceRecommended.Enabled = !matchesRecommended;
+            }
+            catch { }
         }
 
         // When the models textbox changes, add any new non-empty lines to the default model combo box
@@ -1173,6 +1220,8 @@ namespace GxPT
             {
                 this.cmbDefaultModel.EndUpdate();
             }
+
+            UpdateRecommendedButtonStates();
         }
 
         // Ensure working copy is current before saving

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -105,6 +105,23 @@ namespace GxPT
             // Keep default model list updated as models are typed
             this.txtModels.TextChanged += TxtModels_TextChanged;
 
+            // "Recommended models" group: bring the user's list in line with the shipped catalog.
+            // Both buttons edit the textbox only; nothing persists until Save (so the user can review
+            // or back out). Tooltips carry the "why" (append vs. replace, and the deprecated-model cleanup).
+            if (this.btnAddRecommended != null)
+                this.btnAddRecommended.Click += BtnAddRecommended_Click;
+            if (this.btnReplaceRecommended != null)
+                this.btnReplaceRecommended.Click += BtnReplaceRecommended_Click;
+            try
+            {
+                _mcpTip.SetToolTip(this.btnAddRecommended,
+                    "Add GxPT's recommended models that aren't already in your list. Keeps everything you have.");
+                _mcpTip.SetToolTip(this.btnReplaceRecommended,
+                    "Replace your list with GxPT's latest recommended models, removing any that are no longer "
+                    + "available. Nothing is saved until you click Save.");
+            }
+            catch { }
+
             // JSON editor changed -> debounce highlight
             _jsonHighlightTimer = new Timer();
             _jsonHighlightTimer.Interval = 200; // ms
@@ -210,6 +227,9 @@ namespace GxPT
             }
             sb.AppendLine("  ],");
             sb.AppendLine("  \"default_model\": \"" + ModelDefaults.DefaultModel + "\",");
+            // Seed the acknowledged-recommendations fingerprint so a fresh install (which already ships
+            // with the current catalog) doesn't immediately show the "updated models" banner.
+            sb.AppendLine("  \"recommended_hash_seen\": \"" + ModelDefaults.RecommendedHash() + "\",");
             sb.AppendLine("  \"theme\": \"light\",");
             // Default UI color theme
             sb.AppendLine("  \"color_theme\": \"blue\",");
@@ -253,6 +273,7 @@ namespace GxPT
                 openrouter_api_key = "",
                 models = ModelDefaults.ModelList(),
                 default_model = ModelDefaults.DefaultModel,
+                recommended_hash_seen = ModelDefaults.RecommendedHash(),
                 enable_logging = false,
                 font_size = GetChatDefaultFontSize(),
                 theme = "light",
@@ -1057,6 +1078,54 @@ namespace GxPT
             catch { if (target.message_max_width <= 0) target.message_max_width = 90; }
         }
 
+        // Append any recommended models the user doesn't already have, preserving their existing list
+        // and order. Case-insensitive de-dupe mirrors PostProcess so the textbox stays clean.
+        private void BtnAddRecommended_Click(object sender, EventArgs e)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var result = new List<string>();
+            if (this.txtModels.Lines != null)
+            {
+                foreach (var line in this.txtModels.Lines)
+                {
+                    if (line == null) continue;
+                    var t = line.Trim();
+                    if (t.Length == 0) continue;
+                    if (seen.Add(t)) result.Add(t);
+                }
+            }
+
+            bool added = false;
+            foreach (var m in ModelDefaults.Models)
+            {
+                if (seen.Add(m)) { result.Add(m); added = true; }
+            }
+
+            if (!added)
+            {
+                MessageBox.Show(this, "Your list already includes all of GxPT's recommended models.",
+                    "Recommended models", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            // Setting Lines fires TxtModels_TextChanged, which refreshes the default-model combo.
+            this.txtModels.Lines = result.ToArray();
+        }
+
+        // Replace the entire list with the shipped catalog. Confirmed because it discards the user's
+        // customizations; the actual write still waits for Save.
+        private void BtnReplaceRecommended_Click(object sender, EventArgs e)
+        {
+            var answer = MessageBox.Show(this,
+                "Replace your entire model list with GxPT's latest recommended models?\r\n\r\n"
+                + "This removes any models you've added, including ones that may no longer be available. "
+                + "Nothing is saved until you click Save.",
+                "Replace model list", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+            if (answer != DialogResult.OK) return;
+
+            this.txtModels.Lines = (string[])ModelDefaults.Models.Clone();
+        }
+
         // When the models textbox changes, add any new non-empty lines to the default model combo box
         private void TxtModels_TextChanged(object sender, EventArgs e)
         {
@@ -1343,6 +1412,10 @@ namespace GxPT
             public string openrouter_api_key { get; set; }
             public List<string> models { get; set; }
             public string default_model { get; set; }
+            // Fingerprint (ModelDefaults.RecommendedHash) of the recommended catalog the user has
+            // acknowledged. Carried through here so saving settings doesn't drop the key the
+            // "updated recommended models" banner relies on. Not surfaced in the visual editor.
+            public string recommended_hash_seen { get; set; }
             public bool enable_logging { get; set; }
             public double font_size { get; set; }
             public string theme { get; set; }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -105,6 +105,10 @@ namespace GxPT
             // Keep default model list updated as models are typed
             this.txtModels.TextChanged += TxtModels_TextChanged;
 
+            // A multiline TextBox doesn't wire up Ctrl+A select-all natively (the single-line API key
+            // box does), so handle it here.
+            this.txtModels.KeyDown += TxtModels_KeyDown;
+
             // "Recommended models" group: bring the user's list in line with the shipped catalog.
             // Both buttons edit the textbox only; nothing persists until Save (so the user can review
             // or back out). Tooltips carry the "why" (append vs. replace, and the deprecated-model cleanup).
@@ -1174,6 +1178,16 @@ namespace GxPT
         }
 
         // When the models textbox changes, add any new non-empty lines to the default model combo box
+        private void TxtModels_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.A)
+            {
+                this.txtModels.SelectAll();
+                e.SuppressKeyPress = true; // prevent the ding and the default (no-op) handling
+                e.Handled = true;
+            }
+        }
+
         private void TxtModels_TextChanged(object sender, EventArgs e)
         {
             if (_isSyncing) return;

--- a/GxPT/Managers/InputManager.cs
+++ b/GxPT/Managers/InputManager.cs
@@ -18,6 +18,9 @@ namespace GxPT
         private readonly SplitContainer _splitContainer;
         private readonly Panel _pnlApiKeyBanner;
         private readonly Panel _pnlAttachmentsBanner;
+        // Optional extra banner hosted in pnlBottom (the "updated recommended models" notice), registered
+        // after construction because it is built programmatically once the managers already exist.
+        private Panel _pnlModelUpdateBanner;
 
         // Automatic property with both getter and setter
         public bool TextIsHint { get; private set; }
@@ -37,6 +40,24 @@ namespace GxPT
 
             InitializeInput();
             WireEvents();
+        }
+
+        // Register the (programmatically built) model-update banner so its footprint is included in the
+        // available-height math and the input box reflows when it shows/hides.
+        public void SetModelUpdateBanner(Panel banner)
+        {
+            _pnlModelUpdateBanner = banner;
+            try
+            {
+                if (banner != null)
+                {
+                    banner.VisibleChanged += (s, e) => AdjustInputBoxHeight();
+                    banner.Resize += (s, e) => AdjustInputBoxHeight();
+                }
+            }
+            catch { }
+            try { AdjustInputBoxHeight(); }
+            catch { }
         }
 
         // Programmatically set the input text and optionally focus the input box.
@@ -222,6 +243,9 @@ namespace GxPT
                 // Subtract attachments banner if present
                 if (_pnlAttachmentsBanner != null && _pnlAttachmentsBanner.Visible)
                     h = Math.Max(0, h - _pnlAttachmentsBanner.Height);
+                // Subtract the model-update banner if present (also hosted in pnlBottom)
+                if (_pnlModelUpdateBanner != null && _pnlModelUpdateBanner.Visible)
+                    h = Math.Max(0, h - _pnlModelUpdateBanner.Height);
                 return Math.Max(0, h);
             }
             catch

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace GxPT
 {
@@ -38,6 +41,25 @@ namespace GxPT
         public static List<string> ModelList()
         {
             return new List<string>(Models);
+        }
+
+        // Content-derived fingerprint of the recommended catalog. The list is sorted before hashing
+        // so that cosmetic reordering doesn't change the result - only a genuine add/remove does. This
+        // is what drives the "updated recommended models" banner: callers compare it to the last value
+        // the user acknowledged (recommended_hash_seen). Editing Models above changes this automatically,
+        // so there is no version number to bump by hand.
+        public static string RecommendedHash()
+        {
+            var sorted = (string[])Models.Clone();
+            Array.Sort(sorted, StringComparer.Ordinal);
+            string joined = string.Join("\n", sorted);
+            using (var sha = SHA256.Create())
+            {
+                byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(joined));
+                var sb = new StringBuilder(16);
+                for (int i = 0; i < 8 && i < hash.Length; i++) sb.Append(hash[i].ToString("x2"));
+                return sb.ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Existing users' model lists are never overwritten on update, so models that have since been deprecated linger in their list with no easy way to refresh. This adds two ways to bring a list back in line with GxPT's shipped catalog, plus a one-time nudge when the catalog changes.

### Settings → Visual: "Recommended models" group
A group box to the right of the models textbox with two actions, both of which edit the textbox only — nothing is saved until **Save**, so the user can review or back out:

- **Add to list** — appends any recommended models missing from the list (case-insensitive de-dupe), keeping everything the user has.
- **Replace list…** — replaces the list with the shipped catalog (confirmation dialog; clears deprecated entries).

The buttons enable/disable by **content**, independent of the banner's acknowledged-hash:
- *Add to list* is enabled whenever a recommended model is missing.
- *Replace list…* is enabled whenever the list isn't already exactly the recommended set/order — so it doubles as a **"reset to default"** even after the user applied the recommendations and then tweaked them.

### Update banner
A dismissible cream notice docked at the bottom of the transcript / above the input (same slot and font as the API-key banner). It appears when the shipped catalog differs from what the user last acknowledged, links to **Settings**, and can be dismissed; either action records acknowledgement.

Acknowledgement is tracked via `ModelDefaults.RecommendedHash()` — a content hash of the **sorted** catalog, stored as `recommended_hash_seen`. The list is therefore its own version (no number to bump by hand), and reordering doesn't trigger a false alarm. Fresh installs seed the current hash so they aren't nudged about models they already ship with, and the key round-trips through `SettingsData` so saving settings doesn't drop it.

### Misc
- Ctrl+A now selects all in the (multiline) models textbox — it doesn't wire that up natively the way the single-line API-key box does.
- Settings dialog grown so the Models row gives the textbox/group enough height (the memory-system rows had squeezed it), with a `MinimumSize` floor; group collapses to its content height; small gap between the textbox and the group.

## Implementation notes
- `ModelDefaults` stays the single source of truth for the catalog; `RecommendedHash()` derives from it.
- The Settings buttons operate on `txtModels` (reusing the existing de-dupe / combo-refresh path); button states refresh on load and on every edit.
- `InputManager` accounts for the banner's footprint in the input-height math, like the existing API-key/attachments banners.

## Testing
Built and exercised on Windows (this is a .NET 3.5 WinForms app). Worth a sanity check on: the banner showing once for existing users and clearing after review/dismiss, and the enable/disable behavior as the list is edited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCW9cXnkfiKPuy4QLeGsSk)_