### PR TITLE
Wire up tool annotations (readOnlyHint/destructiveHint) end-to-end

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -16,11 +16,29 @@ namespace GxPT.Tests.Mcp
             public ApprovalChoice Ask(ApprovalRequest req) { Calls++; Last = req; return Next; }
         }
 
+        // A fixed annotation source: maps a function name to the readOnlyHint/destructiveHint JObject
+        // the discovered tool would carry (mirrors what McpToolRegistry plumbs from tools/list).
+        private sealed class FakeAnnotations : IToolAnnotationSource
+        {
+            private readonly Dictionary<string, JObject> _map = new Dictionary<string, JObject>();
+            public FakeAnnotations Set(string fn, JObject ann) { _map[fn] = ann; return this; }
+            public JObject AnnotationsFor(string functionName)
+            {
+                JObject a;
+                return _map.TryGetValue(functionName, out a) ? a : null;
+            }
+        }
+
         private static JObject Args(string json) { return JObject.Parse(json); }
 
         private static ToolApprovalPolicy Policy(ScriptedPrompt prompt, IApprovalStore store)
         {
             return new ToolApprovalPolicy(new ToolClassifier(), prompt, store);
+        }
+
+        private static ToolApprovalPolicy Policy(ScriptedPrompt prompt, IApprovalStore store, IToolAnnotationSource annotations)
+        {
+            return new ToolApprovalPolicy(new ToolClassifier(), prompt, store, annotations);
         }
 
         // ---- classification (spec §2) ----
@@ -78,6 +96,59 @@ namespace GxPT.Tests.Mcp
             var unknown = c.Classify("acme__do", null, false);
             Assert.Equal(ToolTier.Write, unknown.Tier);
             Assert.Equal(RememberScope.Tool, unknown.Scope);
+        }
+
+        // ---- annotations plumbed end-to-end through the policy (#94) ----
+
+        [Fact]
+        public void Third_party_read_only_annotation_auto_allows_without_prompt()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var ann = new FakeAnnotations().Set("acme__peek", JObject.Parse("{\"readOnlyHint\":true}"));
+            var pol = Policy(prompt, new InMemoryApprovalStore(), ann);
+
+            // The declared readOnlyHint reaches the classifier -> ReadOnly tier -> allowed, no prompt.
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("acme__peek", Args("{}")));
+            Assert.Equal(0, prompt.Calls);
+        }
+
+        [Fact]
+        public void Third_party_destructive_annotation_prompts_every_time()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberTool }; // even if user tries to remember
+            var ann = new FakeAnnotations().Set("acme__nuke", JObject.Parse("{\"destructiveHint\":true}"));
+            var pol = Policy(prompt, new InMemoryApprovalStore(), ann);
+
+            pol.Check("acme__nuke", Args("{}"));
+            pol.Check("acme__nuke", Args("{}"));
+            Assert.Equal(2, prompt.Calls); // Destructive -> None scope -> never remembered
+        }
+
+        [Fact]
+        public void Third_party_without_annotation_falls_back_to_write_tool()
+        {
+            // Fail-safe default (#94): an absent hint is treated as NOT read-only, so the tool is gated
+            // as Write/Tool (prompt once, then remembered) rather than silently auto-allowed.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberTool };
+            var pol = Policy(prompt, new InMemoryApprovalStore(), new FakeAnnotations());
+
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("acme__do", Args("{}")));
+            Assert.Equal(1, prompt.Calls);
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("acme__do", Args("{}")));
+            Assert.Equal(1, prompt.Calls); // remembered (Tool scope)
+        }
+
+        [Fact]
+        public void First_party_tools_ignore_the_annotation_source()
+        {
+            // First-party tools are classified by the authoritative table, never by annotations — so a
+            // (bogus) readOnlyHint for git__push must not downgrade it out of the Destructive tier.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var ann = new FakeAnnotations().Set("git__push", JObject.Parse("{\"readOnlyHint\":true}"));
+            var pol = Policy(prompt, new InMemoryApprovalStore(), ann);
+
+            pol.Check("git__push", Args("{}"));
+            Assert.Equal(1, prompt.Calls); // still gated (Destructive), not auto-allowed
         }
 
         // ---- decision model (spec §3) ----

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1768,7 +1768,8 @@ namespace GxPT
                         ? new ToolApprovalPolicy(
                             new ToolClassifier(),
                             new TranscriptApprovalPrompt(this, delegate { return ctx.ApprovalPanel; }),
-                            _approvalStore)
+                            _approvalStore,
+                            _mcpRegistry) // classify third-party tools by their declared readOnly/destructive hints
                         : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
                     var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -24,7 +24,7 @@ namespace GxPT
     //
     // Thread-safe: lifecycle methods are driven from connection reader threads (Ready/ToolsChanged/
     // fault), while the orchestrator calls the per-request/resolution methods from its worker thread.
