### PR TITLE
Make global ZDR default a per-conversation seed, not a lock

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1149,8 +1149,9 @@ namespace GxPT
                 dlg.ShowDialog(this);
                 // The dialog writes settings.json directly; drop the cached copy so reads are fresh.
                 AppSettings.Reload();
-                // The global ZDR default may have changed: re-sync the per-tab checkbox (checked +
-                // disabled when ZDR is forced globally; existing conversations don't latch until sent).
+                // Re-sync the per-tab checkbox. Its checked/enabled state now depends only on the
+                // conversation's own toggle and latch — the global default seeds new conversations but
+                // does not retroactively change one that's already open.
                 SyncZdrCheckboxFromActiveTab();
                 // Re-init client in case API key changed
                 InitializeClient();
@@ -1590,10 +1591,10 @@ namespace GxPT
         private bool ResolveZdrForSend(TabManager.ChatTabContext ctx)
         {
             if (ctx == null || ctx.Conversation == null) return false;
-            // Latched conversations stay ZDR for good, even if the global default is later turned off.
-            bool zdr;
-            try { zdr = AppSettings.GetGlobalZdrDefault() || ctx.Conversation.Zdr || ConvIsZdrLatched(ctx); }
-            catch { zdr = ctx.Conversation.Zdr || ConvIsZdrLatched(ctx); }
+            // The per-conversation toggle (seeded from the global default at creation) is the source of
+            // truth; a latched conversation stays ZDR for good. The global default is not re-applied here,
+            // so unchecking the box before the first send genuinely disables ZDR for this conversation.
+            bool zdr = ctx.Conversation.Zdr || ConvIsZdrLatched(ctx);
             if (!zdr) return false;
 
             if (ctx.Conversation.ZdrFirstMessageIndex < 0)
@@ -1680,23 +1681,22 @@ namespace GxPT
             return (slash >= 0 && slash < full.Length - 1) ? full.Substring(slash + 1) : full;
         }
 
-        // Per-tab ZDR checkbox <-> active conversation. Checked = effective ZDR; disabled (locked on)
-        // when the global default forces it or the conversation has already latched ZDR.
+        // Per-tab ZDR checkbox <-> active conversation. Checked = the conversation's own ZDR toggle
+        // (seeded from the global default when the conversation was created), or locked on once latched.
+        // Disabled only when the conversation has latched ZDR — the global default no longer locks the
+        // box, so the user can uncheck it before the first send.
         private bool _syncingZdr;
         private void SyncZdrCheckboxFromActiveTab()
         {
             if (this.chkZdrTab == null) return;
             var ctx = _tabManager != null ? _tabManager.GetActiveContext() : null;
-            bool globalDefault = false;
-            try { globalDefault = AppSettings.GetGlobalZdrDefault(); }
-            catch { }
             bool latched = ConvIsZdrLatched(ctx);
             bool convZdr = ctx != null && ctx.Conversation != null && ctx.Conversation.Zdr;
             _syncingZdr = true;
             try
             {
-                this.chkZdrTab.Checked = globalDefault || convZdr || latched;
-                this.chkZdrTab.Enabled = ctx != null && ctx.Conversation != null && !globalDefault && !latched;
+                this.chkZdrTab.Checked = convZdr || latched;
+                this.chkZdrTab.Enabled = ctx != null && ctx.Conversation != null && !latched;
             }
             finally { _syncingZdr = false; }
         }
@@ -2326,7 +2326,8 @@ namespace GxPT
                 DialogResult dr = dlg.ShowDialog(this);
                 // The dialog writes settings.json directly; drop the cached copy so reads are fresh.
                 AppSettings.Reload();
-                // Reflect any change to the global ZDR default in the per-tab checkbox.
+                // Re-sync the per-tab checkbox after settings may have changed (the global default
+                // seeds new conversations; it does not retroactively re-lock this one).
                 SyncZdrCheckboxFromActiveTab();
                 if (dr == DialogResult.OK)
                 {

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -38,8 +38,10 @@ namespace GxPT
         // Whether the user dismissed the (unset) workspace strip for this conversation; persisted so
         // the strip stays hidden on reopen until they set a folder.
         public bool WorkspaceStripDismissed { get; set; }
-        // Zero data retention for this conversation. Zdr is the per-conversation toggle (effective ZDR
-        // for a send is globalDefault OR Zdr). ZdrFirstMessageIndex is a one-way latch: the History
+        // Zero data retention for this conversation. Zdr is the per-conversation toggle and the sole
+        // source of truth for effective ZDR: it is seeded from the global default when a new conversation
+        // is created (see the constructor), but the global default is NOT a live override - the user can
+        // uncheck the box before the first send. ZdrFirstMessageIndex is a one-way latch: the History
         // index of the first user message actually sent with ZDR on (-1 until then). Once latched it
         // never clears, so the checkbox locks on and the tab/messages are marked from that point.
         public bool Zdr { get; set; }
@@ -53,6 +55,11 @@ namespace GxPT
             Name = GenericName; // initialize to generic name
             SelectedModel = null;
             ZdrFirstMessageIndex = -1; // not latched until a ZDR send occurs
+            // A brand-new conversation inherits the current global ZDR default as its starting value
+            // (seed only - not a live override, so the user can still uncheck it before the first send).
+            // Loaded conversations overwrite this from their saved value in ConversationStore.FromDto.
+            try { Zdr = AppSettings.GetGlobalZdrDefault(); }
+            catch { Zdr = false; }
             LastUpdated = DateTime.Now;
         }
 
@@ -110,12 +117,10 @@ namespace GxPT
                     }
 
                     // Respect ZDR for the title request too (it sends the user's message): effective
-                    // ZDR is the global default OR this conversation's toggle OR a latched conversation.
-                    // If ZDR is in effect it stays in effect for every retry — the title model supports
-                    // ZDR, so we never fall back to a non-ZDR request.
-                    bool zdr;
-                    try { zdr = AppSettings.GetGlobalZdrDefault() || this.Zdr || ZdrFirstMessageIndex >= 0; }
-                    catch { zdr = this.Zdr || ZdrFirstMessageIndex >= 0; }
+                    // ZDR is this conversation's toggle (seeded from the global default at creation) OR a
+                    // latched conversation. If ZDR is in effect it stays in effect for every retry — the
+                    // title model supports ZDR, so we never fall back to a non-ZDR request.
+                    bool zdr = this.Zdr || ZdrFirstMessageIndex >= 0;
 
                     string title = RequestTitleWithRetry(userMsg, zdr);
                     if (!string.IsNullOrEmpty(title))


### PR DESCRIPTION
The global ZDR default previously acted as a hard override: it forced the per-conversation checkbox checked AND disabled, and was OR'd into the send and title-request decisions, so a user could not opt a conversation out of ZDR.

Treat the global default as a seed instead. A brand-new conversation inherits the current global default as its starting Zdr value (in the constructor; loaded conversations keep their saved value). The per-conversation toggle plus the one-way latch are now the sole source of truth for effective ZDR, so the checkbox stays enabled until latched and unchecking before the first send genuinely disables ZDR for that conversation.