### PR TITLE
Add stop button and loading bar for in-flight model requests

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\GxPT\Models\Conversation.cs" Link="Linked\Conversation.cs" />
     <Compile Include="..\GxPT\Models\ChatModels.cs" Link="Linked\ChatModels.cs" />
     <Compile Include="..\GxPT\Services\OpenRouterClient.cs" Link="Linked\OpenRouterClient.cs" />
+    <Compile Include="..\GxPT\Services\RequestCancellation.cs" Link="Linked\RequestCancellation.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IToolApprovalPolicy.cs" Link="Linked\Mcp\IToolApprovalPolicy.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolApproval.cs" Link="Linked\Mcp\ToolApproval.cs" />

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -65,7 +65,8 @@ namespace GxPT.Tests.Mcp
         public readonly List<IList<JObject>> SeenTools = new List<IList<JObject>>();
 
         public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
-                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError,
+                               RequestCancellation cancel)
         {
             int idx = Calls++;
             SeenMessages.Add(messages);

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -48,7 +48,7 @@ namespace GxPT
             // Docked Right gives the button the full padded height; pinning Width to that same value
             // makes it a square (StripHeight minus the top+bottom padding).
             _stop.Width = StripHeight - (VPad * 2);
-            _stop.Margin = new Padding(6, 0, 0, 0); // small gap from the bar
+            _stop.Margin = new Padding(2, 0, 0, 0); // 2px gap from the bar
             _stop.Click += delegate
             {
                 EventHandler h = StopRequested;

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -16,15 +16,15 @@ namespace GxPT
     // app-wide in Program.cs), available on Windows XP and later; without them it renders static.
     //
     // The stop glyph is owner-drawn (not a font character) so it stays a crisp, true square at any
-    // DPI - a Unicode glyph in a stock Button clips vertically and reads as a rectangle.
+    // DPI - a Unicode glyph in a stock Button clips vertically and reads as a rectangle. The button is
+    // docked Right with its width pinned to the padded strip height, so it lays out as a real square.
     internal sealed class GenerationStatusBar : Panel
     {
         private readonly ProgressBar _bar;
         private readonly StopGlyphButton _stop;
 
-        private const int BarVPad = 5;   // vertical inset for both children
-        private const int SideHPad = 6;  // gap from the panel's left/right edges
-        private const int Gap = 6;       // gap between the progress bar and the stop button
+        private const int StripHeight = 28;
+        private const int VPad = 5; // top/bottom inset; also fixes the (square) button's side length
 
         // Raised on the UI thread when the user clicks Stop. The host cancels the in-flight request.
         public event EventHandler StopRequested;
@@ -33,15 +33,22 @@ namespace GxPT
         {
             this.Dock = DockStyle.Bottom;
             this.Visible = false;
-            this.Height = 28;
+            this.Height = StripHeight;
+            this.Padding = new Padding(8, VPad, 6, VPad);
 
-            // Children are positioned manually (Relayout) so the stop button can be a centered square
-            // rather than a full-height docked rectangle.
+            // Fill bar added before the docked button so it occupies the space to the button's left
+            // (WinForms lays the Fill child into whatever the docked siblings leave).
             _bar = new ProgressBar();
+            _bar.Dock = DockStyle.Fill;
             _bar.Style = ProgressBarStyle.Marquee;
             _bar.MarqueeAnimationSpeed = 30;
 
             _stop = new StopGlyphButton();
+            _stop.Dock = DockStyle.Right;
+            // Docked Right gives the button the full padded height; pinning Width to that same value
+            // makes it a square (StripHeight minus the top+bottom padding).
+            _stop.Width = StripHeight - (VPad * 2);
+            _stop.Margin = new Padding(6, 0, 0, 0); // small gap from the bar
             _stop.Click += delegate
             {
                 EventHandler h = StopRequested;
@@ -53,7 +60,6 @@ namespace GxPT
 
             this.Controls.Add(_bar);
             this.Controls.Add(_stop);
-            Relayout();
         }
 
         // Show the strip and start the marquee. Pulls current theme colors so it blends in dark mode.
@@ -61,7 +67,6 @@ namespace GxPT
         {
             ApplyTheme();
             _bar.MarqueeAnimationSpeed = 30; // (re)start the animation if it had been stopped
-            Relayout();
             this.Visible = true;
             // Keep this Bottom-docked strip behind the Fill transcript in z-order, so the transcript
             // shrinks above it rather than the strip overlaying the transcript's bottom edge.
@@ -73,31 +78,6 @@ namespace GxPT
         {
             this.Visible = false;
             _bar.MarqueeAnimationSpeed = 0;
-        }
-
-        protected override void OnSizeChanged(EventArgs e)
-        {
-            base.OnSizeChanged(e);
-            Relayout();
-        }
-
-        // The stop button is a square sized to the strip's height; the progress bar fills the rest.
-        private void Relayout()
-        {
-            int w = this.ClientSize.Width;
-            int h = this.ClientSize.Height;
-            if (w <= 0 || h <= 0) return;
-
-            int side = h - (BarVPad * 2);
-            if (side < 12) side = 12;
-            int stopX = w - SideHPad - side;
-            _stop.SetBounds(stopX, (h - side) / 2, side, side);
-
-            int barLeft = SideHPad;
-            int barWidth = stopX - Gap - barLeft;
-            if (barWidth < 0) barWidth = 0;
-            int barHeight = side; // align the bar's height with the button for a balanced row
-            _bar.SetBounds(barLeft, (h - barHeight) / 2, barWidth, barHeight);
         }
 
         private void ApplyTheme()

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -1,23 +1,30 @@
 using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 
 namespace GxPT
 {
     // A thin status strip docked at the bottom of a tab's chat area, shown only while a model request
     // is in flight. It carries an indeterminate (marquee) progress bar spanning the width, with a
-    // stop button at the right end. Stopping raises StopRequested, which the host wires to the turn's
-    // RequestCancellation so the in-flight curl process is killed (dropping the connection); the
-    // streaming/orchestrator paths then finalize the turn cleanly and the bar is hidden.
+    // square stop button at the right end. Stopping raises StopRequested, which the host wires to the
+    // turn's RequestCancellation so the in-flight curl process is killed (dropping the connection);
+    // the streaming/orchestrator paths then finalize the turn cleanly and the bar is hidden.
     //
     // One instance per tab (created alongside the transcript), mirroring ToolApprovalPanel: it
     // self-docks Bottom and starts hidden. The marquee animation needs visual styles (enabled
-    // app-wide in Program.cs), which are available on Windows XP and later; without them it simply
-    // renders static rather than animating.
+    // app-wide in Program.cs), available on Windows XP and later; without them it renders static.
+    //
+    // The stop glyph is owner-drawn (not a font character) so it stays a crisp, true square at any
+    // DPI - a Unicode glyph in a stock Button clips vertically and reads as a rectangle.
     internal sealed class GenerationStatusBar : Panel
     {
         private readonly ProgressBar _bar;
-        private readonly Button _stop;
+        private readonly StopGlyphButton _stop;
+
+        private const int BarVPad = 5;   // vertical inset for both children
+        private const int SideHPad = 6;  // gap from the panel's left/right edges
+        private const int Gap = 6;       // gap between the progress bar and the stop button
 
         // Raised on the UI thread when the user clicks Stop. The host cancels the in-flight request.
         public event EventHandler StopRequested;
@@ -26,21 +33,15 @@ namespace GxPT
         {
             this.Dock = DockStyle.Bottom;
             this.Visible = false;
-            this.Height = 26;
-            this.Padding = new Padding(6, 3, 6, 3);
+            this.Height = 28;
 
+            // Children are positioned manually (Relayout) so the stop button can be a centered square
+            // rather than a full-height docked rectangle.
             _bar = new ProgressBar();
-            _bar.Dock = DockStyle.Fill;
             _bar.Style = ProgressBarStyle.Marquee;
             _bar.MarqueeAnimationSpeed = 30;
 
-            _stop = new Button();
-            _stop.Dock = DockStyle.Right;
-            _stop.Width = 26;
-            _stop.Text = "\u25A0"; // BLACK SQUARE - present in Tahoma (XP's default UI font)
-            _stop.FlatStyle = FlatStyle.Flat;
-            _stop.TabStop = false;
-            _stop.Margin = new Padding(0);
+            _stop = new StopGlyphButton();
             _stop.Click += delegate
             {
                 EventHandler h = StopRequested;
@@ -50,10 +51,9 @@ namespace GxPT
             ToolTip tip = new ToolTip();
             tip.SetToolTip(_stop, "Stop generating");
 
-            // The Fill bar is added before the docked button so it occupies the space to its left
-            // (WinForms lays the Fill child into whatever the docked siblings leave).
             this.Controls.Add(_bar);
             this.Controls.Add(_stop);
+            Relayout();
         }
 
         // Show the strip and start the marquee. Pulls current theme colors so it blends in dark mode.
@@ -61,6 +61,7 @@ namespace GxPT
         {
             ApplyTheme();
             _bar.MarqueeAnimationSpeed = 30; // (re)start the animation if it had been stopped
+            Relayout();
             this.Visible = true;
             // Keep this Bottom-docked strip behind the Fill transcript in z-order, so the transcript
             // shrinks above it rather than the strip overlaying the transcript's bottom edge.
@@ -74,6 +75,31 @@ namespace GxPT
             _bar.MarqueeAnimationSpeed = 0;
         }
 
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            Relayout();
+        }
+
+        // The stop button is a square sized to the strip's height; the progress bar fills the rest.
+        private void Relayout()
+        {
+            int w = this.ClientSize.Width;
+            int h = this.ClientSize.Height;
+            if (w <= 0 || h <= 0) return;
+
+            int side = h - (BarVPad * 2);
+            if (side < 12) side = 12;
+            int stopX = w - SideHPad - side;
+            _stop.SetBounds(stopX, (h - side) / 2, side, side);
+
+            int barLeft = SideHPad;
+            int barWidth = stopX - Gap - barLeft;
+            if (barWidth < 0) barWidth = 0;
+            int barHeight = side; // align the bar's height with the button for a balanced row
+            _bar.SetBounds(barLeft, (h - barHeight) / 2, barWidth, barHeight);
+        }
+
         private void ApplyTheme()
         {
             try
@@ -82,11 +108,82 @@ namespace GxPT
                 bool dark = !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
                 ThemeColors tc = ThemeService.GetColors(dark);
                 this.BackColor = tc.UiBackground;
-                _stop.ForeColor = tc.UiForeground;
                 _stop.BackColor = tc.UiBackground;
-                _stop.FlatAppearance.BorderColor = tc.UiForeground;
+                _stop.GlyphColor = tc.UiForeground;
+                // Subtle hover wash: nudge the background toward the foreground.
+                _stop.HoverBack = Blend(tc.UiBackground, tc.UiForeground, dark ? 0.22f : 0.12f);
             }
             catch { }
+        }
+
+        private static Color Blend(Color a, Color b, float t)
+        {
+            if (t < 0f) t = 0f; else if (t > 1f) t = 1f;
+            int r = (int)(a.R + (b.R - a.R) * t);
+            int g = (int)(a.G + (b.G - a.G) * t);
+            int bl = (int)(a.B + (b.B - a.B) * t);
+            return Color.FromArgb(r, g, bl);
+        }
+
+        // A flat, square stop button that paints a centered filled square (slightly rounded) instead
+        // of relying on a font glyph - so it never clips and always reads as a square. Hover paints a
+        // soft rounded background for feedback. Control already raises Click on mouse click.
+        private sealed class StopGlyphButton : Control
+        {
+            private bool _hover;
+
+            public Color GlyphColor = Color.Black;
+            public Color HoverBack = Color.Gainsboro;
+
+            public StopGlyphButton()
+            {
+                this.SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer
+                    | ControlStyles.UserPaint | ControlStyles.ResizeRedraw, true);
+                this.Cursor = Cursors.Hand;
+                this.TabStop = false;
+            }
+
+            protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
+            protected override void OnMouseLeave(EventArgs e) { _hover = false; Invalidate(); base.OnMouseLeave(e); }
+
+            protected override void OnPaint(PaintEventArgs e)
+            {
+                Graphics g = e.Graphics;
+                g.Clear(this.BackColor);
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+
+                if (_hover)
+                {
+                    using (SolidBrush hb = new SolidBrush(HoverBack))
+                    using (GraphicsPath hp = Rounded(new Rectangle(0, 0, Width - 1, Height - 1), 4))
+                        g.FillPath(hb, hp);
+                }
+
+                int side = (int)(Math.Min(Width, Height) * 0.5f);
+                if (side < 6) side = 6;
+                int x = (Width - side) / 2;
+                int y = (Height - side) / 2;
+                using (SolidBrush sb = new SolidBrush(GlyphColor))
+                using (GraphicsPath sp = Rounded(new Rectangle(x, y, side, side), 2))
+                    g.FillPath(sb, sp);
+            }
+
+            private static GraphicsPath Rounded(Rectangle r, int radius)
+            {
+                GraphicsPath p = new GraphicsPath();
+                int d = radius * 2;
+                if (d <= 0 || r.Width <= d || r.Height <= d)
+                {
+                    p.AddRectangle(r);
+                    return p;
+                }
+                p.AddArc(r.X, r.Y, d, d, 180, 90);
+                p.AddArc(r.Right - d, r.Y, d, d, 270, 90);
+                p.AddArc(r.Right - d, r.Bottom - d, d, d, 0, 90);
+                p.AddArc(r.X, r.Bottom - d, d, d, 90, 90);
+                p.CloseFigure();
+                return p;
+            }
         }
     }
 }

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -15,16 +15,18 @@ namespace GxPT
     // self-docks Bottom and starts hidden. The marquee animation needs visual styles (enabled
     // app-wide in Program.cs), available on Windows XP and later; without them it renders static.
     //
-    // The stop glyph is owner-drawn (not a font character) so it stays a crisp, true square at any
-    // DPI - a Unicode glyph in a stock Button clips vertically and reads as a rectangle. The button is
-    // docked Right with its width pinned to the padded strip height, so it lays out as a real square.
+    // The stop button matches the tab strip's new/close glyph buttons (GlyphToolStripButton): an
+    // owner-drawn dark-grey glyph with a light-grey hover/press fill, so it reads as part of the same
+    // family. The glyph is painted (not a font character) so it stays a crisp square and never clips.
     internal sealed class GenerationStatusBar : Panel
     {
         private readonly ProgressBar _bar;
+        private readonly Panel _stopHolder;
         private readonly StopGlyphButton _stop;
 
         private const int StripHeight = 28;
-        private const int VPad = 5; // top/bottom inset; also fixes the (square) button's side length
+        private const int VPad = 5;      // top/bottom inset; also fixes the (square) button's side
+        private const int BarGap = 2;    // gap between the progress bar and the stop button
 
         // Raised on the UI thread when the user clicks Stop. The host cancels the in-flight request.
         public event EventHandler StopRequested;
@@ -36,30 +38,35 @@ namespace GxPT
             this.Height = StripHeight;
             this.Padding = new Padding(8, VPad, 6, VPad);
 
-            // Fill bar added before the docked button so it occupies the space to the button's left
-            // (WinForms lays the Fill child into whatever the docked siblings leave).
+            int side = StripHeight - (VPad * 2); // square button side
+
+            // Fill bar added before the docked holder so it occupies the space to the holder's left.
             _bar = new ProgressBar();
             _bar.Dock = DockStyle.Fill;
             _bar.Style = ProgressBarStyle.Marquee;
             _bar.MarqueeAnimationSpeed = 30;
 
+            // A docked Right-edge holder whose left padding provides a reliable gap between the bar and
+            // the button (a docked control's own Margin is ignored by the layout, so the gap lives here).
             _stop = new StopGlyphButton();
-            _stop.Dock = DockStyle.Right;
-            // Docked Right gives the button the full padded height; pinning Width to that same value
-            // makes it a square (StripHeight minus the top+bottom padding).
-            _stop.Width = StripHeight - (VPad * 2);
-            _stop.Margin = new Padding(2, 0, 0, 0); // 2px gap from the bar
+            _stop.Dock = DockStyle.Fill;
             _stop.Click += delegate
             {
                 EventHandler h = StopRequested;
                 if (h != null) h(this, EventArgs.Empty);
             };
 
+            _stopHolder = new Panel();
+            _stopHolder.Dock = DockStyle.Right;
+            _stopHolder.Width = side + BarGap;
+            _stopHolder.Padding = new Padding(BarGap, 0, 0, 0);
+            _stopHolder.Controls.Add(_stop);
+
             ToolTip tip = new ToolTip();
             tip.SetToolTip(_stop, "Stop generating");
 
             this.Controls.Add(_bar);
-            this.Controls.Add(_stop);
+            this.Controls.Add(_stopHolder);
         }
 
         // Show the strip and start the marquee. Pulls current theme colors so it blends in dark mode.
@@ -88,33 +95,25 @@ namespace GxPT
                 bool dark = !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
                 ThemeColors tc = ThemeService.GetColors(dark);
                 this.BackColor = tc.UiBackground;
+                _stopHolder.BackColor = tc.UiBackground;
                 _stop.BackColor = tc.UiBackground;
-                _stop.GlyphColor = tc.UiForeground;
-                // Subtle hover wash: nudge the background toward the foreground.
-                _stop.HoverBack = Blend(tc.UiBackground, tc.UiForeground, dark ? 0.22f : 0.12f);
             }
             catch { }
         }
 
-        private static Color Blend(Color a, Color b, float t)
-        {
-            if (t < 0f) t = 0f; else if (t > 1f) t = 1f;
-            int r = (int)(a.R + (b.R - a.R) * t);
-            int g = (int)(a.G + (b.G - a.G) * t);
-            int bl = (int)(a.B + (b.B - a.B) * t);
-            return Color.FromArgb(r, g, bl);
-        }
-
-        // A flat, square stop button that paints a centered filled square (slightly rounded) instead
-        // of relying on a font glyph - so it never clips and always reads as a square. Hover paints a
-        // soft rounded background for feedback. Control already raises Click on mouse click.
+        // A flat, square stop button styled to match the tab strip's new/close buttons
+        // (GlyphToolStripButton): a dark-grey filled-square glyph, a light-grey hover/press fill with a
+        // matching border, and a thin resting border. Owner-drawn so the glyph never clips. Control
+        // already raises Click on mouse click.
         private sealed class StopGlyphButton : Control
         {
             private bool _hover;
+            private bool _pressed;
 
-            public Color GlyphColor = Color.Black;
-            public Color HoverBack = Color.Gainsboro;
-            public Color BorderColor = Color.Gray;
+            // Mirrors GlyphToolStripButton's palette so the two button families look identical.
+            private static readonly Color GlyphColor = Color.FromArgb(80, 80, 80);
+            private static readonly Color HoverBorder = Color.FromArgb(210, 210, 210);
+            private static readonly Color RestBorder = Color.FromArgb(128, 128, 128); // thin dark-grey resting border
 
             public StopGlyphButton()
             {
@@ -125,50 +124,39 @@ namespace GxPT
             }
 
             protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
-            protected override void OnMouseLeave(EventArgs e) { _hover = false; Invalidate(); base.OnMouseLeave(e); }
+            protected override void OnMouseLeave(EventArgs e) { _hover = false; _pressed = false; Invalidate(); base.OnMouseLeave(e); }
+            protected override void OnMouseDown(MouseEventArgs e) { if (e.Button == MouseButtons.Left) { _pressed = true; Invalidate(); } base.OnMouseDown(e); }
+            protected override void OnMouseUp(MouseEventArgs e) { _pressed = false; Invalidate(); base.OnMouseUp(e); }
 
             protected override void OnPaint(PaintEventArgs e)
             {
                 Graphics g = e.Graphics;
                 g.Clear(this.BackColor);
-                g.SmoothingMode = SmoothingMode.AntiAlias;
+                Rectangle r = new Rectangle(0, 0, this.Width - 1, this.Height - 1);
 
-                if (_hover)
+                // Hover/press fill + border, matching the tab glyph buttons.
+                if (_hover || _pressed)
                 {
-                    using (SolidBrush hb = new SolidBrush(HoverBack))
-                    using (GraphicsPath hp = Rounded(new Rectangle(0, 0, Width - 1, Height - 1), 4))
-                        g.FillPath(hb, hp);
+                    int shade = _pressed ? 210 : 230;
+                    using (SolidBrush sb = new SolidBrush(Color.FromArgb(shade, shade, shade)))
+                        g.FillRectangle(sb, r);
+                    using (Pen hp = new Pen(HoverBorder))
+                        g.DrawRectangle(hp, r);
+                }
+                else
+                {
+                    // Thin dark-grey resting border.
+                    using (Pen rp = new Pen(RestBorder))
+                        g.DrawRectangle(rp, r);
                 }
 
-                int side = (int)(Math.Min(Width, Height) * 0.5f);
+                // Centered filled square (the "stop" glyph), in the tab buttons' glyph colour.
+                int side = Math.Min(r.Width, r.Height) - 8;
                 if (side < 6) side = 6;
-                int x = (Width - side) / 2;
-                int y = (Height - side) / 2;
-                using (SolidBrush sb = new SolidBrush(GlyphColor))
-                using (GraphicsPath sp = Rounded(new Rectangle(x, y, side, side), 2))
-                    g.FillPath(sb, sp);
-
-                // Thin dark-grey border around the button.
-                using (Pen bp = new Pen(BorderColor))
-                using (GraphicsPath bdr = Rounded(new Rectangle(0, 0, Width - 1, Height - 1), 4))
-                    g.DrawPath(bp, bdr);
-            }
-
-            private static GraphicsPath Rounded(Rectangle r, int radius)
-            {
-                GraphicsPath p = new GraphicsPath();
-                int d = radius * 2;
-                if (d <= 0 || r.Width <= d || r.Height <= d)
-                {
-                    p.AddRectangle(r);
-                    return p;
-                }
-                p.AddArc(r.X, r.Y, d, d, 180, 90);
-                p.AddArc(r.Right - d, r.Y, d, d, 270, 90);
-                p.AddArc(r.Right - d, r.Bottom - d, d, d, 0, 90);
-                p.AddArc(r.X, r.Bottom - d, d, d, 90, 90);
-                p.CloseFigure();
-                return p;
+                int x = r.Left + (r.Width - side) / 2;
+                int y = r.Top + (r.Height - side) / 2;
+                using (SolidBrush gb = new SolidBrush(GlyphColor))
+                    g.FillRectangle(gb, new Rectangle(x, y, side, side));
             }
         }
     }

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -114,6 +114,7 @@ namespace GxPT
 
             public Color GlyphColor = Color.Black;
             public Color HoverBack = Color.Gainsboro;
