### PR TITLE
Add a context meter to the status bar

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="..\GxPT\Services\Mcp\DefaultServerConnector.cs" Link="Linked\Mcp\DefaultServerConnector.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
+    <Compile Include="..\GxPT\Services\ModelCatalogService.cs" Link="Linked\ModelCatalogService.cs" />
     <Compile Include="..\GxPT\Services\RecentWorkDirs.cs" Link="Linked\RecentWorkDirs.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillSlug.cs" Link="Linked\Skills\SkillSlug.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillFrontmatter.cs" Link="Linked\Skills\SkillFrontmatter.cs" />

--- a/GxPT.Tests/ModelCatalogServiceTests.cs
+++ b/GxPT.Tests/ModelCatalogServiceTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Pure-logic coverage for the model context-size catalog: the /models JSON parse, the
+    // "id<TAB>tokens" file format round-trip, and the alias/variant-tolerant lookup that the
+    // status bar's context meter depends on. (The curl fetch itself needs a network and is
+    // exercised manually.)
+    public class ModelCatalogServiceTests
+    {
+        // ---- ParseModelsJson ----
+
+        [Fact]
+        public void Parses_ids_and_context_lengths_from_models_payload()
+        {
+            string json = @"{ ""data"": [
+                { ""id"": ""anthropic/claude-sonnet-4.5"", ""context_length"": 200000, ""name"": ""x"" },
+                { ""id"": ""openai/gpt-4o"", ""context_length"": 128000 }
+            ] }";
+            var map = ModelCatalogService.ParseModelsJson(json);
+            Assert.NotNull(map);
+            Assert.Equal(2, map.Count);
+            Assert.Equal(200000, map["anthropic/claude-sonnet-4.5"]);
+            Assert.Equal(128000, map["openai/gpt-4o"]);
+        }
+
+        [Fact]
+        public void Skips_entries_without_a_usable_context_length()
+        {
+            string json = @"{ ""data"": [
+                { ""id"": ""a/no-length"" },
+                { ""id"": ""b/null-length"", ""context_length"": null },
+                { ""id"": ""c/zero"", ""context_length"": 0 },
+                { ""id"": ""d/ok"", ""context_length"": 32768 },
+                { ""context_length"": 9999 },
+                ""not-an-object""
+            ] }";
+            var map = ModelCatalogService.ParseModelsJson(json);
+            Assert.NotNull(map);
+            Assert.Single(map);
+            Assert.Equal(32768, map["d/ok"]);
+        }
+
+        [Fact]
+        public void Returns_null_for_malformed_or_unexpected_payloads()
+        {
+            Assert.Null(ModelCatalogService.ParseModelsJson("not json"));
+            Assert.Null(ModelCatalogService.ParseModelsJson(@"{ ""error"": ""nope"" }"));
+            Assert.Null(ModelCatalogService.ParseModelsJson(@"{ ""data"": ""not-an-array"" }"));
+        }
+
+        // ---- catalog file format ----
+
+        [Fact]
+        public void Catalog_file_round_trips_and_is_sorted()
+        {
+            var map = new Dictionary<string, int>
+            {
+                { "openai/gpt-4o", 128000 },
+                { "anthropic/claude-sonnet-4.5", 200000 }
+            };
+            string text = ModelCatalogService.FormatCatalogFile(map);
+            // Sorted by id, one tab-separated line each.
+            Assert.Equal("anthropic/claude-sonnet-4.5\t200000\nopenai/gpt-4o\t128000\n", text);
+
+            var back = ModelCatalogService.ParseCatalogFile(text);
+            Assert.Equal(2, back.Count);
+            Assert.Equal(200000, back["anthropic/claude-sonnet-4.5"]);
+            Assert.Equal(128000, back["openai/gpt-4o"]);
+        }
+
+        [Fact]
+        public void Catalog_file_parse_tolerates_comments_blanks_and_garbage()
+        {
+            string text = "# hand-edited\r\n\r\nno-tab-here\nbad/number\tNaN\nok/model\t100000\n\tmissing-id\n";
+            var map = ModelCatalogService.ParseCatalogFile(text);
+            Assert.Single(map);
+            Assert.Equal(100000, map["ok/model"]);
+        }
+
+        // ---- TryGetContextLength lookup ladder ----
+
+        [Fact]
+        public void Lookup_matches_verbatim_alias_and_variant_forms()
+        {
+            ModelCatalogService.SetMapForTests(new Dictionary<string, int>
+            {
+                { "anthropic/claude-sonnet-latest", 200000 },
+                { "deepseek/deepseek-v4-pro", 164000 },
+                { "meta-llama/llama-3-8b:free", 8192 }
+            });
+            try
+            {
+                int ctx;
+                // Verbatim.
+                Assert.True(ModelCatalogService.TryGetContextLength("deepseek/deepseek-v4-pro", out ctx));
+                Assert.Equal(164000, ctx);
+                // ":free" entries exist in the catalog and match verbatim.
+                Assert.True(ModelCatalogService.TryGetContextLength("meta-llama/llama-3-8b:free", out ctx));
+                Assert.Equal(8192, ctx);
+                // "~" alias marker stripped.
+                Assert.True(ModelCatalogService.TryGetContextLength("~anthropic/claude-sonnet-latest", out ctx));
+                Assert.Equal(200000, ctx);
+                // ":variant" routing suffix stripped when the suffixed id isn't listed.
+                Assert.True(ModelCatalogService.TryGetContextLength("deepseek/deepseek-v4-pro:nitro", out ctx));
+                Assert.Equal(164000, ctx);
+                // Unknown model: false and zero (status bar falls back to a bare token count).
+                Assert.False(ModelCatalogService.TryGetContextLength("nobody/ever-heard-of-it", out ctx));
+                Assert.Equal(0, ctx);
+                Assert.False(ModelCatalogService.TryGetContextLength(null, out ctx));
+                Assert.False(ModelCatalogService.TryGetContextLength("  ", out ctx));
+            }
+            finally
+            {
+                ModelCatalogService.SetMapForTests(new Dictionary<string, int>());
+            }
+        }
+    }
+}

