### PR TITLE
Workspace strip: reuse blank tab on open, rename to "workspace", center contents

### DIFF
--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -41,7 +41,7 @@ namespace GxPT
             this.Height = 26;
             this.Padding = new Padding(8, 0, 8, 0);
 
-            _change = MakeLink("Set folder...", delegate { Raise(ChangeRequested); });
+            _change = MakeLink("Set workspace...", delegate { Raise(ChangeRequested); });
             _clear = MakeLink("Clear", delegate { Raise(ClearRequested); });
             _dismiss = MakeLink("Dismiss", delegate { Raise(DismissRequested); });
 
@@ -107,7 +107,7 @@ namespace GxPT
             {
                 this.BackColor = SetBack;
                 _text.ForeColor = SetText;
-                _text.Text = "Working folder:  " + dir;
+                _text.Text = "Workspace:  " + dir;
                 _change.Text = "Change...";
                 _clear.Visible = true;
                 _dismiss.Visible = false; // can't dismiss while a folder is set (use Clear)
@@ -116,8 +116,8 @@ namespace GxPT
             {
                 this.BackColor = UnsetBack;
                 _text.ForeColor = UnsetText;
-                _text.Text = "No working folder — file, git, and command tools are disabled for this conversation.";
-                _change.Text = "Set folder...";
+                _text.Text = "No workspace — file, git, and command tools are disabled for this conversation.";
+                _change.Text = "Set workspace...";
                 _clear.Visible = false;
                 _dismiss.Visible = true;
             }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -24,6 +24,7 @@ namespace GxPT
         private static readonly Image SetIcon = ResourceManager.TryGetAssemblyImage("WorkspaceSet.png");
         private static readonly Image UnsetIcon = ResourceManager.TryGetAssemblyImage("WorkspaceUnset.png");
 
+        private readonly TableLayoutPanel _root;
         private readonly PictureBox _icon;
         private readonly Label _text;
         private readonly FlowLayoutPanel _links;
@@ -45,37 +46,55 @@ namespace GxPT
             _clear = MakeLink("Clear", delegate { Raise(ClearRequested); });
             _dismiss = MakeLink("Dismiss", delegate { Raise(DismissRequested); });
 
-            // Links flow left-to-right in add order, right-docked as a group.
+            // Links flow left-to-right in add order. The flow panel sizes to its content (both
+            // dimensions) and is anchored to the right edge of its cell; with neither Top nor
+            // Bottom anchored, the table centers it vertically.
             _links = new FlowLayoutPanel();
-            _links.Dock = DockStyle.Right;
             _links.FlowDirection = FlowDirection.LeftToRight;
             _links.WrapContents = false;
             _links.AutoSize = true;
             _links.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             _links.Margin = new Padding(0);
+            _links.Anchor = AnchorStyles.Right;
             _links.Controls.Add(_change);
             _links.Controls.Add(_clear);
             _links.Controls.Add(_dismiss);
 
             // Small folder icon at the far left; the image is swapped per state in SetWorkingDir.
+            // Anchor=None centers it (both axes) within its auto-sized cell.
             _icon = new PictureBox();
-            _icon.Dock = DockStyle.Left;
-            _icon.Width = 20;
+            _icon.Size = new Size(20, 20);
             _icon.SizeMode = PictureBoxSizeMode.Zoom;
             _icon.Margin = new Padding(0);
+            _icon.Anchor = AnchorStyles.None;
 
             _text = new Label();
+            _text.AutoSize = false;
             _text.Dock = DockStyle.Fill;
             _text.AutoEllipsis = true;
             _text.TextAlign = ContentAlignment.MiddleLeft;
             // ForeColor is set per state in SetWorkingDir (dark green when set, brown when unset).
             // Small gap between the icon and the text.
-            _text.Padding = new Padding(6, 0, 0, 0);
+            _text.Margin = new Padding(6, 0, 0, 0);
 
-            // Fill first, edge-docked controls after — matches the app's working docking order.
-            this.Controls.Add(_text);
-            this.Controls.Add(_links);
-            this.Controls.Add(_icon);
+            // A single-row table deterministically centers each cell's content vertically, which
+            // dock/anchor/autosize alone did not do reliably (the links and text hugged the top).
+            // Columns: icon (auto) | text (fills) | links (auto).
+            _root = new TableLayoutPanel();
+            _root.Dock = DockStyle.Fill;
+            _root.Margin = new Padding(0);
+            _root.Padding = new Padding(0);
+            _root.ColumnCount = 3;
+            _root.RowCount = 1;
+            _root.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            _root.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+            _root.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            _root.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+            _root.Controls.Add(_icon, 0, 0);
+            _root.Controls.Add(_text, 1, 0);
+            _root.Controls.Add(_links, 2, 0);
+
+            this.Controls.Add(_root);
 
             SetWorkingDir(null);
         }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -116,7 +116,7 @@ namespace GxPT
             {
                 this.BackColor = UnsetBack;
                 _text.ForeColor = UnsetText;
-                _text.Text = "No workspace — file, git, and command tools are disabled for this conversation.";
+                _text.Text = "No workspace: file, git, command, and msbuild tools are disabled for this conversation.";
                 _change.Text = "Set workspace...";
                 _clear.Visible = false;
                 _dismiss.Visible = true;

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -135,7 +135,7 @@ namespace GxPT
             {
                 this.BackColor = UnsetBack;
                 _text.ForeColor = UnsetText;
-                _text.Text = "No workspace: file, git, command, and msbuild tools are disabled for this conversation.";
+                _text.Text = "No workspace: some tools are disabled for this conversation.";
                 _change.Text = "Set workspace...";
                 _clear.Visible = false;
                 _dismiss.Visible = true;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -145,7 +145,7 @@
             // 
             this.miOpenRecentWorkDir.Name = "miOpenRecentWorkDir";
             this.miOpenRecentWorkDir.Size = new System.Drawing.Size(221, 22);
-            this.miOpenRecentWorkDir.Text = "Open Recent Work &Dir";
+            this.miOpenRecentWorkDir.Text = "Open Recent &Workspace";
             // 
             // miCloseConversation
             // 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -833,13 +833,16 @@ namespace GxPT
             SyncZdrCheckboxFromActiveTab();
         }
 
-        // Opens a fresh conversation tab whose working folder is preset to 'dir'. Mirrors the
-        // load flow (create tab -> set working dir -> persist -> adopt onto strip + MCP host),
-        // and (via ApplyLoadedWorkingDir) bumps 'dir' to the top of the recent list.
+        // Opens a conversation tab whose working folder is preset to 'dir'. Mirrors the
+        // load flow (set working dir -> persist -> adopt onto strip + MCP host), and (via
+        // ApplyLoadedWorkingDir) bumps 'dir' to the top of the recent list. Like opening a
+        // conversation from history, this reuses a blank tab (no messages) when one exists
+        // instead of stacking a new tab.
         private void OpenNewTabWithWorkingDir(string dir)
         {
             if (_tabManager == null || string.IsNullOrEmpty(dir)) return;
-            TabManager.ChatTabContext ctx = _tabManager.CreateConversationTab();
+            TabManager.ChatTabContext ctx = FindBlankTabPreferActive();
+            if (ctx == null) ctx = _tabManager.CreateConversationTab();
             if (ctx == null) return;
             ctx.WorkingDir = dir;
             if (ctx.Conversation != null)
@@ -849,6 +852,7 @@ namespace GxPT
             }
             PersistWorkingDir(ctx);
             ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
+            try { SelectTab(ctx.Page); } catch { }
         }
 
         // After a conversation is loaded into a tab, adopt its persisted working folder onto the tab
