### PR TITLE
Prompt caching: zoned requests, sticky provider routing, and usage status bar

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -173,6 +173,29 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Usage_is_reported_to_the_host_on_every_iteration_for_any_model()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "SomeHost";   // non-caching model: no stickiness, but usage still flows
+            streamer.ServeCost = 0.01m;
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg); // model "test-model"
+            var reported = new List<ResponseUsage>();
+            orch.UsageReported = delegate(ResponseUsage u) { reported.Add(u); };
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Equal(2, reported.Count); // one per loop iteration
+            Assert.Equal(0.01m, reported[0].Cost);
+            Assert.Equal("SomeHost", reported[1].Provider);
+        }
+
+        [Fact]
         public void Confirmed_provider_preference_survives_an_uncached_response()
         {
             // A cached=0 response from the confirmed provider is usually TTL expiry - keeping the
@@ -213,7 +236,8 @@ namespace GxPT.Tests.Mcp
 
             Assert.Null(streamer.SeenProps[0].ProviderOrder);
             Assert.Null(streamer.SeenProps[1].ProviderOrder);
-            Assert.Null(streamer.SeenProps[0].ProviderServedCallback); // not even tracking
+            // (the usage callback is still registered on non-caching models - cost accounting
+            // applies everywhere - but the stickiness gate inside it never fires)
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -103,7 +103,7 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Sticky_provider_routing_follows_the_serving_provider_on_caching_models()
+        public void Sticky_provider_routing_latches_on_a_demonstrated_cache_hit()
         {
             RegistryFakeTransport ft;
             var reg = RegistryWith(out ft, "files", new ToolDef("read"));
@@ -111,6 +111,7 @@ namespace GxPT.Tests.Mcp
 
             var streamer = new ScriptedStreamer();
             streamer.ServeAs = "Amazon Bedrock";
+            streamer.ServeCachedTokens = 1500; // response demonstrates a cache read
             streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
             streamer.Turns.Add(Chunks.Text("done"));
 
@@ -120,9 +121,55 @@ namespace GxPT.Tests.Mcp
             orch.ProviderServed = delegate(string p) { persisted = p; };
             orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
 
-            Assert.Null(streamer.SeenProps[0].ProviderOrder);            // nothing observed yet
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);            // no hit observed yet
             Assert.Equal("Amazon Bedrock", streamer.SeenProps[1].ProviderOrder[0]); // iteration 2 follows the cache
             Assert.Equal("Amazon Bedrock", persisted);                   // host persistence hook fired
+        }
+
+        [Fact]
+        public void Uncached_responses_do_not_create_provider_stickiness()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "SomeHost";
+            streamer.ServeCachedTokens = 0; // served, but no cache read demonstrated
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "anthropic/claude-sonnet-4.5", null);
+            string persisted = null;
+            orch.ProviderServed = delegate(string p) { persisted = p; };
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);
+            Assert.Null(streamer.SeenProps[1].ProviderOrder); // still load-balanced: no hit, no stick
+            Assert.Null(persisted);
+        }
+
+        [Fact]
+        public void Confirmed_provider_preference_survives_an_uncached_response()
+        {
+            // A cached=0 response from the confirmed provider is usually TTL expiry - keeping the
+            // preference makes the cache rebuild land on the same provider, so it must not clear.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "Anthropic";
+            streamer.ServeCachedTokens = 0;
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "anthropic/claude-sonnet-4.5", null);
+            orch.PreferredProvider = "Amazon Bedrock"; // confirmed on an earlier turn
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Equal("Amazon Bedrock", streamer.SeenProps[0].ProviderOrder[0]);
+            Assert.Equal("Amazon Bedrock", streamer.SeenProps[1].ProviderOrder[0]); // not cleared
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -10,7 +10,7 @@ namespace GxPT.Tests.Mcp
         private static McpToolRegistry RegistryWith(out RegistryFakeTransport ft, string server, params ToolDef[] tools)
         {
             var conn = FakeConn.Ready(server, out ft, tools);
-            var reg = new McpToolRegistry(8, null);
+            var reg = new McpToolRegistry(null);
             reg.AddConnection(conn);
             return reg;
         }
@@ -56,7 +56,7 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Passes_manifest_system_message_and_tools_to_streamer()
+        public void Passes_manifest_tail_and_tools_to_streamer()
         {
             RegistryFakeTransport ft;
             var reg = RegistryWith(out ft, "files", new ToolDef("read"));
@@ -65,16 +65,41 @@ namespace GxPT.Tests.Mcp
 
             New(streamer, reg).RunTurn(new List<ChatMessage>(), "hello", new RecordingUi());
 
-            // first request: agentic guidance leads, then the names manifest, then history
+            // Request layout (prompt-caching zones): stable system head, then history, then the
+            // ephemeral context tail (a trailing user message carrying the names manifest).
             var msgs = streamer.SeenMessages[0];
             Assert.Equal("system", msgs[0].Role);
             Assert.Contains("operating as an agent", msgs[0].Content); // agentic behavior guidance
-            Assert.Equal("system", msgs[1].Role);
-            Assert.Contains("reveal_tools", msgs[1].Content);   // manifest instructs reveal-before-call
-            Assert.Contains("files__read", msgs[1].Content);     // and lists tool names
-            Assert.Equal("user", msgs[2].Role);
+            Assert.Equal("user", msgs[1].Role);
+            Assert.Equal("hello", msgs[1].Content);
+            var tail = msgs[msgs.Count - 1];
+            Assert.Equal("user", tail.Role);
+            Assert.Contains("Ephemeral context", tail.Content);  // framed as host-appended context
+            Assert.Contains("reveal_tools", tail.Content);       // manifest instructs reveal-before-call
+            Assert.Contains("files__read", tail.Content);        // and lists tool names
             // exposed tools always lead with reveal_tools
             Assert.Equal("reveal_tools", (string)streamer.SeenTools[0][0]["function"]["name"]);
+        }
+
+        [Fact]
+        public void Cache_breakpoints_ride_the_stable_head_and_newest_history_message()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("hi"));
+
+            var history = new List<ChatMessage>();
+            New(streamer, reg).RunTurn(history, "hello", new RecordingUi());
+
+            var msgs = streamer.SeenMessages[0];
+            // breakpoint #1: last message of the stable system head
+            Assert.True(msgs[0].CacheControl);
+            // breakpoint #2: the newest history message (the user turn), not the ephemeral tail
+            Assert.True(msgs[1].CacheControl);
+            Assert.False(msgs[msgs.Count - 1].CacheControl);
+            // the flag lands on a request-local clone, never on persisted history
+            Assert.False(history[0].CacheControl);
         }
 
         [Fact]
@@ -148,8 +173,12 @@ namespace GxPT.Tests.Mcp
             orch.RunTurn(history, "loop forever", ui);
 
             Assert.True(ui.Completed);
-            Assert.Equal(4, streamer.Calls);                       // 3 tool iterations + 1 tool-less wrap-up
-            Assert.Null(streamer.SeenTools[3]);                    // wrap-up offers no tools
+            Assert.Equal(4, streamer.Calls);                       // 3 tool iterations + 1 wrap-up
+            // The wrap-up keeps the loop's tools array (dropping it would change position 0 of the
+            // prompt and forfeit the cached prefix) but forbids further calls via tool_choice "none".
+            Assert.NotNull(streamer.SeenTools[3]);
+            Assert.Equal("none", streamer.SeenProps[3].ToolChoice);
+            Assert.Null(streamer.SeenProps[2].ToolChoice);         // loop iterations leave it default
             // The wrap-up instruction must be a trailing user turn, not a system message: Anthropic
             // hoists in-array system messages out of position, leaving nothing for the model to answer.
             var wrapMsgs = streamer.SeenMessages[3];

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -121,9 +121,32 @@ namespace GxPT.Tests.Mcp
             orch.ProviderServed = delegate(string p) { persisted = p; };
             orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
 
-            Assert.Null(streamer.SeenProps[0].ProviderOrder);            // no hit observed yet
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);            // no cache activity observed yet
             Assert.Equal("Amazon Bedrock", streamer.SeenProps[1].ProviderOrder[0]); // iteration 2 follows the cache
             Assert.Equal("Amazon Bedrock", persisted);                   // host persistence hook fired
+        }
+
+        [Fact]
+        public void Sticky_provider_routing_latches_on_a_cache_write_too()
+        {
+            // A cache write proves this endpoint caches AND now holds the conversation's warm
+            // entry, so explicit-caching providers latch from the very first request - no need to
+            // wait for the first hit.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "Anthropic";
+            streamer.ServeCacheWriteTokens = 900; // first request: cold write, no read
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "anthropic/claude-sonnet-4.5", null);
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);
+            Assert.Equal("Anthropic", streamer.SeenProps[1].ProviderOrder[0]); // latched off the write
         }
 
         [Fact]
@@ -135,7 +158,7 @@ namespace GxPT.Tests.Mcp
 
             var streamer = new ScriptedStreamer();
             streamer.ServeAs = "SomeHost";
-            streamer.ServeCachedTokens = 0; // served, but no cache read demonstrated
+            streamer.ServeCachedTokens = 0; // served, but no cache activity demonstrated (read or write)
             streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
             streamer.Turns.Add(Chunks.Text("done"));
 

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -103,6 +103,50 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Sticky_provider_routing_follows_the_serving_provider_on_caching_models()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "Amazon Bedrock";
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            // anthropic/* is a prompt-caching model -> stickiness active
+            var orch = new McpChatOrchestrator(streamer, reg, null, "anthropic/claude-sonnet-4.5", null);
+            string persisted = null;
+            orch.ProviderServed = delegate(string p) { persisted = p; };
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);            // nothing observed yet
+            Assert.Equal("Amazon Bedrock", streamer.SeenProps[1].ProviderOrder[0]); // iteration 2 follows the cache
+            Assert.Equal("Amazon Bedrock", persisted);                   // host persistence hook fired
+        }
+
+        [Fact]
+        public void Sticky_provider_routing_is_off_for_non_caching_models()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.ServeAs = "SomeProvider";
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg); // model "test-model" has no prompt caching
+            orch.PreferredProvider = "SomeProvider"; // even a seeded preference is not emitted
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Null(streamer.SeenProps[0].ProviderOrder);
+            Assert.Null(streamer.SeenProps[1].ProviderOrder);
+            Assert.Null(streamer.SeenProps[0].ProviderServedCallback); // not even tracking
+        }
+
+        [Fact]
         public void Multiple_tool_calls_in_one_turn_run_serially()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -103,6 +103,60 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Intermediate_breakpoints_bridge_long_tool_fanouts()
+        {
+            // A single iteration with K tool calls appends ~2K+1 content blocks; beyond Anthropic's
+            // ~20-block matcher lookback the next request's end breakpoint can't find the previous
+            // cache entry. The two spare breakpoint slots are spaced backward from the end so every
+            // inter-breakpoint span stays within the lookback.
+            var msgs = new List<ChatMessage> { new ChatMessage("system", "head") };
+            int headCount = 1;
+            msgs.Add(new ChatMessage("user", "go"));
+            var asst = new ChatMessage("assistant", "fanning out");
+            asst.ToolCalls = new List<ToolCall>();
+            for (int i = 0; i < 12; i++) asst.ToolCalls.Add(new ToolCall("c" + i, "files__read", "{}"));
+            msgs.Add(asst);
+            for (int i = 0; i < 12; i++)
+            {
+                var t = new ChatMessage("tool", "result " + i);
+                t.ToolCallId = "c" + i;
+                msgs.Add(t);
+            }
+
+            McpChatOrchestrator.ApplyCacheBreakpoints(msgs, headCount);
+
+            int flags = 0;
+            foreach (var m in msgs) if (m.CacheControl) flags++;
+            Assert.True(flags >= 3, "expected intermediate flags, got " + flags);
+            Assert.True(flags <= 4, "must stay within Anthropic's 4-breakpoint limit, got " + flags);
+            Assert.True(msgs[0].CacheControl);                 // stable head
+            Assert.True(msgs[msgs.Count - 1].CacheControl);    // newest message
+
+            // No span between consecutive breakpoints may exceed the ~20-block lookback.
+            int run = 0, maxRun = 0;
+            for (int i = headCount; i < msgs.Count; i++)
+            {
+                run += McpChatOrchestrator.EstimateContentBlocks(msgs[i]);
+                if (msgs[i].CacheControl) { if (run > maxRun) maxRun = run; run = 0; }
+            }
+            Assert.True(maxRun <= 20, "max inter-breakpoint span " + maxRun + " blocks");
+        }
+
+        [Fact]
+        public void Content_block_estimate_counts_tool_calls()
+        {
+            Assert.Equal(1, McpChatOrchestrator.EstimateContentBlocks(new ChatMessage("user", "hi")));
+            var toolMsg = new ChatMessage("tool", "result");
+            Assert.Equal(1, McpChatOrchestrator.EstimateContentBlocks(toolMsg));
+            var asst = new ChatMessage("assistant", "text");
+            asst.ToolCalls = new List<ToolCall> { new ToolCall("a", "t", "{}"), new ToolCall("b", "t", "{}") };
+            Assert.Equal(3, McpChatOrchestrator.EstimateContentBlocks(asst)); // 2 tool_use + 1 text
+            var silent = new ChatMessage("assistant", "");
+            silent.ToolCalls = new List<ToolCall> { new ToolCall("a", "t", "{}") };
+            Assert.Equal(1, McpChatOrchestrator.EstimateContentBlocks(silent)); // tool_use only
+        }
+
+        [Fact]
         public void Sticky_provider_routing_latches_on_a_demonstrated_cache_hit()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/Mcp/McpHostTests.cs
+++ b/GxPT.Tests/Mcp/McpHostTests.cs
@@ -19,7 +19,7 @@ namespace GxPT.Tests.Mcp
         private static McpHost NewHost(out FakeServerConnector connector, out McpToolRegistry reg)
         {
             connector = new FakeServerConnector();
-            reg = new McpToolRegistry(24, null);
+            reg = new McpToolRegistry(null);
             return new McpHost(connector, reg, null, 2000);
         }
 
@@ -243,7 +243,7 @@ namespace GxPT.Tests.Mcp
             // Regression: closing the app while servers were still connecting used to hang for the
             // whole handshake because Start held the host lock across the blocking conn.Open().
             var connector = new GatedServerConnector();
-            var reg = new McpToolRegistry(24, null);
+            var reg = new McpToolRegistry(null);
             var host = new McpHost(connector, reg, null, 5000);
 
             // Connect on a background thread; its eager Open() parks in the gated handshake.

--- a/GxPT.Tests/Mcp/McpToolRegistryTests.cs
+++ b/GxPT.Tests/Mcp/McpToolRegistryTests.cs
@@ -8,9 +8,12 @@ namespace GxPT.Tests.Mcp
 {
     public class McpToolRegistryTests
     {
-        private static McpToolRegistry NewRegistry(int cap)
+        // Reveal state lives on the conversation now (prompt-caching design): tests thread an
+        // explicit revealed-name list through Reveal / ExposedFunctionDefs the way the
+        // orchestrator threads the conversation's list.
+        private static McpToolRegistry NewRegistry()
         {
-            return new McpToolRegistry(cap, null);
+            return new McpToolRegistry(null);
         }
 
         private static List<string> ManifestNames(McpToolRegistry reg)
@@ -22,10 +25,10 @@ namespace GxPT.Tests.Mcp
             return names;
         }
 
-        private static List<string> ExposedNames(McpToolRegistry reg)
+        private static List<string> ExposedNames(McpToolRegistry reg, List<string> revealed)
         {
             var names = new List<string>();
-            foreach (JObject def in reg.ExposedFunctionDefs())
+            foreach (JObject def in reg.ExposedFunctionDefs(revealed))
                 names.Add((string)def["function"]["name"]);
             return names;
         }
@@ -38,10 +41,10 @@ namespace GxPT.Tests.Mcp
             return names;
         }
 
-        private static List<string> ExposedNamesFor(McpToolRegistry reg, string workdir)
+        private static List<string> ExposedNamesFor(McpToolRegistry reg, string workdir, List<string> revealed)
         {
             var names = new List<string>();
-            foreach (JObject def in reg.ExposedFunctionDefs(workdir))
+            foreach (JObject def in reg.ExposedFunctionDefs(workdir, revealed))
                 names.Add((string)def["function"]["name"]);
             return names;
         }
@@ -51,7 +54,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void WorkdirManifest_FolderlessTurn_OmitsScopedTools_KeepsIndependent()
         {
-            var reg = NewRegistry(24);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("web", new ToolDef("search")), null);       // workdir-independent
             reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")), "C:\\proj"); // scoped to a folder
 
@@ -74,15 +77,16 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void WorkdirExposedDefs_DropsRevealedScopedTool_OnFolderlessTurn()
         {
-            var reg = NewRegistry(24);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")), "C:\\proj");
-            reg.Reveal(new[] { "files__read" }); // revealed during a folder turn
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "files__read" }, revealed); // revealed during a folder turn
 
-            var folderless = ExposedNamesFor(reg, null);
+            var folderless = ExposedNamesFor(reg, null, revealed);
             Assert.Contains("reveal_tools", folderless);
             Assert.DoesNotContain("files__read", folderless); // not usable folderless -> not sent
 
-            Assert.Contains("files__read", ExposedNamesFor(reg, "C:\\proj")); // exposed in its folder
+            Assert.Contains("files__read", ExposedNamesFor(reg, "C:\\proj", revealed)); // exposed in its folder
         }
 
         // ---- workdir-aware schema selection across a scoped/independent name collision (skills) ----
@@ -102,27 +106,29 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void WorkdirReveal_PicksSchemaOfTheInstanceTheCallWillReach()
         {
-            var reg = NewRegistry(24);
+            var reg = NewRegistry();
             // Eager workdir-less instance registers FIRST, so it is list[0] (reproduces the collision).
             reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default user", null)), null);
             reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default project", null)), "C:\\proj");
 
             // A folder turn reveals the workdir-scoped instance's schema (the one TryResolve will call).
-            Assert.Equal("scope default project", DescOf(reg.Reveal(new[] { "skills__edit" }, "C:\\proj")));
+            var revealed = new List<string>();
+            Assert.Equal("scope default project", DescOf(reg.Reveal(new[] { "skills__edit" }, "C:\\proj", revealed)));
             // A folderless turn reveals the workdir-less instance's schema.
-            Assert.Equal("scope default user", DescOf(reg.Reveal(new[] { "skills__edit" }, null)));
+            Assert.Equal("scope default user", DescOf(reg.Reveal(new[] { "skills__edit" }, null, revealed)));
         }
 
         [Fact]
         public void WorkdirExposedDefs_UsesSchemaOfTheInstanceTheCallWillReach()
         {
-            var reg = NewRegistry(24);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default user", null)), null);
             reg.AddConnection(FakeConn.Ready("skills", new ToolDef("edit", "scope default project", null)), "C:\\proj");
-            reg.Reveal(new[] { "skills__edit" }, "C:\\proj");
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "skills__edit" }, "C:\\proj", revealed);
 
             string desc = null;
-            foreach (JObject def in reg.ExposedFunctionDefs("C:\\proj"))
+            foreach (JObject def in reg.ExposedFunctionDefs("C:\\proj", revealed))
                 if ((string)def["function"]["name"] == "skills__edit") desc = (string)def["function"]["description"];
             Assert.Equal("scope default project", desc);
         }
@@ -132,7 +138,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Munges_qualified_name_and_resolves_back()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var conn = FakeConn.Ready("files", new ToolDef("read"));
             reg.AddConnection(conn);
 
@@ -150,7 +156,7 @@ namespace GxPT.Tests.Mcp
         {
             // Two instances of the same scoped server (one per working directory) expose the SAME
             // function name. The model sees it once; resolution picks the folder-specific connection.
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var connA = FakeConn.Ready("files", new ToolDef("read"));
             var connB = FakeConn.Ready("files", new ToolDef("read"));
             reg.AddConnection(connA, "C:\\a");
@@ -171,7 +177,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Workdir_independent_tool_resolves_for_any_calling_workdir()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("web", new ToolDef("search")), null);
 
             McpServerConnection r; string tool;
@@ -182,7 +188,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Removing_one_workdir_instance_keeps_the_tool_while_another_provides_it()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var connA = FakeConn.Ready("files", new ToolDef("read"));
             var connB = FakeConn.Ready("files", new ToolDef("read"));
             reg.AddConnection(connA, "C:\\a");
@@ -203,7 +209,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Sanitizes_illegal_characters()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("git", new ToolDef("weird/name")));
             Assert.Contains("git__weird_name", ManifestNames(reg));
         }
@@ -212,7 +218,7 @@ namespace GxPT.Tests.Mcp
         public void Disambiguates_collisions_with_hash_suffix()
         {
             // "x/y" and "x_y" under server "s" both sanitize to base "s__x_y".
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("s", new ToolDef("x/y"), new ToolDef("x_y")));
 
             var names = ManifestNames(reg);
@@ -233,7 +239,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Over_long_names_truncate_to_64_with_hash()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             string longTool = new string('a', 90);
             reg.AddConnection(FakeConn.Ready("srv", new ToolDef(longTool)));
             var names = ManifestNames(reg);
@@ -245,7 +251,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Munging_is_deterministic_across_remove_and_readd()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var conn = FakeConn.Ready("s", new ToolDef("x/y"), new ToolDef("x_y"));
             reg.AddConnection(conn);
             var first = ManifestNames(reg);
@@ -264,7 +270,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Manifest_is_names_only_sorted_and_reflects_mutations()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var files = FakeConn.Ready("files", new ToolDef("write"), new ToolDef("read"));
             var git = FakeConn.Ready("git", new ToolDef("status"));
             reg.AddConnection(files);
@@ -284,10 +290,10 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Exposed_defs_always_lead_with_reveal_tools()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")));
 
-            var exposed = ExposedNames(reg);
+            var exposed = ExposedNames(reg, new List<string>());
             Assert.Equal(McpToolRegistry.RevealToolsName, exposed[0]);
             Assert.Single(exposed); // nothing revealed yet
         }
@@ -295,92 +301,106 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Reveal_adds_defs_and_returns_requested_schemas()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             JObject schema = JObject.Parse("{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}");
             reg.AddConnection(FakeConn.Ready("files", new ToolDef("read", "Read a file", schema)));
 
-            string result = reg.Reveal(new[] { "files__read" });
+            var revealed = new List<string>();
+            string result = reg.Reveal(new[] { "files__read" }, revealed);
             JArray defs = JArray.Parse(result.Split('\n')[0]);
             Assert.Single(defs);
             Assert.Equal("files__read", (string)defs[0]["name"]);
             Assert.Equal("Read a file", (string)defs[0]["description"]);
             Assert.NotNull(defs[0]["parameters"]["properties"]["path"]);
 
-            // now exposed in the tools array
-            Assert.Contains("files__read", ExposedNames(reg));
+            // recorded in the caller's list and now exposed in the tools array
+            Assert.Contains("files__read", revealed);
+            Assert.Contains("files__read", ExposedNames(reg, revealed));
         }
 
         [Fact]
         public void Reveal_notes_unknown_names()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("files", new ToolDef("read")));
-            string result = reg.Reveal(new[] { "files__read", "files__nope" });
+            var revealed = new List<string>();
+            string result = reg.Reveal(new[] { "files__read", "files__nope" }, revealed);
             Assert.Contains("unknown tool: files__nope", result);
+            Assert.DoesNotContain("files__nope", revealed); // unknown names are not recorded
         }
 
-        // ---- LRU ----
+        // ---- reveal-set stability (prompt caching) ----
 
         [Fact]
-        public void Exceeding_cap_evicts_least_recently_used()
+        public void Registry_never_evicts_from_the_callers_revealed_list()
         {
-            var reg = NewRegistry(2);
+            // Eviction is the orchestrator's job and provider-gated; the registry itself only
+            // appends. Reveal any number of tools and all of them stay exposed.
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("s", new ToolDef("a"), new ToolDef("b"), new ToolDef("c")));
 
-            reg.Reveal(new[] { "s__a" });
-            reg.Reveal(new[] { "s__b" });
-            reg.Reveal(new[] { "s__c" }); // cap 2 → s__a (oldest) evicted
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "s__a" }, revealed);
+            reg.Reveal(new[] { "s__b" }, revealed);
+            reg.Reveal(new[] { "s__c" }, revealed);
 
-            var exposed = ExposedNames(reg);
-            Assert.DoesNotContain("s__a", exposed);
+            var exposed = ExposedNames(reg, revealed);
+            Assert.Contains("s__a", exposed);
             Assert.Contains("s__b", exposed);
             Assert.Contains("s__c", exposed);
-
-            // evicted tool is still in the manifest and re-revealable
-            Assert.Contains("s__a", ManifestNames(reg));
-            reg.Reveal(new[] { "s__a" });
-            Assert.Contains("s__a", ExposedNames(reg));
         }
 
         [Fact]
-        public void Resolving_bumps_recency_to_prevent_eviction()
+        public void Exposed_defs_are_name_sorted_regardless_of_reveal_order()
         {
-            var reg = NewRegistry(2);
-            reg.AddConnection(FakeConn.Ready("s", new ToolDef("a"), new ToolDef("b"), new ToolDef("c")));
+            // The tools array renders at position 0 of the prompt: any membership or order change
+            // invalidates the provider's prompt cache for the whole conversation, so emission must
+            // not depend on reveal order or recency.
+            var reg = NewRegistry();
+            reg.AddConnection(FakeConn.Ready("s", new ToolDef("a"), new ToolDef("b")));
 
-            reg.Reveal(new[] { "s__a" });
-            reg.Reveal(new[] { "s__b" });
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "s__b" }, revealed);
+            reg.Reveal(new[] { "s__a" }, revealed);
+            Assert.Equal(new[] { "reveal_tools", "s__a", "s__b" }, ExposedNames(reg, revealed).ToArray());
 
-            // touch s__a via a resolve so it's now most-recent
-            McpServerConnection c; string t;
-            Assert.True(reg.TryResolve("s__a", out c, out t));
+            // A re-reveal bumps recency (the list reorders) without changing the emitted order.
+            reg.Reveal(new[] { "s__b" }, revealed);
+            Assert.Equal(new[] { "s__a", "s__b" }, revealed.ToArray()); // recency: a older than b
+            Assert.Equal(new[] { "reveal_tools", "s__a", "s__b" }, ExposedNames(reg, revealed).ToArray());
+        }
 
-            reg.Reveal(new[] { "s__c" }); // should evict s__b (now the LRU), not s__a
-
-            var exposed = ExposedNames(reg);
-            Assert.Contains("s__a", exposed);
-            Assert.DoesNotContain("s__b", exposed);
-            Assert.Contains("s__c", exposed);
+        [Fact]
+        public void Duplicate_names_in_the_revealed_list_emit_one_def()
+        {
+            var reg = NewRegistry();
+            reg.AddConnection(FakeConn.Ready("s", new ToolDef("a")));
+            var revealed = new List<string> { "s__a", "s__a" };
+            Assert.Equal(new[] { "reveal_tools", "s__a" }, ExposedNames(reg, revealed).ToArray());
         }
 
         // ---- lifecycle ----
 
         [Fact]
-        public void Refresh_prunes_removed_tools_from_catalog_and_revealed()
+        public void Refresh_prunes_removed_tools_from_catalog_and_exposure()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             RegistryFakeTransport ft;
             var conn = FakeConn.Ready("s", out ft, new ToolDef("a"), new ToolDef("b"));
             reg.AddConnection(conn);
-            reg.Reveal(new[] { "s__a", "s__b" });
-            Assert.Contains("s__b", ExposedNames(reg));
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "s__a", "s__b" }, revealed);
+            Assert.Contains("s__b", ExposedNames(reg, revealed));
 
             // server drops tool "b" on a subsequent tools/list
             ft.Tools = new List<ToolDef> { new ToolDef("a") };
             reg.RefreshConnection(conn);
 
             Assert.Equal(new[] { "s__a" }, ManifestNames(reg).ToArray());
-            Assert.DoesNotContain("s__b", ExposedNames(reg)); // pruned from revealed too
+            // The conversation's list keeps the name (so the def reappears if the server brings the
+            // tool back); emission skips it while it is absent from the catalog.
+            Assert.Contains("s__b", revealed);
+            Assert.DoesNotContain("s__b", ExposedNames(reg, revealed));
             McpServerConnection c; string t;
             Assert.False(reg.TryResolve("s__b", out c, out t));
         }
@@ -388,23 +408,24 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Remove_drops_a_faulted_servers_tools()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             var conn = FakeConn.Ready("s", new ToolDef("a"));
             reg.AddConnection(conn);
-            reg.Reveal(new[] { "s__a" });
+            var revealed = new List<string>();
+            reg.Reveal(new[] { "s__a" }, revealed);
 
             reg.RemoveConnection(conn);
 
             Assert.Empty(ManifestNames(reg));
             McpServerConnection c; string t;
             Assert.False(reg.TryResolve("s__a", out c, out t));
-            Assert.Equal(new[] { McpToolRegistry.RevealToolsName }, ExposedNames(reg).ToArray());
+            Assert.Equal(new[] { McpToolRegistry.RevealToolsName }, ExposedNames(reg, revealed).ToArray());
         }
 
         [Fact]
         public void HasTools_reflects_the_catalog()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             Assert.False(reg.HasTools);
             var conn = FakeConn.Ready("files", new ToolDef("read"));
             reg.AddConnection(conn);
@@ -416,7 +437,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Reveal_tools_name_is_never_produced_by_munging()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("reveal", new ToolDef("tools")));
             Assert.Contains("reveal__tools", ManifestNames(reg)); // double underscore, not "reveal_tools"
             Assert.DoesNotContain("reveal_tools", ManifestNames(reg));
@@ -429,7 +450,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Manifest_steers_to_git_tools_when_command_also_present()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("git", new ToolDef("status")));
             reg.AddConnection(FakeConn.Ready("command", new ToolDef("run")));
             Assert.Contains(GitPreferNote, reg.NamesManifestSystemMessage());
@@ -438,7 +459,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Manifest_omits_git_preference_note_without_command()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("git", new ToolDef("status")));
             Assert.DoesNotContain(GitPreferNote, reg.NamesManifestSystemMessage());
         }