+            public Color BorderColor = Color.Gray;
 
             public StopGlyphButton()
             {
@@ -146,6 +147,11 @@ namespace GxPT
                 using (SolidBrush sb = new SolidBrush(GlyphColor))
                 using (GraphicsPath sp = Rounded(new Rectangle(x, y, side, side), 2))
                     g.FillPath(sb, sp);
+
+                // Thin dark-grey border around the button.
+                using (Pen bp = new Pen(BorderColor))
+                using (GraphicsPath bdr = Rounded(new Rectangle(0, 0, Width - 1, Height - 1), 4))
+                    g.DrawPath(bp, bdr);
             }
 
             private static GraphicsPath Rounded(Rectangle r, int radius)

--- a/GxPT/Controls/GenerationStatusBar.cs
+++ b/GxPT/Controls/GenerationStatusBar.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // A thin status strip docked at the bottom of a tab's chat area, shown only while a model request
+    // is in flight. It carries an indeterminate (marquee) progress bar spanning the width, with a
+    // stop button at the right end. Stopping raises StopRequested, which the host wires to the turn's
+    // RequestCancellation so the in-flight curl process is killed (dropping the connection); the
+    // streaming/orchestrator paths then finalize the turn cleanly and the bar is hidden.
+    //
+    // One instance per tab (created alongside the transcript), mirroring ToolApprovalPanel: it
+    // self-docks Bottom and starts hidden. The marquee animation needs visual styles (enabled
+    // app-wide in Program.cs), which are available on Windows XP and later; without them it simply
+    // renders static rather than animating.
+    internal sealed class GenerationStatusBar : Panel
+    {
+        private readonly ProgressBar _bar;
+        private readonly Button _stop;
+
+        // Raised on the UI thread when the user clicks Stop. The host cancels the in-flight request.
+        public event EventHandler StopRequested;
+
+        public GenerationStatusBar()
+        {
+            this.Dock = DockStyle.Bottom;
+            this.Visible = false;
+            this.Height = 26;
+            this.Padding = new Padding(6, 3, 6, 3);
+
+            _bar = new ProgressBar();
+            _bar.Dock = DockStyle.Fill;
+            _bar.Style = ProgressBarStyle.Marquee;
+            _bar.MarqueeAnimationSpeed = 30;
+
+            _stop = new Button();
+            _stop.Dock = DockStyle.Right;
+            _stop.Width = 26;
+            _stop.Text = "\u25A0"; // BLACK SQUARE - present in Tahoma (XP's default UI font)
+            _stop.FlatStyle = FlatStyle.Flat;
+            _stop.TabStop = false;
+            _stop.Margin = new Padding(0);
+            _stop.Click += delegate
+            {
+                EventHandler h = StopRequested;
+                if (h != null) h(this, EventArgs.Empty);
+            };
+
+            ToolTip tip = new ToolTip();
+            tip.SetToolTip(_stop, "Stop generating");
+
+            // The Fill bar is added before the docked button so it occupies the space to its left
+            // (WinForms lays the Fill child into whatever the docked siblings leave).
+            this.Controls.Add(_bar);
+            this.Controls.Add(_stop);
+        }
+
+        // Show the strip and start the marquee. Pulls current theme colors so it blends in dark mode.
+        public void ShowBusy()
+        {
+            ApplyTheme();
+            _bar.MarqueeAnimationSpeed = 30; // (re)start the animation if it had been stopped
+            this.Visible = true;
+            // Keep this Bottom-docked strip behind the Fill transcript in z-order, so the transcript
+            // shrinks above it rather than the strip overlaying the transcript's bottom edge.
+            this.SendToBack();
+        }
+
+        // Hide the strip and stop the marquee (no point animating an invisible bar).
+        public void HideBusy()
+        {
+            this.Visible = false;
+            _bar.MarqueeAnimationSpeed = 0;
+        }
+
+        private void ApplyTheme()
+        {
+            try
+            {
+                string th = AppSettings.GetString("theme");
+                bool dark = !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+                ThemeColors tc = ThemeService.GetColors(dark);
+                this.BackColor = tc.UiBackground;
+                _stop.ForeColor = tc.UiForeground;
+                _stop.BackColor = tc.UiBackground;
+                _stop.FlatAppearance.BorderColor = tc.UiForeground;
+            }
+            catch { }
+        }
+    }
+}

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -678,6 +678,7 @@ namespace GxPT
                 // Bottom approval panel. Add the docked siblings, then send the transcript to front.
                 ctx.Page.Controls.Add(strip);
                 AttachApprovalPanel(ctx);