-    internal sealed class McpToolRegistry
+    internal sealed class McpToolRegistry : IToolAnnotationSource
     {
         public const string RevealToolsName = "reveal_tools";
         public const int DefaultRevealCap = 24; // discovery spec §13
@@ -36,6 +36,7 @@ namespace GxPT
             public string FunctionName;
             public string Description;
             public JObject Schema;
+            public JObject Annotations; // tool capability hints (readOnlyHint/destructiveHint); may be null
             public string Workdir; // null = workdir-independent (web/github/custom)
         }
 
@@ -101,6 +102,7 @@ namespace GxPT
                     e.FunctionName = fn;
                     e.Description = t.Description;
                     e.Schema = t.InputSchema;
+                    e.Annotations = t.Annotations;
                     e.Workdir = workdir;
                     AddEntryLocked(fn, e, fns);
                 }
@@ -134,6 +136,7 @@ namespace GxPT
                     e.FunctionName = fn;
                     e.Description = t.Description;
                     e.Schema = t.InputSchema;
+                    e.Annotations = t.Annotations;
                     e.Workdir = workdir;
                     AddEntryLocked(fn, e, fns);
                 }
@@ -375,6 +378,21 @@ namespace GxPT
             conn = null;
             toolName = null;
             return false;
+        }
+
+        // The discovered capability annotations (readOnlyHint/destructiveHint) for a function name, so
+        // the approval gate can classify a tool by what it declares. Returns a clone (never the stored
+        // token) so the caller can't reparent the catalog's copy; null when the tool set no annotations
+        // — the classifier then fails closed (treats it as not read-only -> Write/Tool tier).
+        public JObject AnnotationsFor(string functionName)
+        {
+            lock (_lock)
+            {
+                CatalogEntry e;
+                if (TryFirstEntryLocked(functionName, out e) && e.Annotations != null)
+                    return (JObject)e.Annotations.DeepClone();
+            }
+            return null;
         }
 
         // ---- internals ----

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -5,6 +5,15 @@ using Newtonsoft.Json.Linq;
 
 namespace GxPT
 {
+    // Supplies the capability annotations (readOnlyHint/destructiveHint) a discovered tool declared,
+    // keyed by qualified function name. Implemented by McpToolRegistry; injected into ToolApprovalPolicy
+    // so third-party tools are classified by their declared hints rather than always falling through to
+    // the conservative Write/Tool tier. Returns null when the tool set no annotations.
+    internal interface IToolAnnotationSource
+    {
+        JObject AnnotationsFor(string functionName);
+    }
+
     // The real approval gate (approval spec §3) behind the orchestrator's IToolApprovalPolicy.Check.
     // Classifies the tool, consults remembered approvals (tool-name set + argument rules), and only
     // prompts (via IToolApprovalPrompt) when not already allowed; persists the user's remembered
@@ -17,12 +26,22 @@ namespace GxPT
         private readonly IToolClassifier _classifier;
         private readonly IToolApprovalPrompt _prompt;
         private readonly IApprovalStore _store;
+        private readonly IToolAnnotationSource _annotations;
 
         public ToolApprovalPolicy(IToolClassifier classifier, IToolApprovalPrompt prompt, IApprovalStore store)
+            : this(classifier, prompt, store, null)
+        {
+        }
+
+        // annotations: source of each tool's declared readOnlyHint/destructiveHint (the registry). When
+        // null, no annotations are available and every non-first-party tool falls back to Write/Tool.
+        public ToolApprovalPolicy(IToolClassifier classifier, IToolApprovalPrompt prompt, IApprovalStore store,
+            IToolAnnotationSource annotations)
         {
             _classifier = classifier != null ? classifier : new ToolClassifier();
             _prompt = prompt;
             _store = store != null ? store : new InMemoryApprovalStore();
+            _annotations = annotations;
         }
 
         // The orchestrator calls this. functionName is the qualified name; args already parsed.
@@ -30,15 +49,21 @@ namespace GxPT
         {
             string server = ServerOf(functionName);
             bool firstParty = server != null && _firstPartyServers.ContainsKey(server);
-            JObject annotations = null; // third-party annotations not yet plumbed; unknown -> Write/Tool
+            // Pull the tool's declared capability hints from the discovered definition. First-party tools
+            // are classified by the authoritative hardcoded table (annotations ignored), so only look them
+            // up for third-party tools. Absent annotations -> null -> classifier fails closed (Write/Tool),
+            // so a forgotten readOnlyHint never silently widens access.
+            JObject annotations = (!firstParty && _annotations != null)
+                ? _annotations.AnnotationsFor(functionName)
+                : null;
             ToolPolicy pol = _classifier.Classify(functionName, annotations, firstParty);
 
             // Read-only tools never modify anything -> always allowed, no prompt. Driven by the
             // classified tier (not a name list), so every ReadOnly tool auto-allows: the read-only
             // built-ins (files read/list/search, git status/diff/log/fetch, web search/extract,
-            // memory read_memory) and any future ReadOnly tool. Third-party tools can't currently
-            // reach ReadOnly (their annotations aren't plumbed; unknown -> Write); if that changes and
-            // you don't want to trust a server's self-declared readOnlyHint, add "&& firstParty" here.
+            // memory read_memory) and any future ReadOnly tool. A third-party tool now reaches ReadOnly
+            // too when it declares readOnlyHint:true (plumbed above); if you don't want to trust a
+            // server's self-declared readOnlyHint, add "&& firstParty" here.
             if (pol.Tier == ToolTier.ReadOnly)
                 return ApprovalDecision.Allow;
 

--- a/docs/mcp35-approval-spec.md
+++ b/docs/mcp35-approval-spec.md
@@ -97,10 +97,21 @@ public interface IToolClassifier {
    Destructive/None; `readOnlyHint:true` → ReadOnly/Tool; otherwise → Write/Tool.
    We can't infer a third-party server's argument semantics, so third-party
    **never** gets command/path parsing — its Destructive tools are
-   `Scope=None` (or an `ExactArgs` rule, §3) only.
+   `Scope=None` (or an `ExactArgs` rule, §3) only. The hints are read from the
+   tool's declared `annotations` in `tools/list`, plumbed through the registry
+   (`McpToolRegistry.AnnotationsFor`) into the gate — *not* the hardcoded null
+   they were stubbed to before.
 4. **No annotation / unknown → Write/Tool** (the accepted tradeoff of advisory
    trust: a side-effecting tool that fails to flag itself is remember-eligible
-   only *after* a first human prompt).
+   only *after* a first human prompt). This is the **fail-safe default**: an
+   absent `readOnlyHint` is treated as **not** read-only, so a forgotten
+   annotation never silently widens access.
+
+> Built-in servers also declare these hints (`ToolAnnotations.ReadOnly/Write/
+> Destructive`) on every tool. First-party classification still comes from the
+> authoritative table above (hints ignored for *tiering*), but the declared
+> `readOnlyHint` is what a capability filter — e.g. a future "read-only"
+> subagent tool set — selects on, so it must be present on the wire.
 
 ---
 

--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -31,6 +31,7 @@ namespace CommandMcpServer
                     .Str("command", true, "The exact command line to run, in Windows cmd.exe syntax.")
                     .Int("timeout_ms", false, "Kill the command after this many milliseconds (default 60000)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Run(config, runner, ctx); });
         }
 

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -41,6 +41,7 @@ namespace FilesMcpServer
                     .Int("end_line", false, "Last line to return (1-based, inclusive)")
                     .Bool("line_numbers", false, "Prefix each returned line with its 1-based line number")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Read(sandbox, ctx); });
 
             server.AddTool("list", "List entries of a directory under the workspace root.",
@@ -48,6 +49,7 @@ namespace FilesMcpServer
                     .Str("path", true, "Directory path relative to the workspace root")
                     .Bool("recursive", false, "Recurse into subdirectories (bounded depth)")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return List(sandbox, ctx); });
 
             server.AddTool("write", "Create or overwrite a text file under the workspace root.",
@@ -56,10 +58,12 @@ namespace FilesMcpServer
                     .Str("content", true, "UTF-8 text content to write")
                     .Bool("create_dirs", false, "Create missing parent directories")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Write(sandbox, ctx); });
 
             server.AddTool("delete", "Delete a file or an empty directory under the workspace root.",
                 SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Delete(sandbox, ctx); });
 
             server.AddTool("edit", "Replace an exact text span in a file under the workspace root. "
@@ -71,6 +75,7 @@ namespace FilesMcpServer
                     .Str("new_string", true, "Replacement text")
                     .Bool("replace_all", false, "Replace every occurrence instead of requiring a unique match")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Edit(sandbox, ctx); });
 
             server.AddTool("search", "Search file contents for a string or regex under the workspace root, "
@@ -89,6 +94,7 @@ namespace FilesMcpServer
                         + "anchors. 'line' is where each match starts. Bounded by the read cap; line-mode streams "
                         + "files of any size, multiline skips files over the cap.")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Search(sandbox, ctx); });
         }
 