@@ -2752,7 +2756,7 @@ namespace GxPT
             if (_tabManager != null) _tabManager.CreateConversationTab();
         }
 
-        // Rebuilds the "Open Recent Work Dir" submenu each time the File menu opens. Lists each
+        // Rebuilds the "Open Recent Workspace" submenu each time the File menu opens. Lists each
         // remembered dir (full path) that still exists; silently drops missing ones. Disables the
         // parent when nothing valid remains.
         private void PopulateRecentWorkDirsMenu()


### PR DESCRIPTION
## Summary

A few related improvements to the working-directory feature and its context strip:

- **Reuse a blank tab when opening a recent workspace.** "Open Recent Work Dir" previously always opened a new tab. It now reuses a blank conversation tab (no messages) when one exists — mirroring how opening a conversation from history replaces a blank tab instead of stacking a new one — and selects it.
- **Rename "work dir" → "workspace" in the UI.** The File menu item is now **Open Recent Workspace**, and the context strip above the transcript says **Workspace:** (set) / **No workspace:** (unset), with the link reading **Set workspace...**.
- **Simplify the unset message.** Now reads: *"No workspace: some tools are disabled for this conversation."* (em-dash replaced with a colon along the way).
- **Vertically center the strip contents.** The strip relied on docking plus an `AutoSize` `FlowLayoutPanel` whose `GrowAndShrink` collapsed its height, leaving the links' `Anchor=None` centering with no vertical slack — so the links (and, less obviously, the icon/text) hugged the top. The icon, label, and link group are now laid out in a single-row `TableLayoutPanel` (`icon auto | text fills | links auto`), which centers each cell's content deterministically regardless of font/DPI.

## Files changed

- `GxPT/Controls/WorkspaceContextStrip.cs` — TableLayoutPanel layout + workspace text
- `GxPT/Forms/MainForm.cs` — `OpenNewTabWithWorkingDir` reuses a blank tab
- `GxPT/Forms/MainForm.Designer.cs` — File menu item text

## Testing notes

These changes weren't compiled or run: this is a Windows .NET Framework WinForms project and the web/Linux environment here has no `msbuild`/`dotnet`. Changes are confined to this control's layout/text and one tab-selection helper (reusing `FindBlankTabPreferActive`/`SelectTab`, both already used elsewhere), so risk is contained — but the visual centering is verified by reasoning, not by running the app. Worth a quick manual look in a real build.

https://claude.ai/code/session_019sKFSbwU9arqqEdUkJoKfw

---
_Generated by [Claude Code](https://claude.ai/code/session_019sKFSbwU9arqqEdUkJoKfw)_