--- a/GxPT/Controls/ContextMeterItem.cs
+++ b/GxPT/Controls/ContextMeterItem.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // The status bar's context meter: how full the active model's context window is, drawn as a
+    // row of discrete "LED" blocks behind a 1px dark-grey border - the look of the classic
+    // pre-Vista progress bar, which suits the app. Owner-drawn ToolStripItem rather than a
+    // hosted ProgressBar: the themed native control sweeps a highlight across the fill even at
+    // a static value (the Vista/7 "pulse"), and un-theming it traded that for handle-recreation
+    // bookkeeping - painting a dozen rectangles ourselves needs neither. The blocks' coarse
+    // quantization is also a feature: small token fluctuations have to earn a whole block
+    // before the meter moves.
+    //
+    // The item's width is DERIVED from the block geometry (border + gap-sized pad + blocks +
+    // gaps) so the blocks sit flush: the spacing between the last block and the border equals
+    // the inter-block gap, with no leftover sliver of track at the right end.
+    //
+    // Fill color tracks how much of the window remains: green while comfortable, yellow once
+    // usage crosses 70%, red past 90%.
+    internal sealed class ContextMeterItem : ToolStripItem
+    {
+        private long _used;
+        private int _max;
+
+        private const int BlockCount = 13;
+        private const int BlockWidth = 5;
+        private const int BlockGap = 1;
+        // 1px border plus a gap-sized pad on every side.
+        private const int Inset = 1 + BlockGap;
+        public const int MeterWidth =
+            2 * Inset + BlockCount * BlockWidth + (BlockCount - 1) * BlockGap; // 81
+        public const int MeterHeight = 15;
+
+        private static readonly Color BorderColor = Color.FromArgb(96, 96, 96);
+        private static readonly Color TrackColor = Color.FromArgb(252, 252, 252);
+        private static readonly Color EmptyBlockColor = Color.FromArgb(228, 228, 228);
+        private static readonly Color GreenFill = Color.FromArgb(76, 160, 66);
+        private static readonly Color YellowFill = Color.FromArgb(226, 168, 22);
+        private static readonly Color RedFill = Color.FromArgb(199, 56, 44);
+
+        public ContextMeterItem()
+        {
+            this.AutoSize = false;
+            this.Size = new Size(MeterWidth, MeterHeight);
+        }
+
+        protected override Size DefaultSize
+        {
+            get { return new Size(MeterWidth, MeterHeight); }
+        }
+
+        // Update what the meter shows (UI thread). No-op when nothing changed, so the frequent
+        // status-strip syncs (tab switches, per-keystroke model edits) don't repaint.
+        public void SetLevel(long usedTokens, int maxTokens)
+        {
+            if (usedTokens < 0) usedTokens = 0;
+            if (_used == usedTokens && _max == maxTokens) return;
+            _used = usedTokens;
+            _max = maxTokens;
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            Graphics g = e.Graphics;
+            int w = this.Width, h = this.Height;
+
+            using (SolidBrush track = new SolidBrush(TrackColor))
+                g.FillRectangle(track, 0, 0, w, h);
+            using (Pen border = new Pen(BorderColor))
+                g.DrawRectangle(border, 0, 0, w - 1, h - 1);
+
+            double frac = (_max > 0) ? (double)_used / _max : 0.0;
+            if (frac < 0.0) frac = 0.0;
+            if (frac > 1.0) frac = 1.0; // a request can overshoot the window (provider trims)
+            int lit = (int)Math.Round(frac * BlockCount, MidpointRounding.AwayFromZero);
+
+            Color fill = frac < 0.70 ? GreenFill : (frac < 0.90 ? YellowFill : RedFill);
+            int blockHeight = h - 2 * Inset;
+            using (SolidBrush on = new SolidBrush(fill))
+            using (SolidBrush off = new SolidBrush(EmptyBlockColor))
+            {
+                int bx = Inset;
+                for (int i = 0; i < BlockCount; i++)
+                {
+                    g.FillRectangle(i < lit ? on : off, bx, Inset, BlockWidth, blockHeight);
+                    bx += BlockWidth + BlockGap;
+                }
+            }
+        }
+    }
+}

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -78,7 +78,7 @@
             this.ssMain = new System.Windows.Forms.StatusStrip();
             this.tslSpring = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
-            this.tspContextMeter = new System.Windows.Forms.ToolStripProgressBar();
+            this.tspContextMeter = new GxPT.ContextMeterItem();
             this.tslContextValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCost = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCostValue = new System.Windows.Forms.ToolStripStatusLabel();
@@ -572,15 +572,12 @@
             //
             // tspContextMeter
             //
-            this.tspContextMeter.AutoSize = false;
             // Right margin offsets tslContextValue's -2 (which tucks the value against the
             // caption when the meter is hidden) so a 3px gap survives when the meter shows.
             this.tspContextMeter.Margin = new System.Windows.Forms.Padding(5, 4, 5, 3);
             this.tspContextMeter.Name = "tspContextMeter";
-            this.tspContextMeter.Size = new System.Drawing.Size(80, 15);
-            // Continuous (PBS_SMOOTH) matters because the control is un-themed at runtime (see
-            // ApplyContextMeterRendering): classic rendering would otherwise draw segmented blocks.
-            this.tspContextMeter.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            // Width is dictated by the item's block geometry (ContextMeterItem.MeterWidth).
+            this.tspContextMeter.Size = new System.Drawing.Size(81, 15);
             this.tspContextMeter.Visible = false;
             //
             // tslContextValue
@@ -702,7 +699,7 @@
         private System.Windows.Forms.StatusStrip ssMain;
         private System.Windows.Forms.ToolStripStatusLabel tslSpring;
         private System.Windows.Forms.ToolStripStatusLabel tslContext;