@@ -446,7 +467,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Manifest_omits_git_preference_note_without_git()
         {
-            var reg = NewRegistry(8);
+            var reg = NewRegistry();
             reg.AddConnection(FakeConn.Ready("command", new ToolDef("run")));
             Assert.DoesNotContain(GitPreferNote, reg.NamesManifestSystemMessage());
         }

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -254,14 +254,15 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Parses_usage_chunk_with_cached_tokens()
+        public void Parses_usage_chunk_with_cache_counters()
         {
             var json = "{\"id\":\"x\",\"choices\":[],\"usage\":{\"prompt_tokens\":1200,\"completion_tokens\":80,"
-                + "\"prompt_tokens_details\":{\"cached_tokens\":1100}}}";
+                + "\"prompt_tokens_details\":{\"cached_tokens\":1100,\"cache_write_tokens\":90}}}";
             var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
             Assert.Equal(1200, chunk.usage.prompt_tokens);
             Assert.Equal(80, chunk.usage.completion_tokens);
             Assert.Equal(1100, chunk.usage.prompt_tokens_details.cached_tokens);
+            Assert.Equal(90, chunk.usage.prompt_tokens_details.cache_write_tokens);
         }
 
         // ---- streaming chunk parsing under Newtonsoft ----

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -274,21 +274,23 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Extracts_generation_stats_for_cost_reconciliation()
         {
-            var root = JObject.Parse("{\"data\":{\"id\":\"gen-x\",\"total_cost\":0.0585,\"cache_discount\":0.0559}}");
-            decimal? cost, discount;
-            Assert.True(OpenRouterClient.TryExtractGenerationStats(root, out cost, out discount));
-            Assert.Equal(0.0585m, cost);
-            Assert.Equal(0.0559m, discount);
+            var stats = OpenRouterClient.ExtractGenerationStats(JObject.Parse(
+                "{\"data\":{\"id\":\"gen-x\",\"total_cost\":0.0585,\"cache_discount\":0.0559,\"provider_name\":\"Amazon Bedrock\"}}"));
+            Assert.NotNull(stats);
+            Assert.Equal(0.0585m, stats.TotalCost);
+            Assert.Equal(0.0559m, stats.CacheDiscount);
+            Assert.Equal("Amazon Bedrock", stats.ProviderName);
 
             // negative discount = net write premium; still extracted
-            var writeHeavy = JObject.Parse("{\"data\":{\"total_cost\":0.138,\"cache_discount\":-0.0225}}");
-            Assert.True(OpenRouterClient.TryExtractGenerationStats(writeHeavy, out cost, out discount));
-            Assert.Equal(-0.0225m, discount);
+            var writeHeavy = OpenRouterClient.ExtractGenerationStats(JObject.Parse(
+                "{\"data\":{\"total_cost\":0.138,\"cache_discount\":-0.0225}}"));
+            Assert.NotNull(writeHeavy);
+            Assert.Equal(-0.0225m, writeHeavy.CacheDiscount);
+            Assert.Null(writeHeavy.ProviderName);
 
-            // malformed / missing data -> false, nothing extracted
-            Assert.False(OpenRouterClient.TryExtractGenerationStats(JObject.Parse("{\"error\":{}}"), out cost, out discount));
-            Assert.Null(cost);
-            Assert.False(OpenRouterClient.TryExtractGenerationStats(null, out cost, out discount));
+            // malformed / missing data -> null, nothing extracted
+            Assert.Null(OpenRouterClient.ExtractGenerationStats(JObject.Parse("{\"error\":{}}")));
+            Assert.Null(OpenRouterClient.ExtractGenerationStats(null));
         }
 
         // ---- streaming chunk parsing under Newtonsoft ----

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -181,19 +181,23 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Cache_breakpoint_is_ignored_for_models_without_explicit_caching()
+        public void Cache_breakpoints_are_emitted_for_every_model()
         {
+            // Providers without explicit caching ignore the annotation (documented by OpenRouter),
+            // while some third-party hosts of auto-caching vendors' models may require it - so the
+            // markers are unconditional rather than vendor-gated.
             var msg = new ChatMessage("user", "hi");
             msg.CacheControl = true;
             var body = OpenRouterClient.BuildRequestBody(
                 "openai/gpt-4o", new List<ChatMessage> { msg }, null, new ClientProperties());
 
-            // plain string content - OpenAI caches automatically; no cache_control shape emitted
-            Assert.Equal("hi", (string)((JArray)JObject.Parse(body)["messages"])[1]["content"]);
+            var content = ((JArray)JObject.Parse(body)["messages"])[1]["content"];
+            Assert.Equal(JTokenType.Array, content.Type);
+            Assert.Equal("ephemeral", (string)content[0]["cache_control"]["type"]);
         }
 
         [Fact]
-        public void Unflagged_messages_keep_plain_string_content_on_supported_models()
+        public void Unflagged_messages_keep_plain_string_content()
         {
             var body = OpenRouterClient.BuildRequestBody(
                 "anthropic/claude-sonnet-4.5", new List<ChatMessage> { new ChatMessage("user", "hi") },
@@ -204,13 +208,7 @@ namespace GxPT.Tests.Mcp
         [Fact]
         public void Model_cache_support_is_vendor_prefixed_and_tilde_alias_aware()
         {
-            Assert.True(OpenRouterClient.ModelSupportsCacheControl("anthropic/claude-opus-4"));
-            Assert.True(OpenRouterClient.ModelSupportsCacheControl("~anthropic/claude-sonnet-latest"));
-            Assert.True(OpenRouterClient.ModelSupportsCacheControl("google/gemini-2.5-pro"));
-            Assert.False(OpenRouterClient.ModelSupportsCacheControl("openai/gpt-4o"));
-            Assert.False(OpenRouterClient.ModelSupportsCacheControl(null));
-
-            // The broader caching gate (drives reveal-set eviction) also covers automatic cachers.
+            // The caching gate (drives reveal-set eviction and sticky routing).
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("openai/gpt-4o"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("deepseek/deepseek-chat"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("qwen/qwen3-coder"));

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -271,6 +271,26 @@ namespace GxPT.Tests.Mcp
             Assert.Equal(0.0031m, chunk.cache_discount);
         }
 
+        [Fact]
+        public void Extracts_generation_stats_for_cost_reconciliation()
+        {
+            var root = JObject.Parse("{\"data\":{\"id\":\"gen-x\",\"total_cost\":0.0585,\"cache_discount\":0.0559}}");
+            decimal? cost, discount;
+            Assert.True(OpenRouterClient.TryExtractGenerationStats(root, out cost, out discount));
+            Assert.Equal(0.0585m, cost);
+            Assert.Equal(0.0559m, discount);
+
+            // negative discount = net write premium; still extracted
+            var writeHeavy = JObject.Parse("{\"data\":{\"total_cost\":0.138,\"cache_discount\":-0.0225}}");
+            Assert.True(OpenRouterClient.TryExtractGenerationStats(writeHeavy, out cost, out discount));
+            Assert.Equal(-0.0225m, discount);
+
+            // malformed / missing data -> false, nothing extracted
+            Assert.False(OpenRouterClient.TryExtractGenerationStats(JObject.Parse("{\"error\":{}}"), out cost, out discount));
+            Assert.Null(cost);
+            Assert.False(OpenRouterClient.TryExtractGenerationStats(null, out cost, out discount));
+        }
+
         // ---- streaming chunk parsing under Newtonsoft ----
 
         [Fact]

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -213,6 +213,7 @@ namespace GxPT.Tests.Mcp
             // The broader caching gate (drives reveal-set eviction) also covers automatic cachers.
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("openai/gpt-4o"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("deepseek/deepseek-chat"));
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("qwen/qwen3-coder"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("~anthropic/claude-sonnet-latest"));
             Assert.False(OpenRouterClient.ModelSupportsPromptCaching("mistralai/mistral-large"));
         }

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -234,6 +234,23 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Provider_order_is_emitted_for_sticky_cache_routing()
+        {
+            var props = new ClientProperties { ProviderOrder = new List<string> { "Amazon Bedrock" } };
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, props);
+            var p = (JObject)JObject.Parse(body)["provider"];
+            Assert.Equal("Amazon Bedrock", (string)((JArray)p["order"])[0]);
+        }
+
+        [Fact]
+        public void Parses_provider_on_chunk()
+        {
+            var json = "{\"id\":\"x\",\"provider\":\"Anthropic\",\"choices\":[{\"delta\":{\"content\":\"h\"},\"finish_reason\":null}]}";
+            var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
+            Assert.Equal("Anthropic", chunk.provider);
+        }
+
+        [Fact]
         public void Parses_usage_chunk_with_cached_tokens()
         {
             var json = "{\"id\":\"x\",\"choices\":[],\"usage\":{\"prompt_tokens\":1200,\"completion_tokens\":80,"

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -214,6 +214,8 @@ namespace GxPT.Tests.Mcp
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("openai/gpt-4o"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("deepseek/deepseek-chat"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("qwen/qwen3-coder"));
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("minimax/minimax-m2"));
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("moonshotai/kimi-k2"));
             Assert.True(OpenRouterClient.ModelSupportsPromptCaching("~anthropic/claude-sonnet-latest"));
             Assert.False(OpenRouterClient.ModelSupportsPromptCaching("mistralai/mistral-large"));
         }

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -254,15 +254,21 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Parses_usage_chunk_with_cache_counters()
+        public void Parses_usage_chunk_with_cache_counters_and_cost()
         {
-            var json = "{\"id\":\"x\",\"choices\":[],\"usage\":{\"prompt_tokens\":1200,\"completion_tokens\":80,"
-                + "\"prompt_tokens_details\":{\"cached_tokens\":1100,\"cache_write_tokens\":90}}}";
+            var json = "{\"id\":\"x\",\"cache_discount\":0.0031,\"choices\":[],"
+                + "\"usage\":{\"prompt_tokens\":1200,\"completion_tokens\":80,\"total_tokens\":1280,\"cost\":0.0145,"
+                + "\"prompt_tokens_details\":{\"cached_tokens\":1100,\"cache_write_tokens\":90},"
+                + "\"completion_tokens_details\":{\"reasoning_tokens\":25}}}";
             var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
             Assert.Equal(1200, chunk.usage.prompt_tokens);
             Assert.Equal(80, chunk.usage.completion_tokens);
+            Assert.Equal(1280, chunk.usage.total_tokens);
+            Assert.Equal(0.0145m, chunk.usage.cost);
             Assert.Equal(1100, chunk.usage.prompt_tokens_details.cached_tokens);
             Assert.Equal(90, chunk.usage.prompt_tokens_details.cache_write_tokens);
+            Assert.Equal(25, chunk.usage.completion_tokens_details.reasoning_tokens);
+            Assert.Equal(0.0031m, chunk.cache_discount);
         }
 
         // ---- streaming chunk parsing under Newtonsoft ----

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -142,6 +142,108 @@ namespace GxPT.Tests.Mcp
             Assert.Null(JObject.Parse(bodyNull)["provider"]);
         }
 
+        // ---- prompt caching ----
+
+        [Fact]
+        public void Usage_accounting_is_always_requested()
+        {
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, new ClientProperties());
+            Assert.True((bool)JObject.Parse(body)["usage"]["include"]);
+        }
+
+        [Fact]
+        public void Cache_breakpoint_emits_content_part_with_cache_control_on_supported_model()
+        {
+            var msg = new ChatMessage("user", "hi");
+            msg.CacheControl = true;
+            var body = OpenRouterClient.BuildRequestBody(
+                "anthropic/claude-sonnet-4.5", new List<ChatMessage> { msg }, null, new ClientProperties());
+
+            var content = ((JArray)JObject.Parse(body)["messages"])[1]["content"];
+            Assert.Equal(JTokenType.Array, content.Type);
+            Assert.Equal("text", (string)content[0]["type"]);
+            Assert.Equal("hi", (string)content[0]["text"]);
+            Assert.Equal("ephemeral", (string)content[0]["cache_control"]["type"]);
+        }
+
+        [Fact]
+        public void Cache_breakpoint_on_tool_message_keeps_tool_call_id()
+        {
+            var tool = new ChatMessage("tool", "result text");
+            tool.ToolCallId = "call_1";
+            tool.CacheControl = true;
+            var body = OpenRouterClient.BuildRequestBody(
+                "anthropic/claude-sonnet-4.5", new List<ChatMessage> { tool }, null, new ClientProperties());
+
+            var msg = (JObject)((JArray)JObject.Parse(body)["messages"])[1];
+            Assert.Equal("call_1", (string)msg["tool_call_id"]);
+            Assert.Equal("ephemeral", (string)msg["content"][0]["cache_control"]["type"]);
+        }
+
+        [Fact]
+        public void Cache_breakpoint_is_ignored_for_models_without_explicit_caching()
+        {
+            var msg = new ChatMessage("user", "hi");
+            msg.CacheControl = true;
+            var body = OpenRouterClient.BuildRequestBody(
+                "openai/gpt-4o", new List<ChatMessage> { msg }, null, new ClientProperties());
+
+            // plain string content - OpenAI caches automatically; no cache_control shape emitted
+            Assert.Equal("hi", (string)((JArray)JObject.Parse(body)["messages"])[1]["content"]);
+        }
+
+        [Fact]
+        public void Unflagged_messages_keep_plain_string_content_on_supported_models()
+        {
+            var body = OpenRouterClient.BuildRequestBody(
+                "anthropic/claude-sonnet-4.5", new List<ChatMessage> { new ChatMessage("user", "hi") },
+                null, new ClientProperties());
+            Assert.Equal("hi", (string)((JArray)JObject.Parse(body)["messages"])[1]["content"]);
+        }
+
+        [Fact]
+        public void Model_cache_support_is_vendor_prefixed_and_tilde_alias_aware()
+        {
+            Assert.True(OpenRouterClient.ModelSupportsCacheControl("anthropic/claude-opus-4"));
+            Assert.True(OpenRouterClient.ModelSupportsCacheControl("~anthropic/claude-sonnet-latest"));
+            Assert.True(OpenRouterClient.ModelSupportsCacheControl("google/gemini-2.5-pro"));
+            Assert.False(OpenRouterClient.ModelSupportsCacheControl("openai/gpt-4o"));
+            Assert.False(OpenRouterClient.ModelSupportsCacheControl(null));
+
+            // The broader caching gate (drives reveal-set eviction) also covers automatic cachers.
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("openai/gpt-4o"));
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("deepseek/deepseek-chat"));
+            Assert.True(OpenRouterClient.ModelSupportsPromptCaching("~anthropic/claude-sonnet-latest"));
+            Assert.False(OpenRouterClient.ModelSupportsPromptCaching("mistralai/mistral-large"));
+        }
+
+        [Fact]
+        public void Tool_choice_is_emitted_only_alongside_tools()
+        {
+            var tools = new List<JObject>
+            {
+                JObject.Parse("{\"type\":\"function\",\"function\":{\"name\":\"f\",\"parameters\":{}}}")
+            };
+            var withTools = OpenRouterClient.BuildRequestBody(
+                "m", new List<ChatMessage>(), tools, new ClientProperties { ToolChoice = "none" });
+            Assert.Equal("none", (string)JObject.Parse(withTools)["tool_choice"]);
+
+            var withoutTools = OpenRouterClient.BuildRequestBody(
+                "m", new List<ChatMessage>(), null, new ClientProperties { ToolChoice = "none" });
+            Assert.Null(JObject.Parse(withoutTools)["tool_choice"]);
+        }
+
+        [Fact]
+        public void Parses_usage_chunk_with_cached_tokens()
+        {
+            var json = "{\"id\":\"x\",\"choices\":[],\"usage\":{\"prompt_tokens\":1200,\"completion_tokens\":80,"
+                + "\"prompt_tokens_details\":{\"cached_tokens\":1100}}}";
+            var chunk = JsonConvert.DeserializeObject<ChatCompletionChunk>(json);
+            Assert.Equal(1200, chunk.usage.prompt_tokens);
+            Assert.Equal(80, chunk.usage.completion_tokens);
+            Assert.Equal(1100, chunk.usage.prompt_tokens_details.cached_tokens);
+        }
+
         // ---- streaming chunk parsing under Newtonsoft ----
 
         [Fact]

--- a/GxPT.Tests/Mcp/OrchestratorSkillDispatchTests.cs
+++ b/GxPT.Tests/Mcp/OrchestratorSkillDispatchTests.cs
@@ -34,11 +34,14 @@ namespace GxPT.Tests.Mcp
             return new McpChatOrchestrator(s, reg, null, "test-model", null);
         }
 
-        private static string JoinSystem(IList<ChatMessage> msgs)
+        // The manifest now rides in the ephemeral context tail (a trailing user message; see the
+        // prompt-caching zones in McpChatOrchestrator), so manifest assertions scan every message
+        // of the request rather than just the system head.
+        private static string JoinAll(IList<ChatMessage> msgs)
         {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < msgs.Count; i++)
-                if (msgs[i] != null && msgs[i].Role == "system") sb.Append(msgs[i].Content).Append('\n');
+                if (msgs[i] != null && msgs[i].Content != null) sb.Append(msgs[i].Content).Append('\n');
             return sb.ToString();
         }
 
@@ -47,7 +50,7 @@ namespace GxPT.Tests.Mcp
         {
             RegistryFakeTransport ft;
             var conn = FakeConn.Ready("skills", out ft, new ToolDef("create_skill"), new ToolDef("validate_skill"));
-            var reg = new McpToolRegistry(8, null);
+            var reg = new McpToolRegistry(null);
             reg.AddConnection(conn);
             ft.OnCall = delegate(string n, JObject a) { return RegistryFakeTransport.TextResult("should not run"); };
 
@@ -61,7 +64,7 @@ namespace GxPT.Tests.Mcp
             orch.RunTurn(new List<ChatMessage>(), "go", ui);
 
             // The manifest lists the visible tool but not the hidden one.
-            string firstReq = JoinSystem(streamer.SeenMessages[0]);
+            string firstReq = JoinAll(streamer.SeenMessages[0]);
             Assert.Contains("skills__validate_skill", firstReq);
             Assert.DoesNotContain("skills__create_skill", firstReq);
 
@@ -76,7 +79,7 @@ namespace GxPT.Tests.Mcp
         {
             RegistryFakeTransport ft;
             var conn = FakeConn.Ready("skills", out ft, new ToolDef("create_skill"));
-            var reg = new McpToolRegistry(8, null);
+            var reg = new McpToolRegistry(null);
             reg.AddConnection(conn);
 
             var streamer = new ScriptedStreamer();
@@ -87,7 +90,7 @@ namespace GxPT.Tests.Mcp
             orch.RunTurn(new List<ChatMessage>(), "hello", new RecordingUi());
 
             // No leftover framing over an empty list.
-            Assert.DoesNotContain("Available tools:", JoinSystem(streamer.SeenMessages[0]));
+            Assert.DoesNotContain("Available tools:", JoinAll(streamer.SeenMessages[0]));
         }
 
         [Fact]
@@ -100,7 +103,7 @@ namespace GxPT.Tests.Mcp
             SkillCatalog cat = SkillCatalog.Build(_bundled, null);
 
             // Empty registry: the only exposed tools are the host meta-tools (open_skill/read_skill_file).
-            var reg = new McpToolRegistry(8, null);
+            var reg = new McpToolRegistry(null);
             var streamer = new ScriptedStreamer();
             streamer.Turns.Add(Chunks.OneToolCall("c1", "open_skill", "{\"names\":[\"greeting\"]}"));
             streamer.Turns.Add(Chunks.Text("done"));

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -59,6 +59,9 @@ namespace GxPT.Tests.Mcp
         public Func<int, ChatCompletionChunk[]> Fallback;
         public string ErrorMessage;   // when set, signal onError instead of streaming
         public int ErrorOnCall = -1;  // -1 = every call; otherwise only this call index
+        // When set, reports this provider name via props.ProviderServedCallback (mimicking the real
+        // client, which reports the serving provider off the first response chunk that carries it).
+        public string ServeAs;
 
         public int Calls;
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
@@ -73,6 +76,9 @@ namespace GxPT.Tests.Mcp
             SeenMessages.Add(messages);
             SeenTools.Add(tools);
             SeenProps.Add(props);
+
+            if (ServeAs != null && props != null && props.ProviderServedCallback != null)
+                props.ProviderServedCallback(ServeAs);
 
             if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
             {

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -60,11 +60,13 @@ namespace GxPT.Tests.Mcp
         public string ErrorMessage;   // when set, signal onError instead of streaming
         public int ErrorOnCall = -1;  // -1 = every call; otherwise only this call index
         // When set, reports this provider name via props.ProviderServedCallback (mimicking the real
-        // client, which reports the serving provider + cached-token count off the response's final
-        // usage-bearing chunk). ServeCachedTokens is the cached_tokens value reported alongside it;
-        // 0 simulates a response with no cache read (cold write / non-caching endpoint).
+        // client, which reports the serving provider + cache counters off the response's final
+        // usage-bearing chunk). ServeCachedTokens / ServeCacheWriteTokens are the cached_tokens and
+        // cache_write_tokens values reported alongside it; both 0 simulates a response with no
+        // cache activity (non-caching endpoint, or an implicit cacher that doesn't report writes).
         public string ServeAs;
         public int ServeCachedTokens;
+        public int ServeCacheWriteTokens;
 
         public int Calls;
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
@@ -81,7 +83,7 @@ namespace GxPT.Tests.Mcp
             SeenProps.Add(props);
 
             if (ServeAs != null && props != null && props.ProviderServedCallback != null)
-                props.ProviderServedCallback(ServeAs, ServeCachedTokens);
+                props.ProviderServedCallback(ServeAs, ServeCachedTokens, ServeCacheWriteTokens);
 
             if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
             {

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -60,8 +60,11 @@ namespace GxPT.Tests.Mcp
         public string ErrorMessage;   // when set, signal onError instead of streaming
         public int ErrorOnCall = -1;  // -1 = every call; otherwise only this call index
         // When set, reports this provider name via props.ProviderServedCallback (mimicking the real
-        // client, which reports the serving provider off the first response chunk that carries it).
+        // client, which reports the serving provider + cached-token count off the response's final
+        // usage-bearing chunk). ServeCachedTokens is the cached_tokens value reported alongside it;
+        // 0 simulates a response with no cache read (cold write / non-caching endpoint).
         public string ServeAs;
+        public int ServeCachedTokens;
 
         public int Calls;
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
@@ -78,7 +81,7 @@ namespace GxPT.Tests.Mcp
             SeenProps.Add(props);
 
             if (ServeAs != null && props != null && props.ProviderServedCallback != null)
-                props.ProviderServedCallback(ServeAs);
+                props.ProviderServedCallback(ServeAs, ServeCachedTokens);
 
             if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
             {

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -59,14 +59,15 @@ namespace GxPT.Tests.Mcp
         public Func<int, ChatCompletionChunk[]> Fallback;
         public string ErrorMessage;   // when set, signal onError instead of streaming
         public int ErrorOnCall = -1;  // -1 = every call; otherwise only this call index
-        // When set, reports this provider name via props.ProviderServedCallback (mimicking the real
-        // client, which reports the serving provider + cache counters off the response's final
-        // usage-bearing chunk). ServeCachedTokens / ServeCacheWriteTokens are the cached_tokens and
-        // cache_write_tokens values reported alongside it; both 0 simulates a response with no
-        // cache activity (non-caching endpoint, or an implicit cacher that doesn't report writes).
+        // When set, reports usage via props.ResponseUsageCallback (mimicking the real client,
+        // which reports off the response's final usage-bearing chunk). ServeAs is the provider
+        // name; ServeCachedTokens / ServeCacheWriteTokens are the cache counters - both 0
+        // simulates a response with no cache activity (non-caching endpoint, or an implicit
+        // cacher that doesn't report writes); ServeCost is the billed credits (null = unreported).
         public string ServeAs;
         public int ServeCachedTokens;
         public int ServeCacheWriteTokens;
+        public decimal? ServeCost;
 
         public int Calls;
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
@@ -82,8 +83,15 @@ namespace GxPT.Tests.Mcp
             SeenTools.Add(tools);
             SeenProps.Add(props);
 
-            if (ServeAs != null && props != null && props.ProviderServedCallback != null)
-                props.ProviderServedCallback(ServeAs, ServeCachedTokens, ServeCacheWriteTokens);
+            if (ServeAs != null && props != null && props.ResponseUsageCallback != null)
+            {
+                var usage = new ResponseUsage();
+                usage.Provider = ServeAs;
+                usage.CachedTokens = ServeCachedTokens;
+                usage.CacheWriteTokens = ServeCacheWriteTokens;
+                usage.Cost = ServeCost;
+                props.ResponseUsageCallback(usage);
+            }
 
             if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
             {

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -63,6 +63,7 @@ namespace GxPT.Tests.Mcp
         public int Calls;
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
         public readonly List<IList<JObject>> SeenTools = new List<IList<JObject>>();
+        public readonly List<ClientProperties> SeenProps = new List<ClientProperties>();
 
         public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
                                ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError,
@@ -71,6 +72,7 @@ namespace GxPT.Tests.Mcp
             int idx = Calls++;
             SeenMessages.Add(messages);
             SeenTools.Add(tools);
+            SeenProps.Add(props);
 
             if (ErrorMessage != null && (ErrorOnCall < 0 || ErrorOnCall == idx))
             {

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -116,6 +116,17 @@ namespace GxPT
                     ? convo.RevealedTools : null,
                 CacheWarmProvider = string.IsNullOrEmpty(convo.CacheWarmProvider)
                     ? null : convo.CacheWarmProvider,
+                // Usage accumulators (status bar): nullable in the DTO so untouched/legacy
+                // conversations stay clean (NullValueHandling.Ignore drops the nulls).
+                TotalCost = convo.TotalCost != 0 ? (decimal?)convo.TotalCost : null,
+                TotalCacheDiscount = convo.TotalCacheDiscount != 0 ? (decimal?)convo.TotalCacheDiscount : null,
+                TotalPromptTokens = convo.TotalPromptTokens != 0 ? (long?)convo.TotalPromptTokens : null,
+                TotalCachedTokens = convo.TotalCachedTokens != 0 ? (long?)convo.TotalCachedTokens : null,
+                TotalCompletionTokens = convo.TotalCompletionTokens != 0 ? (long?)convo.TotalCompletionTokens : null,
+                TotalReasoningTokens = convo.TotalReasoningTokens != 0 ? (long?)convo.TotalReasoningTokens : null,
+                LastPromptTokens = convo.LastPromptTokens != 0 ? (int?)convo.LastPromptTokens : null,
+                LastCachedTokens = convo.LastCachedTokens != 0 ? (int?)convo.LastCachedTokens : null,
+                LastCacheWriteTokens = convo.LastCacheWriteTokens != 0 ? (int?)convo.LastCacheWriteTokens : null,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -189,6 +200,16 @@ namespace GxPT
                 RevealedTools = dto.RevealedTools != null
                     ? new List<string>(dto.RevealedTools) : new List<string>(),
                 CacheWarmProvider = dto.CacheWarmProvider,
+                // Absent in older files -> zeroes (no usage recorded yet).
+                TotalCost = dto.TotalCost.HasValue ? dto.TotalCost.Value : 0,
+                TotalCacheDiscount = dto.TotalCacheDiscount.HasValue ? dto.TotalCacheDiscount.Value : 0,
+                TotalPromptTokens = dto.TotalPromptTokens.HasValue ? dto.TotalPromptTokens.Value : 0,
+                TotalCachedTokens = dto.TotalCachedTokens.HasValue ? dto.TotalCachedTokens.Value : 0,
+                TotalCompletionTokens = dto.TotalCompletionTokens.HasValue ? dto.TotalCompletionTokens.Value : 0,
+                TotalReasoningTokens = dto.TotalReasoningTokens.HasValue ? dto.TotalReasoningTokens.Value : 0,
+                LastPromptTokens = dto.LastPromptTokens.HasValue ? dto.LastPromptTokens.Value : 0,
+                LastCachedTokens = dto.LastCachedTokens.HasValue ? dto.LastCachedTokens.Value : 0,
+                LastCacheWriteTokens = dto.LastCacheWriteTokens.HasValue ? dto.LastCacheWriteTokens.Value : 0,
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -361,6 +382,16 @@ namespace GxPT
             // Sticky cache-routing provider: the endpoint that last demonstrated a cache hit
             // (null/absent in older files -> none observed yet).
             public string CacheWarmProvider { get; set; }
+            // Usage accumulators (status bar); null/absent in older files -> zero.
+            public decimal? TotalCost { get; set; }
+            public decimal? TotalCacheDiscount { get; set; }
+            public long? TotalPromptTokens { get; set; }
+            public long? TotalCachedTokens { get; set; }
+            public long? TotalCompletionTokens { get; set; }
+            public long? TotalReasoningTokens { get; set; }
+            public int? LastPromptTokens { get; set; }
+            public int? LastCachedTokens { get; set; }
+            public int? LastCacheWriteTokens { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -110,6 +110,10 @@ namespace GxPT
                 // Omit an empty map so untouched conversations stay clean (NullValueHandling.Ignore).
                 SkillOverrides = (convo.SkillOverrides != null && convo.SkillOverrides.Count > 0)
                     ? convo.SkillOverrides : null,
+                // Revealed-tool list (prompt caching): persisted so a reopened conversation resumes
+                // with the same tools array instead of silently starting cold. Omitted when empty.
+                RevealedTools = (convo.RevealedTools != null && convo.RevealedTools.Count > 0)
+                    ? convo.RevealedTools : null,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -179,6 +183,9 @@ namespace GxPT
                 SkillOverrides = dto.SkillOverrides != null
                     ? new Dictionary<string, bool>(dto.SkillOverrides, StringComparer.OrdinalIgnoreCase)
                     : new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase),
+                // Absent in older files -> empty list (nothing revealed yet).
+                RevealedTools = dto.RevealedTools != null
+                    ? new List<string>(dto.RevealedTools) : new List<string>(),
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -346,6 +353,8 @@ namespace GxPT
             // from JSON when null/empty via NullValueHandling.Ignore.
             public bool? SkillsFeatureOff { get; set; }
             public Dictionary<string, bool> SkillOverrides { get; set; }
+            // Revealed MCP tool names (prompt caching; null/absent in older files -> none revealed).
+            public List<string> RevealedTools { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -114,8 +114,8 @@ namespace GxPT
                 // with the same tools array instead of silently starting cold. Omitted when empty.
                 RevealedTools = (convo.RevealedTools != null && convo.RevealedTools.Count > 0)
                     ? convo.RevealedTools : null,
-                LastServedProvider = string.IsNullOrEmpty(convo.LastServedProvider)
-                    ? null : convo.LastServedProvider,
+                CacheWarmProvider = string.IsNullOrEmpty(convo.CacheWarmProvider)
+                    ? null : convo.CacheWarmProvider,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -188,7 +188,7 @@ namespace GxPT
                 // Absent in older files -> empty list (nothing revealed yet).
                 RevealedTools = dto.RevealedTools != null
                     ? new List<string>(dto.RevealedTools) : new List<string>(),
-                LastServedProvider = dto.LastServedProvider,
+                CacheWarmProvider = dto.CacheWarmProvider,
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -358,8 +358,9 @@ namespace GxPT
             public Dictionary<string, bool> SkillOverrides { get; set; }
             // Revealed MCP tool names (prompt caching; null/absent in older files -> none revealed).
             public List<string> RevealedTools { get; set; }
-            // Sticky cache-routing provider (null/absent in older files -> none observed yet).
-            public string LastServedProvider { get; set; }
+            // Sticky cache-routing provider: the endpoint that last demonstrated a cache hit
+            // (null/absent in older files -> none observed yet).
+            public string CacheWarmProvider { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -114,6 +114,8 @@ namespace GxPT
                 // with the same tools array instead of silently starting cold. Omitted when empty.
                 RevealedTools = (convo.RevealedTools != null && convo.RevealedTools.Count > 0)
                     ? convo.RevealedTools : null,
+                LastServedProvider = string.IsNullOrEmpty(convo.LastServedProvider)
+                    ? null : convo.LastServedProvider,
                 LastUpdated = convo.LastUpdated,
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
@@ -186,6 +188,7 @@ namespace GxPT
                 // Absent in older files -> empty list (nothing revealed yet).
                 RevealedTools = dto.RevealedTools != null
                     ? new List<string>(dto.RevealedTools) : new List<string>(),
+                LastServedProvider = dto.LastServedProvider,
                 LastUpdated = dto.LastUpdated == default(DateTime) && !string.IsNullOrEmpty(path)
                     ? File.GetLastWriteTimeUtc(path)
                     : (dto.LastUpdated == default(DateTime) ? DateTime.Now : dto.LastUpdated)
@@ -355,6 +358,8 @@ namespace GxPT
             public Dictionary<string, bool> SkillOverrides { get; set; }
             // Revealed MCP tool names (prompt caching; null/absent in older files -> none revealed).
             public List<string> RevealedTools { get; set; }
+            // Sticky cache-routing provider (null/absent in older files -> none observed yet).
+            public string LastServedProvider { get; set; }
             public DateTime LastUpdated { get; set; }
             public List<MessageDto> Messages { get; set; }
         }

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -80,6 +80,7 @@
             this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCost = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSaved = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslSavedValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.msMain.SuspendLayout();
             this.ssMain.SuspendLayout();
             this.pnlInput.SuspendLayout();
@@ -543,7 +544,8 @@
             this.tslSpring,
             this.tslContext,
             this.tslCost,
-            this.tslSaved});
+            this.tslSaved,
+            this.tslSavedValue});
             this.ssMain.Location = new System.Drawing.Point(0, 744);
             this.ssMain.Name = "ssMain";
             this.ssMain.ShowItemToolTips = true;
@@ -573,6 +575,12 @@
             this.tslSaved.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
             this.tslSaved.Name = "tslSaved";
             this.tslSaved.Size = new System.Drawing.Size(0, 17);
+            //
+            // tslSavedValue
+            //
+            this.tslSavedValue.Margin = new System.Windows.Forms.Padding(-2, 3, 0, 2);
+            this.tslSavedValue.Name = "tslSavedValue";
+            this.tslSavedValue.Size = new System.Drawing.Size(0, 17);
             //
             // MainForm
             //
@@ -661,6 +669,7 @@
         private System.Windows.Forms.ToolStripStatusLabel tslContext;
         private System.Windows.Forms.ToolStripStatusLabel tslCost;
         private System.Windows.Forms.ToolStripStatusLabel tslSaved;
+        private System.Windows.Forms.ToolStripStatusLabel tslSavedValue;
         private System.Windows.Forms.ToolStripMenuItem miDeleteConversations;
         private System.Windows.Forms.ToolStripMenuItem miNextTab;
         private System.Windows.Forms.ToolStripMenuItem miPreviousTab;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -577,7 +577,9 @@
             // tslCost
             //
             this.tslCost.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
+            this.tslCost.Margin = new System.Windows.Forms.Padding(5, 3, 0, 2);
             this.tslCost.Name = "tslCost";
+            this.tslCost.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
             this.tslCost.Size = new System.Drawing.Size(0, 17);
             //
             // tslCostValue
@@ -589,7 +591,9 @@
             // tslSaved
             //
             this.tslSaved.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
+            this.tslSaved.Margin = new System.Windows.Forms.Padding(5, 3, 0, 2);
             this.tslSaved.Name = "tslSaved";
+            this.tslSaved.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
             this.tslSaved.Size = new System.Drawing.Size(0, 17);
             //
             // tslSavedValue

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -78,7 +78,9 @@
             this.ssMain = new System.Windows.Forms.StatusStrip();
             this.tslSpring = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslContextValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCost = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslCostValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSaved = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSavedValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.msMain.SuspendLayout();
@@ -543,7 +545,9 @@
             this.ssMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tslSpring,
             this.tslContext,
+            this.tslContextValue,
             this.tslCost,
+            this.tslCostValue,
             this.tslSaved,
             this.tslSavedValue});
             this.ssMain.Location = new System.Drawing.Point(0, 744);
@@ -564,11 +568,23 @@
             this.tslContext.Name = "tslContext";
             this.tslContext.Size = new System.Drawing.Size(0, 17);
             //
+            // tslContextValue
+            //
+            this.tslContextValue.Margin = new System.Windows.Forms.Padding(-2, 3, 0, 2);
+            this.tslContextValue.Name = "tslContextValue";
+            this.tslContextValue.Size = new System.Drawing.Size(0, 17);
+            //
             // tslCost
             //
             this.tslCost.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
             this.tslCost.Name = "tslCost";
             this.tslCost.Size = new System.Drawing.Size(0, 17);
+            //
+            // tslCostValue
+            //
+            this.tslCostValue.Margin = new System.Windows.Forms.Padding(-2, 3, 0, 2);
+            this.tslCostValue.Name = "tslCostValue";
+            this.tslCostValue.Size = new System.Drawing.Size(0, 17);
             //
             // tslSaved
             //
@@ -668,6 +684,8 @@
         private System.Windows.Forms.ToolStripStatusLabel tslSpring;
         private System.Windows.Forms.ToolStripStatusLabel tslContext;
         private System.Windows.Forms.ToolStripStatusLabel tslCost;
+        private System.Windows.Forms.ToolStripStatusLabel tslContextValue;
+        private System.Windows.Forms.ToolStripStatusLabel tslCostValue;
         private System.Windows.Forms.ToolStripStatusLabel tslSaved;
         private System.Windows.Forms.ToolStripStatusLabel tslSavedValue;
         private System.Windows.Forms.ToolStripMenuItem miDeleteConversations;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -49,6 +49,7 @@
             this.miPreviousTab = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.miDarkMode = new System.Windows.Forms.ToolStripMenuItem();
+            this.miStatusBar = new System.Windows.Forms.ToolStripMenuItem();
             this.miHelp = new System.Windows.Forms.ToolStripMenuItem();
             this.miApiKeysHelp = new System.Windows.Forms.ToolStripMenuItem();
             this.miPrivacyHelp = new System.Windows.Forms.ToolStripMenuItem();
@@ -74,7 +75,13 @@
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.chatTranscript = new GxPT.ChatTranscriptControl();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.ssMain = new System.Windows.Forms.StatusStrip();
+            this.tslSpring = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslCost = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslSaved = new System.Windows.Forms.ToolStripStatusLabel();
             this.msMain.SuspendLayout();
+            this.ssMain.SuspendLayout();
             this.pnlInput.SuspendLayout();
             this.pnlInputRight.SuspendLayout();
             this.pnlButtonsFill.SuspendLayout();
@@ -200,7 +207,8 @@
             this.miNextTab,
             this.miPreviousTab,
             this.toolStripSeparator6,
-            this.miDarkMode});
+            this.miDarkMode,
+            this.miStatusBar});
             this.miView.Name = "miView";
             this.miView.Size = new System.Drawing.Size(44, 20);
             this.miView.Text = "&View";
