### PR TITLE
Render skill file edits as a diff in transcript and approval prompt

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -144,6 +144,22 @@ namespace GxPT
                     _previewLabel.Text = "Diff:";
                     handled = true;
                 }
+                else if (string.Equals(req.FunctionName, "skills__edit_skill_file", StringComparison.Ordinal))
+                {
+                    // Same treatment as files__edit: a colored diff of the change. The skill file lives
+                    // outside the workspace, so there's no live file context to fold in - diff the
+                    // old/new spans directly. Header carries the slug + relpath.
+                    string slug = req.Arguments.Value<string>("slug") ?? string.Empty;
+                    string rel = req.Arguments.Value<string>("relpath") ?? string.Empty;
+                    string oldS = req.Arguments.Value<string>("old_string") ?? string.Empty;
+                    string newS = req.Arguments.Value<string>("new_string") ?? string.Empty;
+                    string target = (slug.Length > 0 && rel.Length > 0) ? (slug + "/" + rel)
+                                  : (rel.Length > 0 ? rel : slug);
+                    LineDiffResult diff = DiffUtil.BuildLineDiff(oldS, newS);
+                    _diffPanel.SetContent(target, diff.Body, "diff", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                    _previewLabel.Text = "Diff:";
+                    handled = true;
+                }
                 else if (string.Equals(req.FunctionName, "command__run", StringComparison.Ordinal))
                 {
                     string cmd = req.Arguments.Value<string>("command") ?? string.Empty;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3637,6 +3637,18 @@ namespace GxPT
                     header = rel.Length > 0 ? "Read skill file: " + rel : "Read skill file";
                     return true;
                 }
+                case "skills__edit_skill_file":
+                {
+                    // Mirror files__edit: a colored, collapsible line-diff. The skill file lives under the
+                    // skill folder, so the header carries the slug + relpath for context.
+                    string slug = Str(args, "slug");
+                    string rel = Str(args, "relpath");
+                    LineDiffResult diff = DiffUtil.BuildLineDiff(Str(args, "old_string"), Str(args, "new_string"));
+                    string target = (slug.Length > 0 && rel.Length > 0) ? (slug + "/" + rel)
+                                  : (rel.Length > 0 ? rel : (slug.Length > 0 ? slug : "(skill file)"));
+                    header = "edited " + target;
+                    body = diff.Body; language = "diff"; added = diff.Added; removed = diff.Removed; return true;
+                }
                 case "skills__run_skill_script":
                 {
                     string rel = Str(args, "relpath");


### PR DESCRIPTION
## Summary

Gives the skill editing tool (`skills__edit_skill_file`) the same diff-style treatment as the file edit tool (`files__edit`), since they're functionally similar.

- **Transcript** (`MainForm.cs` → `TryBuildToolRecord`): added a `skills__edit_skill_file` case that builds a colored, collapsible line-diff via `DiffUtil.BuildLineDiff(old_string, new_string)`, with `+N/-N` counts and `diff` highlighting — mirroring `files__edit`. Header reads `edited <slug>/<relpath>`.
- **Tool approval prompt** (`ToolApprovalPanel.cs` → `ShowFor`): added a branch that renders the same diff in the `DiffPreviewPanel` under a "Diff:" label instead of the raw JSON preview.

## Note

`files__edit` folds in surrounding file context (`BuildLineDiffWithContext`) by reading the live workspace file. A skill file lives outside the workspace and isn't reachable from the approval panel's `WorkingDirProvider`, so this diffs the old/new spans directly (`BuildLineDiff`) — the same approach the transcript record uses. The visual treatment (colored diff, syntax highlighting, collapse/expand, counts) is identical.

## Testing

Not built — no `msbuild`/`dotnet` in the environment. Changes mirror the existing `files__edit` code paths and reuse types already present in each file.

https://claude.ai/code/session_01EkZzvYVDV3Z3EpWvPPzK9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkZzvYVDV3Z3EpWvPPzK9V)_