### PR TITLE
Bump versions of Mcp35 assemblies and SkillsMcpServer, and bump appli…

### DIFF
--- a/GxPT.Setup/GxPT.Setup.vdproj
+++ b/GxPT.Setup/GxPT.Setup.vdproj
@@ -586,7 +586,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Mcp35.Client, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Mcp35.Client, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_565B068AE48E18CF1828115FA40B9C19"
@@ -617,7 +617,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Mcp35.Server, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Mcp35.Server, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_5EAF61B5A6C4B6FDBAF6DE42BC48BF23"
@@ -668,7 +668,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Mcp35.Core, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Mcp35.Core, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_7E3A6FA0A21D2C2AFAC5DA8698579058"
@@ -1002,14 +1002,14 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:GxPT"
-        "ProductCode" = "8:{3FDBE21D-D7C7-416D-9832-6793DB0C1136}"
-        "PackageCode" = "8:{C591B7C7-5E01-430F-83E6-63F183F8EB78}"
+        "ProductCode" = "8:{66F7D8A1-6E95-4065-AE74-A18A993B81CC}"
+        "PackageCode" = "8:{8A77624D-E6E7-4B0C-95A2-5DE57681DE8F}"
         "UpgradeCode" = "8:{18C05863-8BD9-4273-B9E8-061F771066DF}"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:0.18.1"
+        "ProductVersion" = "8:0.18.2"
         "Manufacturer" = "8:IFM Innovations"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:"

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -26,7 +26,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.18.1.%2a</ApplicationVersion>
+    <ApplicationVersion>0.18.2.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/GxPT/Properties/AssemblyInfo.cs
+++ b/GxPT/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.18.1.0")]
-[assembly: AssemblyFileVersion("0.18.1.0")]
+[assembly: AssemblyVersion("0.18.2.0")]
+[assembly: AssemblyFileVersion("0.18.2.0")]

--- a/servers/SkillsMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/SkillsMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c1d2e3f4-a5b6-47c8-99da-0b1c2d3e4f50")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/Mcp35.Client/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Client/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a043f034-fff5-44ce-9605-b40ff0016262")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/src/Mcp35.Core/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Core/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("667ac466-f30b-4cdb-bec9-7a139a709aa9")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/src/Mcp35.Server/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Server/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("dca697a6-1b4c-430c-bc45-134cb5f90072")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]


### PR DESCRIPTION
…cation version to 0.18.2

Previously, upgraded installations of GxPT could experience breakages in the SkillsMcpServer because modified subassemblies were not replacing their older versions. This occurred because the assembly version numbers of the Mcp35 dependencies had not been incremented, causing the installer to skip upgrading those specific files.

By bumping the version numbers of the Mcp35 assemblies (to 0.1.1.0) and SkillsMcpServer (to 1.1.0.0) alongside the main application version bump to 0.18.2, Windows Installer can now correctly identify the updated binaries as newer and replace the older files on upgrade.