@@ -248,7 +256,16 @@
             this.miDarkMode.Size = new System.Drawing.Size(228, 22);
             this.miDarkMode.Text = "&Dark Mode";
             this.miDarkMode.Click += new System.EventHandler(this.miDarkMode_Click);
-            // 
+            //
+            // miStatusBar
+            //
+            this.miStatusBar.Checked = true;
+            this.miStatusBar.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.miStatusBar.Name = "miStatusBar";
+            this.miStatusBar.Size = new System.Drawing.Size(228, 22);
+            this.miStatusBar.Text = "&Status Bar";
+            this.miStatusBar.Click += new System.EventHandler(this.miStatusBar_Click);
+            //
             // miHelp
             // 
             this.miHelp.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -519,14 +536,52 @@
             this.splitContainer1.SplitterDistance = 6;
             this.splitContainer1.SplitterWidth = 1;
             this.splitContainer1.TabIndex = 1;
-            // 
+            //
+            // ssMain
+            //
+            this.ssMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tslSpring,
+            this.tslContext,
+            this.tslCost,
+            this.tslSaved});
+            this.ssMain.Location = new System.Drawing.Point(0, 744);
+            this.ssMain.Name = "ssMain";
+            this.ssMain.ShowItemToolTips = true;
+            this.ssMain.Size = new System.Drawing.Size(892, 22);
+            this.ssMain.SizingGrip = false;
+            this.ssMain.TabIndex = 3;
+            //
+            // tslSpring
+            //
+            this.tslSpring.Name = "tslSpring";
+            this.tslSpring.Size = new System.Drawing.Size(700, 17);
+            this.tslSpring.Spring = true;
+            //
+            // tslContext
+            //
+            this.tslContext.Name = "tslContext";
+            this.tslContext.Size = new System.Drawing.Size(0, 17);
+            //
+            // tslCost
+            //
+            this.tslCost.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
+            this.tslCost.Name = "tslCost";
+            this.tslCost.Size = new System.Drawing.Size(0, 17);
+            //
+            // tslSaved
+            //
+            this.tslSaved.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
+            this.tslSaved.Name = "tslSaved";
+            this.tslSaved.Size = new System.Drawing.Size(0, 17);
+            //
             // MainForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(892, 766);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.msMain);
+            this.Controls.Add(this.ssMain);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.msMain;
             this.Name = "MainForm";
@@ -534,6 +589,8 @@
             this.Text = "GxPT - New Conversation";
             this.msMain.ResumeLayout(false);
             this.msMain.PerformLayout();
+            this.ssMain.ResumeLayout(false);
+            this.ssMain.PerformLayout();
             this.pnlInput.ResumeLayout(false);
             this.pnlInput.PerformLayout();
             this.pnlInputRight.ResumeLayout(false);
@@ -598,6 +655,12 @@
         private System.Windows.Forms.Panel pnlButtons;
         private System.Windows.Forms.FlowLayoutPanel pnlAttachmentsBanner;
         private System.Windows.Forms.ToolStripMenuItem miDarkMode;
+        private System.Windows.Forms.ToolStripMenuItem miStatusBar;
+        private System.Windows.Forms.StatusStrip ssMain;
+        private System.Windows.Forms.ToolStripStatusLabel tslSpring;
+        private System.Windows.Forms.ToolStripStatusLabel tslContext;
+        private System.Windows.Forms.ToolStripStatusLabel tslCost;
+        private System.Windows.Forms.ToolStripStatusLabel tslSaved;
         private System.Windows.Forms.ToolStripMenuItem miDeleteConversations;
         private System.Windows.Forms.ToolStripMenuItem miNextTab;
         private System.Windows.Forms.ToolStripMenuItem miPreviousTab;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4809,14 +4809,19 @@ namespace GxPT
             // and the strip looks broken until the first response arrives.
             UsageStats s = (convo != null) ? convo.GetUsageStats() : new UsageStats();
 
+            // Every pane is a caption label + value label pair: the Saved pane needs the split so
+            // only the amount carries the health color, and the other two match it so all three
+            // panes share identical caption/value spacing. Captions (with the dividers) stay
+            // system text; the Saved value goes green once caching has net-saved money, red while
+            // net negative (write premiums not yet amortized by reads), neutral at zero.
             if (this.tslContext != null)
-                this.tslContext.Text = "Context: " + FormatTokenCount(s.LastPromptTokens) + " tok";
+                this.tslContext.Text = "Context:";
+            if (this.tslContextValue != null)
+                this.tslContextValue.Text = FormatTokenCount(s.LastPromptTokens) + " tok";
             if (this.tslCost != null)
-                this.tslCost.Text = "Cost: " + FormatMoney(s.TotalCost);
-            // The Saved pane is two labels so only the amount carries the health color: the
-            // "Saved:" caption (with the divider) stays system text, while the value goes green
-            // once caching has net-saved money, red while net negative (write premiums not yet
-            // amortized by reads), neutral at zero.
+                this.tslCost.Text = "Cost:";
+            if (this.tslCostValue != null)
+                this.tslCostValue.Text = FormatMoney(s.TotalCost);
             if (this.tslSaved != null)
                 this.tslSaved.Text = "Saved:";
             if (this.tslSavedValue != null)
@@ -4827,10 +4832,13 @@ namespace GxPT
             }
 
             string breakdown = BuildUsageTooltip(s);
-            if (this.tslContext != null) this.tslContext.ToolTipText = breakdown;
-            if (this.tslCost != null) this.tslCost.ToolTipText = breakdown;
-            if (this.tslSaved != null) this.tslSaved.ToolTipText = breakdown;
-            if (this.tslSavedValue != null) this.tslSavedValue.ToolTipText = breakdown;
+            ToolStripStatusLabel[] panes = new ToolStripStatusLabel[]
+            {
+                this.tslContext, this.tslContextValue, this.tslCost, this.tslCostValue,
+                this.tslSaved, this.tslSavedValue
+            };
+            foreach (ToolStripStatusLabel pane in panes)
+                if (pane != null) pane.ToolTipText = breakdown;
         }
 
         // The hover breakdown: cache percentages with their time windows labeled explicitly (the

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -73,6 +73,7 @@ namespace GxPT
             // Setup initial tab context for the designer-created tab
             SetupInitialConversationTab();
             _inputManager.SetHintText();
+            InitUsageStatusBar();
 
             // Wire banner link and ensure it lays out nicely
             if (this.lnkOpenSettings != null)
@@ -608,6 +609,8 @@ namespace GxPT
             RebuildAttachmentsBanner();
             // Point the MCP host's workdir-scoped servers (files/git/command) at the active tab's folder.
             SyncMcpWorkingDirFromActiveTab();
+            // Reflect the active conversation's usage/cost totals in the status bar.
+            SyncUsageStatusFromActiveTab();
             if (_inputManager != null) _inputManager.FocusInputSoon();
         }
 
@@ -2094,22 +2097,24 @@ namespace GxPT
                         // Sticky provider routing on cache-supported models: prefer (provider.order,
                         // preference with fallback) the endpoint holding this conversation's warm
                         // prompt cache. Stickiness is confirmation-gated - only a response reporting
-                        // cache activity (a read, cached_tokens > 0, or a write,
-                        // cache_write_tokens > 0) sets or moves the preference; merely serving a
-                        // request proves nothing.
-                        if (OpenRouterClient.ModelSupportsPromptCaching(modelToUse))
+                        // cache activity (a read or a write) sets or moves the preference; merely
+                        // serving a request proves nothing. Usage/cost accounting (status bar)
+                        // records on every model.
+                        Conversation usageConvo = ctx.Conversation;
+                        bool cachingModel = OpenRouterClient.ModelSupportsPromptCaching(modelToUse);
+                        if (usageConvo != null)
                         {
-                            Conversation stickyConvo = ctx.Conversation;
-                            if (stickyConvo != null)
+                            if (cachingModel && !string.IsNullOrEmpty(usageConvo.CacheWarmProvider))
+                                sendProps.ProviderOrder = new List<string> { usageConvo.CacheWarmProvider };
+                            sendProps.ResponseUsageCallback = delegate(ResponseUsage u)
                             {
-                                if (!string.IsNullOrEmpty(stickyConvo.CacheWarmProvider))
-                                    sendProps.ProviderOrder = new List<string> { stickyConvo.CacheWarmProvider };
-                                sendProps.ProviderServedCallback = delegate(string served, int cachedTokens, int cacheWriteTokens)
-                                {
-                                    if ((cachedTokens > 0 || cacheWriteTokens > 0) && !string.IsNullOrEmpty(served))
-                                        stickyConvo.CacheWarmProvider = served;
-                                };
-                            }
+                                if (u == null) return;
+                                if (cachingModel && !string.IsNullOrEmpty(u.Provider)
+                                    && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
+                                    usageConvo.CacheWarmProvider = u.Provider;
+                                usageConvo.RecordUsage(u);
+                                NotifyUsageUpdated(usageConvo);
+                            };
                         }
                         _client.CreateCompletionStream(
                             modelToUse,
@@ -2447,6 +2452,12 @@ namespace GxPT
                         orch.PreferredProvider = revealConvo.CacheWarmProvider;
                         orch.ProviderServed = delegate(string served)
                         { revealConvo.CacheWarmProvider = served; };
+                        // Per-response usage/cost accounting for the status bar (every iteration).
+                        orch.UsageReported = delegate(ResponseUsage u)
+                        {
+                            revealConvo.RecordUsage(u);
+                            NotifyUsageUpdated(revealConvo);
+                        };
                     }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).
@@ -4634,8 +4645,167 @@ namespace GxPT
                 // Also refresh tab headers (font/color may rely on system colors)
                 try { if (this.tabControl1 != null) this.tabControl1.Invalidate(); }
                 catch { }
+
+                // Status bar follows the UI theme
+                ApplyThemeToStatusBar();
             }
             catch { }
+        }
+
+        // ---- usage status bar (prompt caching / cost telemetry) ----
+
+        private void InitUsageStatusBar()
+        {
+            try
+            {
+                bool visible = AppSettings.GetBool("statusbar_visible", true);
+                if (this.ssMain != null) this.ssMain.Visible = visible;
+                if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
+                ApplyThemeToStatusBar();
+                SyncUsageStatusFromActiveTab();
+            }
+            catch { }
+        }
+
+        private void miStatusBar_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                bool visible = !(this.ssMain != null && this.ssMain.Visible);
+                if (this.ssMain != null) this.ssMain.Visible = visible;
+                if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
+                AppSettings.SetBool("statusbar_visible", visible);
+            }
+            catch { }
+        }
+
+        private void ApplyThemeToStatusBar()
+        {
+            try
+            {
+                if (this.ssMain == null) return;
+                bool dark = false;
+                try
+                {
+                    string theme = AppSettings.GetString("theme");
+                    dark = !string.IsNullOrEmpty(theme) && theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+                }
+                catch { }
+                var colors = ThemeService.GetColors(dark);
+                this.ssMain.BackColor = colors.UiBackground;
+                this.ssMain.ForeColor = colors.UiForeground;
+                foreach (ToolStripItem it in this.ssMain.Items)
+                    it.ForeColor = colors.UiForeground;
+            }
+            catch { }
+        }
+
+        private void SyncUsageStatusFromActiveTab()
+        {
+            try
+            {
+                var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
+                UpdateUsageStatusStrip(act != null ? act.Conversation : null);
+            }
+            catch { }
+        }
+
+        // Marshals a usage update from a send worker thread to the UI thread, refreshing the strip
+        // only when the reported conversation is still the active tab's (a background tab's turn
+        // must not paint over the foreground tab's stats; the totals are still recorded and appear
+        // on tab switch via SyncUsageStatusFromActiveTab).
+        private void NotifyUsageUpdated(Conversation convo)
+        {
+            try
+            {
+                if (IsDisposed || !IsHandleCreated) return;
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try
+                    {
+                        var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
+                        if (act != null && ReferenceEquals(act.Conversation, convo))
+                            UpdateUsageStatusStrip(convo);
+                    }
+                    catch { }
+                });
+            }
+            catch { }
+        }
+
+        // Renders a conversation's usage accumulators into the status strip. Panes are running
+        // totals (Cost/Saved) plus the Context gauge (newest request's full prompt size); the cache
+        // percentages live in the tooltip where their time window can be labeled explicitly.
+        private void UpdateUsageStatusStrip(Conversation convo)
+        {
+            if (this.ssMain == null) return;
+            UsageStats s = (convo != null) ? convo.GetUsageStats() : null;
+            if (s == null || (s.TotalPromptTokens == 0 && s.TotalCost == 0))
+            {
+                // Nothing recorded yet (fresh or legacy conversation): an empty strip beats zeros.
+                if (this.tslContext != null) { this.tslContext.Text = string.Empty; this.tslContext.ToolTipText = null; }
+                if (this.tslCost != null) { this.tslCost.Text = string.Empty; this.tslCost.ToolTipText = null; }
+                if (this.tslSaved != null) { this.tslSaved.Text = string.Empty; this.tslSaved.ToolTipText = null; }
+                return;
+            }
+
+            if (this.tslContext != null)
+                this.tslContext.Text = "Context: " + FormatTokenCount(s.LastPromptTokens) + " tok";
+            if (this.tslCost != null)
+                this.tslCost.Text = "Cost: " + FormatMoney(s.TotalCost);
+            if (this.tslSaved != null)
+                this.tslSaved.Text = "Saved: " + FormatMoney(s.TotalCacheDiscount);
+
+            string breakdown = BuildUsageTooltip(s);
+            if (this.tslContext != null) this.tslContext.ToolTipText = breakdown;
+            if (this.tslCost != null) this.tslCost.ToolTipText = breakdown;
+            if (this.tslSaved != null) this.tslSaved.ToolTipText = breakdown;
+        }
+
+        // The hover breakdown: cache percentages with their time windows labeled explicitly (the
+        // glanceable panes deliberately omit them - "last request" vs "lifetime" is ambiguous at a
+        // glance next to running totals).
+        internal static string BuildUsageTooltip(UsageStats s)
+        {
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
+            var sb = new System.Text.StringBuilder();
+            sb.Append("Last request: ").Append(s.LastCachedTokens.ToString("N0", inv))
+              .Append(" of ").Append(s.LastPromptTokens.ToString("N0", inv))
+              .Append(" prompt tokens read from cache");
+            if (s.LastPromptTokens > 0)
+                sb.Append(" (").Append((100.0 * s.LastCachedTokens / s.LastPromptTokens).ToString("0", inv)).Append("%)");
+            if (s.LastCacheWriteTokens > 0)
+                sb.Append("\r\n").Append("              ")
+                  .Append(s.LastCacheWriteTokens.ToString("N0", inv)).Append(" written to cache");
+            sb.Append("\r\nLifetime: ").Append(s.TotalCachedTokens.ToString("N0", inv))
+              .Append(" cached / ").Append(s.TotalPromptTokens.ToString("N0", inv))
+              .Append(" prompt tokens");
+            if (s.TotalPromptTokens > 0)
+                sb.Append(" (").Append((100.0 * s.TotalCachedTokens / s.TotalPromptTokens).ToString("0", inv)).Append("%)");
+            sb.Append("\r\nOutput: ").Append(s.TotalCompletionTokens.ToString("N0", inv)).Append(" tokens");
+            if (s.TotalReasoningTokens > 0)
+                sb.Append(" (reasoning: ").Append(s.TotalReasoningTokens.ToString("N0", inv)).Append(")");
+            return sb.ToString();
+        }
+
+        // "812", "41.2K", "1.3M" - compact enough for a status pane.
+        internal static string FormatTokenCount(long n)
+        {
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
+            if (n >= 1000000) return (n / 1000000.0).ToString("0.0", inv) + "M";
+            if (n >= 1000) return (n / 1000.0).ToString("0.0", inv) + "K";
+            return n.ToString(inv);
+        }
+
+        // OpenRouter credits are dollar-denominated. Two decimals minimum, four maximum so
+        // sub-cent conversations don't render as "$0.00" forever; negatives (a Saved total that is
+        // net write-premium so far) keep the sign visible.
+        internal static string FormatMoney(decimal v)
+        {
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
+            string sign = v < 0 ? "-" : string.Empty;
+            decimal a = Math.Abs(v);
+            return sign + "$" + a.ToString("0.00##", inv);
         }
 
         private void miDeleteConversations_Click(object sender, EventArgs e)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4732,7 +4732,10 @@ namespace GxPT
             // self-cancels the extra GETs if OpenRouter adds cache_discount to SSE chunks.
             if (u.CacheDiscount.HasValue && u.Cost.HasValue) return;
             if (!cachingModel && u.Cost.HasValue) return;
-            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            // A dedicated background thread, not the ThreadPool: the fetch can sleep for up to
+            // ~2 minutes waiting for a slow generation record, and the app's sends/naming also run
+            // on the pool - a tool loop's worth of sleeping fetches must not starve them.
+            var worker = new System.Threading.Thread(delegate()
             {
                 try
                 {
@@ -4752,6 +4755,8 @@ namespace GxPT
                 }
                 catch { }
             });
+            worker.IsBackground = true; // never holds the app open; unreconciled discounts at exit are accepted
+            worker.Start();
         }
 
         // Marshals a usage update from a send worker thread to the UI thread, refreshing the strip

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2092,17 +2092,22 @@ namespace GxPT
 
                         var sendProps = new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null };
                         // Sticky provider routing on cache-supported models: prefer (provider.order,
-                        // preference with fallback) the endpoint that served this conversation last,
-                        // since prompt caches live per provider; remember whoever serves this one.
+                        // preference with fallback) the endpoint that last demonstrated a cache hit
+                        // for this conversation, since prompt caches live per provider. Stickiness is
+                        // confirmation-gated - only a response reporting cached_tokens > 0 sets or
+                        // moves the preference; merely serving a request proves nothing.
                         if (OpenRouterClient.ModelSupportsPromptCaching(modelToUse))
                         {
                             Conversation stickyConvo = ctx.Conversation;
                             if (stickyConvo != null)
                             {
-                                if (!string.IsNullOrEmpty(stickyConvo.LastServedProvider))
-                                    sendProps.ProviderOrder = new List<string> { stickyConvo.LastServedProvider };
-                                sendProps.ProviderServedCallback = delegate(string served)
-                                { stickyConvo.LastServedProvider = served; };
+                                if (!string.IsNullOrEmpty(stickyConvo.CacheWarmProvider))
+                                    sendProps.ProviderOrder = new List<string> { stickyConvo.CacheWarmProvider };
+                                sendProps.ProviderServedCallback = delegate(string served, int cachedTokens)
+                                {
+                                    if (cachedTokens > 0 && !string.IsNullOrEmpty(served))
+                                        stickyConvo.CacheWarmProvider = served;
+                                };
                             }
                         }
                         _client.CreateCompletionStream(
@@ -2435,11 +2440,12 @@ namespace GxPT
                             revealConvo.RevealedTools = new List<string>();
                         orch.RevealedToolNames = revealConvo.RevealedTools;
                         // Sticky provider routing: seed the orchestrator with the provider that
-                        // served this conversation last, and persist whatever serves this turn, so
-                        // requests keep landing on the endpoint holding the warm prompt cache.
-                        orch.PreferredProvider = revealConvo.LastServedProvider;
+                        // last demonstrated a cache hit for this conversation, and persist any
+                        // newly confirmed one, so requests keep landing on the endpoint holding
+                        // the warm prompt cache (the orchestrator gates updates on cached > 0).
+                        orch.PreferredProvider = revealConvo.CacheWarmProvider;
                         orch.ProviderServed = delegate(string served)
-                        { revealConvo.LastServedProvider = served; };
+                        { revealConvo.CacheWarmProvider = served; };
                     }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1147,7 +1147,7 @@ namespace GxPT
                 clientInfo.Name = "GxPT";
                 clientInfo.Version = "1.0";
 
-                _mcpRegistry = new McpToolRegistry(McpToolRegistry.DefaultRevealCap, LoggerSink.Instance);
+                _mcpRegistry = new McpToolRegistry(LoggerSink.Instance);
                 var connector = new DefaultServerConnector(clientInfo, curlPath, caBundle, LoggerSink.Instance);
                 _mcpHost = new McpHost(connector, _mcpRegistry, LoggerSink.Instance);
 
@@ -2069,6 +2069,11 @@ namespace GxPT
                         // Snapshot the history and log it
                         // Build a model snapshot where attachments are appended to content on-the-fly
                         var snapshot = BuildMessagesForModel(ctx.Conversation.History);
+                        // Prompt caching: the newest message carries the cache breakpoint, so each
+                        // turn re-reads the prior turn's prefix and extends it. Snapshot messages are
+                        // request-local clones - the flag never lands in persisted history.
+                        if (snapshot.Count > 0)
+                            snapshot[snapshot.Count - 1].CacheControl = true;
                         try
                         {
                             var sbSnap = new StringBuilder();
@@ -2405,6 +2410,16 @@ namespace GxPT
                                                        model, LoggerSink.Instance);
                     orch.WorkingDir = ctx.WorkingDir;
                     orch.Zdr = zdr ? true : (bool?)null;
+                    // Reveal state is per-conversation (recency-ordered; persisted with the
+                    // conversation) so concurrent tabs don't churn each other's tools array - the
+                    // array must stay byte-stable across requests for prompt caching to hit.
+                    Conversation revealConvo = ctx.Conversation;
+                    if (revealConvo != null)
+                    {
+                        if (revealConvo.RevealedTools == null)
+                            revealConvo.RevealedTools = new List<string>();
+                        orch.RevealedToolNames = revealConvo.RevealedTools;
+                    }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).
                     orch.Cancellation = ctx.Cancellation;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4813,12 +4813,16 @@ namespace GxPT
                 this.tslContext.Text = "Context: " + FormatTokenCount(s.LastPromptTokens) + " tok";
             if (this.tslCost != null)
                 this.tslCost.Text = "Cost: " + FormatMoney(s.TotalCost);
+            // The Saved pane is two labels so only the amount carries the health color: the
+            // "Saved:" caption (with the divider) stays system text, while the value goes green
+            // once caching has net-saved money, red while net negative (write premiums not yet
+            // amortized by reads), neutral at zero.
             if (this.tslSaved != null)
+                this.tslSaved.Text = "Saved:";
+            if (this.tslSavedValue != null)
             {
-                this.tslSaved.Text = "Saved: " + FormatMoney(s.TotalCacheDiscount);
-                // At-a-glance cache health: green once caching has net-saved money, red while net
-                // negative (write premiums not yet amortized by reads), neutral at zero.
-                this.tslSaved.ForeColor = s.TotalCacheDiscount > 0 ? Color.Green
+                this.tslSavedValue.Text = FormatMoney(s.TotalCacheDiscount);
+                this.tslSavedValue.ForeColor = s.TotalCacheDiscount > 0 ? Color.Green
                     : (s.TotalCacheDiscount < 0 ? Color.Firebrick : SystemColors.ControlText);
             }
 
@@ -4826,6 +4830,7 @@ namespace GxPT
             if (this.tslContext != null) this.tslContext.ToolTipText = breakdown;
             if (this.tslCost != null) this.tslCost.ToolTipText = breakdown;
             if (this.tslSaved != null) this.tslSaved.ToolTipText = breakdown;
+            if (this.tslSavedValue != null) this.tslSavedValue.ToolTipText = breakdown;
         }
 
         // The hover breakdown: cache percentages with their time windows labeled explicitly (the

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4709,9 +4709,11 @@ namespace GxPT
         }
 
         // Records a response's streamed usage (instant feedback), then reconciles it against
-        // OpenRouter's authoritative generation record on a background thread. The streamed
-        // usage.cost is the pre-cache-discount estimate and cache_discount never arrives on the
-        // stream, so without reconciliation every cache hit inflates Cost and pins Saved at $0.00.
+        // OpenRouter's authoritative generation record on a background thread. cache_discount
+        // never arrives on the stream, so the generation record is the Saved figure's only data
+        // source; it also corrects Cost wherever a provider's stream estimate differs from billing
+        // (observed accurate on Bedrock; not guaranteed elsewhere - the delta reconcile is a no-op
+        // when they match).
         //
         // Reconciliation is gated by the MODEL's caching capability, never by the streamed cache
         // counters: some provider streams (seen with Amazon Bedrock) omit prompt_tokens_details

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2092,10 +2092,11 @@ namespace GxPT
 
                         var sendProps = new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null };
                         // Sticky provider routing on cache-supported models: prefer (provider.order,
-                        // preference with fallback) the endpoint that last demonstrated a cache hit
-                        // for this conversation, since prompt caches live per provider. Stickiness is
-                        // confirmation-gated - only a response reporting cached_tokens > 0 sets or
-                        // moves the preference; merely serving a request proves nothing.
+                        // preference with fallback) the endpoint holding this conversation's warm
+                        // prompt cache. Stickiness is confirmation-gated - only a response reporting
+                        // cache activity (a read, cached_tokens > 0, or a write,
+                        // cache_write_tokens > 0) sets or moves the preference; merely serving a
+                        // request proves nothing.
                         if (OpenRouterClient.ModelSupportsPromptCaching(modelToUse))
                         {
                             Conversation stickyConvo = ctx.Conversation;
@@ -2103,9 +2104,9 @@ namespace GxPT
                             {
                                 if (!string.IsNullOrEmpty(stickyConvo.CacheWarmProvider))
                                     sendProps.ProviderOrder = new List<string> { stickyConvo.CacheWarmProvider };
-                                sendProps.ProviderServedCallback = delegate(string served, int cachedTokens)
+                                sendProps.ProviderServedCallback = delegate(string served, int cachedTokens, int cacheWriteTokens)
                                 {
-                                    if (cachedTokens > 0 && !string.IsNullOrEmpty(served))
+                                    if ((cachedTokens > 0 || cacheWriteTokens > 0) && !string.IsNullOrEmpty(served))
                                         stickyConvo.CacheWarmProvider = served;
                                 };
                             }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2112,8 +2112,7 @@ namespace GxPT
                                 if (cachingModel && !string.IsNullOrEmpty(u.Provider)
                                     && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
                                     usageConvo.CacheWarmProvider = u.Provider;
-                                usageConvo.RecordUsage(u);
-                                NotifyUsageUpdated(usageConvo);
+                                RecordUsageAndReconcile(usageConvo, u);
                             };
                         }
                         _client.CreateCompletionStream(
@@ -2452,12 +2451,10 @@ namespace GxPT
                         orch.PreferredProvider = revealConvo.CacheWarmProvider;
                         orch.ProviderServed = delegate(string served)
                         { revealConvo.CacheWarmProvider = served; };
-                        // Per-response usage/cost accounting for the status bar (every iteration).
+                        // Per-response usage/cost accounting for the status bar (every iteration),
+                        // with post-stream reconciliation against the billed generation record.
                         orch.UsageReported = delegate(ResponseUsage u)
-                        {
-                            revealConvo.RecordUsage(u);
-                            NotifyUsageUpdated(revealConvo);
-                        };
+                        { RecordUsageAndReconcile(revealConvo, u); };
                     }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).
@@ -4708,6 +4705,35 @@ namespace GxPT
                 UpdateUsageStatusStrip(act != null ? act.Conversation : null);
             }
             catch { }