--- a/servers/GitMcpServer/GitTools.cs
+++ b/servers/GitMcpServer/GitTools.cs
@@ -33,6 +33,7 @@ namespace GitMcpServer
 
             server.AddTool("status", "Show the working tree status (porcelain).",
                 SchemaBuilder.Object().Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Status(config, runner, ctx); });
 
             server.AddTool("diff", "Show changes; optionally only staged changes or a single path.",
@@ -40,10 +41,12 @@ namespace GitMcpServer
                     .Bool("staged", false, "Show staged (cached) changes instead of the working tree")
                     .Str("path", false, "Limit the diff to this path")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Diff(config, runner, ctx); });
 
             server.AddTool("log", "Show recent commit history.",
                 SchemaBuilder.Object().Int("max", false, "Maximum commits to show (default 20)").Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Log(config, runner, ctx); });
 
             server.AddTool("commit", "Stage and commit changes with a message.",
@@ -51,6 +54,7 @@ namespace GitMcpServer
                     .Str("message", true, "The commit message")
                     .Bool("all", false, "Stage all changes (git add -A) before committing")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Commit(config, runner, ctx); });
 
             server.AddTool("push", "Push commits to a remote.",
@@ -58,6 +62,7 @@ namespace GitMcpServer
                     .Str("remote", false, "Remote name (e.g. origin)")
                     .Str("branch", false, "Branch name")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Push(config, runner, ctx); });
 
             // ---- remote sync ----
