### PR TITLE
Clarify memory summary/detail guidance (avoid needless detail files)

### DIFF
--- a/servers/MemoryMcpServer/MemoryTools.cs
+++ b/servers/MemoryMcpServer/MemoryTools.cs
@@ -23,16 +23,19 @@ namespace MemoryMcpServer
                 + "line to the always-loaded memory index and never overwrites an existing memory (use "
                 + "update_memory to change one - a duplicate name is rejected). Use it for durable, "
                 + "reusable facts worth recalling in future conversations (conventions, architecture, "
-                + "decisions, gotchas). Optionally include 'detail' for a longer note stored separately "
-                + "and read on demand.",
+                + "decisions, gotchas). Most memories need only the one-line summary; add 'detail' only "
+                + "when a single line cannot capture it.",
                 SchemaBuilder.Object()
                     .Str("name", true, "Short handle in kebab-case: lowercase words joined by single "
                         + "hyphens (e.g. auth-flow), at most 5 words. It is normalized to kebab-case "
                         + "automatically. Must not match an existing memory.")
-                    .Str("summary", true, "A single concise line describing the memory, shown in the "
-                        + "always-loaded index. Keep it short.")
-                    .Str("detail", false, "Optional longer note stored in <name>.md and retrieved with "
-                        + "read_memory.")
+                    .Str("summary", true, "A single concise line capturing the memory, shown in the "
+                        + "always-loaded index. For a simple fact this is the whole memory - no detail "
+                        + "needed. Keep it short.")
+                    .Str("detail", false, "Optional, and usually unnecessary: omit it when the summary "
+                        + "already captures the memory in full. Add it only when there is substantially "
+                        + "more worth storing than fits in one line - a detail file costs an extra "
+                        + "read_memory call to retrieve later.")
                     .Build(),
                 delegate(ToolCallContext ctx) { return Remember(store, ctx); });
 


### PR DESCRIPTION
## Summary

Tightens the `remember` tool's argument guidance so the model stops creating detail files for trivial memories. Previously the model often wrote a `<name>.md` even when the one-line summary already said everything — which then cost an extra `read_memory` call (and extra context) later to retrieve a file that added nothing.

Follow-up to #104 (now merged).

## Change

`remember`'s description and the `summary`/`detail` arg docs now make the intent explicit and concise:

- **Tool description:** "Most memories need only the one-line summary; add 'detail' only when a single line cannot capture it."
- **`summary`:** "...For a simple fact this is the whole memory — no detail needed."
- **`detail`:** "Optional, and usually unnecessary: omit it when the summary already captures the memory in full. Add it only when there is substantially more worth storing than fits in one line — a detail file costs an extra read_memory call to retrieve later."

That last clause gives the model a concrete cost to weigh, which is the main lever against gratuitous detail files.

## Scope

- `remember` only — `update_memory`/`consolidate` are unchanged, since the issue was specifically `remember` creating detail files for simple memories.
- Description-only change (no behavior/logic change); rebuild `MemoryMcpServer` to pick it up.

https://claude.ai/code/session_01QMvp2YvtfgddQy7hvBKP9A

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMvp2YvtfgddQy7hvBKP9A)_