### PR TITLE
Fix skills scope mismatch and surface skill scope to the model

### DIFF
--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -85,6 +85,48 @@ namespace GxPT.Tests.Mcp
             Assert.Contains("files__read", ExposedNamesFor(reg, "C:\\proj")); // exposed in its folder
         }
 
+        // ---- workdir-aware schema selection across a scoped/independent name collision (skills) ----
+
+        // The skills server runs as TWO instances under one server name: an eager workdir-less one
+        // (default scope "user") and a per-folder workdir-scoped one (default scope "project"). They
+        // collide on one function name, so the model must be shown — and must reveal — the schema of the
+        // instance its call will actually reach. Before the fix the surface always used list[0] (the
+        // eager workdir-less entry), so a folder turn read "default user" but its call ran against the
+        // project-default instance.
+        private static string DescOf(string revealJson)
+        {
+            JArray defs = JArray.Parse(revealJson.Split('\n')[0]);
+            return (string)defs[0]["description"];
+        }
+
+        [Fact]
+        public void WorkdirReveal_PicksSchemaOfTheInstanceTheCallWillReach()
+        {
+            var reg = NewRegistry(24);
+            // Eager workdir-less instance registers FIRST, so it is list[0] (reproduces the collision).
+            reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default user", null)), null);
+            reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default project", null)), "C:\\proj");
+
+            // A folder turn reveals the workdir-scoped instance's schema (the one TryResolve will call).
+            Assert.Equal("scope default project", DescOf(reg.Reveal(new[] { "skills__edit" }, "C:\\proj")));
+            // A folderless turn reveals the workdir-less instance's schema.
+            Assert.Equal("scope default user", DescOf(reg.Reveal(new[] { "skills__edit" }, null)));
+        }
+
+        [Fact]
+        public void WorkdirExposedDefs_UsesSchemaOfTheInstanceTheCallWillReach()
+        {
+            var reg = NewRegistry(24);
+            reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default user", null)), null);
+            reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default project", null)), "C:\\proj");
+            reg.Reveal(new[] { "skills__edit" }, "C:\\proj");
+
+            string desc = null;
+            foreach (JObject def in reg.ExposedFunctionDefs("C:\\proj"))
+                if ((string)def["function"]["name"] == "skills__edit") desc = (string)def["function"]["description"];
+            Assert.Equal("scope default project", desc);
+        }
+
         // ---- munging / bijection ----
 
         [Fact]

--- a/GxPT.Tests/SkillCatalogTests.cs
+++ b/GxPT.Tests/SkillCatalogTests.cs
@@ -188,8 +188,40 @@ namespace GxPT.Tests
             SkillCatalog cat = SkillCatalog.Build(_bundled, _project);
 
             string manifest = cat.BuildManifest();
-            string expected = "- alpha - First.\n- beta - Second.";
+            string expected = "- alpha [bundled] - First.\n- beta [bundled] - Second.";
             Assert.Equal(expected, manifest);
+        }
+
+        [Fact]
+        public void BuildManifest_LabelsEachSkillWithItsScope()
+        {
+            string user = Path.Combine(_root, "user");
+            Directory.CreateDirectory(user);
+            WriteSkill(_bundled, "ships", null, "Bundled.", "b");
+            WriteSkill(user, "mine", null, "User.", "b");
+            WriteSkill(_project, "local", null, "Project.", "b");
+
+            SkillCatalog cat = SkillCatalog.Build(_bundled, user, _project);
+
+            string manifest = cat.BuildManifest();
+            // The label is the literal `scope` token (user/project) so the model can edit in place;
+            // bundled is read-only.
+            string expected = "- local [project] - Project.\n- mine [user] - User.\n- ships [bundled] - Bundled.";
+            Assert.Equal(expected, manifest);
+        }
+
+        [Fact]
+        public void BuildManifest_ShadowedSkill_LabeledByWinningScope()
+        {
+            string user = Path.Combine(_root, "user");
+            Directory.CreateDirectory(user);
+            // Same slug in user and project: project shadows user, so the label reflects project.
+            WriteSkill(user, "dup", null, "User copy.", "b");
+            WriteSkill(_project, "dup", null, "Project copy.", "b");
+
+            SkillCatalog cat = SkillCatalog.Build(_bundled, user, _project);
+
+            Assert.Equal("- dup [project] - Project copy.", cat.BuildManifest());
         }
     }
 }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -401,7 +401,7 @@ namespace GxPT
             {
                 string[] names = ParseRevealNames(call.ArgumentsJson);
                 _log.Log("mcp", "[turn " + turnId + "] reveal_tools: " + names.Length + " name(s)");
-                return _registry.Reveal(names);
+                return _registry.Reveal(names, WorkingDir);
             }
 
             // open_skill is a host meta-tool (no MCP round-trip): load skill bodies by slug. Same

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -224,6 +224,30 @@ namespace GxPT
             return false;
         }
 