+                AttachGenerationStatusBar(ctx);
                 if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
                 // Honor a persisted dismissal (only meaningful when no folder is set; setting one
@@ -704,6 +705,57 @@ namespace GxPT
                 ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
+        }
+
+        // Create this tab's generation status strip (marquee progress bar + stop button, docked below
+        // the transcript, hidden until a request is in flight). Each conversation gets its own strip so
+        // the bar and Stop button track the tab that's actually generating; Stop cancels that tab's
+        // in-flight request.
+        internal void AttachGenerationStatusBar(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Page == null) return;
+            try
+            {
+                var bar = new GenerationStatusBar();
+                ctx.GenerationStatusBar = bar;
+                var ctxRef = ctx;
+                bar.StopRequested += delegate { CancelActiveRequest(ctxRef); };
+                ctx.Page.Controls.Add(bar); // self-docks Bottom, starts hidden
+            }
+            catch { }
+        }
+
+        // Stop button on a tab's status strip: cancel that tab's in-flight model request. Killing the
+        // curl process drops the connection so the API stops generating; the streaming/orchestrator
+        // paths then finalize the turn cleanly (keeping any partial text) and hide the strip.
+        private void CancelActiveRequest(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            try
+            {
+                RequestCancellation c = ctx.Cancellation;
+                if (c != null)
+                {
+                    Logger.Log("Send", "User requested stop.");
+                    c.Cancel();
+                }
+            }
+            catch { }
+        }
+
+        // Show/hide this tab's generation status strip. Safe to call when the strip isn't present.
+        private void ShowGenerationBar(TabManager.ChatTabContext ctx)
+        {
+            if (ctx != null && ctx.GenerationStatusBar != null)
+                try { ctx.GenerationStatusBar.ShowBusy(); }
+                catch { }
+        }
+
+        private void HideGenerationBar(TabManager.ChatTabContext ctx)
+        {
+            if (ctx != null && ctx.GenerationStatusBar != null)
+                try { ctx.GenerationStatusBar.HideBusy(); }
+                catch { }
         }
 
         private void DismissWorkspaceStripForContext(TabManager.ChatTabContext ctx)