-        private System.Windows.Forms.ToolStripProgressBar tspContextMeter;
+        private ContextMeterItem tspContextMeter;
         private System.Windows.Forms.ToolStripStatusLabel tslCost;
         private System.Windows.Forms.ToolStripStatusLabel tslContextValue;
         private System.Windows.Forms.ToolStripStatusLabel tslCostValue;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -78,6 +78,7 @@
             this.ssMain = new System.Windows.Forms.StatusStrip();
             this.tslSpring = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tspContextMeter = new System.Windows.Forms.ToolStripProgressBar();
             this.tslContextValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCost = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslCostValue = new System.Windows.Forms.ToolStripStatusLabel();
@@ -545,6 +546,7 @@
             this.ssMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tslSpring,
             this.tslContext,
+            this.tspContextMeter,
             this.tslContextValue,
             this.tslCost,
             this.tslCostValue,
@@ -567,6 +569,16 @@
             //
             this.tslContext.Name = "tslContext";
             this.tslContext.Size = new System.Drawing.Size(0, 17);
+            //
+            // tspContextMeter
+            //
+            this.tspContextMeter.AutoSize = false;
+            // Right margin offsets tslContextValue's -2 (which tucks the value against the
+            // caption when the meter is hidden) so a 3px gap survives when the meter shows.
+            this.tspContextMeter.Margin = new System.Windows.Forms.Padding(5, 4, 5, 3);
+            this.tspContextMeter.Name = "tspContextMeter";
+            this.tspContextMeter.Size = new System.Drawing.Size(80, 15);
+            this.tspContextMeter.Visible = false;
             //
             // tslContextValue
             //
@@ -687,6 +699,7 @@
         private System.Windows.Forms.StatusStrip ssMain;
         private System.Windows.Forms.ToolStripStatusLabel tslSpring;
         private System.Windows.Forms.ToolStripStatusLabel tslContext;
+        private System.Windows.Forms.ToolStripProgressBar tspContextMeter;
         private System.Windows.Forms.ToolStripStatusLabel tslCost;
         private System.Windows.Forms.ToolStripStatusLabel tslContextValue;
         private System.Windows.Forms.ToolStripStatusLabel tslCostValue;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -578,6 +578,9 @@
             this.tspContextMeter.Margin = new System.Windows.Forms.Padding(5, 4, 5, 3);
             this.tspContextMeter.Name = "tspContextMeter";
             this.tspContextMeter.Size = new System.Drawing.Size(80, 15);
+            // Continuous (PBS_SMOOTH) matters because the control is un-themed at runtime (see
+            // ApplyContextMeterRendering): classic rendering would otherwise draw segmented blocks.
+            this.tspContextMeter.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.tspContextMeter.Visible = false;
             //
             // tslContextValue

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -75,6 +75,14 @@ namespace GxPT
             _inputManager.SetHintText();
             InitUsageStatusBar();
 
+            // Daily, non-blocking refresh of the model context-size catalog (the status bar's
+            // context meter divides by it). The updated event lands on the fetch worker thread;
+            // repaint the strip so meters appear as soon as sizes are known - including the
+            // first-launch case where the strip starts meterless.
+            ModelCatalogService.CatalogUpdated += ModelCatalog_Updated;
+            try { ModelCatalogService.RefreshIfDue(); }
+            catch { }
+
             // Wire banner link and ensure it lays out nicely
             if (this.lnkOpenSettings != null)
                 this.lnkOpenSettings.LinkClicked += lnkOpenSettings_LinkClicked;
@@ -3430,6 +3438,8 @@ namespace GxPT
                         if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
                     }
                 }
+                // The context meter's denominator follows the selected model.
+                SyncUsageStatusFromActiveTab();
             }
             catch { }
         }
@@ -3451,6 +3461,8 @@ namespace GxPT
                         if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
                     }
                 }
+                // The context meter's denominator follows the typed model id.
+                SyncUsageStatusFromActiveTab();
             }
             catch { }
         }
@@ -4709,6 +4721,22 @@ namespace GxPT
             catch { }
         }
 
+        // The model catalog finished a background fetch (worker thread): marshal to the UI
+        // thread and repaint the active tab's Context pane so the meter (dis)appears promptly.
+        private void ModelCatalog_Updated()
+        {
+            try
+            {
+                if (IsDisposed || !IsHandleCreated) return;
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try { SyncUsageStatusFromActiveTab(); }
+                    catch { }
+                });
+            }
+            catch { }
+        }
+
         // Records a response's streamed usage (instant feedback), then reconciles it against
         // OpenRouter's authoritative generation record on a background thread. cache_discount
         // never arrives on the stream, so the generation record is the Saved figure's only data
@@ -4809,6 +4837,16 @@ namespace GxPT
             // and the strip looks broken until the first response arrives.
             UsageStats s = (convo != null) ? convo.GetUsageStats() : new UsageStats();
 
+            // The context meter needs the model's context window. Prefer the conversation's own
+            // model (it tracks the combo and survives tab switches); fall back to whatever the
+            // combo shows for a tab that hasn't picked one yet. Unknown models (catalog not yet
+            // fetched, or a model OpenRouter no longer lists) get no meter, just the token count.
+            string meterModel = (convo != null && !string.IsNullOrEmpty(convo.SelectedModel))
+                ? convo.SelectedModel : GetSelectedModel();
+            int maxContext;
+            bool haveMax = ModelCatalogService.TryGetContextLength(meterModel, out maxContext)
+                && maxContext > 0;
+
             // Every pane is a caption label + value label pair: the Saved pane needs the split so
             // only the amount carries the health color, and the other two match it so all three
             // panes share identical caption/value spacing. Captions (with the dividers) stay
@@ -4816,8 +4854,21 @@ namespace GxPT
             // net negative (write premiums not yet amortized by reads), neutral at zero.
             if (this.tslContext != null)
                 this.tslContext.Text = "Context:";
+            if (this.tspContextMeter != null)
+            {
+                this.tspContextMeter.Visible = haveMax;
+                if (haveMax)
+                {
+                    int pct = (int)Math.Round(100.0 * s.LastPromptTokens / maxContext);
+                    if (pct < 0) pct = 0;
+                    if (pct > 100) pct = 100; // a request can overshoot the window (provider trims)
+                    this.tspContextMeter.Value = pct;
+                }
+            }
             if (this.tslContextValue != null)