+        }
+
+        // Records a response's streamed usage (instant feedback), then reconciles it against
+        // OpenRouter's authoritative generation record on a background thread. The streamed
+        // usage.cost is the pre-cache-discount estimate and cache_discount never arrives on the
+        // stream, so without reconciliation every cache hit inflates Cost and pins Saved at $0.00.
+        // Fetched only when the request showed cache activity or reported no cost at all - for
+        // plain uncached requests the streamed figure already matches billing.
+        private void RecordUsageAndReconcile(Conversation convo, ResponseUsage u)
+        {
+            if (convo == null || u == null) return;
+            convo.RecordUsage(u);
+            NotifyUsageUpdated(convo);
+
+            if (string.IsNullOrEmpty(u.Id) || _client == null) return;
+            if (u.CachedTokens <= 0 && u.CacheWriteTokens <= 0 && u.Cost.HasValue) return;
+            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            {
+                try
+                {
+                    decimal? totalCost, cacheDiscount;
+                    if (_client.TryFetchGenerationStats(u.Id, out totalCost, out cacheDiscount))
+                    {
+                        convo.ReconcileUsage(u, totalCost, cacheDiscount);
+                        NotifyUsageUpdated(convo);
+                    }
+                }
+                catch { }
+            });
         }
 
         // Marshals a usage update from a send worker thread to the UI thread, refreshing the strip

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -90,6 +90,11 @@ namespace GxPT
                 MaybeShowModelUpdateBanner();
                 try { RestoreOpenTabsOnStartup(); }
                 catch { }
+                // The status bar synced in the constructor, before tabs were restored - and no
+                // OnTabSelected fires for the tab that is already selected, so without this the
+                // first visible tab shows empty usage stats until the user switches away and back.
+                try { SyncUsageStatusFromActiveTab(); }
+                catch { }
                 // After restoring tabs, if no API key is configured, open the API Keys Help tab and focus it
                 try
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4727,7 +4727,11 @@ namespace GxPT
             NotifyUsageUpdated(convo);
 
             if (string.IsNullOrEmpty(u.Id) || _client == null) return;
-            if (!cachingModel && u.Cost.HasValue) return; // streamed figure already matches billing
+            // Stream-first, fetch-as-fallback: the fetch exists for cache_discount (and as a cost
+            // correction). When a stream ever carries both, there is nothing left to fetch - this
+            // self-cancels the extra GETs if OpenRouter adds cache_discount to SSE chunks.
+            if (u.CacheDiscount.HasValue && u.Cost.HasValue) return;
+            if (!cachingModel && u.Cost.HasValue) return;
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
                 try

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4682,23 +4682,19 @@ namespace GxPT
             catch { }
         }
 
+        // The status strip matches the menu bar's system chrome rather than the transcript theme:
+        // the MenuStrip stays system-rendered in both light and dark modes, and a transcript-white
+        // strip looked out of place against it. Saved's health color is reapplied by the sync.
         private void ApplyThemeToStatusBar()
         {
             try
             {
                 if (this.ssMain == null) return;
-                bool dark = false;
-                try
-                {
-                    string theme = AppSettings.GetString("theme");
-                    dark = !string.IsNullOrEmpty(theme) && theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
-                }
-                catch { }
-                var colors = ThemeService.GetColors(dark);
-                this.ssMain.BackColor = colors.UiBackground;
-                this.ssMain.ForeColor = colors.UiForeground;
+                this.ssMain.BackColor = SystemColors.Control;
+                this.ssMain.ForeColor = SystemColors.ControlText;
                 foreach (ToolStripItem it in this.ssMain.Items)
-                    it.ForeColor = colors.UiForeground;
+                    it.ForeColor = SystemColors.ControlText;
+                SyncUsageStatusFromActiveTab();
             }
             catch { }
         }
@@ -4809,22 +4805,22 @@ namespace GxPT
         private void UpdateUsageStatusStrip(Conversation convo)
         {
             if (this.ssMain == null) return;
-            UsageStats s = (convo != null) ? convo.GetUsageStats() : null;
-            if (s == null || (s.TotalPromptTokens == 0 && s.TotalCost == 0))
-            {
-                // Nothing recorded yet (fresh or legacy conversation): an empty strip beats zeros.
-                if (this.tslContext != null) { this.tslContext.Text = string.Empty; this.tslContext.ToolTipText = null; }
-                if (this.tslCost != null) { this.tslCost.Text = string.Empty; this.tslCost.ToolTipText = null; }
-                if (this.tslSaved != null) { this.tslSaved.Text = string.Empty; this.tslSaved.ToolTipText = null; }
-                return;
-            }
+            // Zeros, not blanks, for fresh conversations: empty labels collapse the pane dividers
+            // and the strip looks broken until the first response arrives.
+            UsageStats s = (convo != null) ? convo.GetUsageStats() : new UsageStats();
 
             if (this.tslContext != null)
                 this.tslContext.Text = "Context: " + FormatTokenCount(s.LastPromptTokens) + " tok";
             if (this.tslCost != null)
                 this.tslCost.Text = "Cost: " + FormatMoney(s.TotalCost);
             if (this.tslSaved != null)
+            {
                 this.tslSaved.Text = "Saved: " + FormatMoney(s.TotalCacheDiscount);
+                // At-a-glance cache health: green once caching has net-saved money, red while net
+                // negative (write premiums not yet amortized by reads), neutral at zero.
+                this.tslSaved.ForeColor = s.TotalCacheDiscount > 0 ? Color.Green
+                    : (s.TotalCacheDiscount < 0 ? Color.Firebrick : SystemColors.ControlText);
+            }
 
             string breakdown = BuildUsageTooltip(s);
             if (this.tslContext != null) this.tslContext.ToolTipText = breakdown;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2112,7 +2112,7 @@ namespace GxPT
                                 if (cachingModel && !string.IsNullOrEmpty(u.Provider)
                                     && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
                                     usageConvo.CacheWarmProvider = u.Provider;
-                                RecordUsageAndReconcile(usageConvo, u);
+                                RecordUsageAndReconcile(usageConvo, u, cachingModel);
                             };
                         }
                         _client.CreateCompletionStream(
@@ -2453,8 +2453,9 @@ namespace GxPT
                         { revealConvo.CacheWarmProvider = served; };
                         // Per-response usage/cost accounting for the status bar (every iteration),
                         // with post-stream reconciliation against the billed generation record.
+                        bool cachingForUsage = OpenRouterClient.ModelSupportsPromptCaching(model);
                         orch.UsageReported = delegate(ResponseUsage u)
-                        { RecordUsageAndReconcile(revealConvo, u); };
+                        { RecordUsageAndReconcile(revealConvo, u, cachingForUsage); };
                     }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).
@@ -4711,26 +4712,37 @@ namespace GxPT
         // OpenRouter's authoritative generation record on a background thread. The streamed
         // usage.cost is the pre-cache-discount estimate and cache_discount never arrives on the
         // stream, so without reconciliation every cache hit inflates Cost and pins Saved at $0.00.
-        // Fetched only when the request showed cache activity or reported no cost at all - for
-        // plain uncached requests the streamed figure already matches billing.
-        private void RecordUsageAndReconcile(Conversation convo, ResponseUsage u)
+        //
+        // Reconciliation is gated by the MODEL's caching capability, never by the streamed cache
+        // counters: some provider streams (seen with Amazon Bedrock) omit prompt_tokens_details
+        // entirely, so a counter-based gate silently skips exactly the requests that need
+        // reconciling - the failure mode where Saved stays frozen at $0.00 while the OpenRouter
+        // dashboard shows cache activity on every request.
+        private void RecordUsageAndReconcile(Conversation convo, ResponseUsage u, bool cachingModel)
         {
             if (convo == null || u == null) return;
             convo.RecordUsage(u);
             NotifyUsageUpdated(convo);
 
             if (string.IsNullOrEmpty(u.Id) || _client == null) return;
-            if (u.CachedTokens <= 0 && u.CacheWriteTokens <= 0 && u.Cost.HasValue) return;
+            if (!cachingModel && u.Cost.HasValue) return; // streamed figure already matches billing
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
                 try
                 {
-                    decimal? totalCost, cacheDiscount;
-                    if (_client.TryFetchGenerationStats(u.Id, out totalCost, out cacheDiscount))
+                    GenerationStats stats = _client.FetchGenerationStats(u.Id);
+                    if (stats == null) return;
+                    convo.ReconcileUsage(u, stats.TotalCost, stats.CacheDiscount);
+                    // Streams that omit cache counters also starve the stream-side stickiness
+                    // gate; a nonzero billed discount is the same proof of cache activity,
+                    // observed late. Latch the conversation-level preference here - the next
+                    // turn emits it (mid-turn iterations still rely on stream counters).
+                    if (cachingModel && stats.CacheDiscount.HasValue && stats.CacheDiscount.Value != 0)
                     {
-                        convo.ReconcileUsage(u, totalCost, cacheDiscount);
-                        NotifyUsageUpdated(convo);
+                        string prov = !string.IsNullOrEmpty(u.Provider) ? u.Provider : stats.ProviderName;
+                        if (!string.IsNullOrEmpty(prov)) convo.CacheWarmProvider = prov;
                     }
+                    NotifyUsageUpdated(convo);
                 }
                 catch { }
             });

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4834,27 +4834,27 @@ namespace GxPT
 
         // The hover breakdown: cache percentages with their time windows labeled explicitly (the
         // glanceable panes deliberately omit them - "last request" vs "lifetime" is ambiguous at a
-        // glance next to running totals).
+        // glance next to running totals). Short bulleted lines on purpose: the native tooltip
+        // word-wraps long lines at an arbitrary width, which mangled the prose layout.
         internal static string BuildUsageTooltip(UsageStats s)
         {
             var inv = System.Globalization.CultureInfo.InvariantCulture;
             var sb = new System.Text.StringBuilder();
-            sb.Append("Last request: ").Append(s.LastCachedTokens.ToString("N0", inv))
-              .Append(" of ").Append(s.LastPromptTokens.ToString("N0", inv))
-              .Append(" prompt tokens read from cache");
+            sb.Append("Last request:");
+            sb.Append("\r\n- ").Append(s.LastPromptTokens.ToString("N0", inv)).Append(" prompt tokens");
+            sb.Append("\r\n- ").Append(s.LastCachedTokens.ToString("N0", inv)).Append(" read from cache");
             if (s.LastPromptTokens > 0)
                 sb.Append(" (").Append((100.0 * s.LastCachedTokens / s.LastPromptTokens).ToString("0", inv)).Append("%)");
             if (s.LastCacheWriteTokens > 0)
-                sb.Append("\r\n").Append("              ")
-                  .Append(s.LastCacheWriteTokens.ToString("N0", inv)).Append(" written to cache");
-            sb.Append("\r\nLifetime: ").Append(s.TotalCachedTokens.ToString("N0", inv))
-              .Append(" cached / ").Append(s.TotalPromptTokens.ToString("N0", inv))
-              .Append(" prompt tokens");
+                sb.Append("\r\n- ").Append(s.LastCacheWriteTokens.ToString("N0", inv)).Append(" written to cache");
+            sb.Append("\r\n\r\nLifetime:");
+            sb.Append("\r\n- ").Append(s.TotalPromptTokens.ToString("N0", inv)).Append(" prompt tokens");
+            sb.Append("\r\n- ").Append(s.TotalCachedTokens.ToString("N0", inv)).Append(" read from cache");
             if (s.TotalPromptTokens > 0)
                 sb.Append(" (").Append((100.0 * s.TotalCachedTokens / s.TotalPromptTokens).ToString("0", inv)).Append("%)");
-            sb.Append("\r\nOutput: ").Append(s.TotalCompletionTokens.ToString("N0", inv)).Append(" tokens");
+            sb.Append("\r\n- ").Append(s.TotalCompletionTokens.ToString("N0", inv)).Append(" output tokens");
             if (s.TotalReasoningTokens > 0)
-                sb.Append(" (reasoning: ").Append(s.TotalReasoningTokens.ToString("N0", inv)).Append(")");
+                sb.Append(" (").Append(s.TotalReasoningTokens.ToString("N0", inv)).Append(" reasoning)");
             return sb.ToString();
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2090,10 +2090,25 @@ namespace GxPT
                         }
                         catch { }
 
+                        var sendProps = new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null };
+                        // Sticky provider routing on cache-supported models: prefer (provider.order,
+                        // preference with fallback) the endpoint that served this conversation last,
+                        // since prompt caches live per provider; remember whoever serves this one.
+                        if (OpenRouterClient.ModelSupportsPromptCaching(modelToUse))
+                        {
+                            Conversation stickyConvo = ctx.Conversation;
+                            if (stickyConvo != null)
+                            {
+                                if (!string.IsNullOrEmpty(stickyConvo.LastServedProvider))
+                                    sendProps.ProviderOrder = new List<string> { stickyConvo.LastServedProvider };
+                                sendProps.ProviderServedCallback = delegate(string served)
+                                { stickyConvo.LastServedProvider = served; };
+                            }
+                        }
                         _client.CreateCompletionStream(
                             modelToUse,
                             snapshot,
-                            new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null },
+                            sendProps,
                             delegate(string d)
                             {
                                 if (string.IsNullOrEmpty(d)) return;
@@ -2419,6 +2434,12 @@ namespace GxPT
                         if (revealConvo.RevealedTools == null)
                             revealConvo.RevealedTools = new List<string>();
                         orch.RevealedToolNames = revealConvo.RevealedTools;
+                        // Sticky provider routing: seed the orchestrator with the provider that
+                        // served this conversation last, and persist whatever serves this turn, so
+                        // requests keep landing on the endpoint holding the warm prompt cache.
+                        orch.PreferredProvider = revealConvo.LastServedProvider;
+                        orch.ProviderServed = delegate(string served)
+                        { revealConvo.LastServedProvider = served; };
                     }
                     // Stop button cancellation: kills the in-flight model stream and lets the loop bail
                     // out cleanly between steps. Set once before the turn runs (read-only thereafter).

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4741,7 +4741,7 @@ namespace GxPT
                 {
                     GenerationStats stats = _client.FetchGenerationStats(u.Id);
                     if (stats == null) return;
-                    convo.ReconcileUsage(u, stats.TotalCost, stats.CacheDiscount);
+                    bool changed = convo.ReconcileUsage(u, stats.TotalCost, stats.CacheDiscount);
                     // Streams that omit cache counters also starve the stream-side stickiness
                     // gate; a nonzero billed discount is the same proof of cache activity,
                     // observed late. Latch the conversation-level preference here - the next
@@ -4752,6 +4752,22 @@ namespace GxPT
                         if (!string.IsNullOrEmpty(prov)) convo.CacheWarmProvider = prov;
                     }
                     NotifyUsageUpdated(convo);
+                    // Persist the corrected totals: a reconcile can land minutes after the turn's
+                    // normal save, and would otherwise be lost on app close / conversation close.
+                    // Update-only - never re-create a file the user deleted while the fetch was in
+                    // flight. The try/catch save matches the house pattern: a save that races a
+                    // running turn's history mutation throws and is skipped, and the next save
+                    // (which includes these totals) catches up.
+                    if (changed)
+                    {
+                        try
+                        {
+                            string path = ConversationStore.GetPathForId(convo.Id);
+                            if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
+                                ConversationStore.Save(convo);
+                        }
+                        catch { }
+                    }
                 }
                 catch { }
             });

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -85,6 +85,9 @@ namespace GxPT
         // Token accounting; arrives on the final SSE chunk when the request asked for it
         // (usage: {include: true}). Null on every other chunk.
         public UsageInfo usage { get; set; }
+        // Net credits saved (positive) or extra paid (negative, cache-write premium) due to prompt
+        // caching on this request. Top-level response field; may be absent on some providers.
+        public decimal? cache_discount { get; set; }
 
         internal sealed class Choice
         {
@@ -103,7 +106,11 @@ namespace GxPT
         {
             public int? prompt_tokens { get; set; }
             public int? completion_tokens { get; set; }
+            public int? total_tokens { get; set; }
+            // Credits charged to the account for this request (OpenRouter credits ~= USD).
+            public decimal? cost { get; set; }
             public PromptTokensDetails prompt_tokens_details { get; set; }
+            public CompletionTokensDetails completion_tokens_details { get; set; }
         }
 
         // cached_tokens is the prompt-cache read count: the prompt-prefix tokens the provider served
@@ -117,6 +124,11 @@ namespace GxPT
         {
             public int? cached_tokens { get; set; }
             public int? cache_write_tokens { get; set; }
+        }
+
+        internal sealed class CompletionTokensDetails
+        {
+            public int? reasoning_tokens { get; set; }
         }
     }
 

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -27,10 +27,11 @@ namespace GxPT
         // Tool-call loop (phase 4): set on "tool"-role messages; the id of the call being answered.
         public string ToolCallId;
         // Prompt-cache breakpoint (request-time only; never persisted). OpenRouterClient emits this
-        // message's content as a content-part array carrying cache_control {type: ephemeral} when the
-        // model's provider supports explicit caching. Set only on request-scoped message objects (the
-        // orchestrator clones history messages via WithCacheControl) so flags can never accumulate in
-        // persisted history across turns - Anthropic rejects requests with more than 4 breakpoints.
+        // message's content as a content-part array carrying cache_control {type: ephemeral} for
+        // every model - providers without explicit caching ignore the annotation. Set only on
+        // request-scoped message objects (the orchestrator clones history messages via
+        // WithCacheControl) so flags can never accumulate in persisted history across turns -
+        // Anthropic rejects requests with more than 4 breakpoints.
         public bool CacheControl;
 
         public ChatMessage() { }

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -26,6 +26,12 @@ namespace GxPT
         public List<ToolCall> ToolCalls;
         // Tool-call loop (phase 4): set on "tool"-role messages; the id of the call being answered.
         public string ToolCallId;
+        // Prompt-cache breakpoint (request-time only; never persisted). OpenRouterClient emits this
+        // message's content as a content-part array carrying cache_control {type: ephemeral} when the
+        // model's provider supports explicit caching. Set only on request-scoped message objects (the
+        // orchestrator clones history messages via WithCacheControl) so flags can never accumulate in
+        // persisted history across turns - Anthropic rejects requests with more than 4 breakpoints.
+        public bool CacheControl;
 
         public ChatMessage() { }
         public ChatMessage(string role, string content)
@@ -36,6 +42,17 @@ namespace GxPT
         public ChatMessage(string role, string content, List<AttachedFile> attachments)
         {
             Role = role; Content = content ?? string.Empty; Attachments = attachments;
+        }
+
+        // A shallow copy with the cache breakpoint set: flags a persisted history message at request
+        // time without mutating it (the copy lives only in the outgoing request list).
+        internal ChatMessage WithCacheControl()
+        {
+            var c = new ChatMessage(Role, Content, Attachments);
+            c.ToolCalls = ToolCalls;
+            c.ToolCallId = ToolCallId;
+            c.CacheControl = true;
+            return c;
         }
     }
 
@@ -61,6 +78,9 @@ namespace GxPT
         public long created { get; set; }
         public string model { get; set; }
         public List<Choice> choices { get; set; }
+        // Token accounting; arrives on the final SSE chunk when the request asked for it
+        // (usage: {include: true}). Null on every other chunk.
+        public UsageInfo usage { get; set; }
 
         internal sealed class Choice
         {
@@ -73,6 +93,21 @@ namespace GxPT
             public string role { get; set; }
             public string content { get; set; }
             public List<ToolCallDelta> tool_calls { get; set; }
+        }
+
+        internal sealed class UsageInfo
+        {
+            public int? prompt_tokens { get; set; }
+            public int? completion_tokens { get; set; }
+            public PromptTokensDetails prompt_tokens_details { get; set; }
+        }
+
+        // cached_tokens is the prompt-cache read count: the prompt-prefix tokens the provider served
+        // from cache (billed at the provider's discounted cache-read rate). Zero across repeated
+        // identical-prefix requests means a silent cache invalidator is at work.
+        internal sealed class PromptTokensDetails
+        {
+            public int? cached_tokens { get; set; }
         }
     }
 

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -77,6 +77,10 @@ namespace GxPT
         public string @object { get; set; }
         public long created { get; set; }
         public string model { get; set; }
+        // The provider endpoint that served this request (e.g. "Anthropic", "Amazon Bedrock").
+        // Drives sticky provider routing: prompt caches live per provider, so the next request of
+        // the conversation prefers (provider.order) whoever holds the warm cache.
+        public string provider { get; set; }
         public List<Choice> choices { get; set; }
         // Token accounting; arrives on the final SSE chunk when the request asked for it
         // (usage: {include: true}). Null on every other chunk.

--- a/GxPT/Models/ChatModels.cs
+++ b/GxPT/Models/ChatModels.cs
@@ -109,9 +109,14 @@ namespace GxPT
         // cached_tokens is the prompt-cache read count: the prompt-prefix tokens the provider served
         // from cache (billed at the provider's discounted cache-read rate). Zero across repeated
         // identical-prefix requests means a silent cache invalidator is at work.
+        // cache_write_tokens is the cache write count: tokens written to a new cache entry (billed
+        // at the provider's write premium). Large repeated writes are the signature of an
+        // invalidator re-billing the prefix; a write also proves this endpoint caches and now holds
+        // the conversation's warm entry (drives sticky provider routing from the first request).
         internal sealed class PromptTokensDetails
         {
             public int? cached_tokens { get; set; }
+            public int? cache_write_tokens { get; set; }
         }
     }
 

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -115,18 +115,28 @@ namespace GxPT
         // MainForm.RecordUsageAndReconcile): the streamed usage.cost is pre-cache-discount and
         // cache_discount never rides the stream, so without this every cache hit inflates TotalCost
         // and Saved never moves. Deltas against what RecordUsage already added for this request, so
-        // totals land on billed reality regardless of what the stream carried.
-        internal void ReconcileUsage(ResponseUsage original, decimal? totalCost, decimal? cacheDiscount)
+        // totals land on billed reality regardless of what the stream carried. Returns true when a
+        // total actually changed (the caller persists the conversation then - reconciles can land
+        // minutes after the turn's normal save, and would otherwise be lost on close).
+        internal bool ReconcileUsage(ResponseUsage original, decimal? totalCost, decimal? cacheDiscount)
         {
-            if (original == null) return;
+            if (original == null) return false;
+            bool changed = false;
             lock (_usageGate)
             {
                 if (totalCost.HasValue)
-                    TotalCost += totalCost.Value - (original.Cost.HasValue ? original.Cost.Value : 0);
+                {
+                    decimal delta = totalCost.Value - (original.Cost.HasValue ? original.Cost.Value : 0);
+                    if (delta != 0) { TotalCost += delta; changed = true; }
+                }
                 if (cacheDiscount.HasValue)
-                    TotalCacheDiscount += cacheDiscount.Value
+                {
+                    decimal delta = cacheDiscount.Value
                         - (original.CacheDiscount.HasValue ? original.CacheDiscount.Value : 0);
+                    if (delta != 0) { TotalCacheDiscount += delta; changed = true; }
+                }
             }
+            return changed;
         }
 
         // A consistent copy for the UI thread (decimal/long reads aren't atomic on x86).

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -72,6 +72,64 @@ namespace GxPT
         // cache at all) never land here. Null until a hit is observed; harmless when stale (it's a
         // preference with fallback, and after TTL expiry any consistent choice works).
         public string CacheWarmProvider { get; set; }
+
+        // ---- usage / cost accounting (status bar) ----
+        // Running totals across the conversation's lifetime plus a last-request snapshot, fed by
+        // RecordUsage (worker thread) and read by the status bar via GetUsageStats (UI thread);
+        // _usageGate keeps cross-thread reads consistent. Persisted with the conversation so a
+        // reopened tab keeps its lifetime cost. Totals are billed-as-reported (OpenRouter usage
+        // accounting); the naming-model title call is deliberately not counted.
+        private readonly object _usageGate = new object();
+        public decimal TotalCost { get; set; }           // sum of usage.cost (credits ~= USD)
+        public decimal TotalCacheDiscount { get; set; }  // net sum of cache_discount (+saved/-premium)
+        public long TotalPromptTokens { get; set; }      // total prompt tokens (cached subset included)
+        public long TotalCachedTokens { get; set; }      // of TotalPromptTokens, served from cache
+        public long TotalCompletionTokens { get; set; }
+        public long TotalReasoningTokens { get; set; }
+        public int LastPromptTokens { get; set; }        // newest request's full context size
+        public int LastCachedTokens { get; set; }
+        public int LastCacheWriteTokens { get; set; }
+
+        // Accumulate one response's usage (called once per model request, including every tool-loop
+        // iteration). Cost/discount are null when the endpoint didn't report them - skipped, not
+        // counted as zero, so totals stay "sum of what was billed and reported".
+        internal void RecordUsage(ResponseUsage u)
+        {
+            if (u == null) return;
+            lock (_usageGate)
+            {
+                if (u.Cost.HasValue) TotalCost += u.Cost.Value;
+                if (u.CacheDiscount.HasValue) TotalCacheDiscount += u.CacheDiscount.Value;
+                TotalPromptTokens += u.PromptTokens;
+                TotalCachedTokens += u.CachedTokens;
+                TotalCompletionTokens += u.CompletionTokens;
+                TotalReasoningTokens += u.ReasoningTokens;
+                LastPromptTokens = u.PromptTokens;
+                LastCachedTokens = u.CachedTokens;
+                LastCacheWriteTokens = u.CacheWriteTokens;
+            }
+            LastUpdated = DateTime.Now;
+        }
+
+        // A consistent copy for the UI thread (decimal/long reads aren't atomic on x86).
+        internal UsageStats GetUsageStats()
+        {
+            lock (_usageGate)
+            {
+                UsageStats s = new UsageStats();
+                s.TotalCost = TotalCost;
+                s.TotalCacheDiscount = TotalCacheDiscount;
+                s.TotalPromptTokens = TotalPromptTokens;
+                s.TotalCachedTokens = TotalCachedTokens;
+                s.TotalCompletionTokens = TotalCompletionTokens;
+                s.TotalReasoningTokens = TotalReasoningTokens;
+                s.LastPromptTokens = LastPromptTokens;
+                s.LastCachedTokens = LastCachedTokens;
+                s.LastCacheWriteTokens = LastCacheWriteTokens;
+                return s;
+            }
+        }
+
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 
@@ -315,5 +373,19 @@ namespace GxPT
             if (s.Length > 80) s = s.Substring(0, 80).Trim();
             return s;
         }
+    }
+
+    // Snapshot of a conversation's usage accumulators for UI display (see Conversation.GetUsageStats).
+    internal sealed class UsageStats
+    {
+        public decimal TotalCost;
+        public decimal TotalCacheDiscount;
+        public long TotalPromptTokens;
+        public long TotalCachedTokens;
+        public long TotalCompletionTokens;
+        public long TotalReasoningTokens;
+        public int LastPromptTokens;
+        public int LastCachedTokens;
+        public int LastCacheWriteTokens;
     }
 }

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -64,6 +64,12 @@ namespace GxPT
         // McpChatOrchestrator.RevealedToolNames). Stale names (server removed/disabled) are skipped
         // by the registry at request time, so the list never needs pruning here.
         public List<string> RevealedTools { get; set; }
+        // The OpenRouter provider endpoint that served this conversation's most recent request
+        // (e.g. "Anthropic", "Amazon Bedrock"). Prompt caches live per provider, so on cache-
+        // supported models the next request prefers this provider via provider.order - routing
+        // follows the warm cache instead of flapping between endpoints. Null until first observed;
+        // harmless when stale (it's a preference with fallback, and any consistent choice works).
+        public string LastServedProvider { get; set; }
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -64,12 +64,14 @@ namespace GxPT
         // McpChatOrchestrator.RevealedToolNames). Stale names (server removed/disabled) are skipped
         // by the registry at request time, so the list never needs pruning here.
         public List<string> RevealedTools { get; set; }
-        // The OpenRouter provider endpoint that served this conversation's most recent request
-        // (e.g. "Anthropic", "Amazon Bedrock"). Prompt caches live per provider, so on cache-
-        // supported models the next request prefers this provider via provider.order - routing
-        // follows the warm cache instead of flapping between endpoints. Null until first observed;
-        // harmless when stale (it's a preference with fallback, and any consistent choice works).
-        public string LastServedProvider { get; set; }
+        // The OpenRouter provider endpoint that last demonstrated a prompt-cache hit for this
+        // conversation (cached_tokens > 0 on its response; e.g. "Anthropic", "Amazon Bedrock").
+        // Prompt caches live per provider, so on cache-supported models the next request prefers
+        // this provider via provider.order - routing follows the warm cache instead of flapping
+        // between endpoints. Confirmation-gated: providers that merely served a request (or don't
+        // cache at all) never land here. Null until a hit is observed; harmless when stale (it's a
+        // preference with fallback, and after TTL expiry any consistent choice works).
+        public string CacheWarmProvider { get; set; }
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -111,6 +111,24 @@ namespace GxPT
             LastUpdated = DateTime.Now;
         }
 