@@ -1877,6 +1929,11 @@ namespace GxPT
 
             // Lock sending immediately to avoid duplicate sends from rapid clicks/Enter
             ctx.IsSending = true;
+            // Fresh cancellation handle for this turn, and show the in-flight status strip (covers both
+            // the plain stream below and the tool-loop path in BeginToolSend, including the wait before
+            // the first token while the model thinks / assembles a long tool call).
+            ctx.Cancellation = new RequestCancellation();
+            ShowGenerationBar(ctx);
 
             try
             {
@@ -1972,6 +2029,9 @@ namespace GxPT
                 if (zdrForSend) ctx.Transcript.SetMessageZdrTag(assistantIndex, true);
                 Logger.Log("Send", "Assistant placeholder index=" + assistantIndex);
                 var assistantBuilder = new StringBuilder();
+                // Capture this turn's cancellation handle for the streaming callbacks (the field is
+                // cleared to null when the turn finalizes).
+                RequestCancellation cancel = ctx.Cancellation;
 
                 // Throttle UI updates with a WinForms timer (coalesces rapid deltas)
                 var sbLock = new object();
@@ -2042,16 +2102,31 @@ namespace GxPT
                                     catch { }
                                     try { ctx.Transcript.StickToBottomDuringStreaming = false; }
                                     catch { }
-                                    ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
-                                    ctx.Conversation.AddAssistantMessage(finalText);
-                                    ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                                    // Save assistant completion if allowed
-                                    if (!ctx.NoSaveUntilUserSend)
-                                        ConversationStore.Save(ctx.Conversation); // save only after streaming completes
-                                    try { Logger.Log("Transcript", "Final assistant message at index=" + assistantIndex + ":\n" + (finalText ?? string.Empty)); }
-                                    catch { }
-                                    Logger.Log("Send", "Assistant finalized at index=" + assistantIndex + ", chars=" + (finalText != null ? finalText.Length : 0));
+                                    // A user stop ends the stream via onDone (no error). If nothing
+                                    // streamed yet, drop the empty placeholder rather than committing an
+                                    // empty assistant message; otherwise keep the partial text as normal.
+                                    bool cancelled = (cancel != null && cancel.IsCancelled);
+                                    if (cancelled && finalText.Trim().Length == 0)
+                                    {
+                                        if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                            ctx.Transcript.RemoveLastMessage();
+                                        Logger.Log("Send", "Stream stopped by user before any output at index=" + assistantIndex);
+                                    }
+                                    else
+                                    {
+                                        ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
+                                        ctx.Conversation.AddAssistantMessage(finalText);
+                                        ctx.Conversation.SelectedModel = ctx.SelectedModel;
+                                        // Save assistant completion if allowed
+                                        if (!ctx.NoSaveUntilUserSend)
+                                            ConversationStore.Save(ctx.Conversation); // save only after streaming completes
+                                        try { Logger.Log("Transcript", "Final assistant message at index=" + assistantIndex + ":\n" + (finalText ?? string.Empty)); }
+                                        catch { }
+                                        Logger.Log("Send", "Assistant finalized at index=" + assistantIndex + ", chars=" + (finalText != null ? finalText.Length : 0) + (cancelled ? " (stopped by user)" : string.Empty));
+                                    }
                                     ctx.IsSending = false;
+                                    ctx.Cancellation = null;
+                                    HideGenerationBar(ctx);
                                     if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
                                 });
                             },