+        // The candidate whose metadata the model should see for a turn with `workdir`: the SAME one
+        // TryResolve would route the call to (exact-workdir match first, then a workdir-independent
+        // candidate). This keeps the advertised/revealed schema in lockstep with the connection that
+        // will actually execute the call. It matters when one server is offered as BOTH a workdir-
+        // scoped and a workdir-less instance (skills): those two carry DIFFERENT schemas (e.g. the
+        // default `scope` they apply), so picking list[0] could show the model the schema of an
+        // instance the call never reaches. Falls back to list[0] only when nothing matches (the caller
+        // has already filtered to resolvable names, so a match is guaranteed in practice).
+        private bool TryBestEntryLocked(string fn, string workdir, out CatalogEntry e)
+        {
+            List<CatalogEntry> list;
+            if (fn != null && _byFunctionName.TryGetValue(fn, out list) && list.Count > 0)
+            {
+                for (int i = 0; i < list.Count; i++)
+                    if (WorkdirEquals(list[i].Workdir, workdir)) { e = list[i]; return true; }
+                for (int i = 0; i < list.Count; i++)
+                    if (list[i].Workdir == null) { e = list[i]; return true; }
+                e = list[0];
+                return true;
+            }
+            e = null;
+            return false;
+        }
+
         // ---- per-request (from the orchestrator) ----
 
         // True when at least one connected server has contributed a tool — the host uses this to
@@ -349,7 +373,7 @@ namespace GxPT
                     if (!_byFunctionName.TryGetValue(fns[i], out list)) continue;
                     if (!ResolvableForWorkdirLocked(list, workdir)) continue;
                     CatalogEntry e;
-                    if (TryFirstEntryLocked(fns[i], out e))
+                    if (TryBestEntryLocked(fns[i], workdir, out e))
                         result.Add(FunctionDef(e.FunctionName, e.Description, CloneSchema(e.Schema)));
                 }
             }
@@ -385,7 +409,16 @@ namespace GxPT
             return functionName == RevealToolsName;
         }
 
+        // Workdir-agnostic reveal (independent tools, or tests that don't run a folder turn).
         public string Reveal(string[] names)
+        {
+            return Reveal(names, null);
+        }
+
+        // Reveal the named tools' full defs for a turn with `workdir`, choosing each tool's schema from
+        // the candidate that turn will actually call (TryBestEntryLocked) so the revealed schema matches
+        // the executing connection — see TryBestEntryLocked.
+        public string Reveal(string[] names, string workdir)
         {
             JArray defs = new JArray();
             List<string> notes = new List<string>();
@@ -398,7 +431,7 @@ namespace GxPT
                     {
                         string n = names[i];
                         CatalogEntry e;
-                        if (n != null && TryFirstEntryLocked(n, out e))
+                        if (n != null && TryBestEntryLocked(n, workdir, out e))
                         {
                             _revealed[n] = ++_tick; // add or bump recency
                             JObject d = new JObject();

--- a/GxPT/Services/Skills/SkillCatalog.cs
+++ b/GxPT/Services/Skills/SkillCatalog.cs
@@ -102,7 +102,12 @@ namespace GxPT
             return new Skill(slug, name, fm.Description, dir, file, source);
         }
 
-        // The manifest body the model sees: one "- <slug> - <description>" line per skill, slug-ordered.
+        // The manifest body the model sees: one "- <slug> [<scope>] - <description>" line per skill,
+        // slug-ordered. The scope label is the skill's source, spelled as the literal `scope` argument
+        // the authoring tools (edit_skill_file/update_skill/...) take - "user" or "project" - so the
+        // model can edit a skill in the right scope on the first call instead of guessing the default
+        // and failing on a cross-scope skill. "bundled" skills are shipped read-only (the writer targets
+        // only the project/user roots), so the label doubles as a "not editable in place" signal.
         // The surrounding system-message framing + enable filtering is a later phase; this is the list.
         public string BuildManifest()
         {
@@ -115,9 +120,23 @@ namespace GxPT
             foreach (Skill s in skills)
             {
                 if (sb.Length > 0) sb.Append('\n');
-                sb.Append("- ").Append(s.Slug).Append(" - ").Append(s.Description);
+                sb.Append("- ").Append(s.Slug)
+                    .Append(" [").Append(ScopeLabel(s.Source)).Append("]")
+                    .Append(" - ").Append(s.Description);
             }
             return sb.ToString();
+        }
+
+        // The skill's source as the literal `scope` token the authoring tools accept (user/project);
+        // bundled skills have no writable scope, so they're labeled "bundled".
+        private static string ScopeLabel(SkillSource source)
+        {
+            switch (source)
+            {
+                case SkillSource.Project: return "project";
+                case SkillSource.User: return "user";
+                default: return "bundled";
+            }
         }
     }
 }