@@ -67,6 +72,7 @@ namespace GitMcpServer
                     .Str("remote", false, "Remote name (default: the configured/default remote)")
                     .Bool("prune", false, "Remove remote-tracking refs that no longer exist on the remote")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Fetch(config, runner, ctx); });
 
             server.AddTool("pull", "Fetch from and integrate with a remote (merge by default, or rebase).",
@@ -75,6 +81,7 @@ namespace GitMcpServer
                     .Str("branch", false, "Branch name")
                     .Bool("rebase", false, "Rebase the current branch onto the upstream instead of merging")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Pull(config, runner, ctx); });
 
             // ---- branches / working tree ----
@@ -85,6 +92,7 @@ namespace GitMcpServer
                     .Bool("create", false, "Create a new branch from the current HEAD (git checkout -b)")
                     .Str("start_point", false, "When create=true, the commit/branch to start the new branch from")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Checkout(config, runner, ctx); });
 
             server.AddTool("restore", "Restore working-tree files (discard local changes) or unstage them.",
@@ -93,6 +101,7 @@ namespace GitMcpServer
                     .Bool("staged", false, "Restore the staged content (unstage) instead of the working tree")
                     .Str("source", false, "Restore the files' content from this commit/ref")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Restore(config, runner, ctx); });
 
             server.AddTool("branch", "List, create, delete, or rename branches.",
@@ -103,6 +112,7 @@ namespace GitMcpServer
                     .Bool("all", false, "Include remote-tracking branches when listing")
                     .Bool("force", false, "Force the operation (e.g. delete an unmerged branch)")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Branch(config, runner, ctx); });
 
             // ---- integrate ----