@@ -2075,9 +2150,12 @@ namespace GxPT
                                     ShowTranscriptError(ctx.Transcript, err);
                                     Logger.Log("Send", "Stream error at index=" + assistantIndex + ": " + err);
                                     ctx.IsSending = false;
+                                    ctx.Cancellation = null;
+                                    HideGenerationBar(ctx);
                                     // don't save on failure; no new assistant content
                                 });
-                            }
+                            },
+                            cancel
                         );
                     }
                     catch (Exception ex)
@@ -2097,6 +2175,8 @@ namespace GxPT
                             ShowTranscriptError(ctx.Transcript, ex.Message);
                             Logger.Log("Send", "Exception in streaming worker: " + ex.Message);
                             ctx.IsSending = false;
+                            ctx.Cancellation = null;
+                            HideGenerationBar(ctx);
                         });
                     }
                 });
@@ -2105,6 +2185,8 @@ namespace GxPT
             {
                 Logger.Log("Send", "Send failed unexpectedly; unlocking.");
                 ctx.IsSending = false;
+                ctx.Cancellation = null;
+                HideGenerationBar(ctx);
                 throw;
             }
         }
@@ -2319,6 +2401,9 @@ namespace GxPT
                                                        model, LoggerSink.Instance);
                     orch.WorkingDir = ctx.WorkingDir;
                     orch.Zdr = zdr ? true : (bool?)null;