--- a/GxPT/Services/Skills/SkillInjection.cs
+++ b/GxPT/Services/Skills/SkillInjection.cs
@@ -66,10 +66,13 @@ namespace GxPT
             StringBuilder sb = new StringBuilder();
             sb.Append("# Skills\n\n");
             sb.Append("Skills are reusable procedures available for this conversation, listed below as ");
-            sb.Append("`- <slug> - <description>`. When a task matches one, load its full instructions by ");
-            sb.Append("calling open_skill({\"names\":[\"<slug>\"]}) and then follow them. open_skill is ");
-            sb.Append("directly callable - you do NOT need to reveal it first - and you may open several ");
-            sb.Append("skills at once. Do not mention skills unless they are relevant to the request.\n\n");
+            sb.Append("`- <slug> [<scope>] - <description>`. When a task matches one, load its full ");
+            sb.Append("instructions by calling open_skill({\"names\":[\"<slug>\"]}) and then follow them. ");
+            sb.Append("open_skill is directly callable - you do NOT need to reveal it first - and you may ");
+            sb.Append("open several skills at once. The <scope> is where the skill lives (user or project; ");
+            sb.Append("bundled skills are read-only); pass it as the `scope` argument when editing a skill ");
+            sb.Append("so the edit targets the right one. Do not mention skills unless they are relevant ");
+            sb.Append("to the request.\n\n");
             sb.Append("Available skills:\n");
             sb.Append(SkillCatalog.BuildManifest(enabledSkills));
             return sb.ToString();


### PR DESCRIPTION
## Problem

Editing a user-global skill from a conversation that has a working folder failed with `skill '<slug>' does not exist` unless `scope: "user"` was passed explicitly — even though the tool advertised `user` as the default.

### Root cause

The skills MCP server runs as **two processes under one server name**:
- an eager **workdir-less** instance (default scope `user`, advertises *"project unavailable"*), and
- a per-folder **workdir-scoped** instance (default scope `project`).

They collide on one function name (e.g. `skills__edit_skill_file`), so the registry holds two candidates for it. The two host code paths then disagreed:

- **What the model saw** — `Reveal()` / `ExposedFunctionDefs()` picked `list[0]` (the eager workdir-less entry, registered first) → schema said *"omit scope → user"*.
- **What executed the call** — `TryResolve(name, workdir)` prefers the exact-workdir match → the workdir-scoped instance → *omit scope → project*.

So in a folder turn the model read "user" but its call ran against the project-default instance. The omitted-scope edit of a user-global skill looked in `<workdir>/.gxpt/skills` and failed. Passing `scope:"user"` bypassed the default, which is why that worked.

## Fix

**1. Align the advertised schema with the routed instance** (`McpToolRegistry`, `McpChatOrchestrator`)

Added `TryBestEntryLocked(fn, workdir)`, mirroring `TryResolve`'s exact-match-then-workdir-independent selection, and used it in `Reveal` (now workdir-aware, threaded from the orchestrator) and `ExposedFunctionDefs(workdir)`. The model is now shown the schema of the instance its call will actually reach. This is also the "a folder turn only interacts with the workdir-scoped skills server" behavior — done per-turn, without disturbing the shared eager process that folderless tabs still need.

**2. Label each skill with its scope in the always-on manifest** (`SkillCatalog`, `SkillInjection`)

The remaining issue was purely an information gap: the model didn't know which scope a skill lived in, so it guessed the default. Each `Skill` already carries its `Source`, so the manifest now reads:

```
- vendor-review [user] - use this when reviewing a third-party vendor...
```

The label is the literal `scope` token (`user`/`project`, or `bundled` for read-only shipped skills), so the model targets the right scope on the first edit instead of guessing. The framing text was updated to explain it.

## Tests

- New `McpToolRegistry` regression tests reproducing the two-instance skills collision (folder turn reveals the project-default schema; folderless turn reveals the user-default schema; exposed defs match).
- New `SkillCatalog` tests for per-source scope labels and shadowing (a slug present in both user and project is labeled by the winning scope).
- Updated the one exact-match manifest test for the new `[scope]` format.

## Note

I could not compile or run the tests in this environment — there's no .NET toolchain available (`dotnet`/`msbuild`/`mono` absent) and the projects target `net48`. Changes were verified by review and kept mechanical; please run `dotnet test` / build in VS to confirm green before merging.

https://claude.ai/code/session_01JMDEj21URqvW4Fnr13Wo96

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMDEj21URqvW4Fnr13Wo96)_