### PR TITLE
docs: add Skills, Memory, slash commands to feature lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ A native chatbot client and coding agent for Windows XP. GxPT aims to provide a 
    - Ada, ASM, Bash, Basic, Batch, C, Clojure, C++, C#, CSS, CSV, Dart, EBNF, Elixir, Erlang, F#, Fortran, Go, Haskell, HTML, Java, JavaScript, JSON, Kotlin, Lisp (Common, Scheme/Racket, Clojure, Emacs), Lua, OCaml, Pascal, Perl, PHP, PowerShell, Properties, Python, Ruby, Regex, Rust, Scala, SQL, Swift, TypeScript, Visual Basic, XML, YAML, Zig
 - **Conversation Management**: Tabbed conversations and conversation history.
 - **Agentic Workflows**: GxPT autonomously chains tool calls until your task is done, powering **agentic coding** (file/git/shell), **web search**, and **GitHub** access. Tools connect via the [Model Context Protocol](https://modelcontextprotocol.io/); add custom servers in `mcp.json`.
+- **Skills**: Teach GxPT reusable workflows. Skills bundle instructions (and optional scripts) the model can pull in on demand. A built-in **skill-writer** helps you author your own, and you can enable skills per conversation or globally with the `/skills`, `/skill`, and `/use` commands.
+- **Persistent Memory**: GxPT can record durable facts about each workspace and recall them in later conversations, so context carries over without re-explaining your project. Toggle it and set a size limit in settings.
 - **Tool Approval & Sandboxing**: Every tool call is gated by an in-app approval prompt showing the exact tool and arguments before it runs, with approvals remembered per session. File/git/command tools are confined to the working folder you choose.
+- **Slash Commands**: Type `/` for quick actions with autocomplete, including `/model` (switch models), `/tool` (toggle MCP servers), `/new`, `/export`, and `/compact`.
+- **Recent Working Folders**: Quickly reattach to the working directories you used most recently.
 - **File Attachments**: Add text file attachments to your messages to avoid cluttering up the conversation with long pasted text.
 - **Conversation Editing**: Don't like the response a model gave you? Go back and edit your message and get a new response.
 - **Privacy & Local Storage**: Conversations are stored locally and can be exported/imported to migrate across machines. Enforce **Zero Data Retention (ZDR)** per conversation to route only to providers that won't store your prompts or responses.

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,10 @@
           <h2 class="bar">Features</h2>
           <ul class="features">
             <li><b>Agentic Workflows</b> &mdash; autonomously chains tool calls until your task is done: agentic coding (file/git/shell), web search, and GitHub access via MCP.</li>
+            <li><b>Skills</b> &mdash; teach GxPT reusable workflows that bundle instructions and optional scripts; author your own with the built-in skill-writer and enable them with <code>/skills</code>, <code>/skill</code>, and <code>/use</code>.</li>
+            <li><b>Persistent Memory</b> &mdash; records durable facts about each workspace and recalls them in later conversations, so context carries over.</li>
             <li><b>Tool Approval &amp; Sandboxing</b> &mdash; every tool call is gated by an in-app approval prompt; file/git/command tools stay confined to the working folder you choose.</li>
+            <li><b>Slash Commands</b> &mdash; quick <code>/</code> actions with autocomplete: <code>/model</code>, <code>/tool</code>, <code>/new</code>, <code>/export</code>, and <code>/compact</code>.</li>
             <li><b>Markdown &amp; Syntax Highlighting</b> &mdash; rich Markdown rendering plus code highlighting for 50+ languages.</li>
             <li><b>Privacy &amp; Local Storage</b> &mdash; conversations stored locally; enforce Zero Data Retention (ZDR) per conversation.</li>
             <li><b>Frontier Model Support</b> &mdash; a huge range of AI models through the OpenRouter.ai API.</li>


### PR DESCRIPTION
Surface recently added features in the README and website home page:
Skills (authoring + /skills, /skill, /use), persistent per-workspace
Memory, slash commands with autocomplete, and recent working folders.