+        // Replaces a request's streamed estimate with the authoritative generation record (see
+        // MainForm.RecordUsageAndReconcile): the streamed usage.cost is pre-cache-discount and
+        // cache_discount never rides the stream, so without this every cache hit inflates TotalCost
+        // and Saved never moves. Deltas against what RecordUsage already added for this request, so
+        // totals land on billed reality regardless of what the stream carried.
+        internal void ReconcileUsage(ResponseUsage original, decimal? totalCost, decimal? cacheDiscount)
+        {
+            if (original == null) return;
+            lock (_usageGate)
+            {
+                if (totalCost.HasValue)
+                    TotalCost += totalCost.Value - (original.Cost.HasValue ? original.Cost.Value : 0);
+                if (cacheDiscount.HasValue)
+                    TotalCacheDiscount += cacheDiscount.Value
+                        - (original.CacheDiscount.HasValue ? original.CacheDiscount.Value : 0);
+            }
+        }
+
         // A consistent copy for the UI thread (decimal/long reads aren't atomic on x86).
         internal UsageStats GetUsageStats()
         {

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -56,6 +56,14 @@ namespace GxPT
         // = force off); a slug absent inherits the global default. Set by the /skills and /skill commands.
         public bool? SkillsFeatureOff { get; set; }
         public Dictionary<string, bool> SkillOverrides { get; set; }
+        // Server-qualified MCP tool names this conversation has revealed, in recency order (reveal
+        // and call both move a name to the end). Owned by the conversation - not the registry - so
+        // concurrent tabs don't share reveal state (which would churn each other's tools array and
+        // break prompt caching) and the working set survives save/reopen. Append-only on prompt-
+        // caching providers; trimmed to a cap at turn start on non-caching ones (see
+        // McpChatOrchestrator.RevealedToolNames). Stale names (server removed/disabled) are skipped
+        // by the registry at request time, so the list never needs pruning here.
+        public List<string> RevealedTools { get; set; }
         public DateTime LastUpdated { get; set; }
         public event Action<string> NameGenerated;
 
@@ -65,6 +73,7 @@ namespace GxPT
             Name = GenericName; // initialize to generic name
             SelectedModel = null;
             SkillOverrides = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            RevealedTools = new List<string>();
             ZdrFirstMessageIndex = -1; // not latched until a ZDR send occurs
             // A brand-new conversation inherits the current global ZDR default as its starting value
             // (seed only - not a live override, so the user can still uncheck it before the first send).

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -120,6 +120,19 @@ namespace GxPT
         // Set per send (the orchestrator is built fresh each turn), so it's not shared/racy.
         public ICollection<string> HiddenToolNames { get; set; }
 
+        // Sticky provider routing (prompt caching): the provider endpoint that served this
+        // conversation's previous request, seeded by the host from Conversation.LastServedProvider.
+        // Prompt caches live per provider, so on cache-supported models each request emits
+        // provider.order = [PreferredProvider] - a preference with fallback, not a pin - and the
+        // value updates from the response so mid-turn loop iterations follow the warm cache too.
+        // Ignored (no emission, no tracking) on models without prompt caching, where stickiness
+        // would only constrain load balancing for no benefit.
+        public string PreferredProvider { get; set; }
+
+        // Notifies the host whenever the serving provider is observed on a response, so it can
+        // persist the value to the conversation for the next turn. Invoked from the worker thread.
+        public Action<string> ProviderServed { get; set; }
+
         // Provider data-collection preference applied to every request in the turn. Null leaves
         // it unset (provider default).
         public bool? ProviderDataCollectionAllowed { get; set; }
@@ -397,6 +410,19 @@ namespace GxPT
             props.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
             props.Zdr = Zdr;
             props.ToolChoice = toolChoice;
+
+            // Sticky provider routing on cache-supported models (see PreferredProvider).
+            if (OpenRouterClient.ModelSupportsPromptCaching(_model))
+            {
+                if (!string.IsNullOrEmpty(PreferredProvider))
+                    props.ProviderOrder = new List<string> { PreferredProvider };
+                props.ProviderServedCallback = delegate(string served)
+                {
+                    PreferredProvider = served;
+                    Action<string> cb = ProviderServed;
+                    if (cb != null) cb(served);
+                };
+            }
 
             Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
             ToolCallAssembler asm = new ToolCallAssembler(textSink);

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -127,12 +127,14 @@ namespace GxPT
         // preference with fallback, not a pin. Confirmation-gated on purpose: merely serving a
         // request proves nothing (the endpoint may not cache at all - e.g. a third-party host of an
         // open-weights model - and pinning there would constrain load balancing for no benefit),
-        // while a cache read proves this is where the conversation's warm cache lives. A later
-        // cached=0 from the confirmed provider does NOT clear the preference - that is usually TTL
-        // expiry between turns, where keeping the rebuild on one provider is exactly the point; the
-        // preference moves only when a different provider demonstrates a hit. Cold start: the first
-        // request of a conversation is a cache write (cached=0), so stickiness latches on the first
-        // observed hit - typically iteration 2 of a tool loop. Ignored entirely on models without
+        // while cache activity proves it: a read (cached_tokens > 0) shows the warm cache lives
+        // here, and a write (cache_write_tokens > 0) shows it was just created here - either
+        // latches the preference, so explicit-caching providers stick from the conversation's very
+        // first request. A later no-activity response from the confirmed provider does NOT clear
+        // the preference - that is usually TTL expiry between turns, where keeping the rebuild on
+        // one provider is exactly the point; the preference moves only when a different provider
+        // demonstrates cache activity. Providers that report neither (implicit cachers whose writes
+        // are silent) latch on their first observed hit instead. Ignored entirely on models without
         // prompt caching.
         public string PreferredProvider { get; set; }
 
@@ -419,15 +421,15 @@ namespace GxPT
             props.ToolChoice = toolChoice;
 
             // Sticky provider routing on cache-supported models (see PreferredProvider). Stickiness
-            // is confirmation-gated: only a response that demonstrates a cache read (cached > 0)
-            // establishes or moves the preference.
+            // is confirmation-gated: only a response demonstrating cache activity - a read
+            // (cached > 0) or a write (cacheWrite > 0) - establishes or moves the preference.
             if (OpenRouterClient.ModelSupportsPromptCaching(_model))
             {
                 if (!string.IsNullOrEmpty(PreferredProvider))
                     props.ProviderOrder = new List<string> { PreferredProvider };
-                props.ProviderServedCallback = delegate(string served, int cachedTokens)
+                props.ProviderServedCallback = delegate(string served, int cachedTokens, int cacheWriteTokens)
                 {
-                    if (cachedTokens <= 0 || string.IsNullOrEmpty(served)) return;
+                    if ((cachedTokens <= 0 && cacheWriteTokens <= 0) || string.IsNullOrEmpty(served)) return;
                     PreferredProvider = served;
                     Action<string> cb = ProviderServed;
                     if (cb != null) cb(served);

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -20,6 +20,9 @@ namespace GxPT
     {
         public const int DefaultMaxIterations = 25;
         public const int DefaultCallTimeoutMs = 60000;
+        // Reveal-set cap, enforced only on models whose provider has no prompt caching (see the
+        // eviction note on RevealedToolNames). Matches the old registry-global LRU cap.
+        public const int RevealEvictionCap = 24;
 
         // Tool-result content returned when the user denies a call. Lives here (this file is linked
         // into the test project) so the transcript renderer can recognize a denied call; McpMarkers
@@ -44,7 +47,10 @@ namespace GxPT
             + "tool again later with adjusted arguments or once the situation changes.\n\n"
             + "Do not list or describe your tools or capabilities unless the user asks. Reply to "
             + "greetings and casual messages naturally and briefly, and bring up what you can do "
-            + "only when it is relevant to the user's request.";
+            + "only when it is relevant to the user's request.\n\n"
+            + "Some requests end with an extra user-role message marked [Ephemeral context ...]. "
+            + "It is appended by the host application (workspace memory, skills, tool availability), "
+            + "not written by the user; treat it as background information from the system.";
 
         // Per-turn workspace block, built from WorkingDir and injected as its own ephemeral system
         // message right after the agent prompt (only when a workspace is set). Kept separate from
@@ -67,10 +73,30 @@ namespace GxPT
         private readonly int _maxIterations;
         private readonly int _callTimeoutMs;
 
+        // The tools array offered on the most recent loop iteration. The cap wrap-up re-sends it
+        // (with tool_choice "none") so the wrap-up request's prompt prefix stays byte-identical to
+        // the loop's requests and re-reads the turn's prompt cache - omitting the array would change
+        // position 0 of the prompt and re-bill the whole transcript on the turn's largest request.
+        private IList<JObject> _lastOfferedTools;
+
         // Optional hook to transform history into the messages actually sent (e.g. inline file
         // attachments) without mutating the persisted history. Identity transform when null. Must
-        // preserve assistant ToolCalls and tool-role ToolCallId.
+        // preserve assistant ToolCalls and tool-role ToolCallId, and must be byte-deterministic per
+        // message: any nondeterminism (timestamps, fresh temp paths) silently zeroes the prompt-cache
+        // hit rate for everything after the first differing byte.
         public Func<IList<ChatMessage>, IList<ChatMessage>> RequestMessageTransform { get; set; }
+
+        // The conversation's revealed-tool list (server-qualified names), owned by the Conversation
+        // and persisted with it. Per-conversation scoping keeps one tab's reveals out of another
+        // tab's tools array; the registry validates each name against the live catalog at request
+        // time, so stale names are skipped harmlessly. The list is kept in recency order (reveal and
+        // call both bump a name to the end). Eviction is provider-gated at turn start: on prompt-
+        // caching providers the set is append-only - evicting a def changes the tools array at
+        // position 0 of the prompt and re-bills the whole transcript, which always costs more than
+        // the few hundred cache-discounted tokens the stale def occupies - while on non-caching
+        // providers the list is trimmed to RevealEvictionCap, oldest first, since stale defs are
+        // pure per-turn cost there. Defaults to a turn-local list when the host doesn't supply one.
+        public IList<string> RevealedToolNames { get; set; }
 
         // Optional provider of the persistent-memory system block (the current .gxpt/memory.md index
         // plus its framing), rebuilt from disk each request and injected as an ephemeral, non-persisted
@@ -163,6 +189,23 @@ namespace GxPT
             _log.Log("mcp", "[turn " + turnId + "] start: model=" + _model + ", history=" + history.Count
                 + " msg(s), maxIterations=" + _maxIterations);
 
+            if (RevealedToolNames == null) RevealedToolNames = new List<string>();
+            // Provider-gated eviction, at turn boundaries only (mid-loop eviction would churn the
+            // tools array between iterations for no benefit). See RevealedToolNames for the rationale.
+            if (RevealedToolNames.Count > RevealEvictionCap
+                && !OpenRouterClient.ModelSupportsPromptCaching(_model))
+            {
+                int evicted = 0;
+                while (RevealedToolNames.Count > RevealEvictionCap)
+                {
+                    RevealedToolNames.RemoveAt(0); // recency order: index 0 is least recently used
+                    evicted++;
+                }
+                _log.Log("mcp", "[turn " + turnId + "] evicted " + evicted
+                    + " least-recently-used revealed tool def(s) (non-caching provider, cap "
+                    + RevealEvictionCap + ")");
+            }
+
             // The cap is a budget rather than a fixed loop bound so the user can grant another batch
             // when it's reached (ContinuationDecider) instead of dead-ending the turn.
             int budget = _maxIterations;
@@ -189,7 +232,7 @@ namespace GxPT
                     {
                         _log.Log("mcp", "[turn " + turnId + "] iteration cap reached at " + iter
                             + "; wrapping up");
-                        RunCapWrapUp(history, ui, turnId);
+                        RunCapWrapUp(history, _lastOfferedTools, ui, turnId);
                         return;
                     }
                 }
@@ -199,7 +242,8 @@ namespace GxPT
                 // Filter by THIS turn's workdir so a folderless turn never advertises another folder's
                 // scoped tools (files/git/run_skill_script, ...) that it couldn't actually call.
                 bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(WorkingDir);
-                IList<JObject> tools = hasMcpTools ? _registry.ExposedFunctionDefs(WorkingDir) : null;
+                IList<JObject> tools = hasMcpTools
+                    ? _registry.ExposedFunctionDefs(WorkingDir, RevealedToolNames) : null;
                 string manifest = hasMcpTools ? _registry.NamesManifestSystemMessage(WorkingDir) : null;
                 if (SkillTools != null && SkillTools.HasSkills)
                 {
@@ -219,43 +263,51 @@ namespace GxPT
                 // over an empty list (e.g. a folderless turn whose only resolvable tools are all hidden).
                 if (manifest != null && manifest.IndexOf("\n- ", StringComparison.Ordinal) < 0)
                     manifest = null;
+                _lastOfferedTools = tools;
                 _log.Log("mcp", "[turn " + turnId + "] iteration " + (iter + 1) + "/" + budget
                     + ": requesting model with " + (tools != null ? tools.Count : 0) + " exposed tool(s)");
 
-                // The names manifest rides as an extra system message in front of history; it is not
-                // persisted (rebuilt each request from the live catalog).
-                // Ephemeral system messages, ordered stable -> volatile for prompt-cache reuse:
-                // constant agent prompt, then the workspace block (constant for the turn), then
-                // memory (changes rarely within a turn), then the skills manifest, then the MCP names
-                // manifest (rebuilt every request). None are persisted into history.
-                List<ChatMessage> requestMessages = new List<ChatMessage>();
-                requestMessages.Add(new ChatMessage("system", AgentSystemPrompt));
-                string workspaceBlock = WorkspaceSystemMessage(WorkingDir);
-                if (!string.IsNullOrEmpty(workspaceBlock))
-                    requestMessages.Add(new ChatMessage("system", workspaceBlock));
-                if (MemorySystemMessageProvider != null)
-                {
-                    string memoryBlock = MemorySystemMessageProvider();
-                    if (!string.IsNullOrEmpty(memoryBlock))
-                        requestMessages.Add(new ChatMessage("system", memoryBlock));
-                }
-                if (SkillsManifestSystemMessageProvider != null)
-                {
-                    string skillsBlock = SkillsManifestSystemMessageProvider();
-                    if (!string.IsNullOrEmpty(skillsBlock))
-                        requestMessages.Add(new ChatMessage("system", skillsBlock));
-                }
-                if (!string.IsNullOrEmpty(manifest))
-                    requestMessages.Add(new ChatMessage("system", manifest));
+                // Request layout, designed for prompt-cache reuse (three zones by volatility):
+                //   Zone A - stable head: constant agent prompt + workspace block (system messages;
+                //            byte-identical for the conversation's lifetime). Cache breakpoint #1 on
+                //            its last message caches tools + system head together (tools render at
+                //            position 0 of the prompt).
+                //   Zone B - the persisted history (append-only). Cache breakpoint #2 rides the
+                //            newest message, so each loop iteration / turn reads the previous
+                //            request's prefix from cache and extends it incrementally.
+                //   Zone C - one ephemeral user-role tail message holding everything that may change
+                //            between requests (memory, skills manifest, MCP names manifest). Placed
+                //            AFTER the breakpoints so its churn never invalidates the cached
+                //            transcript. Never persisted; rebuilt every request.
+                List<ChatMessage> requestMessages = BuildStableHead();
+                requestMessages[requestMessages.Count - 1].CacheControl = true;
+                int headCount = requestMessages.Count;
+
                 // Build the sent messages from history, optionally transformed (e.g. attachments
                 // inlined). The transform must not drop tool_calls / tool_call_id.
                 IList<ChatMessage> contextMessages = RequestMessageTransform != null
                     ? RequestMessageTransform(history) : history;
                 requestMessages.AddRange(contextMessages);
+                // Breakpoint #2 on a request-local clone, never on the persisted message itself -
+                // otherwise stale flags accumulate across turns and overrun the provider's
+                // breakpoint limit (Anthropic allows at most 4 per request).
+                if (requestMessages.Count > headCount)
+                {
+                    int last = requestMessages.Count - 1;
+                    requestMessages[last] = requestMessages[last].WithCacheControl();
+                }
+
+                string memoryBlock = MemorySystemMessageProvider != null
+                    ? MemorySystemMessageProvider() : null;
+                string skillsBlock = SkillsManifestSystemMessageProvider != null
+                    ? SkillsManifestSystemMessageProvider() : null;
+                string ephemeralTail = BuildEphemeralContextText(memoryBlock, skillsBlock, manifest);
+                if (!string.IsNullOrEmpty(ephemeralTail))
+                    requestMessages.Add(new ChatMessage("user", ephemeralTail));
 
                 bool errored;
                 string errMessage;
-                ToolCallAssembler asm = StreamOnce(requestMessages, tools, ui, out errored, out errMessage);
+                ToolCallAssembler asm = StreamOnce(requestMessages, tools, null, ui, out errored, out errMessage);
                 if (errored)
                 {
                     _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
@@ -270,7 +322,7 @@ namespace GxPT
                 if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
                 {
                     _log.Log("mcp", "[turn " + turnId + "] empty response (no tool calls, no text); retrying once");
-                    asm = StreamOnce(requestMessages, tools, ui, out errored, out errMessage);
+                    asm = StreamOnce(requestMessages, tools, null, ui, out errored, out errMessage);
                     if (errored)
                     {
                         _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
@@ -335,14 +387,16 @@ namespace GxPT
         }
 
         // One streamed model request into a fresh assembler. Shared by the main loop, the
-        // empty-response retry, and (with tools = null) the cap wrap-up.
+        // empty-response retry, and (with toolChoice = "none") the cap wrap-up.
         private ToolCallAssembler StreamOnce(IList<ChatMessage> requestMessages, IList<JObject> tools,
-                                             IToolLoopUi ui, out bool errored, out string errMessage)
+                                             string toolChoice, IToolLoopUi ui, out bool errored,
+                                             out string errMessage)
         {
             ClientProperties props = new ClientProperties();
             props.Stream = true;
             props.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
             props.Zdr = Zdr;
+            props.ToolChoice = toolChoice;
 
             Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
             ToolCallAssembler asm = new ToolCallAssembler(textSink);
@@ -367,15 +421,28 @@ namespace GxPT
                 + (asm.Truncated ? " [TRUNCATED: model output cut off by length]" : ""));
         }
 
-        // Cap reached and not continued: one final tool-less model call asking it to summarize and
-        // ask how to proceed, so the turn ends with a readable assistant message rather than a
-        // cryptic dead-end. The user can simply reply to keep going (a fresh budget next turn).
-        private void RunCapWrapUp(IList<ChatMessage> history, IToolLoopUi ui, string turnId)
+        // Cap reached and not continued: one final model call (tool_choice "none") asking it to
+        // summarize and ask how to proceed, so the turn ends with a readable assistant message
+        // rather than a cryptic dead-end. The user can simply reply to keep going (a fresh budget
+        // next turn). The request reuses the loop's prompt shape - same stable head, same history,
+        // same tools array - rather than dropping tools: on Anthropic a tool_choice change
+        // invalidates only the message-tier cache, while removing the tools array would change
+        // position 0 of the prompt and invalidate the tools+system tiers as well. The next user
+        // turn (back on tool_choice auto) still extends the loop's cached prefix unharmed.
+        private void RunCapWrapUp(IList<ChatMessage> history, IList<JObject> tools, IToolLoopUi ui,
+                                  string turnId)
         {
-            List<ChatMessage> requestMessages = new List<ChatMessage>();
+            List<ChatMessage> requestMessages = BuildStableHead();
+            requestMessages[requestMessages.Count - 1].CacheControl = true;
+            int headCount = requestMessages.Count;
             IList<ChatMessage> contextMessages = RequestMessageTransform != null
                 ? RequestMessageTransform(history) : history;
             requestMessages.AddRange(contextMessages);
+            if (requestMessages.Count > headCount)
+            {
+                int last = requestMessages.Count - 1;
+                requestMessages[last] = requestMessages[last].WithCacheControl();
+            }
             // Sent as a user message, not system: Anthropic (via OpenRouter) hoists in-array system
             // messages to the top-level system parameter, which would leave the conversation ending
             // on a tool result and the model with nothing in-position to answer (it replies with a
@@ -386,10 +453,11 @@ namespace GxPT
                 + "request any more tools now. Briefly summarize what you have done so far and what "
                 + "still remains, then ask the user how they would like to proceed."));
 
-            // No tools offered, so the model must answer with text.
+            // tool_choice "none": the model must answer with text, while the unchanged tools array
+            // keeps the cached prefix intact.
             bool errored;
             string errMessage;
-            ToolCallAssembler asm = StreamOnce(requestMessages, null, ui, out errored, out errMessage);
+            ToolCallAssembler asm = StreamOnce(requestMessages, tools, "none", ui, out errored, out errMessage);
 
             string text;
             if (errored || IsEmptyText(asm.Text))
@@ -408,6 +476,45 @@ namespace GxPT
 
             history.Add(new ChatMessage("assistant", text));
             if (ui != null) ui.Complete();
+        }
+
+        // Zone A: the stable system head, byte-identical for every request of a conversation (the
+        // agent prompt is constant; the workspace block is constant while the workspace is). Fresh
+        // message objects each call, so callers may set CacheControl on them directly.
+        private List<ChatMessage> BuildStableHead()
+        {
+            List<ChatMessage> head = new List<ChatMessage>();
+            head.Add(new ChatMessage("system", AgentSystemPrompt));
+            string workspaceBlock = WorkspaceSystemMessage(WorkingDir);
+            if (!string.IsNullOrEmpty(workspaceBlock))
+                head.Add(new ChatMessage("system", workspaceBlock));
+            return head;
+        }
+
+        // Zone C: the ephemeral context tail - one user-role message holding everything that may
+        // change between requests (memory index, skills manifest, MCP names manifest). User role
+        // because Anthropic (via OpenRouter) hoists in-array system messages to the top-level system
+        // parameter, which would put this back in front of the cached history; as a trailing user
+        // message it merges into the same user turn as any preceding tool results ([tool_result...,
+        // text] is the order Anthropic requires). Returns null when every block is empty, so a turn
+        // without memory/skills/tools leaves no trace. Never persisted; the UI never renders it.
+        internal static string BuildEphemeralContextText(string memory, string skills, string toolManifest)
+        {
+            bool hasMemory = !string.IsNullOrEmpty(memory);
+            bool hasSkills = !string.IsNullOrEmpty(skills);
+            bool hasManifest = !string.IsNullOrEmpty(toolManifest);
+            if (!hasMemory && !hasSkills && !hasManifest) return null;
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[Ephemeral context appended by the host application for this request. ");
+            sb.Append("It is not part of the user's message.]");
+            if (hasMemory)
+                sb.Append("\n\n<memory>\n").Append(memory).Append("\n</memory>");
+            if (hasSkills)
+                sb.Append("\n\n<skills>\n").Append(skills).Append("\n</skills>");
+            if (hasManifest)
+                sb.Append("\n\n<available_tools>\n").Append(toolManifest).Append("\n</available_tools>");
+            return sb.ToString();
         }
 
         private static bool IsEmptyText(string s)
@@ -446,7 +553,7 @@ namespace GxPT
             {
                 string[] names = ParseRevealNames(call.ArgumentsJson);
                 _log.Log("mcp", "[turn " + turnId + "] reveal_tools: " + names.Length + " name(s)");
-                return _registry.Reveal(names, WorkingDir);
+                return _registry.Reveal(names, WorkingDir, RevealedToolNames);
             }
 
             // open_skill is a host meta-tool (no MCP round-trip): load skill bodies by slug. Same
@@ -484,6 +591,15 @@ namespace GxPT
                 _log.Log("mcp", "[turn " + turnId + "] unresolved tool '" + call.Name + "' (workdir="
                     + (string.IsNullOrEmpty(WorkingDir) ? "(none)" : WorkingDir) + ")");
                 return "[Unknown tool: " + call.Name + "]";
+            }
+
+            // An actively-called tool moves to the end of the recency-ordered reveal list, so the
+            // provider-gated eviction (non-caching models only) trims idle defs first. Reordering the
+            // list is cache-safe: the emitted tools array is sorted by name, not list order.
+            if (RevealedToolNames != null && RevealedToolNames.Contains(call.Name))
+            {
+                RevealedToolNames.Remove(call.Name);
+                RevealedToolNames.Add(call.Name);
             }
 
             JObject args;

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -120,17 +120,24 @@ namespace GxPT
         // Set per send (the orchestrator is built fresh each turn), so it's not shared/racy.
         public ICollection<string> HiddenToolNames { get; set; }
 
-        // Sticky provider routing (prompt caching): the provider endpoint that served this
-        // conversation's previous request, seeded by the host from Conversation.LastServedProvider.
-        // Prompt caches live per provider, so on cache-supported models each request emits
-        // provider.order = [PreferredProvider] - a preference with fallback, not a pin - and the
-        // value updates from the response so mid-turn loop iterations follow the warm cache too.
-        // Ignored (no emission, no tracking) on models without prompt caching, where stickiness
-        // would only constrain load balancing for no benefit.
+        // Sticky provider routing (prompt caching): the provider endpoint that last DEMONSTRATED a
+        // cache hit for this conversation (cached_tokens > 0 on its response), seeded by the host
+        // from Conversation.CacheWarmProvider. Prompt caches live per provider, so on
+        // cache-supported models each request emits provider.order = [PreferredProvider] - a
+        // preference with fallback, not a pin. Confirmation-gated on purpose: merely serving a
+        // request proves nothing (the endpoint may not cache at all - e.g. a third-party host of an
+        // open-weights model - and pinning there would constrain load balancing for no benefit),
+        // while a cache read proves this is where the conversation's warm cache lives. A later
+        // cached=0 from the confirmed provider does NOT clear the preference - that is usually TTL
+        // expiry between turns, where keeping the rebuild on one provider is exactly the point; the
+        // preference moves only when a different provider demonstrates a hit. Cold start: the first
+        // request of a conversation is a cache write (cached=0), so stickiness latches on the first
+        // observed hit - typically iteration 2 of a tool loop. Ignored entirely on models without
+        // prompt caching.
         public string PreferredProvider { get; set; }
 
-        // Notifies the host whenever the serving provider is observed on a response, so it can
-        // persist the value to the conversation for the next turn. Invoked from the worker thread.
+        // Notifies the host when a provider demonstrates a cache hit, so it can persist the value
+        // to the conversation for the next turn. Invoked from the worker thread.
         public Action<string> ProviderServed { get; set; }
 
         // Provider data-collection preference applied to every request in the turn. Null leaves
@@ -411,13 +418,16 @@ namespace GxPT
             props.Zdr = Zdr;
             props.ToolChoice = toolChoice;
 
-            // Sticky provider routing on cache-supported models (see PreferredProvider).
+            // Sticky provider routing on cache-supported models (see PreferredProvider). Stickiness
+            // is confirmation-gated: only a response that demonstrates a cache read (cached > 0)
+            // establishes or moves the preference.
             if (OpenRouterClient.ModelSupportsPromptCaching(_model))
             {
                 if (!string.IsNullOrEmpty(PreferredProvider))
                     props.ProviderOrder = new List<string> { PreferredProvider };
-                props.ProviderServedCallback = delegate(string served)
+                props.ProviderServedCallback = delegate(string served, int cachedTokens)
                 {
+                    if (cachedTokens <= 0 || string.IsNullOrEmpty(served)) return;
                     PreferredProvider = served;
                     Action<string> cb = ProviderServed;
                     if (cb != null) cb(served);

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -306,7 +306,6 @@ namespace GxPT
                 //            AFTER the breakpoints so its churn never invalidates the cached
                 //            transcript. Never persisted; rebuilt every request.
                 List<ChatMessage> requestMessages = BuildStableHead();
-                requestMessages[requestMessages.Count - 1].CacheControl = true;
                 int headCount = requestMessages.Count;
 
                 // Build the sent messages from history, optionally transformed (e.g. attachments
@@ -314,14 +313,7 @@ namespace GxPT
                 IList<ChatMessage> contextMessages = RequestMessageTransform != null
                     ? RequestMessageTransform(history) : history;
                 requestMessages.AddRange(contextMessages);
-                // Breakpoint #2 on a request-local clone, never on the persisted message itself -
-                // otherwise stale flags accumulate across turns and overrun the provider's
-                // breakpoint limit (Anthropic allows at most 4 per request).
-                if (requestMessages.Count > headCount)
-                {
-                    int last = requestMessages.Count - 1;
-                    requestMessages[last] = requestMessages[last].WithCacheControl();
-                }
+                ApplyCacheBreakpoints(requestMessages, headCount);
 
                 string memoryBlock = MemorySystemMessageProvider != null
                     ? MemorySystemMessageProvider() : null;
@@ -480,16 +472,11 @@ namespace GxPT
                                   string turnId)
         {
             List<ChatMessage> requestMessages = BuildStableHead();
-            requestMessages[requestMessages.Count - 1].CacheControl = true;
             int headCount = requestMessages.Count;
             IList<ChatMessage> contextMessages = RequestMessageTransform != null
                 ? RequestMessageTransform(history) : history;
             requestMessages.AddRange(contextMessages);
-            if (requestMessages.Count > headCount)
-            {
-                int last = requestMessages.Count - 1;
-                requestMessages[last] = requestMessages[last].WithCacheControl();
-            }
+            ApplyCacheBreakpoints(requestMessages, headCount);
             // Sent as a user message, not system: Anthropic (via OpenRouter) hoists in-array system
             // messages to the top-level system parameter, which would leave the conversation ending
             // on a tool result and the model with nothing in-position to answer (it replies with a
@@ -523,6 +510,53 @@ namespace GxPT
 
             history.Add(new ChatMessage("assistant", text));
             if (ui != null) ui.Complete();
+        }
+
+        // Flags the request's cache breakpoints (Anthropic allows at most 4 per request):
+        //   #1  last message of the stable head (request-local object; flagged directly),
+        //   #2  the newest history message (a WithCacheControl clone - the flag must never land
+        //       on, or accumulate in, persisted history),
+        //   plus up to TWO intermediate flags spaced ~12 estimated content blocks apart, walking
+        //   back from the end. The intermediates bridge Anthropic's ~20-block matcher lookback:
+        //   without them, a single iteration that appends more blocks than the lookback covers
+        //   (an assistant message with K tool calls renders as ~K+1 blocks and its results as K
+        //   more, so K >= ~10 outruns it) leaves the next request's breakpoint unable to find the
+        //   previous cache entry - a silent full miss. With both spares, fan-outs up to ~18 calls
+        //   per iteration stay bridged; a single message wider than the lookback (~20+ calls in
+        //   one assistant turn) is unbridgeable by placement and accepted. When the appended span
+        //   is short, the spares land in older, already-cached content, which is harmless.
+        internal static void ApplyCacheBreakpoints(List<ChatMessage> requestMessages, int headCount)
+        {
+            if (headCount > 0 && requestMessages.Count >= headCount)
+                requestMessages[headCount - 1].CacheControl = true;
+            if (requestMessages.Count <= headCount) return;
+
+            int last = requestMessages.Count - 1;
+            requestMessages[last] = requestMessages[last].WithCacheControl();
+
+            int blocksSinceFlag = 0;
+            int extraFlags = 0;
+            for (int i = last - 1; i >= headCount && extraFlags < 2; i--)
+            {
+                blocksSinceFlag += EstimateContentBlocks(requestMessages[i]);
+                if (blocksSinceFlag >= 12)
+                {
+                    requestMessages[i] = requestMessages[i].WithCacheControl();
+                    blocksSinceFlag = 0;
+                    extraFlags++;
+                }
+            }
+        }
+
+        // How many Anthropic content blocks one OpenAI-format message renders as: an assistant
+        // message contributes one tool_use block per call plus a text block when it carried text;
+        // everything else (user text, tool result, system) is a single block.
+        internal static int EstimateContentBlocks(ChatMessage m)
+        {
+            if (m == null) return 0;
+            int blocks = (m.ToolCalls != null) ? m.ToolCalls.Count : 0;
+            if (blocks == 0 || !string.IsNullOrEmpty(m.Content)) blocks++;
+            return blocks;
         }
 
         // Zone A: the stable system head, byte-identical for every request of a conversation (the

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -142,6 +142,10 @@ namespace GxPT
         // to the conversation for the next turn. Invoked from the worker thread.
         public Action<string> ProviderServed { get; set; }
 
+        // Per-response usage/cost accounting (every model, every loop iteration), for the host to
+        // accumulate on the conversation and surface in the UI. Invoked from the worker thread.
+        public Action<ResponseUsage> UsageReported { get; set; }
+
         // Provider data-collection preference applied to every request in the turn. Null leaves
         // it unset (provider default).
         public bool? ProviderDataCollectionAllowed { get; set; }
@@ -420,21 +424,26 @@ namespace GxPT
             props.Zdr = Zdr;
             props.ToolChoice = toolChoice;
 
-            // Sticky provider routing on cache-supported models (see PreferredProvider). Stickiness
-            // is confirmation-gated: only a response demonstrating cache activity - a read
-            // (cached > 0) or a write (cacheWrite > 0) - establishes or moves the preference.
-            if (OpenRouterClient.ModelSupportsPromptCaching(_model))
+            // Sticky provider routing on cache-supported models (see PreferredProvider); usage
+            // accounting on every model. Stickiness is confirmation-gated: only a response
+            // demonstrating cache activity - a read or a write - establishes or moves the
+            // preference.
+            bool cachingModel = OpenRouterClient.ModelSupportsPromptCaching(_model);
+            if (cachingModel && !string.IsNullOrEmpty(PreferredProvider))
+                props.ProviderOrder = new List<string> { PreferredProvider };
+            props.ResponseUsageCallback = delegate(ResponseUsage u)
             {
-                if (!string.IsNullOrEmpty(PreferredProvider))
-                    props.ProviderOrder = new List<string> { PreferredProvider };
-                props.ProviderServedCallback = delegate(string served, int cachedTokens, int cacheWriteTokens)
+                if (u == null) return;
+                if (cachingModel && !string.IsNullOrEmpty(u.Provider)
+                    && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
                 {
-                    if ((cachedTokens <= 0 && cacheWriteTokens <= 0) || string.IsNullOrEmpty(served)) return;
-                    PreferredProvider = served;
+                    PreferredProvider = u.Provider;
                     Action<string> cb = ProviderServed;
-                    if (cb != null) cb(served);
-                };
-            }
+                    if (cb != null) cb(u.Provider);
+                }
+                Action<ResponseUsage> ucb = UsageReported;
+                if (ucb != null) ucb(u);
+            };
 
             Action<string> textSink = (ui != null) ? new Action<string>(ui.AppendTextDelta) : null;
             ToolCallAssembler asm = new ToolCallAssembler(textSink);

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -11,9 +11,19 @@ using Newtonsoft.Json.Linq;
 namespace GxPT
 {
     // The host's tool-discovery component (phase 5). Aggregates every connected server's tools into
-    // (a) a cheap names manifest, (b) a small LRU-capped set of "revealed" full definitions, and
+    // (a) a cheap names manifest, (b) full definitions for a conversation's "revealed" set, and
     // (c) reveal_tools, the meta-tool that moves a tool from "known by name" to "callable". Owns the
     // server-qualified function-name bijection so tool_calls resolve back to (connection, toolName).
+    //
+    // Reveal state lives on the CONVERSATION, not here (prompt-caching design): each conversation
+    // owns an append-only, never-evicted list of revealed names that it passes into Reveal /
+    // ExposedFunctionDefs. Per-conversation scoping keeps one tab's reveals out of another tab's
+    // tools array, and append-only keeps the serialized tools array stable - the array renders at
+    // position 0 of the prompt, so any membership or order change invalidates the provider's prompt
+    // cache for the conversation's entire transcript. (Eviction never pays: a revealed def costs a
+    // few hundred cache-discounted tokens per turn; evicting it re-bills the whole transcript once.)
+    // The registry validates every name against the live catalog at emission time, so a stale
+    // revealed name (server removed or disabled) is skipped harmlessly rather than pruned.
     //
     // Workdir-scoped servers (files/git/command) run as one process PER working directory, so several
     // connections can expose the SAME function name (e.g. files__read) for different folders. The
@@ -27,7 +37,6 @@ namespace GxPT
     internal sealed class McpToolRegistry : IToolAnnotationSource
     {
         public const string RevealToolsName = "reveal_tools";
-        public const int DefaultRevealCap = 24; // discovery spec §13
 
         private sealed class CatalogEntry
         {
@@ -51,17 +60,13 @@ namespace GxPT
         // which carries only the connection) can rebuild its entries with the right workdir tag.
         private readonly Dictionary<McpServerConnection, string> _connWorkdir =
             new Dictionary<McpServerConnection, string>();
-        private readonly Dictionary<string, long> _revealed = new Dictionary<string, long>(StringComparer.Ordinal);
 
-        private readonly int _revealCap;
         private readonly ILogSink _log;
-        private long _tick;
         private string _manifestCache;
         private bool _manifestDirty = true;
 
-        public McpToolRegistry(int revealCap, ILogSink log)
+        public McpToolRegistry(ILogSink log)
         {
-            _revealCap = revealCap > 0 ? revealCap : DefaultRevealCap;
             _log = log != null ? log : NullLogSink.Instance;
         }
 
@@ -199,10 +204,12 @@ namespace GxPT
                         for (int j = list.Count - 1; j >= 0; j--)
                             if (ReferenceEquals(list[j].Conn, conn)) list.RemoveAt(j);
                         // The name disappears from the surface only when no connection provides it.
+                        // Conversations' revealed lists keep the name; ExposedFunctionDefs skips
+                        // names absent from the catalog, so the def simply stops being emitted (and
+                        // reappears if the server comes back).
                         if (list.Count == 0)
                         {
                             _byFunctionName.Remove(fn);
-                            _revealed.Remove(fn);
                         }
                     }
                 }
@@ -338,42 +345,41 @@ namespace GxPT
             return sb.ToString();
         }
 
-        public IList<JObject> ExposedFunctionDefs()
+        // Workdir-agnostic exposed defs (kept for callers/tests that don't run a folder-scoped turn).
+        public IList<JObject> ExposedFunctionDefs(IEnumerable<string> revealed)
         {
-            List<JObject> result = new List<JObject>();
-            result.Add(RevealToolsDef());
-            lock (_lock)
-            {
-                // Order the revealed set by recency (oldest first) for a stable, deterministic array.
-                List<string> fns = new List<string>(_revealed.Keys);
-                fns.Sort(delegate(string a, string b) { return _revealed[a].CompareTo(_revealed[b]); });
-                for (int i = 0; i < fns.Count; i++)
-                {
-                    CatalogEntry e;
-                    if (TryFirstEntryLocked(fns[i], out e))
-                        result.Add(FunctionDef(e.FunctionName, e.Description, CloneSchema(e.Schema)));
-                }
-            }
-            return result;
+            return ExposedFunctionDefs(null, revealed);
         }
 
-        // The exposed defs (reveal_tools + revealed tools) usable on a turn with this working directory.
-        // A revealed tool that only exists for another folder is dropped, so it can't be sent then fail.
-        public IList<JObject> ExposedFunctionDefs(string workdir)
+        // The exposed defs for a turn: reveal_tools plus the conversation's revealed set, usable on a
+        // turn with this working directory. A revealed tool that only exists for another folder is
+        // dropped, so it can't be sent then fail; a name no longer in the catalog is skipped.
+        //
+        // Order is BY NAME, never by reveal order or recency: the tools array renders at position 0
+        // of the prompt, so the serialization must be byte-identical between requests or every
+        // request misses the provider's prompt cache. (The old recency order re-sorted the array
+        // whenever a tool was called, which would have invalidated the cache on every loop iteration.)
+        public IList<JObject> ExposedFunctionDefs(string workdir, IEnumerable<string> revealed)
         {
             List<JObject> result = new List<JObject>();
             result.Add(RevealToolsDef());
+            if (revealed == null) return result;
+
+            List<string> fns = new List<string>(revealed);
+            fns.Sort(StringComparer.Ordinal);
             lock (_lock)
             {
-                List<string> fns = new List<string>(_revealed.Keys);
-                fns.Sort(delegate(string a, string b) { return _revealed[a].CompareTo(_revealed[b]); });
+                string prev = null;
                 for (int i = 0; i < fns.Count; i++)
                 {
+                    string fn = fns[i];
+                    if (fn == null || fn == prev) continue; // defensive dedup (sorted, so adjacent)
+                    prev = fn;
                     List<CatalogEntry> list;
-                    if (!_byFunctionName.TryGetValue(fns[i], out list)) continue;
+                    if (!_byFunctionName.TryGetValue(fn, out list)) continue;
                     if (!ResolvableForWorkdirLocked(list, workdir)) continue;
                     CatalogEntry e;
-                    if (TryBestEntryLocked(fns[i], workdir, out e))
+                    if (TryBestEntryLocked(fn, workdir, out e))
                         result.Add(FunctionDef(e.FunctionName, e.Description, CloneSchema(e.Schema)));
                 }
             }
@@ -410,15 +416,18 @@ namespace GxPT
         }
 
         // Workdir-agnostic reveal (independent tools, or tests that don't run a folder turn).
-        public string Reveal(string[] names)
+        public string Reveal(string[] names, IList<string> revealed)
         {
-            return Reveal(names, null);
+            return Reveal(names, null, revealed);
         }
 
         // Reveal the named tools' full defs for a turn with `workdir`, choosing each tool's schema from
         // the candidate that turn will actually call (TryBestEntryLocked) so the revealed schema matches
-        // the executing connection — see TryBestEntryLocked.
-        public string Reveal(string[] names, string workdir)
+        // the executing connection — see TryBestEntryLocked. Successful names are recorded in
+        // `revealed`, the conversation's reveal list; the list is kept in recency order (a re-reveal
+        // moves the name to the end) so the orchestrator's provider-gated eviction can trim oldest
+        // first. Emission order is independent of list order (ExposedFunctionDefs sorts by name).
+        public string Reveal(string[] names, string workdir, IList<string> revealed)
         {
             JArray defs = new JArray();
             List<string> notes = new List<string>();
@@ -433,7 +442,11 @@ namespace GxPT
                         CatalogEntry e;
                         if (n != null && TryBestEntryLocked(n, workdir, out e))
                         {
-                            _revealed[n] = ++_tick; // add or bump recency
+                            if (revealed != null)
+                            {
+                                revealed.Remove(n); // no-op when absent; bump-to-end when present
+                                revealed.Add(n);
+                            }
                             JObject d = new JObject();
                             d["name"] = e.FunctionName;
                             d["description"] = e.Description != null ? e.Description : string.Empty;
@@ -446,7 +459,6 @@ namespace GxPT
                         }
                     }
                 }
-                EnforceCapLocked();
             }
 
             StringBuilder sb = new StringBuilder();