+                    // Stop button cancellation: kills the in-flight model stream and lets the loop bail
+                    // out cleanly between steps. Set once before the turn runs (read-only thereafter).
+                    orch.Cancellation = ctx.Cancellation;
                     // At the tool-call cap, confirm in-transcript (like a tool-approval prompt) whether
                     // to continue: Continue grants another batch, Stop has the model wrap up and ask how
                     // to proceed. Needs this tab's panel to host the prompt; without one the orchestrator
@@ -2497,6 +2582,8 @@ namespace GxPT
                 if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation);
             }
             ctx.IsSending = false;
+            ctx.Cancellation = null;
+            HideGenerationBar(ctx);
             if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
         }
 

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Services\Logger.cs" />
     <Compile Include="Services\OpenRouterClient.cs">
     </Compile>
+    <Compile Include="Services\RequestCancellation.cs" />
     <Compile Include="Services\Mcp\IChatStreamer.cs" />
     <Compile Include="Services\Mcp\IToolApprovalPolicy.cs" />
     <Compile Include="Services\Mcp\ToolApproval.cs" />
@@ -156,6 +157,9 @@
     <Compile Include="Services\Mcp\TranscriptApprovalPrompt.cs" />
     <Compile Include="Services\Mcp\TranscriptContinuationPrompt.cs" />
     <Compile Include="Controls\ToolApprovalPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Controls\GenerationStatusBar.cs">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\WorkspaceContextStrip.cs">

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -45,6 +45,12 @@ namespace GxPT
             // The per-tab tool-approval panel docked at the bottom of this tab's transcript (set by
             // MainForm). A pending approval shows only on the conversation that requested it.
             public ToolApprovalPanel ApprovalPanel;
+            // The per-tab status strip (marquee progress bar + stop button) docked below the transcript,
+            // shown only while this tab has a request in flight (set by MainForm).
+            public GenerationStatusBar GenerationStatusBar;
+            // The in-flight request's cancellation handle (null when idle). The status strip's Stop
+            // button calls Cancel() on it to kill the model request.
+            public RequestCancellation Cancellation;
             // True when this tab's conversation has been opened but its transcript has NOT yet been
             // built (deferred at startup so only the visible tab pays the cost; built on first view).
             public bool NeedsTranscriptRebuild;

--- a/GxPT/Services/Mcp/IChatStreamer.cs
+++ b/GxPT/Services/Mcp/IChatStreamer.cs
@@ -10,9 +10,12 @@ namespace GxPT
     // stub stream, with no network and no JSON wire format.
     internal interface IChatStreamer
     {
+        // cancel (may be null) lets the host kill the in-flight request: the implementation registers
+        // its curl process on the handle so a Stop click drops the connection mid-stream.
         void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
                         ClientProperties props,
-                        Action<ChatCompletionChunk> onChunk, Action<string> onError);
+                        Action<ChatCompletionChunk> onChunk, Action<string> onError,
+                        RequestCancellation cancel);
     }
 
     // The orchestrator's view of the transcript UI. Phase 4 ships a minimal representation: text

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -109,6 +109,13 @@ namespace GxPT
         // user answers, which is correct (the user is present).
         public Func<int, bool> ContinuationDecider { get; set; }
 
+        // Per-turn cancellation handle for the in-flight model request (may be null). When the user
+        // stops the turn, Cancel() kills the current model stream via the streamer; this loop also
+        // reads IsCancelled to bail out cleanly between steps - the partial assistant text is kept and
+        // the turn is Completed (not surfaced as an error). Graceful by design: a stop that lands while
+        // a tool is executing lets that one call finish, then stops before the next model call.
+        public RequestCancellation Cancellation { get; set; }
+
         // The working directory of the conversation running this turn. Resolution of workdir-scoped
         // tools (files/git/command) is routed to the server bound to THIS folder, so concurrent turns
         // in different tabs hit their own folders' servers. Null = no workspace (scoped tools won't