@@ -112,6 +122,7 @@ namespace GitMcpServer
                     .Str("branch", true, "Branch or commit to merge into the current branch")
                     .Bool("no_ff", false, "Always create a merge commit (--no-ff)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Merge(config, runner, ctx); });
 
             server.AddTool("rebase", "Rebase the current branch, or continue/abort/skip an in-progress rebase.",
@@ -119,6 +130,7 @@ namespace GitMcpServer
                     .Str("action", false, "start | continue | abort | skip (default: start)")
                     .Str("onto", false, "Upstream branch/commit to rebase onto (required when action=start)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Rebase(config, runner, ctx); });
 
             server.AddTool("cherry_pick", "Apply the changes of an existing commit onto the current branch.",
@@ -126,6 +138,7 @@ namespace GitMcpServer
                     .Str("commit", true, "Commit (or range) to cherry-pick")
                     .Bool("no_commit", false, "Apply the changes without committing (-n)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return CherryPick(config, runner, ctx); });
 
             // ---- staging / stash ----
@@ -135,6 +148,7 @@ namespace GitMcpServer
                     .Arr("paths", "string", false, "Files/pathspecs to stage")
                     .Bool("all", false, "Stage all changes (git add -A)")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Add(config, runner, ctx); });
 
             server.AddTool("reset", "Reset the current HEAD, or unstage specific paths.",
@@ -143,6 +157,7 @@ namespace GitMcpServer
                     .Str("target", false, "Commit/ref to reset to (default: HEAD)")
                     .Arr("paths", "string", false, "Unstage only these paths (leaves working tree and HEAD untouched)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Reset(config, runner, ctx); });
 
             server.AddTool("rm", "Remove files from the working tree and the index.",
@@ -151,6 +166,7 @@ namespace GitMcpServer
                     .Bool("cached", false, "Remove only from the index, keeping the working-tree file (--cached)")
                     .Bool("recursive", false, "Allow recursive removal of directories (-r)")
                     .Build(),
+                ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return Rm(config, runner, ctx); });
 
             server.AddTool("stash", "Save, restore, list, or drop stashed changes.",
@@ -159,6 +175,7 @@ namespace GitMcpServer
                     .Str("message", false, "Description for the stash (action=push)")
                     .Int("index", false, "Stash index N (refers to stash@{N}) for pop/apply/drop")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Stash(config, runner, ctx); });
         }
 

--- a/servers/MSBuildMcpServer/MsBuildTools.cs
+++ b/servers/MSBuildMcpServer/MsBuildTools.cs
@@ -36,6 +36,7 @@ namespace MSBuildMcpServer
                 MsBuildInstall inst = install; // capture a per-iteration copy for the closure
                 string toolName = "build_" + inst.Version.Replace('.', '_');
                 server.AddTool(toolName, BuildDescription(inst), BuildSchema(inst),
+                    ToolAnnotations.Destructive(),
                     delegate(ToolCallContext ctx) { return Run(config, runner, inst, ctx); });
             }
 
@@ -47,6 +48,7 @@ namespace MSBuildMcpServer
                 DevenvInstall vs = ide; // capture a per-iteration copy for the closure
                 string toolName = "build_solution_" + vs.Year;
                 server.AddTool(toolName, BuildDevenvDescription(vs), BuildDevenvSchema(),
+                    ToolAnnotations.Destructive(),
                     delegate(ToolCallContext ctx) { return RunDevenv(config, runner, vs, ctx); });
             }
         }

--- a/servers/MemoryMcpServer/MemoryTools.cs
+++ b/servers/MemoryMcpServer/MemoryTools.cs
@@ -37,6 +37,7 @@ namespace MemoryMcpServer
                         + "more worth storing than fits in one line - a detail file costs an extra "
                         + "read_memory call to retrieve later.")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Remember(store, ctx); });
 
             server.AddTool("read_memory",
@@ -45,6 +46,7 @@ namespace MemoryMcpServer
                 SchemaBuilder.Object()
                     .Str("name", true, "The memory's name (as shown in the index).")
                     .Build(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Read(store, ctx); });
 
             server.AddTool("update_memory",
@@ -58,6 +60,7 @@ namespace MemoryMcpServer
                     .Str("detail", false, "New full detail contents (replaces <name>.md entirely; empty "
                         + "removes it).")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Update(store, ctx); });
 
             server.AddTool("forget",
@@ -65,6 +68,7 @@ namespace MemoryMcpServer
                 SchemaBuilder.Object()
                     .Str("name", true, "The memory's name (as shown in the index).")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Forget(store, ctx); });
 
             server.AddTool("consolidate",
@@ -81,6 +85,7 @@ namespace MemoryMcpServer
                     .Str("detail", true, "The merged note: one section per absorbed memory, keyed by its "
                         + "original name.")
                     .Build(),
+                ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Consolidate(store, ctx); });
         }
 