-                this.tslContextValue.Text = FormatTokenCount(s.LastPromptTokens) + " tok";
+                this.tslContextValue.Text = haveMax
+                    ? FormatTokenCount(s.LastPromptTokens) + " / " + FormatTokenCount(maxContext)
+                    : FormatTokenCount(s.LastPromptTokens) + " tok";
             if (this.tslCost != null)
                 this.tslCost.Text = "Cost:";
             if (this.tslCostValue != null)
@@ -4831,13 +4882,13 @@ namespace GxPT
                     : (s.TotalCacheDiscount < 0 ? Color.Firebrick : SystemColors.ControlText);
             }
 
-            string breakdown = BuildUsageTooltip(s);
-            ToolStripStatusLabel[] panes = new ToolStripStatusLabel[]
+            string breakdown = BuildUsageTooltip(s, haveMax ? maxContext : 0);
+            ToolStripItem[] panes = new ToolStripItem[]
             {
-                this.tslContext, this.tslContextValue, this.tslCost, this.tslCostValue,
-                this.tslSaved, this.tslSavedValue
+                this.tslContext, this.tspContextMeter, this.tslContextValue,
+                this.tslCost, this.tslCostValue, this.tslSaved, this.tslSavedValue
             };
-            foreach (ToolStripStatusLabel pane in panes)
+            foreach (ToolStripItem pane in panes)
                 if (pane != null) pane.ToolTipText = breakdown;
         }
 
@@ -4845,10 +4896,18 @@ namespace GxPT
         // glanceable panes deliberately omit them - "last request" vs "lifetime" is ambiguous at a
         // glance next to running totals). Short bulleted lines on purpose: the native tooltip
         // word-wraps long lines at an arbitrary width, which mangled the prose layout.
-        internal static string BuildUsageTooltip(UsageStats s)
+        // maxContext is the model's context window in tokens; 0 = unknown (line omitted).
+        internal static string BuildUsageTooltip(UsageStats s, int maxContext)
         {
             var inv = System.Globalization.CultureInfo.InvariantCulture;
             var sb = new System.Text.StringBuilder();
+            if (maxContext > 0)
+            {
+                sb.Append("Model context window: ").Append(maxContext.ToString("N0", inv)).Append(" tokens");
+                if (s.LastPromptTokens > 0)
+                    sb.Append(" (").Append((100.0 * s.LastPromptTokens / maxContext).ToString("0", inv)).Append("% used)");
+                sb.Append("\r\n\r\n");
+            }
             sb.Append("Last request:");
             sb.Append("\r\n- ").Append(s.LastPromptTokens.ToString("N0", inv)).Append(" prompt tokens");
             sb.Append("\r\n- ").Append(s.LastCachedTokens.ToString("N0", inv)).Append(" read from cache");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4676,45 +4676,47 @@ namespace GxPT
                 bool visible = AppSettings.GetBool("statusbar_visible", true);
                 if (this.ssMain != null) this.ssMain.Visible = visible;
                 if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
-                SuppressContextMeterPulse();
+                // Un-theme the meter the moment its native control exists. The handle is created
+                // lazily (a hidden-at-startup item may not get one until the strip first lays it
+                // out), so a one-shot here can run before there is anything to un-theme - hence
+                // the hook plus the re-check on every strip update in UpdateUsageStatusStrip.
+                ProgressBar meterBar = (this.tspContextMeter != null) ? this.tspContextMeter.ProgressBar : null;
+                if (meterBar != null) meterBar.HandleCreated += delegate { ApplyContextMeterRendering(); };
+                ApplyContextMeterRendering();
                 ApplyThemeToStatusBar();
                 SyncUsageStatusFromActiveTab();
             }
             catch { }
         }
 
-        // ---- context meter pulse suppression ----
+        // ---- context meter rendering ----
         // Vista/7's themed progress bar periodically sweeps a highlight ("pulse") across the
         // fill even when the value never changes - distracting on a meter that's meant to sit
-        // still. PBM_SETSTATE -> PBST_PAUSED stops that animation. CAVEAT under evaluation:
-        // Win7 renders a paused bar amber/yellow instead of green; if that reads as a warning,
-        // the fallback plan is to un-theme the control (SetWindowTheme) instead. Harmlessly
-        // ignored on XP/classic rendering, where the pulse doesn't exist.
+        // still. (PBM_SETSTATE/PBST_PAUSED stopped it, but painted the bar amber - reads as a
+        // warning.) Un-theming just this control makes Windows render it classic-style: a flat,
+        // animation-free fill (solid, not segmented, thanks to the Continuous style set in the
+        // designer). XP loses the themed chrome on this one control too, which suits the status
+        // strip's plain system look.
 