@@ -483,8 +495,6 @@ namespace GxPT
                             if (list[i].Workdir == null) { best = list[i]; break; }
                     if (best != null)
                     {
-                        if (_revealed.ContainsKey(functionName))
-                            _revealed[functionName] = ++_tick; // keep an actively-called tool alive
                         conn = best.Conn;
                         toolName = best.OriginalName;
                         return true;
@@ -518,21 +528,6 @@ namespace GxPT
             if (a == null) return b == null;
             if (b == null) return false;
             return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private void EnforceCapLocked()
-        {
-            while (_revealed.Count > _revealCap)
-            {
-                string victim = null;
-                long min = long.MaxValue;
-                foreach (KeyValuePair<string, long> kv in _revealed)
-                {
-                    if (kv.Value < min) { min = kv.Value; victim = kv.Key; }
-                }
-                if (victim == null) break;
-                _revealed.Remove(victim);
-            }
         }
 
         private static JObject RevealToolsDef()

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -312,7 +312,7 @@ namespace GxPT
             ClientProperties props, Action<ChatCompletionChunk> onChunk)
         {
             if (props == null || props.ProviderServedCallback == null) return onChunk;
-            Action<string, int> report = props.ProviderServedCallback;
+            Action<string, int, int> report = props.ProviderServedCallback;
             bool[] reported = new bool[1];    // closure-mutable state (C# 3.5: no local functions)
             string[] provider = new string[1];
             return delegate(ChatCompletionChunk chunk)
@@ -323,11 +323,11 @@ namespace GxPT
                     if (!reported[0] && chunk.usage != null && provider[0] != null)
                     {
                         reported[0] = true;
-                        int cached = 0;
-                        if (chunk.usage.prompt_tokens_details != null
-                            && chunk.usage.prompt_tokens_details.cached_tokens.HasValue)
-                            cached = chunk.usage.prompt_tokens_details.cached_tokens.Value;
-                        try { report(provider[0], cached); }
+                        int cached = 0, written = 0;
+                        ChatCompletionChunk.PromptTokensDetails d = chunk.usage.prompt_tokens_details;
+                        if (d != null && d.cached_tokens.HasValue) cached = d.cached_tokens.Value;
+                        if (d != null && d.cache_write_tokens.HasValue) written = d.cache_write_tokens.Value;
+                        try { report(provider[0], cached, written); }
                         catch { }
                     }
                 }
@@ -463,16 +463,20 @@ namespace GxPT
                 catch { }
 
                 // Prompt-cache telemetry: cached = prompt-prefix tokens served from the provider's
-                // cache (discounted). cached=0 on a long conversation means the prefix missed - look
-                // for a cache invalidator (tools array changed, non-deterministic serialization).
+                // cache (discounted); cacheWrite = tokens written to a new entry (write premium).
+                // cached=0 on a long conversation means the prefix missed, and repeated large
+                // cacheWrite values are the signature of an invalidator re-billing the prefix
+                // (tools array changed, non-deterministic serialization).
                 try
                 {
                     if (usage != null)
                     {
-                        int? cached = (usage.prompt_tokens_details != null)
-                            ? usage.prompt_tokens_details.cached_tokens : null;
+                        ChatCompletionChunk.PromptTokensDetails d = usage.prompt_tokens_details;
+                        int? cached = (d != null) ? d.cached_tokens : null;
+                        int? written = (d != null) ? d.cache_write_tokens : null;
                         Logger.Log("Usage", "prompt=" + (usage.prompt_tokens.HasValue ? usage.prompt_tokens.Value.ToString() : "?")
                             + " cached=" + (cached.HasValue ? cached.Value.ToString() : "?")
+                            + " cacheWrite=" + (written.HasValue ? written.Value.ToString() : "?")
                             + " completion=" + (usage.completion_tokens.HasValue ? usage.completion_tokens.Value.ToString() : "?"));
                     }
                 }
@@ -685,11 +689,12 @@ namespace GxPT
         // request at the head so routing follows the warm prompt cache (caches are per provider).
         public IList<string> ProviderOrder { get; set; }
         // Invoked (at most once per request, from the stream-reading thread) with the provider that
-        // served the request and the cached_tokens count from its usage accounting (0 when the
-        // response reported no cache read). Fires on the final SSE chunk - the one carrying usage -
-        // so callers can make stickiness conditional on a demonstrated cache hit; never fires when
-        // the endpoint omits usage (no cache evidence -> no stickiness signal).
-        public Action<string, int> ProviderServedCallback { get; set; }
+        // served the request and the cached_tokens / cache_write_tokens counts from its usage
+        // accounting (0 when the response reported neither). Fires on the final SSE chunk - the one
+        // carrying usage - so callers can make stickiness conditional on demonstrated cache
+        // activity (a read proves the warm cache lives here; a write proves it just got created
+        // here); never fires when the endpoint omits usage (no cache evidence -> no signal).
+        public Action<string, int, int> ProviderServedCallback { get; set; }
         public decimal? ProviderMaxPricePrompt { get; set; }
         public decimal? ProviderMaxPriceCompletion { get; set; }
         // tool_choice for the request ("none", "auto", ...). Null leaves it at the provider default.

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -204,7 +204,9 @@ namespace GxPT
                 || m.StartsWith("openai/", StringComparison.OrdinalIgnoreCase)    // automatic (>=1024 tokens)
                 || m.StartsWith("deepseek/", StringComparison.OrdinalIgnoreCase)  // automatic
                 || m.StartsWith("x-ai/", StringComparison.OrdinalIgnoreCase)      // automatic (Grok)
-                || m.StartsWith("qwen/", StringComparison.OrdinalIgnoreCase);     // automatic (context cache)
+                || m.StartsWith("qwen/", StringComparison.OrdinalIgnoreCase)      // automatic (context cache)
+                || m.StartsWith("minimax/", StringComparison.OrdinalIgnoreCase)   // automatic
+                || m.StartsWith("moonshotai/", StringComparison.OrdinalIgnoreCase); // automatic (Kimi)
         }
 
         // "~"-prefixed model aliases (e.g. "~anthropic/claude-sonnet-latest") resolve to the same

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -41,10 +41,6 @@ namespace GxPT
             usageOpt["include"] = true;
             payload["usage"] = usageOpt;
 
-            // cache_control breakpoints are only emitted for providers that use explicit caching;
-            // everywhere else flagged messages serialize as plain strings (see ContentValue).
-            bool cacheable = ModelSupportsCacheControl((string)payload["model"]);
-
             var msgs = new List<object>();
             // Prepend a system instruction to avoid emoji in all responses.
             var sys = new Dictionary<string, object>();
@@ -62,7 +58,7 @@ namespace GxPT
                     if (m.Role == "tool")
                     {
                         // Tool result, keyed back to the assistant's call id.
-                        mm["content"] = ContentValue(m, cacheable);
+                        mm["content"] = ContentValue(m);
                         mm["tool_call_id"] = m.ToolCallId;
                     }
                     else if (m.ToolCalls != null && m.ToolCalls.Count > 0)
@@ -85,7 +81,7 @@ namespace GxPT
                     }
                     else
                     {
-                        mm["content"] = ContentValue(m, cacheable);
+                        mm["content"] = ContentValue(m);
                     }
                     msgs.Add(mm);
                 }
@@ -156,14 +152,18 @@ namespace GxPT
         }
 
         // A message's content value: a plain string normally; a one-part content array carrying
-        // cache_control {type: ephemeral} when the message is flagged as a cache breakpoint and the
-        // model's provider supports explicit caching (the array form is the OpenAI-compatible shape
-        // OpenRouter requires for cache_control). Empty content always stays a plain string - there
-        // is nothing to cache and Anthropic rejects empty text parts.
-        private static object ContentValue(ChatMessage m, bool modelSupportsCaching)
+        // cache_control {type: ephemeral} when the message is flagged as a cache breakpoint (the
+        // array form is the OpenAI-compatible shape OpenRouter requires for cache_control). Emitted
+        // for EVERY model: providers without explicit caching ignore the annotation (documented by
+        // OpenRouter; field-verified harmless), while some third-party hosts may implement
+        // explicit-marker caching even for models whose author caches automatically (suspected of
+        // SiliconFlow-hosted DeepSeek, which never auto-cached prefix-stable requests). Empty
+        // content always stays a plain string - there is nothing to cache and Anthropic rejects
+        // empty text parts.
+        private static object ContentValue(ChatMessage m)
         {
             string text = m.Content != null ? m.Content : string.Empty;
-            if (!modelSupportsCaching || !m.CacheControl || text.Length == 0) return text;
+            if (!m.CacheControl || text.Length == 0) return text;
 
             var part = new Dictionary<string, object>();
             part["type"] = "text";
@@ -172,20 +172,6 @@ namespace GxPT
             cc["type"] = "ephemeral";
             part["cache_control"] = cc;
             return new List<object> { part };
-        }
-
-        // Providers that use explicit cache_control breakpoints via OpenRouter (Anthropic requires
-        // them; Gemini accepts them on top of its implicit caching). OpenAI/DeepSeek/Grok cache
-        // automatically on a stable prefix and need no annotation. OpenRouter documents unsupported
-        // cache_control as ignored, but gating by vendor prefix costs nothing and removes any risk
-        // of an unknown provider rejecting the content-part form. "~"-prefixed model aliases resolve
-        // to the same vendor, so the prefix is stripped before matching.
-        internal static bool ModelSupportsCacheControl(string model)
-        {
-            if (string.IsNullOrEmpty(model)) return false;
-            string m = StripModelAliasPrefix(model);
-            return m.StartsWith("anthropic/", StringComparison.OrdinalIgnoreCase)
-                || m.StartsWith("google/", StringComparison.OrdinalIgnoreCase);
         }
 
         // Providers whose prompt caching (explicit cache_control OR implicit/automatic prefix

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -303,21 +303,33 @@ namespace GxPT
             StreamRawChunks(body, WrapWithProviderReport(props, onChunk), onError, cancel);
         }
 
-        // Decorates a chunk sink to report the serving provider (once, from the first chunk that
-        // carries it) via props.ProviderServedCallback. Identity when no callback is registered.
+        // Decorates a chunk sink to report (once, on the final usage-bearing chunk) the serving
+        // provider together with the response's cached-token count, via
+        // props.ProviderServedCallback. The provider name arrives on the first chunk but
+        // cached_tokens only on the last, so the report waits for usage. Identity when no callback
+        // is registered.
         private static Action<ChatCompletionChunk> WrapWithProviderReport(
             ClientProperties props, Action<ChatCompletionChunk> onChunk)
         {
             if (props == null || props.ProviderServedCallback == null) return onChunk;
-            Action<string> report = props.ProviderServedCallback;
-            bool[] reported = new bool[1]; // closure-mutable flag (C# 3.5: no local functions)
+            Action<string, int> report = props.ProviderServedCallback;
+            bool[] reported = new bool[1];    // closure-mutable state (C# 3.5: no local functions)
+            string[] provider = new string[1];
             return delegate(ChatCompletionChunk chunk)
             {
-                if (!reported[0] && chunk != null && !string.IsNullOrEmpty(chunk.provider))
+                if (chunk != null)
                 {
-                    reported[0] = true;
-                    try { report(chunk.provider); }
-                    catch { }
+                    if (!string.IsNullOrEmpty(chunk.provider)) provider[0] = chunk.provider;
+                    if (!reported[0] && chunk.usage != null && provider[0] != null)
+                    {
+                        reported[0] = true;
+                        int cached = 0;
+                        if (chunk.usage.prompt_tokens_details != null
+                            && chunk.usage.prompt_tokens_details.cached_tokens.HasValue)
+                            cached = chunk.usage.prompt_tokens_details.cached_tokens.Value;
+                        try { report(provider[0], cached); }
+                        catch { }
+                    }
                 }
                 if (onChunk != null) onChunk(chunk);
             };
@@ -672,11 +684,12 @@ namespace GxPT
         // not a pin like `only`. Callers put the provider that served the conversation's previous
         // request at the head so routing follows the warm prompt cache (caches are per provider).
         public IList<string> ProviderOrder { get; set; }
-        // Invoked (at most once per request, from the stream-reading thread) with the name of the
-        // provider that served the request, as reported by OpenRouter on the response chunks. Hosts
-        // use it to remember the conversation's cache-warm provider for the next request's
-        // ProviderOrder. Never invoked when OpenRouter omits the field.
-        public Action<string> ProviderServedCallback { get; set; }
+        // Invoked (at most once per request, from the stream-reading thread) with the provider that
+        // served the request and the cached_tokens count from its usage accounting (0 when the
+        // response reported no cache read). Fires on the final SSE chunk - the one carrying usage -
+        // so callers can make stickiness conditional on a demonstrated cache hit; never fires when
+        // the endpoint omits usage (no cache evidence -> no stickiness signal).
+        public Action<string, int> ProviderServedCallback { get; set; }
         public decimal? ProviderMaxPricePrompt { get; set; }
         public decimal? ProviderMaxPriceCompletion { get; set; }
         // tool_choice for the request ("none", "auto", ...). Null leaves it at the provider default.

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -130,6 +130,15 @@ namespace GxPT
                         if (onlyList.Count > 0) provider["only"] = onlyList;
                     }
 
+                    // order: sticky cache-routing preference (see ClientProperties.ProviderOrder).
+                    if (props.ProviderOrder != null && props.ProviderOrder.Count > 0)
+                    {
+                        var orderList = new List<string>();
+                        foreach (var s in props.ProviderOrder)
+                            if (!string.IsNullOrEmpty(s)) orderList.Add(s);
+                        if (orderList.Count > 0) provider["order"] = orderList;
+                    }
+
                     // max_price: include any provided fields
                     var maxPrice = new Dictionary<string, object>();
                     if (props.ProviderMaxPricePrompt.HasValue)
@@ -288,7 +297,27 @@ namespace GxPT
             if (props == null) props = new ClientProperties();
             if (!props.Stream.HasValue) props.Stream = true;
             string body = BuildRequestBody(model, messages, tools, props);
-            StreamRawChunks(body, onChunk, onError, cancel);
+            StreamRawChunks(body, WrapWithProviderReport(props, onChunk), onError, cancel);
+        }
+
+        // Decorates a chunk sink to report the serving provider (once, from the first chunk that
+        // carries it) via props.ProviderServedCallback. Identity when no callback is registered.
+        private static Action<ChatCompletionChunk> WrapWithProviderReport(
+            ClientProperties props, Action<ChatCompletionChunk> onChunk)
+        {
+            if (props == null || props.ProviderServedCallback == null) return onChunk;
+            Action<string> report = props.ProviderServedCallback;
+            bool[] reported = new bool[1]; // closure-mutable flag (C# 3.5: no local functions)
+            return delegate(ChatCompletionChunk chunk)
+            {
+                if (!reported[0] && chunk != null && !string.IsNullOrEmpty(chunk.provider))
+                {
+                    reported[0] = true;
+                    try { report(chunk.provider); }
+                    catch { }
+                }
+                if (onChunk != null) onChunk(chunk);
+            };
         }
 
         public void CreateCompletionStream(string model, IList<ChatMessage> messages, Action<string> onDelta, Action onDone, Action<string> onError)
@@ -307,7 +336,7 @@ namespace GxPT
 
             bool failed = false;
             StreamRawChunks(body,
-                delegate(ChatCompletionChunk chunk)
+                WrapWithProviderReport(props, delegate(ChatCompletionChunk chunk)
                 {
                     if (chunk != null && chunk.choices != null)
                     {
@@ -317,7 +346,7 @@ namespace GxPT
                             if (!string.IsNullOrEmpty(content) && onDelta != null) onDelta(content);
                         }
                     }
-                },
+                }),
                 delegate(string err) { failed = true; if (onError != null) onError(err); },
                 cancel);
 
@@ -635,6 +664,16 @@ namespace GxPT
         // endpoints with a zero-retention policy. Null/false omits it (no effect on routing).
         public bool? Zdr { get; set; }
         public IList<string> ProviderOnly { get; set; }
+        // order: provider preference (sticky cache routing). OpenRouter tries these endpoints first
+        // and still falls back to others on failure (allow_fallbacks defaults true) - a preference,
+        // not a pin like `only`. Callers put the provider that served the conversation's previous
+        // request at the head so routing follows the warm prompt cache (caches are per provider).
+        public IList<string> ProviderOrder { get; set; }
+        // Invoked (at most once per request, from the stream-reading thread) with the name of the
+        // provider that served the request, as reported by OpenRouter on the response chunks. Hosts
+        // use it to remember the conversation's cache-warm provider for the next request's
+        // ProviderOrder. Never invoked when OpenRouter omits the field.
+        public Action<string> ProviderServedCallback { get; set; }
         public decimal? ProviderMaxPricePrompt { get; set; }
         public decimal? ProviderMaxPriceCompletion { get; set; }
         // tool_choice for the request ("none", "auto", ...). Null leaves it at the provider default.

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -294,47 +294,54 @@ namespace GxPT
         // Fetches the authoritative accounting for a completed generation (GET /api/v1/generation).
         // The streamed usage.cost is the pre-cache-discount estimate and cache_discount never rides
         // the stream, so on cache-hit requests the stream-time numbers overstate cost and report no
-        // savings; this record carries the billed total_cost and the net cache_discount. The record
-        // materializes shortly after the stream ends - the retry loop covers that gap. Runs a
-        // blocking curl GET; call from a background thread.
-        public bool TryFetchGenerationStats(string generationId, out decimal? totalCost, out decimal? cacheDiscount)
+        // savings; the generation record carries the billed total_cost and the net cache_discount.
+        // The record materializes shortly after the stream ends - and total_cost can materialize
+        // before cache_discount - so the retry loop keeps polling briefly until the discount shows
+        // up, settling for whatever it got when it doesn't. Runs blocking curl GETs; call from a
+        // background thread. Null when nothing could be fetched.
+        public GenerationStats FetchGenerationStats(string generationId)
         {
-            totalCost = null;
-            cacheDiscount = null;
-            if (string.IsNullOrEmpty(generationId) || !IsConfigured) return false;
-            for (int attempt = 0; attempt < 3; attempt++)
+            if (string.IsNullOrEmpty(generationId) || !IsConfigured) return null;
+            GenerationStats best = null;
+            for (int attempt = 0; attempt < 4; attempt++)
             {
-                if (attempt > 0) System.Threading.Thread.Sleep(750);
+                if (attempt > 0) System.Threading.Thread.Sleep(1000);
                 string body = HttpGet("https://openrouter.ai/api/v1/generation?id="
                     + Uri.EscapeDataString(generationId));
                 if (string.IsNullOrEmpty(body)) continue;
-                if (TryExtractGenerationStats(SafeParse(body), out totalCost, out cacheDiscount))
-                {
-                    try
-                    {
-                        Logger.Log("Usage", "generation " + generationId + ": total_cost="
-                            + (totalCost.HasValue ? totalCost.Value.ToString() : "?")
-                            + " cache_discount=" + (cacheDiscount.HasValue ? cacheDiscount.Value.ToString() : "?"));
-                    }
-                    catch { }
-                    return true;
-                }
+                GenerationStats s = ExtractGenerationStats(SafeParse(body));
+                if (s == null) continue;
+                best = s;
+                if (s.CacheDiscount.HasValue) break;
             }
-            return false;
+            if (best != null)
+            {
+                try
+                {
+                    Logger.Log("Usage", "generation " + generationId + ": total_cost="
+                        + (best.TotalCost.HasValue ? best.TotalCost.Value.ToString() : "?")
+                        + " cache_discount=" + (best.CacheDiscount.HasValue ? best.CacheDiscount.Value.ToString() : "?")
+                        + (string.IsNullOrEmpty(best.ProviderName) ? string.Empty : " provider=" + best.ProviderName));
+                }
+                catch { }
+            }
+            return best;
         }
 
-        // { "data": { "total_cost": 0.0585, "cache_discount": 0.0559, ... } } -> the billed cost and
-        // net cache savings. True when at least one of the two is present.
-        internal static bool TryExtractGenerationStats(JObject root, out decimal? totalCost, out decimal? cacheDiscount)
+        // { "data": { "total_cost": 0.0585, "cache_discount": 0.0559, "provider_name": "Amazon
+        // Bedrock", ... } } -> billed cost, net cache savings (negative = write premium), and the
+        // serving provider. Null when the payload carries none of them.
+        internal static GenerationStats ExtractGenerationStats(JObject root)
         {
-            totalCost = null;
-            cacheDiscount = null;
-            if (root == null) return false;
+            if (root == null) return null;
             JToken data = root["data"];
-            if (data == null || data.Type != JTokenType.Object) return false;
-            totalCost = AsDecimal(data["total_cost"]);
-            cacheDiscount = AsDecimal(data["cache_discount"]);
-            return totalCost.HasValue || cacheDiscount.HasValue;
+            if (data == null || data.Type != JTokenType.Object) return null;
+            GenerationStats s = new GenerationStats();
+            s.TotalCost = AsDecimal(data["total_cost"]);
+            s.CacheDiscount = AsDecimal(data["cache_discount"]);
+            JToken pn = data["provider_name"];
+            if (pn != null && pn.Type == JTokenType.String) s.ProviderName = (string)pn;
+            return (s.TotalCost.HasValue || s.CacheDiscount.HasValue || s.ProviderName != null) ? s : null;
         }
 
         private static decimal? AsDecimal(JToken t)
@@ -829,6 +836,15 @@ namespace GxPT
         public string ToolChoice { get; set; }
     }
 
+    // The slice of OpenRouter's generation record (GET /api/v1/generation) used for usage
+    // reconciliation - the post-hoc, billed truth that the stream-time estimate converges to.
+    public sealed class GenerationStats
+    {
+        public decimal? TotalCost;     // billed credits (post cache discount / write premium)
+        public decimal? CacheDiscount; // net credits saved (+) / extra paid (-) by caching
+        public string ProviderName;    // serving endpoint; fallback when the stream omitted it
+    }
+
     // One streamed response's usage accounting, assembled from OpenRouter's final usage-bearing
     // SSE chunk (see ClientProperties.ResponseUsageCallback). Drives sticky cache routing
     // (Provider + the cache counters) and per-conversation cost tracking (Cost/CacheDiscount).
@@ -842,7 +858,7 @@ namespace GxPT
         // Cost is the STREAM-TIME estimate, which is pre-cache-discount (and CacheDiscount is, in
         // practice, never present on SSE chunks) - on a cache-hit request it overstates the billed
         // amount by the discount. Treat it as provisional and reconcile against the authoritative
-        // generation record (TryFetchGenerationStats) keyed by Id.
+        // generation record (FetchGenerationStats) keyed by Id.
         public string Id;              // OpenRouter generation id (chunk.id); keys the generation record
         public string Provider;        // serving endpoint (e.g. "Anthropic"); null when not reported
         public int PromptTokens;       // total prompt tokens (cached + written + uncached)

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -291,6 +291,110 @@ namespace GxPT
             }
         }
 