--- a/servers/WebSearchMcpServer/WebSearchTools.cs
+++ b/servers/WebSearchMcpServer/WebSearchTools.cs
@@ -26,12 +26,14 @@ namespace WebSearchMcpServer
                 "Search the web and return relevant results, each with a title, URL, and content snippet (optionally a synthesized answer). " +
                 "Start here when you need current information. The returned URLs can be passed to web__extract to read full page content.",
                 BuildSearchSchema(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Search(config, client, ctx); });
 
             server.AddTool("extract",
                 "Fetch the full text of specific web pages you ALREADY have URLs for (for example, URLs returned by web__search). " +
                 "Requires the 'urls' argument: one or more absolute http(s) URLs. Do not call this without URLs — run web__search first to find them.",
                 BuildExtractSchema(),
+                ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Extract(config, client, ctx); });
         }
 

--- a/src/Mcp35.Server/Mcp35.Server.csproj
+++ b/src/Mcp35.Server/Mcp35.Server.csproj
@@ -43,6 +43,7 @@
     <Compile Include="ToolRegistration.cs" />
     <Compile Include="ToolResults.cs" />
     <Compile Include="SchemaBuilder.cs" />
+    <Compile Include="ToolAnnotations.cs" />
     <Compile Include="StdErrLogSink.cs" />
     <Compile Include="Process\ProcessRunner.cs" />
     <Compile Include="Process\ProcessRequest.cs" />

--- a/src/Mcp35.Server/McpServer.cs
+++ b/src/Mcp35.Server/McpServer.cs
@@ -39,6 +39,14 @@ namespace Mcp35.Server
 
         public void AddTool(string name, string description, JObject inputSchema, ToolHandler handler)
         {
+            AddTool(name, description, inputSchema, null, handler);
+        }
+
+        // Overload that also carries the tool's capability annotations (readOnlyHint/destructiveHint,
+        // see ToolAnnotations). The host classifies tools by these hints, so built-in servers should
+        // declare them; an absent annotations object passes through as no hints (host fails closed).
+        public void AddTool(string name, string description, JObject inputSchema, JObject annotations, ToolHandler handler)
+        {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Tool name is required.", "name");
             if (handler == null) throw new ArgumentNullException("handler");
             if (_started) throw new InvalidOperationException("Cannot add tools after Run() has started.");
@@ -48,6 +56,7 @@ namespace Mcp35.Server
             descriptor.Name = name;
             descriptor.Description = description;
             descriptor.InputSchema = inputSchema ?? EmptyObjectSchema();
+            descriptor.Annotations = annotations; // null => omitted from tools/list (NullValueHandling.Ignore)
 
             _tools[name] = new RegisteredTool(descriptor, handler);
             _toolOrder.Add(name);

--- a/src/Mcp35.Server/ToolAnnotations.cs
+++ b/src/Mcp35.Server/ToolAnnotations.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json.Linq;
+
+namespace Mcp35.Server
+{
+    /// <summary>
+    /// Builds the small annotations object an MCP tool advertises about its capability — the
+    /// <c>readOnlyHint</c> / <c>destructiveHint</c> fields the host reads to classify a tool into an
+    /// approval tier (and that a "read-only" subagent filter selects on). Built-in servers should
+    /// declare one per tool via <see cref="McpServer.AddTool(string,string,JObject,JObject,ToolHandler)"/>.
+    ///
+    /// Fail-safe convention (mirrors the host classifier): an ABSENT <c>readOnlyHint</c> is treated as
+    /// NOT read-only, so a forgotten annotation never silently widens access. Hints are emitted
+    /// explicitly here so the declared capability round-trips losslessly to the host.
+    /// </summary>
+    public static class ToolAnnotations
+    {
+        /// <summary>Inspects/reads only; never mutates state. Auto-allowed by the host.</summary>
+        public static JObject ReadOnly()
+        {
+            JObject a = new JObject();
+            a["readOnlyHint"] = true;
+            a["destructiveHint"] = false;
+            return a;
+        }
+
+        /// <summary>Mutates state but does not destroy or discard existing data (e.g. create/append).</summary>
+        public static JObject Write()
+        {
+            JObject a = new JObject();
+            a["readOnlyHint"] = false;
+            a["destructiveHint"] = false;
+            return a;
+        }
+
+        /// <summary>May overwrite, delete, or otherwise irreversibly discard data.</summary>
+        public static JObject Destructive()
+        {
+            JObject a = new JObject();
+            a["readOnlyHint"] = false;
+            a["destructiveHint"] = true;
+            return a;
+        }
+    }
+}

--- a/tests/Mcp35.Server.Tests/McpServerTests.cs
+++ b/tests/Mcp35.Server.Tests/McpServerTests.cs
@@ -75,6 +75,25 @@ namespace Mcp35.Server.Tests
         }
 
         [Fact]