@@ -161,6 +168,14 @@ namespace GxPT
             int budget = _maxIterations;
             for (int iter = 0; ; iter++)
             {
+                // Stop requested between iterations (e.g. while the previous iteration's tools ran):
+                // don't call the model again - finalize the turn cleanly.
+                if (CancelRequested())
+                {
+                    FinishCancelled(history, null, ui, turnId);
+                    return;
+                }
+
                 if (iter >= budget)
                 {
                     bool cont = (ContinuationDecider != null) && ContinuationDecider(iter);
@@ -266,6 +281,15 @@ namespace GxPT
                     LogResponse(turnId, iter, asm);
                 }
 
+                // Stop requested during (or just after) the model stream: the stream was killed, so its
+                // tool calls are partial/unexecutable. Keep any text it produced and finalize - never
+                // act on a half-streamed tool call.
+                if (CancelRequested())
+                {
+                    FinishCancelled(history, asm, ui, turnId);
+                    return;
+                }
+
                 if (!asm.ProducedToolCalls)
                 {
                     if (IsEmptyText(asm.Text))
@@ -326,7 +350,8 @@ namespace GxPT
             string emsg = null;
             _streamer.StreamChat(_model, requestMessages, tools, props,
                 asm.OnChunk,
-                delegate(string e) { err = true; emsg = e; });
+                delegate(string e) { err = true; emsg = e; },
+                Cancellation);
             asm.Finish();
             errored = err;
             errMessage = emsg;
@@ -388,6 +413,26 @@ namespace GxPT
         private static bool IsEmptyText(string s)
         {
             return s == null || s.Trim().Length == 0;
+        }
+
+        private bool CancelRequested()
+        {
+            return Cancellation != null && Cancellation.IsCancelled;
+        }
+
+        // Cancellation landed: finalize the turn cleanly. Persist any partial assistant text (so the
+        // streamed bubble isn't lost), then signal completion - never an error, since the user asked
+        // to stop. asm may be null (cancel between iterations, before this iteration streamed). Only
+        // plain text is recorded: a partial tool call is dropped so history can't end on a tool_call
+        // with no matching result, which the next request would reject.
+        private void FinishCancelled(IList<ChatMessage> history, ToolCallAssembler asm, IToolLoopUi ui, string turnId)
+        {
+            string partial = (asm != null) ? asm.Text : null;
+            if (!IsEmptyText(partial))
+                history.Add(new ChatMessage("assistant", partial));
+            _log.Log("mcp", "[turn " + turnId + "] cancelled by user"
+                + (IsEmptyText(partial) ? string.Empty : " (kept " + partial.Length + " chars of partial text)"));
+            if (ui != null) ui.Complete();
         }
 
         // Executes one tool call, returning the text to feed back as the tool message content.

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -209,22 +209,24 @@ namespace GxPT
         // IChatStreamer: build the body (with tools) then stream parsed chunks. Used by the
         // McpChatOrchestrator; the assembler reassembles tool_calls and forwards text deltas.
         public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
-                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+                               ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError,
+                               RequestCancellation cancel)
         {
             if (props == null) props = new ClientProperties();
             if (!props.Stream.HasValue) props.Stream = true;
             string body = BuildRequestBody(model, messages, tools, props);
-            StreamRawChunks(body, onChunk, onError);
+            StreamRawChunks(body, onChunk, onError, cancel);
         }
 
         public void CreateCompletionStream(string model, IList<ChatMessage> messages, Action<string> onDelta, Action onDone, Action<string> onError)
         {
             // Backward-compatible API: defaults to stream
-            CreateCompletionStream(model, messages, null, onDelta, onDone, onError);
+            CreateCompletionStream(model, messages, null, onDelta, onDone, onError, null);
         }
 
         // Text-only streaming wrapper over StreamRawChunks (no tools): forwards content deltas.
-        public void CreateCompletionStream(string model, IList<ChatMessage> messages, ClientProperties props, Action<string> onDelta, Action onDone, Action<string> onError)
+        // cancel (may be null) lets the caller kill the in-flight request mid-stream.
+        public void CreateCompletionStream(string model, IList<ChatMessage> messages, ClientProperties props, Action<string> onDelta, Action onDone, Action<string> onError, RequestCancellation cancel)
         {
             if (props == null) props = new ClientProperties();
             if (!props.Stream.HasValue) props.Stream = true;
@@ -243,15 +245,21 @@ namespace GxPT
                         }
                     }
                 },
-                delegate(string err) { failed = true; if (onError != null) onError(err); });
+                delegate(string err) { failed = true; if (onError != null) onError(err); },
+                cancel);
 
+            // A user-initiated stop returns from StreamRawChunks without an error (the connection was
+            // dropped on purpose). onDone still fires so the caller finalizes whatever text streamed;
+            // it inspects the cancel handle to decide how to treat an empty result.
             if (!failed && onDone != null) onDone();
         }
 
         // The shared curl + SSE streaming loop. Each "data:" line is parsed (Newtonsoft) into a
         // ChatCompletionChunk and handed to onChunk; if the whole stream yields no chunks, the body
-        // is inspected for a JSON error and onError is called.
-        public void StreamRawChunks(string body, Action<ChatCompletionChunk> onChunk, Action<string> onError)
+        // is inspected for a JSON error and onError is called. When cancel is non-null its curl
+        // process is registered so a Stop click can kill it; a kill is reported as a clean stop (no
+        // onError) rather than a request failure.
+        public void StreamRawChunks(string body, Action<ChatCompletionChunk> onChunk, Action<string> onError, RequestCancellation cancel)
         {
             List<string> tempFiles;
             string args = BuildCurlArgs(body, out tempFiles);
@@ -272,6 +280,9 @@ namespace GxPT
                 proc.StartInfo = psi;
                 proc.EnableRaisingEvents = false;
                 proc.Start();
+                // Register the live process so a Stop click can kill it (dropping the connection,
+                // which unblocks the ReadLine loop below). If Cancel already fired, this kills now.
+                if (cancel != null) cancel.Attach(proc);
 
                 // Read lines as they arrive (SSE: lines like "data: {...}") with explicit UTF-8 decoding
                 var utf8 = new UTF8Encoding(false, false);
@@ -332,6 +343,18 @@ namespace GxPT
                 try { Logger.Log("Stream", "curl exit=" + exitCode + " chunks=" + chunkCount + (sawAnyChunk ? string.Empty : " (no chunks)")); }
                 catch { }
 
+                // User-initiated stop: killing curl makes it exit non-zero / end without [DONE], which
+                // would otherwise look like a failure. Treat it as a clean stop - keep whatever
+                // streamed, raise no error - so the caller finalizes the partial answer.
+                if (cancel != null && cancel.IsCancelled)
+                {
+                    try { Logger.Log("Stream", "stream cancelled by user (chunks=" + chunkCount + ")"); }
+                    catch { }
+                    cancel.Detach();
+                    CleanupTempFiles(tempFiles);
+                    return;
+                }
+
                 // Treat the request as failed if curl reported a non-zero exit (--fail-with-body makes
                 // it exit non-zero on every HTTP error), if no content chunks arrived at all, or if the
                 // body carried a JSON error payload. Any of these means the user got no real answer.
@@ -357,16 +380,22 @@ namespace GxPT
                                 : (exitCode != 0 ? ("Request failed (curl exit " + exitCode + ")") : "Request failed"));
                         onError(msg.Trim());
                     }