+        // Fetches the authoritative accounting for a completed generation (GET /api/v1/generation).
+        // The streamed usage.cost is the pre-cache-discount estimate and cache_discount never rides
+        // the stream, so on cache-hit requests the stream-time numbers overstate cost and report no
+        // savings; this record carries the billed total_cost and the net cache_discount. The record
+        // materializes shortly after the stream ends - the retry loop covers that gap. Runs a
+        // blocking curl GET; call from a background thread.
+        public bool TryFetchGenerationStats(string generationId, out decimal? totalCost, out decimal? cacheDiscount)
+        {
+            totalCost = null;
+            cacheDiscount = null;
+            if (string.IsNullOrEmpty(generationId) || !IsConfigured) return false;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                if (attempt > 0) System.Threading.Thread.Sleep(750);
+                string body = HttpGet("https://openrouter.ai/api/v1/generation?id="
+                    + Uri.EscapeDataString(generationId));
+                if (string.IsNullOrEmpty(body)) continue;
+                if (TryExtractGenerationStats(SafeParse(body), out totalCost, out cacheDiscount))
+                {
+                    try
+                    {
+                        Logger.Log("Usage", "generation " + generationId + ": total_cost="
+                            + (totalCost.HasValue ? totalCost.Value.ToString() : "?")
+                            + " cache_discount=" + (cacheDiscount.HasValue ? cacheDiscount.Value.ToString() : "?"));
+                    }
+                    catch { }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // { "data": { "total_cost": 0.0585, "cache_discount": 0.0559, ... } } -> the billed cost and
+        // net cache savings. True when at least one of the two is present.
+        internal static bool TryExtractGenerationStats(JObject root, out decimal? totalCost, out decimal? cacheDiscount)
+        {
+            totalCost = null;
+            cacheDiscount = null;
+            if (root == null) return false;
+            JToken data = root["data"];
+            if (data == null || data.Type != JTokenType.Object) return false;
+            totalCost = AsDecimal(data["total_cost"]);
+            cacheDiscount = AsDecimal(data["cache_discount"]);
+            return totalCost.HasValue || cacheDiscount.HasValue;
+        }
+
+        private static decimal? AsDecimal(JToken t)
+        {
+            if (t == null) return null;
+            if (t.Type != JTokenType.Float && t.Type != JTokenType.Integer) return null;
+            try { return (decimal)t; }
+            catch { return null; }
+        }
+
+        // Authenticated GET via curl (the API key rides the temp config file, off the command
+        // line, mirroring the POST paths). Returns the body, or null on any failure.
+        private string HttpGet(string url)
+        {
+            var tempFiles = new List<string>();
+            try
+            {
+                var utf8NoBom = new UTF8Encoding(false);
+                string configPath = Path.Combine(Path.GetTempPath(), "gxpt_cfg_" + Guid.NewGuid().ToString("N") + ".txt");
+                string args;
+                try
+                {
+                    File.WriteAllText(configPath,
+                        "header = \"Authorization: Bearer " + EscapeForCurlConfig(_apiKey) + "\"\n", utf8NoBom);
+                    tempFiles.Add(configPath);
+                    args = "-sS --fail-with-body \"" + url + "\" -K \"" + configPath + "\"";
+                }
+                catch
+                {
+                    args = "-sS --fail-with-body \"" + url + "\" -H \"Authorization: Bearer " + _apiKey + "\"";
+                }
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = _curlPath,
+                    Arguments = args,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using (var p = Process.Start(psi))
+                {
+                    var utf8 = new UTF8Encoding(false, false);
+                    string output;
+                    using (var outReader = new StreamReader(p.StandardOutput.BaseStream, utf8, false))
+                        output = outReader.ReadToEnd();
+                    try { p.StandardError.ReadToEnd(); }
+                    catch { }
+                    p.WaitForExit();
+                    int exitCode = -1;
+                    try { exitCode = p.ExitCode; }
+                    catch { }
+                    return exitCode == 0 ? output : null;
+                }
+            }
+            catch { return null; }
+            finally { CleanupTempFiles(tempFiles); }
+        }
+
         // IChatStreamer: build the body (with tools) then stream parsed chunks. Used by the
         // McpChatOrchestrator; the assembler reassembles tool_calls and forwards text deltas.
         public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
@@ -314,6 +418,7 @@ namespace GxPT
             Action<ResponseUsage> report = props.ResponseUsageCallback;
             bool[] reported = new bool[1];      // closure-mutable state (C# 3.5: no local functions)
             string[] provider = new string[1];
+            string[] genId = new string[1];
             // cache_discount may ride a different chunk than usage; remember the latest seen.
             decimal?[] discount = new decimal?[1];
             return delegate(ChatCompletionChunk chunk)
@@ -321,11 +426,12 @@ namespace GxPT
                 if (chunk != null)
                 {
                     if (!string.IsNullOrEmpty(chunk.provider)) provider[0] = chunk.provider;
+                    if (!string.IsNullOrEmpty(chunk.id)) genId[0] = chunk.id;
                     if (chunk.cache_discount.HasValue) discount[0] = chunk.cache_discount;
                     if (!reported[0] && chunk.usage != null)
                     {
                         reported[0] = true;
-                        try { report(BuildResponseUsage(provider[0], chunk.usage, discount[0])); }
+                        try { report(BuildResponseUsage(genId[0], provider[0], chunk.usage, discount[0])); }
                         catch { }
                     }
                 }
@@ -334,9 +440,10 @@ namespace GxPT
         }
 
         private static ResponseUsage BuildResponseUsage(
-            string provider, ChatCompletionChunk.UsageInfo u, decimal? cacheDiscount)
+            string generationId, string provider, ChatCompletionChunk.UsageInfo u, decimal? cacheDiscount)
         {
             ResponseUsage r = new ResponseUsage();
+            r.Id = generationId;
             r.Provider = provider;
             r.PromptTokens = u.prompt_tokens.HasValue ? u.prompt_tokens.Value : 0;
             r.CompletionTokens = u.completion_tokens.HasValue ? u.completion_tokens.Value : 0;
@@ -495,7 +602,8 @@ namespace GxPT
                         Logger.Log("Usage", "prompt=" + (usage.prompt_tokens.HasValue ? usage.prompt_tokens.Value.ToString() : "?")
                             + " cached=" + (cached.HasValue ? cached.Value.ToString() : "?")
                             + " cacheWrite=" + (written.HasValue ? written.Value.ToString() : "?")
-                            + " completion=" + (usage.completion_tokens.HasValue ? usage.completion_tokens.Value.ToString() : "?"));
+                            + " completion=" + (usage.completion_tokens.HasValue ? usage.completion_tokens.Value.ToString() : "?")
+                            + " cost=" + (usage.cost.HasValue ? usage.cost.Value.ToString() : "?") + " (pre-discount estimate)");
                     }
                 }
                 catch { }
@@ -730,6 +838,12 @@ namespace GxPT
         // prompt size, and CachedTokens / CacheWriteTokens are subsets of it (unlike Anthropic's
         // native API, where input_tokens is the uncached remainder). PromptTokens is therefore the
         // conversation's "context size" gauge as-is; never add the cache counters to it.
+        //
+        // Cost is the STREAM-TIME estimate, which is pre-cache-discount (and CacheDiscount is, in
+        // practice, never present on SSE chunks) - on a cache-hit request it overstates the billed
+        // amount by the discount. Treat it as provisional and reconcile against the authoritative
+        // generation record (TryFetchGenerationStats) keyed by Id.
+        public string Id;              // OpenRouter generation id (chunk.id); keys the generation record
         public string Provider;        // serving endpoint (e.g. "Anthropic"); null when not reported
         public int PromptTokens;       // total prompt tokens (cached + written + uncached)
         public int CompletionTokens;   // output tokens, reasoning included

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -292,40 +292,59 @@ namespace GxPT
         }
 
         // Fetches the authoritative accounting for a completed generation (GET /api/v1/generation).
-        // The streamed usage.cost is the pre-cache-discount estimate and cache_discount never rides
-        // the stream, so on cache-hit requests the stream-time numbers overstate cost and report no
-        // savings; the generation record carries the billed total_cost and the net cache_discount.
-        // The record materializes shortly after the stream ends - and total_cost can materialize
-        // before cache_discount - so the retry loop keeps polling briefly until the discount shows
-        // up, settling for whatever it got when it doesn't. Runs blocking curl GETs; call from a
+        // The streamed usage.cost has been observed billing-accurate (cache pricing included) on
+        // some providers, but cache_discount never rides the stream - this record is the Saved
+        // figure's only data source, and the billing correction for any provider whose stream
+        // estimate differs (the delta-based reconcile is a no-op when they already match). The
+        // record can take several seconds to become queryable after the stream ends, so the retry
+        // loop is patient; it also keeps polling briefly when total_cost materializes before
+        // cache_discount. Failures are logged - a silent failure here looks like "Saved frozen at
+        // $0.00" in the UI and is otherwise undiagnosable. Runs blocking curl GETs; call from a
         // background thread. Null when nothing could be fetched.
         public GenerationStats FetchGenerationStats(string generationId)
         {
             if (string.IsNullOrEmpty(generationId) || !IsConfigured) return null;
+            string url = "https://openrouter.ai/api/v1/generation?id=" + Uri.EscapeDataString(generationId);
+            int[] delaysMs = new int[] { 0, 1000, 2000, 3000, 4000 };
             GenerationStats best = null;
-            for (int attempt = 0; attempt < 4; attempt++)
+            HttpGetResult last = null;
+            for (int attempt = 0; attempt < delaysMs.Length; attempt++)
             {
-                if (attempt > 0) System.Threading.Thread.Sleep(1000);
-                string body = HttpGet("https://openrouter.ai/api/v1/generation?id="
-                    + Uri.EscapeDataString(generationId));
-                if (string.IsNullOrEmpty(body)) continue;
-                GenerationStats s = ExtractGenerationStats(SafeParse(body));
+                if (delaysMs[attempt] > 0) System.Threading.Thread.Sleep(delaysMs[attempt]);
+                last = HttpGetEx(url);
+                if (last == null || last.ExitCode != 0 || string.IsNullOrEmpty(last.Body)) continue;
+                GenerationStats s = ExtractGenerationStats(SafeParse(last.Body));
                 if (s == null) continue;
                 best = s;
                 if (s.CacheDiscount.HasValue) break;
             }
-            if (best != null)
+            try
             {
-                try
+                if (best != null)
                 {
                     Logger.Log("Usage", "generation " + generationId + ": total_cost="
                         + (best.TotalCost.HasValue ? best.TotalCost.Value.ToString() : "?")
                         + " cache_discount=" + (best.CacheDiscount.HasValue ? best.CacheDiscount.Value.ToString() : "?")
                         + (string.IsNullOrEmpty(best.ProviderName) ? string.Empty : " provider=" + best.ProviderName));
                 }
-                catch { }
+                else
+                {
+                    string detail = last == null
+                        ? "no response"
+                        : "exit=" + last.ExitCode + " body=" + Snippet(last.Body, 200);
+                    Logger.Log("Usage", "generation " + generationId + ": fetch FAILED after "
+                        + delaysMs.Length + " attempts (" + detail + ")");
+                }
             }
+            catch { }
             return best;
+        }
+
+        private static string Snippet(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s)) return "(empty)";
+            s = s.Replace("\r", " ").Replace("\n", " ");
+            return s.Length > max ? s.Substring(0, max) + "..." : s;
         }
 
         // { "data": { "total_cost": 0.0585, "cache_discount": 0.0559, "provider_name": "Amazon
@@ -353,9 +372,17 @@ namespace GxPT
         }
 
         // Authenticated GET via curl (the API key rides the temp config file, off the command
-        // line, mirroring the POST paths). Returns the body, or null on any failure.
-        private string HttpGet(string url)
+        // line, mirroring the POST paths). Returns the exit code and body so callers can log
+        // failures usefully (a 404 here usually means the generation record isn't queryable yet).
+        private sealed class HttpGetResult
         {
+            public int ExitCode = -1;
+            public string Body;
+        }
+
+        private HttpGetResult HttpGetEx(string url)
+        {
+            var result = new HttpGetResult();
             var tempFiles = new List<string>();
             try
             {
@@ -386,20 +413,18 @@ namespace GxPT
                 using (var p = Process.Start(psi))
                 {
                     var utf8 = new UTF8Encoding(false, false);
-                    string output;
                     using (var outReader = new StreamReader(p.StandardOutput.BaseStream, utf8, false))
-                        output = outReader.ReadToEnd();
+                        result.Body = outReader.ReadToEnd();
                     try { p.StandardError.ReadToEnd(); }
                     catch { }
                     p.WaitForExit();
-                    int exitCode = -1;
-                    try { exitCode = p.ExitCode; }
+                    try { result.ExitCode = p.ExitCode; }
                     catch { }
-                    return exitCode == 0 ? output : null;
                 }
             }
-            catch { return null; }
+            catch { }
             finally { CleanupTempFiles(tempFiles); }
+            return result;
         }
 
         // IChatStreamer: build the body (with tools) then stream parsed chunks. Used by the
@@ -610,7 +635,7 @@ namespace GxPT
                             + " cached=" + (cached.HasValue ? cached.Value.ToString() : "?")
                             + " cacheWrite=" + (written.HasValue ? written.Value.ToString() : "?")
                             + " completion=" + (usage.completion_tokens.HasValue ? usage.completion_tokens.Value.ToString() : "?")
-                            + " cost=" + (usage.cost.HasValue ? usage.cost.Value.ToString() : "?") + " (pre-discount estimate)");
+                            + " cost=" + (usage.cost.HasValue ? usage.cost.Value.ToString() : "?") + " (streamed)");
                     }
                 }
                 catch { }
@@ -855,10 +880,12 @@ namespace GxPT
         // native API, where input_tokens is the uncached remainder). PromptTokens is therefore the
         // conversation's "context size" gauge as-is; never add the cache counters to it.
         //
-        // Cost is the STREAM-TIME estimate, which is pre-cache-discount (and CacheDiscount is, in
-        // practice, never present on SSE chunks) - on a cache-hit request it overstates the billed
-        // amount by the discount. Treat it as provisional and reconcile against the authoritative
-        // generation record (FetchGenerationStats) keyed by Id.
+        // Cost is the STREAM-TIME figure. Observed billing-accurate (cache pricing included) on
+        // Bedrock-served Anthropic models, but CacheDiscount is, in practice, never present on SSE
+        // chunks, and other providers' stream estimates aren't guaranteed to match billing. Treat
+        // Cost as provisional and reconcile against the authoritative generation record
+        // (FetchGenerationStats) keyed by Id - the delta-based reconcile is a no-op when the
+        // stream was already accurate.
         public string Id;              // OpenRouter generation id (chunk.id); keys the generation record
         public string Provider;        // serving endpoint (e.g. "Anthropic"); null when not reported
         public int PromptTokens;       // total prompt tokens (cached + written + uncached)

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -203,7 +203,8 @@ namespace GxPT
                 || m.StartsWith("google/", StringComparison.OrdinalIgnoreCase)    // implicit + cache_control
                 || m.StartsWith("openai/", StringComparison.OrdinalIgnoreCase)    // automatic (>=1024 tokens)
                 || m.StartsWith("deepseek/", StringComparison.OrdinalIgnoreCase)  // automatic
-                || m.StartsWith("x-ai/", StringComparison.OrdinalIgnoreCase);     // automatic (Grok)
+                || m.StartsWith("x-ai/", StringComparison.OrdinalIgnoreCase)      // automatic (Grok)
+                || m.StartsWith("qwen/", StringComparison.OrdinalIgnoreCase);     // automatic (context cache)
         }
 
         // "~"-prefixed model aliases (e.g. "~anthropic/claude-sonnet-latest") resolve to the same

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -303,36 +303,54 @@ namespace GxPT
             StreamRawChunks(body, WrapWithProviderReport(props, onChunk), onError, cancel);
         }
 
-        // Decorates a chunk sink to report (once, on the final usage-bearing chunk) the serving
-        // provider together with the response's cached-token count, via
-        // props.ProviderServedCallback. The provider name arrives on the first chunk but
-        // cached_tokens only on the last, so the report waits for usage. Identity when no callback
-        // is registered.
+        // Decorates a chunk sink to report (once, on the final usage-bearing chunk) the response's
+        // usage accounting via props.ResponseUsageCallback. The provider name arrives on the first
+        // chunk but the usage counters only on the last, so the report waits for usage. Identity
+        // when no callback is registered.
         private static Action<ChatCompletionChunk> WrapWithProviderReport(
             ClientProperties props, Action<ChatCompletionChunk> onChunk)
         {
-            if (props == null || props.ProviderServedCallback == null) return onChunk;
-            Action<string, int, int> report = props.ProviderServedCallback;
-            bool[] reported = new bool[1];    // closure-mutable state (C# 3.5: no local functions)
+            if (props == null || props.ResponseUsageCallback == null) return onChunk;
+            Action<ResponseUsage> report = props.ResponseUsageCallback;
+            bool[] reported = new bool[1];      // closure-mutable state (C# 3.5: no local functions)
             string[] provider = new string[1];
+            // cache_discount may ride a different chunk than usage; remember the latest seen.
+            decimal?[] discount = new decimal?[1];
             return delegate(ChatCompletionChunk chunk)
             {
                 if (chunk != null)
                 {
                     if (!string.IsNullOrEmpty(chunk.provider)) provider[0] = chunk.provider;
-                    if (!reported[0] && chunk.usage != null && provider[0] != null)
+                    if (chunk.cache_discount.HasValue) discount[0] = chunk.cache_discount;
+                    if (!reported[0] && chunk.usage != null)
                     {
                         reported[0] = true;
-                        int cached = 0, written = 0;
-                        ChatCompletionChunk.PromptTokensDetails d = chunk.usage.prompt_tokens_details;
-                        if (d != null && d.cached_tokens.HasValue) cached = d.cached_tokens.Value;
-                        if (d != null && d.cache_write_tokens.HasValue) written = d.cache_write_tokens.Value;
-                        try { report(provider[0], cached, written); }
+                        try { report(BuildResponseUsage(provider[0], chunk.usage, discount[0])); }
                         catch { }
                     }
                 }
                 if (onChunk != null) onChunk(chunk);
             };
+        }
+
+        private static ResponseUsage BuildResponseUsage(
+            string provider, ChatCompletionChunk.UsageInfo u, decimal? cacheDiscount)
+        {
+            ResponseUsage r = new ResponseUsage();
+            r.Provider = provider;
+            r.PromptTokens = u.prompt_tokens.HasValue ? u.prompt_tokens.Value : 0;
+            r.CompletionTokens = u.completion_tokens.HasValue ? u.completion_tokens.Value : 0;
+            r.Cost = u.cost;
+            r.CacheDiscount = cacheDiscount;
+            ChatCompletionChunk.PromptTokensDetails pd = u.prompt_tokens_details;
+            if (pd != null)
+            {
+                if (pd.cached_tokens.HasValue) r.CachedTokens = pd.cached_tokens.Value;
+                if (pd.cache_write_tokens.HasValue) r.CacheWriteTokens = pd.cache_write_tokens.Value;
+            }
+            ChatCompletionChunk.CompletionTokensDetails cd = u.completion_tokens_details;
+            if (cd != null && cd.reasoning_tokens.HasValue) r.ReasoningTokens = cd.reasoning_tokens.Value;
+            return r;
         }
 
         public void CreateCompletionStream(string model, IList<ChatMessage> messages, Action<string> onDelta, Action onDone, Action<string> onError)
@@ -688,13 +706,12 @@ namespace GxPT
         // not a pin like `only`. Callers put the provider that served the conversation's previous
         // request at the head so routing follows the warm prompt cache (caches are per provider).
         public IList<string> ProviderOrder { get; set; }
-        // Invoked (at most once per request, from the stream-reading thread) with the provider that
-        // served the request and the cached_tokens / cache_write_tokens counts from its usage
-        // accounting (0 when the response reported neither). Fires on the final SSE chunk - the one
-        // carrying usage - so callers can make stickiness conditional on demonstrated cache
-        // activity (a read proves the warm cache lives here; a write proves it just got created
-        // here); never fires when the endpoint omits usage (no cache evidence -> no signal).
-        public Action<string, int, int> ProviderServedCallback { get; set; }
+        // Invoked (at most once per request, from the stream-reading thread) with the response's
+        // usage accounting: serving provider, token counts, cache read/write counts, billed cost,
+        // and cache discount. Fires on the final SSE chunk - the one carrying usage - so callers
+        // can both gate provider stickiness on demonstrated cache activity and accumulate
+        // per-conversation cost; never fires when the endpoint omits usage entirely.
+        public Action<ResponseUsage> ResponseUsageCallback { get; set; }
         public decimal? ProviderMaxPricePrompt { get; set; }
         public decimal? ProviderMaxPriceCompletion { get; set; }
         // tool_choice for the request ("none", "auto", ...). Null leaves it at the provider default.
@@ -702,5 +719,24 @@ namespace GxPT
         // forbid further tool calls while keeping the tools array (and so the cached prompt prefix)
         // identical to the loop's requests.
         public string ToolChoice { get; set; }
+    }
+
+    // One streamed response's usage accounting, assembled from OpenRouter's final usage-bearing
+    // SSE chunk (see ClientProperties.ResponseUsageCallback). Drives sticky cache routing
+    // (Provider + the cache counters) and per-conversation cost tracking (Cost/CacheDiscount).
+    public sealed class ResponseUsage
+    {
+        // NOTE - OpenRouter normalizes usage to OpenAI conventions: PromptTokens is the TOTAL
+        // prompt size, and CachedTokens / CacheWriteTokens are subsets of it (unlike Anthropic's
+        // native API, where input_tokens is the uncached remainder). PromptTokens is therefore the
+        // conversation's "context size" gauge as-is; never add the cache counters to it.
+        public string Provider;        // serving endpoint (e.g. "Anthropic"); null when not reported
+        public int PromptTokens;       // total prompt tokens (cached + written + uncached)
+        public int CompletionTokens;   // output tokens, reasoning included
+        public int ReasoningTokens;    // of CompletionTokens, how many were reasoning
+        public int CachedTokens;       // of PromptTokens, how many were read from the provider's cache
+        public int CacheWriteTokens;   // of PromptTokens, how many were written to a new cache entry
+        public decimal? Cost;          // credits charged for this request; null when not reported
+        public decimal? CacheDiscount; // net credits saved (+) / extra paid (-) by caching; null when not reported
     }
 }

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -305,7 +305,11 @@ namespace GxPT
         {
             if (string.IsNullOrEmpty(generationId) || !IsConfigured) return null;
             string url = "https://openrouter.ai/api/v1/generation?id=" + Uri.EscapeDataString(generationId);
-            int[] delaysMs = new int[] { 0, 1000, 2000, 3000, 4000 };
+            // Field-measured: records materialize with variable latency clustered around 10-15s
+            // after completion, with stragglers beyond - a short schedule permanently loses the
+            // stragglers' discounts (there is no later retry). Front-loaded for the fast cases,
+            // patient tail for the slow ones (~2 minutes total).
+            int[] delaysMs = new int[] { 0, 1000, 2000, 3000, 4000, 10000, 15000, 30000, 60000 };
             GenerationStats best = null;
             HttpGetResult last = null;
             for (int attempt = 0; attempt < delaysMs.Length; attempt++)

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -34,6 +34,17 @@ namespace GxPT
             bool streamFlag = (props != null && props.Stream.HasValue) ? props.Stream.Value : false;
             payload["stream"] = streamFlag;
 
+            // Ask OpenRouter to return token-usage accounting (including prompt-cache read counts) -
+            // on streaming requests it arrives on the final SSE chunk. This is how cache hits are
+            // verified: see the "Usage" log line in StreamRawChunks.
+            var usageOpt = new Dictionary<string, object>();
+            usageOpt["include"] = true;
+            payload["usage"] = usageOpt;
+
+            // cache_control breakpoints are only emitted for providers that use explicit caching;
+            // everywhere else flagged messages serialize as plain strings (see ContentValue).
+            bool cacheable = ModelSupportsCacheControl((string)payload["model"]);
+
             var msgs = new List<object>();
             // Prepend a system instruction to avoid emoji in all responses.
             var sys = new Dictionary<string, object>();
@@ -51,7 +62,7 @@ namespace GxPT
                     if (m.Role == "tool")
                     {
                         // Tool result, keyed back to the assistant's call id.
-                        mm["content"] = m.Content != null ? m.Content : string.Empty;
+                        mm["content"] = ContentValue(m, cacheable);
                         mm["tool_call_id"] = m.ToolCallId;
                     }
                     else if (m.ToolCalls != null && m.ToolCalls.Count > 0)
@@ -74,19 +85,23 @@ namespace GxPT
                     }
                     else
                     {
-                        mm["content"] = m.Content != null ? m.Content : string.Empty;
+                        mm["content"] = ContentValue(m, cacheable);
                     }
                     msgs.Add(mm);
                 }
             }
             payload["messages"] = msgs;
 
-            // Expose tools (tool_choice left at the provider default of "auto").
+            // Expose tools (tool_choice defaults to the provider's "auto"; the orchestrator's cap
+            // wrap-up sets "none" so the prompt prefix - which starts with the tools array - stays
+            // byte-identical to the loop's requests and re-reads the turn's prompt cache).
             if (tools != null && tools.Count > 0)
             {
                 var toolList = new List<object>();
                 foreach (var t in tools) toolList.Add(t);
                 payload["tools"] = toolList;
+                if (props != null && !string.IsNullOrEmpty(props.ToolChoice))
+                    payload["tool_choice"] = props.ToolChoice;
             }
 
             // Optionally add provider object if any of the provider properties are set.
@@ -129,6 +144,64 @@ namespace GxPT
             catch { }
 
             return JsonConvert.SerializeObject(payload);
+        }
+
+        // A message's content value: a plain string normally; a one-part content array carrying
+        // cache_control {type: ephemeral} when the message is flagged as a cache breakpoint and the
+        // model's provider supports explicit caching (the array form is the OpenAI-compatible shape
+        // OpenRouter requires for cache_control). Empty content always stays a plain string - there
+        // is nothing to cache and Anthropic rejects empty text parts.
+        private static object ContentValue(ChatMessage m, bool modelSupportsCaching)
+        {
+            string text = m.Content != null ? m.Content : string.Empty;
+            if (!modelSupportsCaching || !m.CacheControl || text.Length == 0) return text;
+
+            var part = new Dictionary<string, object>();
+            part["type"] = "text";
+            part["text"] = text;
+            var cc = new Dictionary<string, object>();
+            cc["type"] = "ephemeral";
+            part["cache_control"] = cc;
+            return new List<object> { part };
+        }
+
+        // Providers that use explicit cache_control breakpoints via OpenRouter (Anthropic requires
+        // them; Gemini accepts them on top of its implicit caching). OpenAI/DeepSeek/Grok cache
+        // automatically on a stable prefix and need no annotation. OpenRouter documents unsupported
+        // cache_control as ignored, but gating by vendor prefix costs nothing and removes any risk
+        // of an unknown provider rejecting the content-part form. "~"-prefixed model aliases resolve
+        // to the same vendor, so the prefix is stripped before matching.
+        internal static bool ModelSupportsCacheControl(string model)
+        {
+            if (string.IsNullOrEmpty(model)) return false;
+            string m = StripModelAliasPrefix(model);
+            return m.StartsWith("anthropic/", StringComparison.OrdinalIgnoreCase)
+                || m.StartsWith("google/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Providers whose prompt caching (explicit cache_control OR implicit/automatic prefix
+        // caching) makes a byte-stable prompt prefix valuable. Gates reveal-set eviction in the
+        // orchestrator: on these providers an evicted tool def changes the tools array (position 0
+        // of the prompt) and re-bills the conversation's whole transcript at full price, which costs
+        // far more than the stale def it saves - so the revealed set stays append-only. Providers
+        // not listed here get no caching benefit from a stable prefix, so trimming stale defs is a
+        // pure token saving there.
+        internal static bool ModelSupportsPromptCaching(string model)
+        {
+            if (string.IsNullOrEmpty(model)) return false;
+            string m = StripModelAliasPrefix(model);
+            return m.StartsWith("anthropic/", StringComparison.OrdinalIgnoreCase)  // explicit (cache_control)
+                || m.StartsWith("google/", StringComparison.OrdinalIgnoreCase)    // implicit + cache_control
+                || m.StartsWith("openai/", StringComparison.OrdinalIgnoreCase)    // automatic (>=1024 tokens)
+                || m.StartsWith("deepseek/", StringComparison.OrdinalIgnoreCase)  // automatic
+                || m.StartsWith("x-ai/", StringComparison.OrdinalIgnoreCase);     // automatic (Grok)
+        }
+
+        // "~"-prefixed model aliases (e.g. "~anthropic/claude-sonnet-latest") resolve to the same
+        // vendor as their bare form; strip the marker before prefix-matching.
+        private static string StripModelAliasPrefix(string model)
+        {
+            return model.StartsWith("~", StringComparison.Ordinal) ? model.Substring(1) : model;
         }
 
         public string CreateCompletion(string model, IList<ChatMessage> messages)
@@ -291,6 +364,7 @@ namespace GxPT
                 string line;
                 bool sawAnyChunk = false;
                 int chunkCount = 0;
+                ChatCompletionChunk.UsageInfo usage = null;
                 var stdoutBuf = new StringBuilder();
                 while ((line = sr.ReadLine()) != null)
                 {
@@ -318,6 +392,7 @@ namespace GxPT
                     {
                         sawAnyChunk = true;
                         chunkCount++;
+                        if (chunk.usage != null) usage = chunk.usage; // final SSE chunk carries usage
                         if (onChunk != null) onChunk(chunk);
                     }
                 }
@@ -341,6 +416,22 @@ namespace GxPT
                 }
 
                 try { Logger.Log("Stream", "curl exit=" + exitCode + " chunks=" + chunkCount + (sawAnyChunk ? string.Empty : " (no chunks)")); }
+                catch { }
+
+                // Prompt-cache telemetry: cached = prompt-prefix tokens served from the provider's
+                // cache (discounted). cached=0 on a long conversation means the prefix missed - look
+                // for a cache invalidator (tools array changed, non-deterministic serialization).
+                try
+                {
+                    if (usage != null)
+                    {
+                        int? cached = (usage.prompt_tokens_details != null)
+                            ? usage.prompt_tokens_details.cached_tokens : null;
+                        Logger.Log("Usage", "prompt=" + (usage.prompt_tokens.HasValue ? usage.prompt_tokens.Value.ToString() : "?")
+                            + " cached=" + (cached.HasValue ? cached.Value.ToString() : "?")
+                            + " completion=" + (usage.completion_tokens.HasValue ? usage.completion_tokens.Value.ToString() : "?"));
+                    }
+                }
                 catch { }
 
                 // User-initiated stop: killing curl makes it exit non-zero / end without [DONE], which
@@ -546,5 +637,10 @@ namespace GxPT
         public IList<string> ProviderOnly { get; set; }
         public decimal? ProviderMaxPricePrompt { get; set; }
         public decimal? ProviderMaxPriceCompletion { get; set; }
+        // tool_choice for the request ("none", "auto", ...). Null leaves it at the provider default.
+        // Only emitted when a tools array is present. The orchestrator's cap wrap-up uses "none" to
+        // forbid further tool calls while keeping the tools array (and so the cached prompt prefix)
+        // identical to the loop's requests.
+        public string ToolChoice { get; set; }
     }
 }

--- a/docs/mcp35-discovery-spec.md
+++ b/docs/mcp35-discovery-spec.md
@@ -18,8 +18,8 @@ This is the last phase before the **repo split** (architecture §4).
 
 - **In scope:** catalog aggregation across `McpServerConnection`s,
   server-qualified **name munging + bijection**, the names manifest system