+        public void ToolsList_emits_annotations_when_provided_and_omits_them_otherwise()
+        {
+            var server = NewServer();
+            server.AddTool("peek", "Read only.", EchoSchema(), ToolAnnotations.ReadOnly(),
+                ctx => ToolResults.Text("ok"));
+            server.AddTool("plain", "No annotations.", EchoSchema(),
+                ctx => ToolResults.Text("ok"));
+
+            var msgs = ServerHarness.Exchange(server, ServerHarness.ToolsList(2));
+            JArray tools = (JArray)msgs[0]["result"]["tools"];
+
+            // Annotated tool carries the declared hints verbatim.
+            Assert.Equal(true, (bool)tools[0]["annotations"]["readOnlyHint"]);
+            Assert.Equal(false, (bool)tools[0]["annotations"]["destructiveHint"]);
+            // Unannotated tool omits the field entirely (NullValueHandling.Ignore).
+            Assert.Null(tools[1]["annotations"]);
+        }
+
+        [Fact]
         public void ToolsList_preserves_registration_order()
         {
             var server = NewServer();


### PR DESCRIPTION
Fixes #94.

MCP tool annotations (`readOnlyHint` / `destructiveHint`) were never populated on built-in tools, and the approval policy hardcoded them to `null` — so the annotation classification path was dead code and third-party read-only tools were always gated as `Write`. This plumbs annotations through both ends.

## SDK (`Mcp35.Server`)
- **`McpServer.AddTool`** — added an overload taking an `annotations` `JObject` that populates `Tool.Annotations`. The existing 4-arg signature is preserved (delegates with `null`). Annotations serialize into `tools/list` and are omitted when absent.
- **`ToolAnnotations`** (new) — `ReadOnly()` / `Write()` / `Destructive()` helpers that emit the `readOnlyHint`/`destructiveHint` fields the host classifies on.

## Built-in servers
Tagged every tool with its capability:
- **Files**: read/list/search → ReadOnly; write/edit → Write; delete → Destructive
- **Git**: status/diff/log/fetch → ReadOnly; commit/add/branch/stash → Write; push/pull/checkout/restore/merge/rebase/reset/rm/cherry_pick → Destructive
- **Web**: search/extract → ReadOnly
- **Command**: run → Destructive
- **Memory**: read_memory → ReadOnly; remember/update_memory/forget/consolidate → Write
- **MSBuild**: build tools → Destructive

## Host (`GxPT`)
- **`McpToolRegistry`** captures each discovered tool's annotations and exposes them via a new `IToolAnnotationSource.AnnotationsFor` lookup (returns a clone, or `null`).
- **`ToolApprovalPolicy.Check`** now pulls annotations from that source for **third-party** tools instead of passing `null`. First-party tools keep using the authoritative hardcoded table.
- **`MainForm`** injects the registry as the annotation source.

## Fail-safe default
Per the issue's point 4: an absent `readOnlyHint` is treated as **not** read-only (fail closed), so a forgotten annotation never silently widens access. Documented in the approval spec and enforced by the classifier.

## Tests & docs
- Policy tests: third-party read-only auto-allows without a prompt, destructive prompts every time, missing annotation falls back to Write/Tool, first-party ignores the annotation source.
- SDK test: `tools/list` round-trips annotations and omits the field when unset.
- Updated `docs/mcp35-approval-spec.md`.

This also unblocks the planned subagent `readonly` permission filter, which selects tools by `readOnlyHint == true` — built-in tools now actually emit it.

> [!NOTE]
> This is a net35/VS2008 codebase with no build toolchain in the Linux session environment, so the changes were verified by review against existing patterns and call sites rather than a local compile/test run.

https://claude.ai/code/session_011f26KSCrVhTr2tP7JgktuB

---
_Generated by [Claude Code](https://claude.ai/code/session_011f26KSCrVhTr2tP7JgktuB)_