+                    if (cancel != null) cancel.Detach();
                     CleanupTempFiles(tempFiles);
                     return;
                 }
 
+                if (cancel != null) cancel.Detach();
                 CleanupTempFiles(tempFiles);
             }
             catch (Exception ex)
             {
                 Logger.Log("Stream", "Exception: " + ex.Message);
+                if (cancel != null) cancel.Detach();
                 CleanupTempFiles(tempFiles);
+                // A kill mid-read can surface as an IOException here; if the user asked to stop, that's
+                // expected - swallow it rather than reporting a request failure.
+                if (cancel != null && cancel.IsCancelled) return;
                 if (onError != null) onError(ex.Message);
             }
         }

--- a/GxPT/Services/RequestCancellation.cs
+++ b/GxPT/Services/RequestCancellation.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+
+namespace GxPT
+{
+    // A per-request cancellation handle for an in-flight model stream. The streaming code runs curl
+    // via a Process and blocks reading its stdout; cancellation works by killing that process, which
+    // drops the HTTP connection so the API stops generating. Created fresh per send and stored on the
+    // tab context, so cancelling one tab never touches another tab's concurrent stream.
+    //
+    // Threading: Cancel() runs on the UI thread (the Stop button); Attach/Detach run on the streaming
+    // worker thread. A lock coordinates the two, and the cancelled flag is honored even when Cancel
+    // races ahead of Attach - the process is killed as soon as it is registered.
+    internal sealed class RequestCancellation
+    {
+        private readonly object _gate = new object();
+        private Process _proc;
+        private volatile bool _cancelled;
+
+        // True once Cancel() has been called. The streaming and orchestrator loops read this to bail
+        // out cleanly, treating the stop as a user action rather than an error.
+        public bool IsCancelled { get { return _cancelled; } }
+
+        // Register the live curl process so a (possibly already-requested) Cancel can kill it. If
+        // Cancel arrived first, the process is killed immediately on registration.
+        public void Attach(Process proc)
+        {
+            lock (_gate)
+            {
+                _proc = proc;
+                if (_cancelled) TryKill(proc);
+            }
+        }
+
+        // Forget the process once it has exited normally, so a late Cancel can't kill an unrelated
+        // process that happened to reuse its PID.
+        public void Detach()
+        {
+            lock (_gate) { _proc = null; }
+        }
+
+        // Request cancellation: latch the flag and kill the in-flight process if one is registered.
+        public void Cancel()
+        {
+            Process p;
+            lock (_gate)
+            {
+                _cancelled = true;
+                p = _proc;
+            }
+            if (p != null) TryKill(p);
+        }
+
+        private static void TryKill(Process p)
+        {
+            try { if (!p.HasExited) p.Kill(); }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ability to stop an in-flight model request/response, with an indeterminate loading bar that shows while the model is working — including during "thinking" and long tool-call assembly that otherwise render nothing in the UI.

## How cancellation works

Because requests run through `curl.exe` (via `Process`), cancellation works by **killing the curl process**, which drops the HTTP connection so the API stops generating server-side — exactly the cURL-architecture approach.

- New `RequestCancellation` handle (`Services/RequestCancellation.cs`) registers the live curl `Process`; `Cancel()` kills it. Thread-safe, and handles the race where Stop is clicked before the process is even registered. (.NET 3.5 has no `CancellationToken`, hence the custom handle.)
- Threaded through both request paths:
  - **Plain stream** (`CreateCompletionStream` → `StreamRawChunks`): a kill returns *without* raising an error, so the existing `onDone` path finalizes whatever streamed instead of flashing a red error banner. An empty partial drops the placeholder bubble.
  - **Tool loop** (`McpChatOrchestrator`): bails at the top of each iteration and right after each model stream. **Graceful** by design — a stop landing while a tool executes lets that one call finish, then stops before the next model call. Partial assistant text is kept; a half-streamed tool call is dropped so history can't end on a dangling `tool_call`.

## The loading bar / stop button

- New per-tab `GenerationStatusBar` (`Controls/GenerationStatusBar.cs`), docked below the transcript like `ToolApprovalPanel`: a full-width indeterminate **marquee** progress bar with a **square stop button** at the right end.
- Shown the moment a send locks (covers thinking + silent tool-call assembly) and hidden when the turn finalizes — across success, error, cancel, and worker-exception paths.
- The stop button is owner-drawn to match the tab strip's new/close glyph buttons (`GlyphToolStripButton`): dark-grey `(80,80,80)` filled-square glyph, light-grey `230/210` hover/press fill with a `210` border, square corners, plus a thin dark-grey resting border.
- Marquee relies on visual styles (already enabled app-wide), so it animates on Windows XP and later.

## Notes

- This is a Windows-only .NET 3.5 WinForms project, so it could not be compiled/run in the dev environment — please build in Visual Studio to confirm. All call sites of the three changed signatures were reviewed for consistency.
- Reasoning/"thinking" *content* is still not rendered (separate, larger feature); the bar indicates the model is busy during it.

## Files

- **New:** `Services/RequestCancellation.cs`, `Controls/GenerationStatusBar.cs`
- **Changed:** `OpenRouterClient.cs`, `IChatStreamer.cs`, `McpChatOrchestrator.cs`, `MainForm.cs`, `TabManager.cs`, `GxPT.csproj`, and the orchestrator test stub (`OrchestratorTestSupport.cs`)

https://claude.ai/code/session_0185MUebvNCjZ5FoYxvLmTtv

---
_Generated by [Claude Code](https://claude.ai/code/session_0185MUebvNCjZ5FoYxvLmTtv)_