-        private const int PBM_SETSTATE = 0x0410; // WM_USER + 16
-        private const int PBST_PAUSED = 0x0003;
+        [System.Runtime.InteropServices.DllImport("uxtheme.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+        // The native handle the un-theme was last applied to. Guards both repeats (each
+        // SetWindowTheme call triggers a WM_THEMECHANGED repaint) and handle recreations,
+        // which discard the un-theme and would otherwise bring the pulse back.
+        private IntPtr _contextMeterUnthemed = IntPtr.Zero;
 
-        private void SuppressContextMeterPulse()
+        private void ApplyContextMeterRendering()
         {
             try
             {
-                if (this.tspContextMeter == null) return;
-                ProgressBar bar = this.tspContextMeter.ProgressBar;
-                if (bar == null) return;
-                // The state lives on the native control, so it must be (re)applied every time
-                // WinForms creates the handle - recreations (e.g. a RecreateHandle) reset it.
-                bar.HandleCreated += delegate { SetContextMeterPaused(bar); };
-                if (bar.IsHandleCreated) SetContextMeterPaused(bar);
+                ProgressBar bar = (this.tspContextMeter != null) ? this.tspContextMeter.ProgressBar : null;
+                if (bar == null || !bar.IsHandleCreated) return;
+                IntPtr h = bar.Handle;
+                if (h == _contextMeterUnthemed) return;
+                SetWindowTheme(h, string.Empty, string.Empty);
+                _contextMeterUnthemed = h;
             }
-            catch { }
-        }
-
-        private static void SetContextMeterPaused(ProgressBar bar)
-        {
-            try { SendMessage(bar.Handle, PBM_SETSTATE, new IntPtr(PBST_PAUSED), IntPtr.Zero); }
             catch { }
         }
 
@@ -4893,6 +4895,9 @@ namespace GxPT
             if (this.tspContextMeter != null)
             {
                 this.tspContextMeter.Visible = haveMax;
+                // Becoming visible can create the native control on the spot; make sure the
+                // un-theme has landed on this handle (no-op when already applied).
+                ApplyContextMeterRendering();
                 if (haveMax)
                 {
                     int pct = (int)Math.Round(100.0 * s.LastPromptTokens / maxContext);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4676,46 +4676,8 @@ namespace GxPT
                 bool visible = AppSettings.GetBool("statusbar_visible", true);
                 if (this.ssMain != null) this.ssMain.Visible = visible;
                 if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
-                // Un-theme the meter the moment its native control exists. The handle is created
-                // lazily (a hidden-at-startup item may not get one until the strip first lays it
-                // out), so a one-shot here can run before there is anything to un-theme - hence
-                // the hook plus the re-check on every strip update in UpdateUsageStatusStrip.
-                ProgressBar meterBar = (this.tspContextMeter != null) ? this.tspContextMeter.ProgressBar : null;
-                if (meterBar != null) meterBar.HandleCreated += delegate { ApplyContextMeterRendering(); };
-                ApplyContextMeterRendering();
                 ApplyThemeToStatusBar();
                 SyncUsageStatusFromActiveTab();
-            }
-            catch { }
-        }
-
-        // ---- context meter rendering ----
-        // Vista/7's themed progress bar periodically sweeps a highlight ("pulse") across the
-        // fill even when the value never changes - distracting on a meter that's meant to sit
-        // still. (PBM_SETSTATE/PBST_PAUSED stopped it, but painted the bar amber - reads as a
-        // warning.) Un-theming just this control makes Windows render it classic-style: a flat,
-        // animation-free fill (solid, not segmented, thanks to the Continuous style set in the
-        // designer). XP loses the themed chrome on this one control too, which suits the status
-        // strip's plain system look.
-
-        [System.Runtime.InteropServices.DllImport("uxtheme.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
-
-        // The native handle the un-theme was last applied to. Guards both repeats (each
-        // SetWindowTheme call triggers a WM_THEMECHANGED repaint) and handle recreations,
-        // which discard the un-theme and would otherwise bring the pulse back.
-        private IntPtr _contextMeterUnthemed = IntPtr.Zero;
-
-        private void ApplyContextMeterRendering()
-        {
-            try
-            {
-                ProgressBar bar = (this.tspContextMeter != null) ? this.tspContextMeter.ProgressBar : null;
-                if (bar == null || !bar.IsHandleCreated) return;
-                IntPtr h = bar.Handle;
-                if (h == _contextMeterUnthemed) return;
-                SetWindowTheme(h, string.Empty, string.Empty);
-                _contextMeterUnthemed = h;
             }
             catch { }
         }
@@ -4895,16 +4857,7 @@ namespace GxPT
             if (this.tspContextMeter != null)
             {
                 this.tspContextMeter.Visible = haveMax;
-                // Becoming visible can create the native control on the spot; make sure the
-                // un-theme has landed on this handle (no-op when already applied).
-                ApplyContextMeterRendering();
-                if (haveMax)
-                {
-                    int pct = (int)Math.Round(100.0 * s.LastPromptTokens / maxContext);
-                    if (pct < 0) pct = 0;
-                    if (pct > 100) pct = 100; // a request can overshoot the window (provider trims)
-                    this.tspContextMeter.Value = pct;
-                }
+                if (haveMax) this.tspContextMeter.SetLevel(s.LastPromptTokens, maxContext);
             }
             if (this.tslContextValue != null)
                 this.tslContextValue.Text = haveMax

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4676,9 +4676,45 @@ namespace GxPT
                 bool visible = AppSettings.GetBool("statusbar_visible", true);
                 if (this.ssMain != null) this.ssMain.Visible = visible;
                 if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
+                SuppressContextMeterPulse();
                 ApplyThemeToStatusBar();
                 SyncUsageStatusFromActiveTab();
             }
+            catch { }
+        }
+
+        // ---- context meter pulse suppression ----
+        // Vista/7's themed progress bar periodically sweeps a highlight ("pulse") across the
+        // fill even when the value never changes - distracting on a meter that's meant to sit
+        // still. PBM_SETSTATE -> PBST_PAUSED stops that animation. CAVEAT under evaluation:
+        // Win7 renders a paused bar amber/yellow instead of green; if that reads as a warning,
+        // the fallback plan is to un-theme the control (SetWindowTheme) instead. Harmlessly
+        // ignored on XP/classic rendering, where the pulse doesn't exist.
+
+        private const int PBM_SETSTATE = 0x0410; // WM_USER + 16
+        private const int PBST_PAUSED = 0x0003;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        private void SuppressContextMeterPulse()
+        {
+            try
+            {
+                if (this.tspContextMeter == null) return;
+                ProgressBar bar = this.tspContextMeter.ProgressBar;
+                if (bar == null) return;
+                // The state lives on the native control, so it must be (re)applied every time
+                // WinForms creates the handle - recreations (e.g. a RecreateHandle) reset it.
+                bar.HandleCreated += delegate { SetContextMeterPaused(bar); };
+                if (bar.IsHandleCreated) SetContextMeterPaused(bar);
+            }
+            catch { }
+        }
+
+        private static void SetContextMeterPaused(ProgressBar bar)
+        {
+            try { SendMessage(bar.Handle, PBM_SETSTATE, new IntPtr(PBST_PAUSED), IntPtr.Zero); }
             catch { }
         }
 

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -48,6 +48,7 @@
             this.grpRecommended = new System.Windows.Forms.GroupBox();
             this.btnAddRecommended = new System.Windows.Forms.Button();
             this.btnReplaceRecommended = new System.Windows.Forms.Button();
+            this.btnUpdateModelInfo = new System.Windows.Forms.Button();
             this.cmbDefaultModel = new System.Windows.Forms.ComboBox();
             this.cmbTheme = new System.Windows.Forms.ComboBox();
             this.nudTranscriptMaxWidth = new System.Windows.Forms.NumericUpDown();
@@ -302,6 +303,7 @@
             // pnlModelsRight
             // 
             this.pnlModelsRight.Controls.Add(this.grpRecommended);
+            this.pnlModelsRight.Controls.Add(this.btnUpdateModelInfo);
             this.pnlModelsRight.Dock = System.Windows.Forms.DockStyle.Right;
             this.pnlModelsRight.Location = new System.Drawing.Point(274, 0);
             this.pnlModelsRight.Name = "pnlModelsRight";
@@ -338,9 +340,19 @@
             this.btnReplaceRecommended.TabIndex = 1;
             this.btnReplaceRecommended.Text = "Replace list...";
             this.btnReplaceRecommended.UseVisualStyleBackColor = true;
-            // 
+            //
+            // btnUpdateModelInfo
+            //
+            this.btnUpdateModelInfo.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.btnUpdateModelInfo.Location = new System.Drawing.Point(4, 99);
+            this.btnUpdateModelInfo.Name = "btnUpdateModelInfo";
+            this.btnUpdateModelInfo.Size = new System.Drawing.Size(185, 23);
+            this.btnUpdateModelInfo.TabIndex = 22;
+            this.btnUpdateModelInfo.Text = "Update Model Info";
+            this.btnUpdateModelInfo.UseVisualStyleBackColor = true;
+            //
             // cmbDefaultModel
-            // 
+            //
             this.cmbDefaultModel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cmbDefaultModel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbDefaultModel.DropDownWidth = 175;
@@ -789,6 +801,7 @@
         private System.Windows.Forms.GroupBox grpRecommended;
         private System.Windows.Forms.Button btnAddRecommended;
         private System.Windows.Forms.Button btnReplaceRecommended;
+        private System.Windows.Forms.Button btnUpdateModelInfo;
         private System.Windows.Forms.TextBox txtApiKey;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabVisual;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -116,6 +116,10 @@ namespace GxPT
                 this.btnAddRecommended.Click += BtnAddRecommended_Click;
             if (this.btnReplaceRecommended != null)
                 this.btnReplaceRecommended.Click += BtnReplaceRecommended_Click;
+            // Manual re-fetch of OpenRouter's model metadata (context window sizes) - the same
+            // fetch that runs automatically once a day at app open.
+            if (this.btnUpdateModelInfo != null)
+                this.btnUpdateModelInfo.Click += BtnUpdateModelInfo_Click;
             try
             {
                 _mcpTip.SetToolTip(this.btnAddRecommended,
@@ -123,6 +127,9 @@ namespace GxPT
                 _mcpTip.SetToolTip(this.btnReplaceRecommended,
                     "Replace your list with GxPT's latest recommended models, removing any that are no longer "
                     + "available. Nothing is saved until you click Save.");
+                _mcpTip.SetToolTip(this.btnUpdateModelInfo,
+                    "Re-download each model's context window size from OpenRouter now (also refreshed "
+                    + "automatically once a day). The status bar's context meter uses these.");
             }
             catch { }
 
@@ -1114,6 +1121,41 @@ namespace GxPT
 
             // Setting Lines fires TxtModels_TextChanged, which refreshes the combo and button states.
             this.txtModels.Lines = result.ToArray();
+        }
+
+        // Force-refresh the model context-size catalog (ModelCatalogService) in the background.
+        // The button doubles as the progress indicator; quiet on success (the status bar's
+        // context meter updates by itself via CatalogUpdated), a message box only on failure -
+        // the one case where the user, who explicitly asked, would otherwise see nothing happen.
+        private void BtnUpdateModelInfo_Click(object sender, EventArgs e)
+        {
+            var btn = this.btnUpdateModelInfo;
+            if (btn == null || !btn.Enabled) return;
+            string idleText = btn.Text;
+            btn.Enabled = false;
+            btn.Text = "Updating...";
+            ModelCatalogService.ForceRefresh(delegate(bool ok)
+            {
+                // Worker thread; the form may have been closed while the fetch ran.
+                try
+                {
+                    if (IsDisposed || !IsHandleCreated) return;
+                    BeginInvoke((MethodInvoker)delegate
+                    {
+                        try
+                        {
+                            btn.Text = idleText;
+                            btn.Enabled = true;
+                            if (!ok)
+                                MessageBox.Show(this,
+                                    "Could not update model info from OpenRouter. Check your network connection and try again.",
+                                    "Update Model Info", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        }
+                        catch { }
+                    });
+                }
+                catch { }
+            });
         }
 
         // Replace the entire list with the shipped catalog. Confirmed because it discards the user's

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -163,6 +163,9 @@
     <Compile Include="Controls\GenerationStatusBar.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\ContextMeterItem.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\WorkspaceContextStrip.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Models\ChatModels.cs" />
     <Compile Include="Models\Conversation.cs" />
     <Compile Include="Models\ModelDefaults.cs" />
+    <Compile Include="Services\ModelCatalogService.cs" />
     <Compile Include="Data\ConversationStore.cs" />
     <Compile Include="Forms\FileViewerForm.cs">
       <SubType>Form</SubType>

--- a/GxPT/Services/ModelCatalogService.cs
+++ b/GxPT/Services/ModelCatalogService.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // Each OpenRouter model's context window size, for the status bar's context meter.
+    // OpenRouter has no single-model endpoint, so the full GET /api/v1/models list (public, no
+    // auth) is fetched at most once per RefreshInterval when the app opens - always on a
+    // background thread, never blocking the UI - and persisted as a plain "id<TAB>tokens" line
+    // file under %AppData%\GxPT: dependency-free, XP-safe, and readable in Notepad. Until the
+    // first fetch completes (fresh install, or a model missing from the list - e.g. one the user
+    // added before today's fetch landed), TryGetContextLength misses and the status bar falls
+    // back to the bare token count without the meter.
+    internal static class ModelCatalogService
+    {
+        // Raised (on the fetch worker thread) after a fetch actually changed the in-memory map;
+        // the UI marshals to its own thread and repaints the context meter.
+        public static event Action CatalogUpdated;
+
+        private const string CatalogFileName = "model-context.txt";
+        private const string ModelsUrl = "https://openrouter.ai/api/v1/models";
+        // Once daily: context windows change rarely (new model releases), and the Settings
+        // dialog's Update Model Info button covers the impatient case.
+        private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
+
+        // model id -> context tokens, loaded lazily from the catalog file and replaced wholesale
+        // by a successful fetch. Guarded by _gate (lookups ride the UI thread, fetches don't).
+        private static readonly object _gate = new object();
+        private static Dictionary<string, int> _map;
+        private static int _refreshing; // 1 while a fetch thread is running (Interlocked)
+
+        public static string CatalogPath
+        {
+            get { return Path.Combine(AppSettings.SettingsDirectory, CatalogFileName); }
+        }
+
+        // The context window for a model id as configured by the user: tries the id verbatim,
+        // then without the "~" alias marker, then without an OpenRouter ":variant" suffix (e.g.
+        // ":nitro" routing variants that aren't separate catalog entries; ":free" usually is one
+        // and matches verbatim). False when the catalog simply doesn't know the model yet.
+        public static bool TryGetContextLength(string model, out int contextLength)
+        {
+            contextLength = 0;
+            if (string.IsNullOrEmpty(model)) return false;
+            string id = model.Trim();
+            if (id.Length == 0) return false;
+
+            lock (_gate)
+            {
+                EnsureLoadedLocked();
+                if (_map.TryGetValue(id, out contextLength)) return true;
+                if (id.StartsWith("~", StringComparison.Ordinal))
+                {
+                    id = id.Substring(1);
+                    if (_map.TryGetValue(id, out contextLength)) return true;
+                }
+                int colon = id.LastIndexOf(':');
+                if (colon > 0 && _map.TryGetValue(id.Substring(0, colon), out contextLength)) return true;
+            }
+            contextLength = 0;
+            return false;
+        }
+
+        // App-open refresh: fetch only when the on-disk catalog is missing or older than
+        // RefreshInterval. Returns immediately; the fetch (if any) runs on a background thread.
+        public static void RefreshIfDue()
+        {
+            StartRefresh(false, null);
+        }
+
+        // Settings' Update Model Info button: fetch now regardless of age. onDone(success) is
+        // invoked on the worker thread when the fetch finishes (immediately with false if a
+        // refresh is already running, so the button can re-enable).
+        public static void ForceRefresh(Action<bool> onDone)
+        {
+            StartRefresh(true, onDone);
+        }
+
+        private static void StartRefresh(bool force, Action<bool> onDone)
+        {
+            if (!force && !IsStale()) return;
+            // One fetch at a time; a second request while one is in flight just reports failure
+            // (the running fetch's result will arrive moments later anyway).
+            if (System.Threading.Interlocked.CompareExchange(ref _refreshing, 1, 0) != 0)
+            {
+                if (onDone != null) { try { onDone(false); } catch { } }
+                return;
+            }
+            var worker = new System.Threading.Thread(delegate()
+            {
+                bool ok = false;
+                try { ok = FetchAndStore(); }
+                catch (Exception ex)
+                {
+                    try { Logger.Log("Models", "catalog refresh failed: " + ex.Message); }
+                    catch { }
+                }
+                finally
+                {
+                    System.Threading.Interlocked.Exchange(ref _refreshing, 0);
+                    if (onDone != null) { try { onDone(ok); } catch { } }
+                }
+            });
+            worker.IsBackground = true; // never holds the app open
+            worker.Name = "ModelCatalogRefresh";
+            worker.Start();
+        }
+
+        private static bool IsStale()
+        {
+            try
+            {
+                string path = CatalogPath;
+                if (!File.Exists(path)) return true;
+                return (DateTime.UtcNow - File.GetLastWriteTimeUtc(path)) >= RefreshInterval;
+            }
+            catch { return true; }
+        }
+
+        // Must be called while holding _gate.
+        private static void EnsureLoadedLocked()
+        {
+            if (_map != null) return;
+            string text = null;
+            try
+            {
+                string path = CatalogPath;
+                if (File.Exists(path)) text = File.ReadAllText(path, Encoding.UTF8);
+            }
+            catch { }
+            _map = ParseCatalogFile(text);
+        }
+
+        // Blocking fetch + parse + persist; runs on the worker thread only. A failed or empty
+        // fetch keeps the previous catalog (stale context sizes beat no context sizes).
+        private static bool FetchAndStore()
+        {
+            string body = HttpGetModels();
+            if (string.IsNullOrEmpty(body))
+            {
+                try { Logger.Log("Models", "catalog fetch returned no body"); }
+                catch { }
+                return false;
+            }
+            Dictionary<string, int> fetched = ParseModelsJson(body);
+            if (fetched == null || fetched.Count == 0)
+            {
+                try { Logger.Log("Models", "catalog fetch parsed no models (len=" + body.Length + ")"); }
+                catch { }
+                return false;
+            }
+
+            try { FileSafe.WriteAllTextAtomic(CatalogPath, FormatCatalogFile(fetched), new UTF8Encoding(false)); }
+            catch (Exception ex)
+            {
+                // Keep the in-memory update even if the disk write failed; next launch refetches.
+                try { Logger.Log("Models", "catalog write failed: " + ex.Message); }
+                catch { }
+            }
+
+            lock (_gate) { _map = fetched; }
+            try { Logger.Log("Models", "catalog updated: " + fetched.Count + " models"); }
+            catch { }
+
+            Action h = CatalogUpdated;
+            if (h != null) { try { h(); } catch { } }
+            return true;
+        }
+
+        // GET /api/v1/models via the bundled curl (no auth header needed - the endpoint is
+        // public, so this works before an API key is configured). --max-time bounds a hung
+        // connection so the refresh latch can't stay held forever.
+        private static string HttpGetModels()
+        {
+            string curlPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Lib\\curl.exe");
+            if (!File.Exists(curlPath)) return null;
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = curlPath,
+                Arguments = "-sS --fail-with-body --max-time 60 " + ModelsUrl,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using (var p = Process.Start(psi))
+            {
+                var utf8 = new UTF8Encoding(false, false);
+                string output;
+                using (var outReader = new StreamReader(p.StandardOutput.BaseStream, utf8, false))
+                    output = outReader.ReadToEnd();
+                try { p.StandardError.ReadToEnd(); }
+                catch { }
+                p.WaitForExit();
+                int exitCode = -1;
+                try { exitCode = p.ExitCode; }
+                catch { }
+                if (exitCode != 0)
+                {
+                    try { Logger.Log("Models", "catalog fetch curl exit=" + exitCode); }
+                    catch { }
+                    return null;
+                }
+                return output;
+            }
+        }
+
+        // { "data": [ { "id": "anthropic/...", "context_length": 200000, ... }, ... ] }
+        // -> id -> context_length. Entries without a positive context_length are skipped (they
+        // can't drive a meter). Null when the payload isn't the expected shape.
+        internal static Dictionary<string, int> ParseModelsJson(string json)
+        {
+            JObject root;
+            try { root = JObject.Parse(json); }
+            catch { return null; }
+            JArray data = root["data"] as JArray;
+            if (data == null) return null;
+
+            var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (JToken item in data)
+            {
+                if (item == null || item.Type != JTokenType.Object) continue;
+                JToken idTok = item["id"];
+                if (idTok == null || idTok.Type != JTokenType.String) continue;
+                string id = ((string)idTok ?? string.Empty).Trim();
+                if (id.Length == 0) continue;
+                JToken len = item["context_length"];
+                if (len == null || (len.Type != JTokenType.Integer && len.Type != JTokenType.Float)) continue;
+                int ctx;
+                try { ctx = (int)len; }
+                catch { continue; }
+                if (ctx > 0) map[id] = ctx;
+            }
+            return map;
+        }
+
+        // One "id<TAB>tokens" line per model, sorted by id so successive fetches diff cleanly.
+        internal static string FormatCatalogFile(Dictionary<string, int> map)
+        {
+            var ids = new List<string>(map.Keys);
+            ids.Sort(StringComparer.Ordinal);
+            var sb = new StringBuilder();
+            foreach (string id in ids)
+                sb.Append(id).Append('\t').Append(map[id].ToString(System.Globalization.CultureInfo.InvariantCulture)).Append('\n');
+            return sb.ToString();
+        }
+
+        // Tolerant inverse of FormatCatalogFile: blank lines, "#" comments, and lines that don't
+        // parse are skipped, so a hand-edited file degrades to missing meters, never a crash.
+        internal static Dictionary<string, int> ParseCatalogFile(string text)
+        {
+            var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(text)) return map;
+            string[] lines = text.Split(new char[] { '\n', '\r' });
+            foreach (string raw in lines)
+            {
+                if (raw == null) continue;
+                string line = raw.Trim();
+                if (line.Length == 0 || line[0] == '#') continue;
+                int tab = line.IndexOf('\t');
+                if (tab <= 0 || tab >= line.Length - 1) continue;
+                string id = line.Substring(0, tab).Trim();
+                int ctx;
+                if (id.Length == 0) continue;
+                if (!int.TryParse(line.Substring(tab + 1).Trim(),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out ctx)) continue;
+                if (ctx > 0) map[id] = ctx;
+            }
+            return map;
+        }
+
+        // Test seam: replace the in-memory map without touching disk.
+        internal static void SetMapForTests(Dictionary<string, int> map)
+        {
+            lock (_gate)
+            {
+                _map = (map != null) ? new Dictionary<string, int>(map, StringComparer.OrdinalIgnoreCase) : null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

The status bar's Context pane gains a meter showing how full the active model's context window is, alongside the existing token count (now rendered as `172.3K / 1.0M`). The hover tooltip gains the model's context window size and percent used.

## How it works

**Context sizes** — OpenRouter has no single-model endpoint, so the new `ModelCatalogService` fetches the full `GET /api/v1/models` list (public, no auth — works before an API key is configured) **at most once a day when the app opens, always on a background thread**. Results persist as a plain `id<TAB>tokens` line file under `%AppData%\GxPT\model-context.txt` — XP-safe, hand-editable, zero new dependencies, written atomically via `FileSafe`. Lookups tolerate the `~` alias marker and `:variant` routing suffixes. A failed or empty fetch keeps the previous catalog.

**Fallback** — until the first fetch lands, or for any model the catalog doesn't know (e.g. one added to the list before today's fetch finished), the meter hides and the pane shows the bare token count exactly as before.

**Manual refresh** — Settings > model section gains an "Update Model Info" button that forces the re-fetch without waiting for the daily cycle (quiet on success; warning box on failure).

**Rendering** — the meter is `ContextMeterItem`, an owner-drawn `ToolStripItem`: a 1px dark-grey border around 13 discrete "LED" blocks, in the style of the classic pre-Vista progress bar. Fill color tracks usage: green below 70% used, yellow 70–90%, red above 90%. Owner-drawing was the third iteration here: the original hosted `ToolStripProgressBar` has an idle "pulse" animation on Vista/7, `PBM_SETSTATE`/paused stopped it but painted the bar amber, and `SetWindowTheme` un-theming worked but needed handle-recreation bookkeeping. Painting the blocks ourselves needs no native control, no theme, no P/Invoke — and the block quantization keeps small token fluctuations from nudging a pixel edge around.

The meter retargets live when the model combo changes and repaints when a background catalog fetch completes mid-session.

## Tests

`ModelCatalogServiceTests` (linked-source, same pattern as the rest of `GxPT.Tests`) covers the `/models` JSON parse including malformed payloads and entries missing `context_length`, the catalog file round-trip and its tolerance for hand-edits, and the alias/variant lookup ladder.

https://claude.ai/code/session_01M46ZegxYRJv1DKJT6BHYUP