### PR TITLE
Fix conversation rename to strip ZDR prefix from display text

### DIFF
--- a/GxPT/Managers/SidebarManager.cs
+++ b/GxPT/Managers/SidebarManager.cs
@@ -564,7 +564,14 @@ namespace GxPT
 
                 // Create textbox for inline editing
                 _renameTextBox = new TextBox();
-                _renameTextBox.Text = lvi.Text;
+                // Seed with the raw conversation name, not the displayed row text: the latter
+                // carries the "[zdr] " marker prefix, which must not become part of the name.
+                string editText = lvi.Text;
+                if (info.Zdr && editText != null && editText.StartsWith(MainForm.ZdrTitlePrefix))
+                {
+                    editText = editText.Substring(MainForm.ZdrTitlePrefix.Length);
+                }
+                _renameTextBox.Text = editText;
                 _renameTextBox.BorderStyle = BorderStyle.None;
                 // Allow explicit height by using multiline (single-line behavior preserved by AcceptsReturn=false)
                 _renameTextBox.Multiline = true;


### PR DESCRIPTION
## Summary
Fixed an issue where renaming a conversation would incorrectly include the "[zdr] " display prefix in the new conversation name. The rename textbox now seeds with the raw conversation name instead of the displayed list item text.

## Changes
- Modified `StartRenameSelectedConversation()` to extract the actual conversation name before populating the rename textbox
- Added logic to detect and strip the `MainForm.ZdrTitlePrefix` from the display text when the conversation has the ZDR flag set
- The textbox now initializes with the clean conversation name, preventing the prefix from being accidentally saved as part of the name

## Implementation Details
- Checks both the ZDR flag (`info.Zdr`) and whether the display text starts with the prefix before stripping
- Uses `String.Substring()` to remove only the prefix portion, preserving the actual conversation name
- Maintains backward compatibility by only applying the strip logic when conditions are met

https://claude.ai/code/session_01GKr9xCBdk6iAijEmnT8CQz