### PR TITLE
Bump WebSearchMcpServer assembly version to 0.2.0.0

### DIFF
--- a/servers/WebSearchMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/WebSearchMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("785b59bd-b282-488c-bd78-4529cd80ba49")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]


### PR DESCRIPTION
Bumps the `WebSearchMcpServer` assembly version from `0.1.0.0` to `0.2.0.0` (both `AssemblyVersion` and `AssemblyFileVersion`).

This was missed when #123 merged. The minor bump reflects the new `web__get` / `web__http` raw-HTTP tools added alongside the existing `search` / `extract` tools.

No code changes — version metadata only.

https://claude.ai/code/session_01NriUc7eQdnnZK3mqdnBtrm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NriUc7eQdnnZK3mqdnBtrm)_