-  message, the **revealed set with an LRU cap**, and `reveal_tools` handling +
-  call resolution.
+  message, the **revealed set** (conversation-owned; see the prompt-caching
+  revision note in §8), and `reveal_tools` handling + call resolution.
 - **Out of scope:** the loop itself (phase 4), approval (phase 6), ranking /
   `search_tools` (deferred). All multi-server policy lives here (D11).
 - Constraints: **net35**, Newtonsoft (`JObject`) per D16, thread-safe (touched
@@ -34,7 +34,8 @@ McpHost  ──owns──►  McpServerConnection × N        (phase 3)
    │                      │ Ready / ToolsChanged / faulted
    ▼                      ▼
 McpToolRegistry  ◄── aggregates tools/list, owns names↔(conn,tool) bijection,
-   │                 names manifest, revealed set (LRU), reveal_tools
+   │                 names manifest, reveal_tools; reveal STATE lives on the
+   │                 Conversation (see §8 revision note)
    ▼
 McpChatOrchestrator (phase 4): NamesManifestSystemMessage() + ExposedFunctionDefs()
                                → BuildRequestBody;  Reveal() / TryResolve() on tool_calls
@@ -176,26 +177,37 @@ bool TryResolve(string functionName, out McpServerConnection conn, out string to
 ```
 
 Resolving (i.e. the model actually calling a tool) **bumps recency**, so an
-actively-used tool is never the LRU victim.
+actively-used tool is never the eviction victim. *(Revised: recency now lives
+on the conversation's reveal list and is bumped by the orchestrator, not in
+`TryResolve` — see §8.)*
 
 ---
 
-## 8. LRU cap & eviction
+## 8. Reveal-set ownership & eviction
 
-```csharp
-void EnforceCap():
-   while _revealed.Count > _revealCap:
-      victim = key of _revealed with min tick
-      _revealed.Remove(victim)
-```
+> **Revised by the prompt-caching work** (see `prompt-caching-design.md`,
+> which is authoritative for everything in this section). The original
+> registry-owned LRU described below was replaced because it broke provider
+> prompt caching two ways: the recency-sorted emission reordered the `tools`
+> array (position 0 of the prompt) whenever a tool was called, and the
+> registry-global set let concurrent tabs churn each other's arrays.
 
-- The cap bounds **only the revealed set** (the full schemas in `tools`); the
-  names manifest is always complete (cheap).
-- `reveal_tools` is *not* in `_revealed` (it's prepended separately), so it can
-  never be evicted.
-- A single `Reveal` batch larger than the cap leaves only the most-recent `cap`
-  callable; the model saw every requested schema in the result and can re-reveal.
-- `_revealCap` default is a tuning value (§13).
+Current model:
+
+- **Reveal state lives on the `Conversation`** (`RevealedTools`, persisted,
+  restored on reopen), threaded through `Reveal` / `ExposedFunctionDefs` by
+  the orchestrator. The registry is stateless with respect to reveals.
+- **Emission is name-sorted**, never reveal- or recency-ordered, so the
+  serialized `tools` array is byte-stable across requests.
+- The list itself is **recency-ordered** (reveal and call both bump a name to
+  the end), used only for eviction order.
+- **Eviction is provider-gated, at turn start only** (`McpChatOrchestrator`):
+  prompt-caching providers never evict (an evicted def re-bills the whole
+  cached transcript — always a net loss); non-caching providers trim to
+  `RevealEvictionCap` (24), least recently used first.
+- `reveal_tools` is prepended separately and can never be evicted; stale
+  revealed names (server removed/disabled) are skipped at emission time, not
+  pruned, so a returning server restores its defs.
 
 ---
 
@@ -278,10 +290,13 @@ small seam returning canned `Tool` lists):
    invalidated on mutation.
 3. **Reveal** — `ExposedFunctionDefs` always leads with `reveal_tools`; revealing
    adds defs; the result returns all requested schemas; unknown names noted.
-4. **LRU** — exceeding the cap evicts least-recently-used; `TryResolve` bumps
-   recency (prevents eviction of an active tool); evicted tool re-revealable.
-5. **Lifecycle** — refresh prunes removed tools from catalog + revealed; remove
-   drops a faulted server's tools so they can't be resolved.
+4. **Reveal-set stability** *(revised; see §8)* — the registry never evicts
+   from the caller's list; exposed defs are name-sorted regardless of reveal or
+   call order; duplicate names emit one def. Provider-gated eviction is the
+   orchestrator's job and covered by its tests.
+5. **Lifecycle** — refresh prunes removed tools from the catalog and exposure
+   (the conversation's list keeps the name; emission skips it); remove drops a
+   faulted server's tools so they can't be resolved.
 
 Passing this completes the discovery layer; the roadmap then **splits `Mcp35.*`
 into its own repo** before phases 6–8.
@@ -290,9 +305,10 @@ into its own repo** before phases 6–8.
 
 ## 13. Resolved questions
 
-- **`_revealCap` default** — *resolved*: **24** (mid of the 16–32 range), a named
+- **Reveal cap default** — *resolved*: **24** (mid of the 16–32 range), a named
   constant so it stays tunable without a design change (closes architecture §15
-  "reveal cap value").
+  "reveal cap value"). *(Revised: now `McpChatOrchestrator.RevealEvictionCap`,
+  enforced only on non-caching providers — see §8.)*
 - **Manifest format** — *resolved*: **flat list** of qualified names. The
   `server__tool` prefix already groups names visually (`github__…`, `files__…`),
   so explicit per-server headers add tokens for little gain; revisit only if

--- a/docs/mcp35-toolloop-spec.md
+++ b/docs/mcp35-toolloop-spec.md
@@ -96,10 +96,11 @@ registry maintains a **bijection** `functionName ↔ (connection, originalToolNa
 ### `reveal_tools` — host meta-tool (not from any server)
 Always exposed: `{ name:"reveal_tools", description, parameters:{ names: string[] } }`.
 When the model calls it, the **host handles it locally** (no MCP round-trip):
-validate names against the manifest, add them to the **revealed set** (LRU cap,
-architecture §7), and return the revealed tools' **full definitions** as the
-tool result so the model can read their schemas. They become callable on the
-next iteration.
+validate names against the manifest, add them to the **revealed set** (owned by
+the Conversation; provider-gated eviction — see discovery spec §8 and
+`prompt-caching-design.md`), and return the revealed tools' **full
+definitions** as the tool result so the model can read their schemas. They
+become callable on the next iteration.
 
 ### Result → `tool` message content
 `CallToolResult.content[]` → a string for the `tool` message:
@@ -245,11 +246,13 @@ ExecuteCall(c):
   decision), e.g. a compact list. This is cheap and keeps discovery
   deterministic.
 - The exposed `tools` array each turn = **`reveal_tools`** + the **revealed
-  set** (full schemas, LRU-capped). The model reads the manifest → calls
-  `reveal_tools(names)` → those defs join the `tools` array next iteration → it
-  calls them.
-- `reveal_tools` execution is local (host): validate names, update the revealed
-  set (touch LRU recency), return the revealed schemas as the tool result.
+  set** (full schemas, name-sorted for prompt-cache stability; conversation-
+  owned with provider-gated eviction — see discovery spec §8). The model reads
+  the manifest → calls `reveal_tools(names)` → those defs join the `tools`
+  array next iteration → it calls them.
+- `reveal_tools` execution is local (host): validate names, update the
+  conversation's revealed list (bump recency), return the revealed schemas as
+  the tool result.
 
 ---
 

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -96,10 +96,15 @@ So requests on cache-supported models carry `provider.order = [<cache-warm provi
   caching-model-gated.
 - **The streamed `usage.cost` is the pre-cache-discount estimate, and `cache_discount` does not
   ride the SSE stream.** On a cache-hit request the stream-time cost overstates billing by the
-  discount. Requests with cache activity are therefore reconciled post-stream against the
+  discount. Caching-capable models therefore reconcile every request post-stream against the
   authoritative generation record (`GET /api/v1/generation?id=` -> `total_cost`,
-  `cache_discount`; `OpenRouterClient.TryFetchGenerationStats` +
-  `Conversation.ReconcileUsage`), which is also where the Saved figure comes from.
+  `cache_discount`, `provider_name`; `OpenRouterClient.FetchGenerationStats` +
+  `Conversation.ReconcileUsage`), which is also where the Saved figure comes from. The
+  reconcile gate must NOT depend on the streamed cache counters: some provider streams (seen
+  with Amazon Bedrock) omit `prompt_tokens_details` entirely, which would skip exactly the
+  requests that need reconciling - and starve the stream-side stickiness gate, which is why a
+  nonzero billed `cache_discount` also latches `CacheWarmProvider` as a late cache-activity
+  signal.
 - Semantics note: OpenRouter normalizes usage to OpenAI conventions - `prompt_tokens` is the
   TOTAL prompt size and the cache counters are subsets of it (unlike Anthropic's native API,
   where `input_tokens` is the uncached remainder). Never add the counters to `prompt_tokens`.

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -94,17 +94,17 @@ So requests on cache-supported models carry `provider.order = [<cache-warm provi
   callback feeds the status bar's per-conversation cost/savings accounting
   (`Conversation.RecordUsage`), which runs on every model - only the stickiness gate inside it is
   caching-model-gated.
-- **The streamed `usage.cost` is the pre-cache-discount estimate, and `cache_discount` does not
-  ride the SSE stream.** On a cache-hit request the stream-time cost overstates billing by the
-  discount. Caching-capable models therefore reconcile every request post-stream against the
-  authoritative generation record (`GET /api/v1/generation?id=` -> `total_cost`,
-  `cache_discount`, `provider_name`; `OpenRouterClient.FetchGenerationStats` +
-  `Conversation.ReconcileUsage`), which is also where the Saved figure comes from. The
-  reconcile gate must NOT depend on the streamed cache counters: some provider streams (seen
-  with Amazon Bedrock) omit `prompt_tokens_details` entirely, which would skip exactly the
-  requests that need reconciling - and starve the stream-side stickiness gate, which is why a
-  nonzero billed `cache_discount` also latches `CacheWarmProvider` as a late cache-activity
-  signal.
+- **`cache_discount` does not ride the SSE stream** - the post-hoc generation record
+  (`GET /api/v1/generation?id=` -> `total_cost`, `cache_discount`, `provider_name`;
+  `OpenRouterClient.FetchGenerationStats` + `Conversation.ReconcileUsage`) is the Saved
+  figure's only data source. The streamed `usage.cost` was observed billing-accurate (cache
+  pricing included) on Bedrock-served Anthropic models, but that isn't guaranteed across
+  providers, so caching-capable models reconcile every request; the delta-based reconcile is a
+  no-op when the stream was already accurate. Operational notes: the record can take several
+  seconds to become queryable (the fetch retries patiently and logs failures - a silent fetch
+  failure looks like "Saved frozen at $0.00"); the reconcile gate must not depend on streamed
+  cache counters being present; and a nonzero billed `cache_discount` also latches
+  `CacheWarmProvider` as a late cache-activity signal for streams that omit counters.
 - Semantics note: OpenRouter normalizes usage to OpenAI conventions - `prompt_tokens` is the
   TOTAL prompt size and the cache counters are subsets of it (unlike Anthropic's native API,
   where `input_tokens` is the uncached remainder). Never add the counters to `prompt_tokens`.

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -89,11 +89,17 @@ So requests on cache-supported models carry `provider.order = [<cache-warm provi
 "cache-warm" means **confirmed by a demonstrated hit**, not merely "served last":
 
 - OpenRouter reports the serving provider on response chunks (`chunk.provider`) and the usage
-  accounting (cache counters, billed cost, cache discount) on the final usage chunk; the client
-  surfaces it once per request as a `ResponseUsage` via `ClientProperties.ResponseUsageCallback`.
-  The same callback feeds the status bar's per-conversation cost/savings accounting
+  accounting (cache counters, cost estimate) on the final usage chunk; the client surfaces it
+  once per request as a `ResponseUsage` via `ClientProperties.ResponseUsageCallback`. The same
+  callback feeds the status bar's per-conversation cost/savings accounting
   (`Conversation.RecordUsage`), which runs on every model - only the stickiness gate inside it is
   caching-model-gated.
+- **The streamed `usage.cost` is the pre-cache-discount estimate, and `cache_discount` does not
+  ride the SSE stream.** On a cache-hit request the stream-time cost overstates billing by the
+  discount. Requests with cache activity are therefore reconciled post-stream against the
+  authoritative generation record (`GET /api/v1/generation?id=` -> `total_cost`,
+  `cache_discount`; `OpenRouterClient.TryFetchGenerationStats` +
+  `Conversation.ReconcileUsage`), which is also where the Saved figure comes from.
 - Semantics note: OpenRouter normalizes usage to OpenAI conventions - `prompt_tokens` is the
   TOTAL prompt size and the cache counters are subsets of it (unlike Anthropic's native API,
   where `input_tokens` is the uncached remainder). Never add the counters to `prompt_tokens`.

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -88,9 +88,15 @@ lookback), double write-premiums at worst.
 So requests on cache-supported models carry `provider.order = [<cache-warm provider>]`, where
 "cache-warm" means **confirmed by a demonstrated hit**, not merely "served last":
 
-- OpenRouter reports the serving provider on response chunks (`chunk.provider`) and the cache
-  counters (`cached_tokens`, `cache_write_tokens`) on the final usage chunk; the client surfaces
-  them once per request via `ClientProperties.ProviderServedCallback(provider, cached, written)`.
+- OpenRouter reports the serving provider on response chunks (`chunk.provider`) and the usage
+  accounting (cache counters, billed cost, cache discount) on the final usage chunk; the client
+  surfaces it once per request as a `ResponseUsage` via `ClientProperties.ResponseUsageCallback`.
+  The same callback feeds the status bar's per-conversation cost/savings accounting
+  (`Conversation.RecordUsage`), which runs on every model - only the stickiness gate inside it is
+  caching-model-gated.
+- Semantics note: OpenRouter normalizes usage to OpenAI conventions - `prompt_tokens` is the
+  TOTAL prompt size and the cache counters are subsets of it (unlike Anthropic's native API,
+  where `input_tokens` is the uncached remainder). Never add the counters to `prompt_tokens`.
 - Stickiness is **confirmation-gated**: only a response demonstrating cache activity - a read
   (`cached_tokens > 0`) or a write (`cache_write_tokens > 0`) - sets or moves the preference.
   Merely serving proves nothing (a third-party host of an open-weights model may not cache at

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -89,17 +89,18 @@ So requests on cache-supported models carry `provider.order = [<cache-warm provi
 "cache-warm" means **confirmed by a demonstrated hit**, not merely "served last":
 
 - OpenRouter reports the serving provider on response chunks (`chunk.provider`) and the cache
-  read count on the final usage chunk; the client surfaces both once per request via
-  `ClientProperties.ProviderServedCallback(provider, cachedTokens)`.
-- Stickiness is **confirmation-gated**: only a response with `cached_tokens > 0` sets or moves
-  the preference. Merely serving proves nothing - a third-party host of an open-weights model
-  may not cache at all, and pinning there would constrain load balancing for no benefit. A hit
-  proves this endpoint holds the conversation's warm cache.
-- A later `cached=0` from the confirmed provider does NOT clear the preference: that is usually
-  TTL expiry between turns, where keeping the rebuild on one provider is exactly the point. The
-  preference moves only when a different provider demonstrates a hit.
-- Cold start: the first request is a cache write (`cached=0`), so stickiness latches on the
-  first observed hit - typically iteration 2 of a tool loop.
+  counters (`cached_tokens`, `cache_write_tokens`) on the final usage chunk; the client surfaces
+  them once per request via `ClientProperties.ProviderServedCallback(provider, cached, written)`.
+- Stickiness is **confirmation-gated**: only a response demonstrating cache activity - a read
+  (`cached_tokens > 0`) or a write (`cache_write_tokens > 0`) - sets or moves the preference.
+  Merely serving proves nothing (a third-party host of an open-weights model may not cache at
+  all, and pinning there would constrain load balancing for no benefit); a read proves the warm
+  cache lives here, a write proves it was just created here. Explicit-caching providers
+  therefore latch from the conversation's first request; implicit cachers whose writes aren't
+  reported latch on their first observed hit.
+- A later no-activity response from the confirmed provider does NOT clear the preference: that
+  is usually TTL expiry between turns, where keeping the rebuild on one provider is exactly the
+  point. The preference moves only when a different provider demonstrates cache activity.
 - The orchestrator keeps the value in `PreferredProvider` (mid-turn loop iterations follow the
   warm cache immediately); the host persists it as `Conversation.CacheWarmProvider`.
 - `order` is a preference with fallback (allow_fallbacks defaults true), not a pin: an outage

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -41,9 +41,17 @@ ephemeral context tail rebuilt every request, never cached               Zone C
   would put the volatile content back in front of the cached history. It is never persisted and
   never rendered by the UI; the agent prompt tells the model what it is. Memory, the skills
   manifest, and the MCP names manifest may all change per request at zero cache cost here.
-- **Breakpoints** are `ChatMessage.CacheControl` flags. Zone A's flag goes on a request-local
-  head message; Zone B's goes on a `WithCacheControl()` clone so the flag never lands in
-  persisted history (stale flags would accumulate past Anthropic's 4-breakpoint limit).
+- **Breakpoints** are `ChatMessage.CacheControl` flags, placed by
+  `McpChatOrchestrator.ApplyCacheBreakpoints`. Zone A's flag goes on a request-local head
+  message; Zone B's goes on a `WithCacheControl()` clone so the flag never lands in persisted
+  history (stale flags would accumulate past Anthropic's 4-breakpoint limit). The two spare
+  slots become **intermediate flags spaced ~12 estimated content blocks apart** walking back
+  from the newest message: Anthropic's matcher only looks back ~20 blocks from a breakpoint for
+  a prior cache entry, so a single iteration appending more than that (an assistant message
+  with K tool calls renders ~K+1 blocks plus K result blocks; K >= ~10) would otherwise leave
+  the next request unable to find the previous entry - a silent full miss. Bridged up to ~18
+  calls per iteration; a single assistant message wider than the lookback (~20+ calls) is
+  unbridgeable by placement and accepted.
 - During the tool-call loop, breakpoint #2 rides the newest tool result, so iteration N+1 reads
   everything through iteration N from cache. This is where most of the savings are.
 

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -58,9 +58,12 @@ ephemeral context tail rebuilt every request, never cached               Zone C
 ## 3. Wire format (OpenRouterClient)
 
 - A flagged message's content is emitted as `[{type:"text", text, cache_control:{type:"ephemeral"}}]`
-  — but only when `ModelSupportsCacheControl(model)` (vendor prefixes `anthropic/`, `google/`,
-  with `~` aliases stripped). Other providers cache automatically (OpenAI, DeepSeek, Grok) or not
-  at all; they get plain string content.
+  — for **every** model, not just explicit-caching vendors. Providers without explicit caching
+  ignore the annotation (documented by OpenRouter; field-verified harmless), and the markers can
+  matter even for models whose author caches automatically: a third-party host may implement
+  explicit-marker caching only (suspected of SiliconFlow-hosted DeepSeek, which never auto-cached
+  prefix-stable requests). The original vendor gate (`ModelSupportsCacheControl`) was removed
+  once the ignored-not-errored behavior was field-verified.
 - Every request carries `usage: {include: true}`. The final SSE chunk's
   `usage.prompt_tokens_details.cached_tokens` is logged (`Usage` log tag) — this is the
   verification signal. `cached=0` on a long conversation means a silent invalidator.

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -77,7 +77,27 @@ ephemeral context tail rebuilt every request, never cached               Zone C
 - Stale revealed names (server removed/disabled) are skipped at emission time, never pruned from
   the conversation's list, so a returning server restores its defs.
 
-## 5. Invalidation events (what still misses, by design)
+## 5. Sticky provider routing
+
+A model on OpenRouter can be served by several provider endpoints (Anthropic, Amazon Bedrock,
+Google Vertex, ...), and **prompt caches live per provider**: an entry written by Anthropic is
+invisible to Bedrock. Routing that flaps between endpoints fragments the cache — partial hits at
+best (bounded by the TTL running while a provider sits unused, and by the ~20-block matcher
+lookback), double write-premiums at worst.
+
+So requests on cache-supported models carry `provider.order = [<last serving provider>]`:
+
+- OpenRouter reports the serving provider on response chunks (`chunk.provider`); the client
+  surfaces it once per request via `ClientProperties.ProviderServedCallback`.
+- The orchestrator keeps it in `PreferredProvider` (so mid-turn loop iterations follow the warm
+  cache immediately) and the host persists it as `Conversation.LastServedProvider` for the next
+  turn / reopen.
+- `order` is a preference with fallback (allow_fallbacks defaults true), not a pin: an outage
+  reroutes and costs one cold cache write, then stickiness follows the new provider. This
+  self-corrects in a way a static "first-party provider" map would not.
+- Gated by `ModelSupportsPromptCaching`: non-caching models keep full load balancing.
+
+## 6. Invalidation events (what still misses, by design)
 
 | Event | Cost | Frequency |
 |---|---|---|
@@ -87,7 +107,7 @@ ephemeral context tail rebuilt every request, never cached               Zone C
 | loop iteration, normal user turn | incremental read + small write | the common case |
 | > provider TTL (~5 min) between turns | one re-write | normal chat pacing |
 
-## 6. Rules for future changes
+## 7. Rules for future changes
 
 1. Never interpolate timestamps, IDs, counters, or any per-request value into Zone A or the
    manifests' position before history. Volatile content goes in Zone C.

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -1,0 +1,99 @@
+# Prompt Caching Design
+
+Provider prompt caching (via OpenRouter) bills a request's repeated prompt prefix at a steep
+discount instead of full price. This document records how GxPT structures its requests to hit
+that cache, and the invariants every future change to request assembly must preserve.
+
+> Supersedes the LRU/eviction model described in `mcp35-discovery-spec.md` §8/§13 and the
+> "revealed set (LRU, registry-owned)" wording in `mcp35-toolloop-spec.md`: the revealed set now
+> lives on the Conversation (append-only on caching providers; cap-trimmed at turn start on
+> non-caching ones), and the registry is stateless with respect to reveals.
+
+## 1. The one invariant
+
+**Prompt caching is a prefix match.** The provider caches the rendered prompt up to a marker (or
+automatically, depending on provider) and re-serves it when a later request starts with the exact
+same bytes. One changed byte at position N re-bills everything after N. The tools array renders
+at position 0, before system messages and history, so it is the most invalidation-sensitive
+content in the request.
+
+Consequence: everything in the request is ordered by volatility, and anything that can change
+between requests must come after everything that cannot.
+
+## 2. Request layout (zones)
+
+Assembled per request in `McpChatOrchestrator.RunTurn` (tool turns) and `MainForm` (plain turns):
+
+```
+tools array            append-only per conversation, name-sorted        ┐ Zone A
+emoji system message   constant (prepended by OpenRouterClient)         │ frozen for the
+agent system prompt    constant                                         │ conversation
+workspace system msg   constant while the workspace is unchanged        ┘
+        ◄── cache breakpoint #1 (last system message)
+persisted history      append-only (user/assistant/tool messages)        Zone B
+        ◄── cache breakpoint #2 (newest persisted message, cloned)
+ephemeral context tail rebuilt every request, never cached               Zone C
+  [Ephemeral context...] <memory> <skills> <available_tools>
+```
+
+- **Zone C is one trailing user-role message** (`BuildEphemeralContextText`). User role because
+  OpenRouter hoists in-array system messages to Anthropic's top-level system parameter, which
+  would put the volatile content back in front of the cached history. It is never persisted and
+  never rendered by the UI; the agent prompt tells the model what it is. Memory, the skills
+  manifest, and the MCP names manifest may all change per request at zero cache cost here.
+- **Breakpoints** are `ChatMessage.CacheControl` flags. Zone A's flag goes on a request-local
+  head message; Zone B's goes on a `WithCacheControl()` clone so the flag never lands in
+  persisted history (stale flags would accumulate past Anthropic's 4-breakpoint limit).
+- During the tool-call loop, breakpoint #2 rides the newest tool result, so iteration N+1 reads
+  everything through iteration N from cache. This is where most of the savings are.
+
+## 3. Wire format (OpenRouterClient)
+
+- A flagged message's content is emitted as `[{type:"text", text, cache_control:{type:"ephemeral"}}]`
+  — but only when `ModelSupportsCacheControl(model)` (vendor prefixes `anthropic/`, `google/`,
+  with `~` aliases stripped). Other providers cache automatically (OpenAI, DeepSeek, Grok) or not
+  at all; they get plain string content.
+- Every request carries `usage: {include: true}`. The final SSE chunk's
+  `usage.prompt_tokens_details.cached_tokens` is logged (`Usage` log tag) — this is the
+  verification signal. `cached=0` on a long conversation means a silent invalidator.
+- The cap wrap-up request keeps the loop's tools array and sets `tool_choice: "none"` instead of
+  dropping tools: removing the array would change position 0 and forfeit the tools+system cache.
+
+## 4. Reveal system
+
+- The revealed-tool set is **per-conversation** (`Conversation.RevealedTools`, persisted), not
+  registry-global: concurrent tabs no longer churn each other's tools array, and a reopened
+  conversation resumes with its working set instead of starting cold.
+- The list is recency-ordered (reveal and call bump a name to the end) but **emitted name-sorted**
+  (`McpToolRegistry.ExposedFunctionDefs`), so neither reveal order nor calling a tool reorders
+  the serialized array. (The old recency-sorted emission reordered the array on every call —
+  a guaranteed full cache miss every loop iteration.)
+- **Eviction is provider-gated** (`McpChatOrchestrator`, turn start only):
+  - Prompt-caching providers (`OpenRouterClient.ModelSupportsPromptCaching`): never evict.
+    An evicted def changes the tools array and re-bills the whole transcript once, which always
+    costs more than the few hundred cache-discounted tokens a stale def occupies.
+  - Non-caching providers: trim to `RevealEvictionCap` (24), least recently used first — stale
+    defs are pure per-turn cost there.
+- Stale revealed names (server removed/disabled) are skipped at emission time, never pruned from
+  the conversation's list, so a returning server restores its defs.
+
+## 5. Invalidation events (what still misses, by design)
+
+| Event | Cost | Frequency |
+|---|---|---|
+| reveal_tools / gate flip / cap eviction | one full prefix re-write | occasional, implies new work anyway |
+| workspace or model change mid-conversation | one full re-write / cold cache | rare |
+| memory write, skills change, manifest change | nothing (Zone C) | — |
+| loop iteration, normal user turn | incremental read + small write | the common case |
+| > provider TTL (~5 min) between turns | one re-write | normal chat pacing |
+
+## 6. Rules for future changes
+
+1. Never interpolate timestamps, IDs, counters, or any per-request value into Zone A or the
+   manifests' position before history. Volatile content goes in Zone C.
+2. Never reorder or conditionally serialize the tools array; keep emission name-sorted and
+   deterministic.
+3. `RequestMessageTransform` implementations must be byte-deterministic per message.
+4. Never set `CacheControl` on a persisted `ChatMessage`; flag request-local objects or clones.
+5. After touching request assembly, verify with the `Usage` log line: `cached` should be a large
+   share of `prompt` from the second request of a conversation onward (on caching providers).

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -85,15 +85,25 @@ invisible to Bedrock. Routing that flaps between endpoints fragments the cache â
 best (bounded by the TTL running while a provider sits unused, and by the ~20-block matcher
 lookback), double write-premiums at worst.
 
-So requests on cache-supported models carry `provider.order = [<last serving provider>]`:
+So requests on cache-supported models carry `provider.order = [<cache-warm provider>]`, where
+"cache-warm" means **confirmed by a demonstrated hit**, not merely "served last":
 
-- OpenRouter reports the serving provider on response chunks (`chunk.provider`); the client
-  surfaces it once per request via `ClientProperties.ProviderServedCallback`.
-- The orchestrator keeps it in `PreferredProvider` (so mid-turn loop iterations follow the warm
-  cache immediately) and the host persists it as `Conversation.LastServedProvider` for the next
-  turn / reopen.
+- OpenRouter reports the serving provider on response chunks (`chunk.provider`) and the cache
+  read count on the final usage chunk; the client surfaces both once per request via
+  `ClientProperties.ProviderServedCallback(provider, cachedTokens)`.
+- Stickiness is **confirmation-gated**: only a response with `cached_tokens > 0` sets or moves
+  the preference. Merely serving proves nothing - a third-party host of an open-weights model
+  may not cache at all, and pinning there would constrain load balancing for no benefit. A hit
+  proves this endpoint holds the conversation's warm cache.
+- A later `cached=0` from the confirmed provider does NOT clear the preference: that is usually
+  TTL expiry between turns, where keeping the rebuild on one provider is exactly the point. The
+  preference moves only when a different provider demonstrates a hit.
+- Cold start: the first request is a cache write (`cached=0`), so stickiness latches on the
+  first observed hit - typically iteration 2 of a tool loop.
+- The orchestrator keeps the value in `PreferredProvider` (mid-turn loop iterations follow the
+  warm cache immediately); the host persists it as `Conversation.CacheWarmProvider`.
 - `order` is a preference with fallback (allow_fallbacks defaults true), not a pin: an outage
-  reroutes and costs one cold cache write, then stickiness follows the new provider. This
+  reroutes, and once the substitute provider produces hits the preference follows it. This
   self-corrects in a way a static "first-party provider" map would not.
 - Gated by `ModelSupportsPromptCaching`: non-caching models keep full load balancing.
 


### PR DESCRIPTION
## Summary

Adds OpenRouter prompt caching to GxPT, cutting input-token costs by up to ~90% on the repeated prompt prefix — which matters most in agentic tool loops, where the full transcript is re-sent on every iteration. Field-tested on Bedrock-served Anthropic models with verified incremental cache reads across loop iterations.

Full architecture and invariants: `docs/prompt-caching-design.md`.

## Request restructuring (the core)

Every request is assembled into volatility zones so providers' prefix caches hit:

- **Zone A (frozen):** tools array + emoji/agent/workspace system messages.
- **Zone B (append-only history):** the persisted conversation.
- **Zone C (ephemeral tail):** memory, skills manifest, and MCP names manifest move from system messages *in front of* history to one rebuilt-per-request user-role message *after* it — their churn no longer invalidates the cached transcript. Never persisted; never rendered.

`cache_control` breakpoints (Anthropic's 4-slot limit, exactly used): stable head, newest history message (request-local clone — flags never land in persisted history), plus up to two intermediate flags spaced ~12 estimated content blocks apart to bridge Anthropic's ~20-block matcher lookback on large tool fan-outs. Markers are emitted for every model: providers without explicit caching ignore them (documented, field-verified), and some third-party hosts may require them even where the model author auto-caches.

## Reveal-system redesign

- Revealed-tool state moves from a registry-global LRU to a **per-conversation, persisted list** — tabs no longer churn each other's tools array, and reopened conversations resume their working set.
- Exposed defs are **emitted name-sorted** (the old recency order re-sorted the array — position 0 of the prompt — on every tool call: a guaranteed full cache miss per iteration).
- **Eviction is provider-gated** at turn boundaries: append-only on prompt-caching providers (an evicted def re-bills the whole transcript), LRU cap 24 on non-caching ones.
- The cap wrap-up keeps the loop's tools array with `tool_choice: "none"` instead of dropping it.

## Sticky provider routing

Prompt caches live per provider endpoint; routing that flaps between hosts fragments them. On caching-capable models, requests emit `provider.order = [CacheWarmProvider]` — a preference with fallback, not a pin. Stickiness is **confirmation-gated**: only a response demonstrating cache activity (a read or a write) latches the preference, so non-caching hosts of open-weights models never constrain load balancing. A nonzero billed `cache_discount` latches it too, covering streams that omit cache counters.

## Usage status bar

Bottom `StatusStrip` (View ▸ Status Bar toggle, system chrome, persisted setting):

`Context: 173.7K tok | Cost: $0.267 | Saved: $0.133`

- Context = newest request's full prompt size; Cost/Saved = running totals; Saved is sign-colored (green/red) and **net** of cache-write premiums.
- Tooltip carries the labeled cache percentages (last-request vs lifetime) and output/reasoning tokens.
- All accumulators persist with the conversation and restore on reopen.
- Cost/savings are stream-first with post-hoc reconciliation against OpenRouter's generation record (`/api/v1/generation`): `cache_discount` never rides the SSE stream, and the record can take 10s+ to materialize, so the fetch retries over ~2 minutes on a dedicated background thread, logs failures, self-cancels if the stream ever starts carrying the discount, and persists late corrections.

## Telemetry & diagnostics

Every request logs `prompt/cached/cacheWrite/completion/cost` (`Usage` tag) plus the reconciled generation record — broken caching is visible as `cached=0` with repeated large `cacheWrite`, and fetch failures log curl exit + body.

## Docs & tests

- New `docs/prompt-caching-design.md` (zones, invariants, invalidation table, rules for future changes); `mcp35-discovery-spec.md` §8 and `mcp35-toolloop-spec.md` revised to match shipped behavior.
- Tests cover wire-format emission/gating, name-sort stability, no-eviction semantics, breakpoint placement (incl. fan-out span coverage), sticky-routing latch rules, usage parsing, and generation-record extraction.

## Verification notes

- Field-verified on Bedrock-served Claude: incremental prefix extension across loop iterations (reads exactly match prior writes), billing-accurate streamed costs, reconciled savings.
- This branch was developed in an environment without a .NET toolchain — the solution builds and runs per field testing, but the xunit suite should get one CI/local run to confirm the new tests are green as written.
- Open observation: SiliconFlow-hosted DeepSeek showed no cache activity despite listed cache pricing; the now-unconditional `cache_control` markers are the experiment in flight. If they don't engage it, the next lever is seeding `provider.order` with the model author's first-party endpoint.

https://claude.ai/code/session_01Bwoufg61roR1sWpkTzPZrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bwoufg61roR1sWpkTzPZrW)_