### PR TITLE
Inject the workspace root's AGENTS.md into the Zone A stable head

### DIFF
--- a/GxPT.Tests/AgentsFileInjectionTests.cs
+++ b/GxPT.Tests/AgentsFileInjectionTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentsFileInjectionTests : IDisposable
+    {
+        private readonly string _root;
+
+        public AgentsFileInjectionTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_agentsmd_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void Builds_framed_block_from_workspace_root_agents_md()
+        {
+            File.WriteAllText(Path.Combine(_root, "AGENTS.md"), "# Rules\n\nAlways run the tests.\n");
+
+            string block = AgentsFileInjection.Build(_root);
+
+            Assert.NotNull(block);
+            Assert.Contains("AGENTS.md", block);                  // framing names the source
+            Assert.Contains("Always run the tests.", block);      // and carries the content
+            Assert.False(block.EndsWith("\n"));                   // trailing newlines trimmed
+        }
+
+        [Fact]
+        public void No_workspace_no_file_or_empty_file_yields_null()
+        {
+            Assert.Null(AgentsFileInjection.Build(null));
+            Assert.Null(AgentsFileInjection.Build(_root)); // no AGENTS.md present
+
+            File.WriteAllText(Path.Combine(_root, "AGENTS.md"), "");
+            Assert.Null(AgentsFileInjection.Build(_root));
+        }
+
+        [Fact]
+        public void Oversized_file_is_truncated_with_marker()
+        {
+            File.WriteAllText(Path.Combine(_root, "AGENTS.md"), new string('x', 40 * 1024));
+
+            string block = AgentsFileInjection.Build(_root);
+
+            Assert.NotNull(block);
+            Assert.Contains("[AGENTS.md truncated]", block);
+            Assert.True(block.Length < 40 * 1024);
+        }
+    }
+}

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\GxPT\Services\Skills\Skill.cs" Link="Linked\Skills\Skill.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillCatalog.cs" Link="Linked\Skills\SkillCatalog.cs" />
     <Compile Include="..\GxPT\Services\Mcp\MemoryInjection.cs" Link="Linked\Mcp\MemoryInjection.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\AgentsFileInjection.cs" Link="Linked\Mcp\AgentsFileInjection.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillInjection.cs" Link="Linked\Skills\SkillInjection.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillTools.cs" Link="Linked\Skills\SkillTools.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillEnablement.cs" Link="Linked\Skills\SkillEnablement.cs" />

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -103,6 +103,32 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Project_instructions_join_the_stable_head_and_carry_breakpoint_1()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("hi"));
+
+            var orch = New(streamer, reg);
+            orch.ProjectInstructions = "AGENTS.md says: always run the tests.";
+            orch.RunTurn(new List<ChatMessage>(), "hello", new RecordingUi());
+
+            // Zone A: agent prompt, then the project-instructions block as the last head message
+            // (no workspace block here - WorkingDir is unset), so breakpoint #1 rides it and the
+            // tools + system head cache as one prefix.
+            var msgs = streamer.SeenMessages[0];
+            Assert.Equal("system", msgs[0].Role);
+            Assert.Contains("operating as an agent", msgs[0].Content);
+            Assert.Equal("system", msgs[1].Role);
+            Assert.Equal("AGENTS.md says: always run the tests.", msgs[1].Content);
+            Assert.False(msgs[0].CacheControl);
+            Assert.True(msgs[1].CacheControl);   // breakpoint #1: last message of the stable head
+            Assert.Equal("user", msgs[2].Role);  // history starts right after the head
+            Assert.Equal("hello", msgs[2].Content);
+        }
+
+        [Fact]
         public void Intermediate_breakpoints_bridge_long_tool_fanouts()
         {
             // A single iteration with K tool calls appends ~2K+1 content blocks; beyond Anthropic's

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2488,6 +2488,12 @@ namespace GxPT
                         if (asList == null) asList = new List<ChatMessage>(h);
                         return BuildMessagesForModel(asList);
                     };
+                    // AGENTS.md: inject the workspace root's project instructions into the stable
+                    // head (Zone A - cached, so a large file bills once per conversation). Read
+                    // once per send, here on the worker thread, so the block stays byte-identical
+                    // across the turn's loop iterations; an edit takes effect on the next turn.
+                    orch.ProjectInstructions = AgentsFileInjection.Build(ctx.WorkingDir);
+
                     // Inject the workspace's persistent memory index (rebuilt from .gxpt/memory.md each
                     // request) only when memory is enabled and this conversation has a workspace.
                     if (AppSettings.GetBool("mcp_memory_enabled", false) && !string.IsNullOrEmpty(ctx.WorkingDir))

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Services\Mcp\McpServerSpec.cs" />
     <Compile Include="Services\Mcp\McpConfig.cs" />
     <Compile Include="Services\Mcp\MemoryInjection.cs" />
+    <Compile Include="Services\Mcp\AgentsFileInjection.cs" />
     <Compile Include="Services\Mcp\GitProbe.cs" />
     <Compile Include="Services\Mcp\MsBuildProbe.cs" />
     <Compile Include="Services\Mcp\IServerConnector.cs" />

--- a/GxPT/Services/Mcp/AgentsFileInjection.cs
+++ b/GxPT/Services/Mcp/AgentsFileInjection.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace GxPT
+{
+    // Host side of AGENTS.md support: reads the workspace root's AGENTS.md (the cross-tool
+    // convention for per-project agent instructions) and wraps it with framing for injection as a
+    // stable-head system message (McpChatOrchestrator.ProjectInstructions, Zone A of the prompt-
+    // caching layout). Zone A rather than the ephemeral tail because the file can be large and
+    // changes on a documentation cadence: cached it bills once per conversation, while Zone C
+    // would re-bill it on every request. The host reads it once per send, so an on-disk edit
+    // takes effect on the next turn at the cost of one cache prefix re-write - the same class of
+    // event as a workspace change (docs/prompt-caching-design.md sec.6).
+    internal static class AgentsFileInjection
+    {
+        public const string FileName = "AGENTS.md";
+
+        // Cap the read so a runaway file can't dominate the prompt. More generous than the memory
+        // index cap: this content lives in the cached prefix, billed once per conversation rather
+        // than per request.
+        private const int MaxChars = 32 * 1024;
+
+        // Build the AGENTS.md system block for a workspace. Null when there is no workspace, no
+        // AGENTS.md, or the file is empty/unreadable, so a project without one leaves no trace
+        // in context.
+        public static string Build(string workingDir)
+        {
+            string text = ReadFile(workingDir);
+            if (string.IsNullOrEmpty(text)) return null;
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The workspace root contains an AGENTS.md file with project-specific ");
+            sb.Append("instructions for agents. Follow these instructions while working in ");
+            sb.Append("this workspace:\n\n");
+            sb.Append(text);
+            return sb.ToString();
+        }
+
+        private static string ReadFile(string workingDir)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(workingDir)) return null;
+                string path = Path.Combine(workingDir, FileName);
+                if (!File.Exists(path)) return null;
+                string text = File.ReadAllText(path, Encoding.UTF8);
+                if (string.IsNullOrEmpty(text)) return null;
+                if (text.Length > MaxChars)
+                    text = text.Substring(0, MaxChars) + "\n[AGENTS.md truncated]";
+                return text.TrimEnd('\n', '\r');
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -98,6 +98,15 @@ namespace GxPT
         // pure per-turn cost there. Defaults to a turn-local list when the host doesn't supply one.
         public IList<string> RevealedToolNames { get; set; }
 
+        // Optional project-instructions block (the workspace root's AGENTS.md, framed by
+        // AgentsFileInjection), injected as the last stable-head system message (Zone A). A plain
+        // string set per send rather than a provider: Zone A must stay byte-identical across the
+        // turn's loop iterations, so the host reads the file once before the turn and an edit
+        // (including one the model makes itself through file tools) takes effect on the NEXT turn,
+        // re-billing the prefix once. Null/empty => no block, so a project without AGENTS.md
+        // leaves no trace in context.
+        public string ProjectInstructions { get; set; }
+
         // Optional provider of the persistent-memory system block (the current .gxpt/memory.md index
         // plus its framing), rebuilt from disk each request and injected as an ephemeral, non-persisted
         // system message - the same treatment as the names manifest. Returns null/empty when memory is
@@ -294,8 +303,9 @@ namespace GxPT
                     + ": requesting model with " + (tools != null ? tools.Count : 0) + " exposed tool(s)");
 
                 // Request layout, designed for prompt-cache reuse (three zones by volatility):
-                //   Zone A - stable head: constant agent prompt + workspace block (system messages;
-                //            byte-identical for the conversation's lifetime). Cache breakpoint #1 on
+                //   Zone A - stable head: constant agent prompt + workspace block + AGENTS.md
+                //            project instructions (system messages; byte-identical for the
+                //            conversation's lifetime). Cache breakpoint #1 on
                 //            its last message caches tools + system head together (tools render at
                 //            position 0 of the prompt).
                 //   Zone B - the persisted history (append-only). Cache breakpoint #2 rides the
@@ -560,7 +570,8 @@ namespace GxPT
         }
 
         // Zone A: the stable system head, byte-identical for every request of a conversation (the
-        // agent prompt is constant; the workspace block is constant while the workspace is). Fresh
+        // agent prompt is constant; the workspace block is constant while the workspace is; the
+        // project-instructions block is fixed per turn and constant while AGENTS.md is). Fresh
         // message objects each call, so callers may set CacheControl on them directly.
         private List<ChatMessage> BuildStableHead()
         {
@@ -569,6 +580,8 @@ namespace GxPT
             string workspaceBlock = WorkspaceSystemMessage(WorkingDir);
             if (!string.IsNullOrEmpty(workspaceBlock))
                 head.Add(new ChatMessage("system", workspaceBlock));
+            if (!string.IsNullOrEmpty(ProjectInstructions))
+                head.Add(new ChatMessage("system", ProjectInstructions));
             return head;
         }
 

--- a/docs/prompt-caching-design.md
+++ b/docs/prompt-caching-design.md
@@ -28,7 +28,8 @@ Assembled per request in `McpChatOrchestrator.RunTurn` (tool turns) and `MainFor
 tools array            append-only per conversation, name-sorted        ┐ Zone A
 emoji system message   constant (prepended by OpenRouterClient)         │ frozen for the
 agent system prompt    constant                                         │ conversation
-workspace system msg   constant while the workspace is unchanged        ┘
+workspace system msg   constant while the workspace is unchanged        │
+AGENTS.md system msg   constant while the file is unchanged             ┘
         ◄── cache breakpoint #1 (last system message)
 persisted history      append-only (user/assistant/tool messages)        Zone B
         ◄── cache breakpoint #2 (newest persisted message, cloned)
@@ -41,6 +42,11 @@ ephemeral context tail rebuilt every request, never cached               Zone C
   would put the volatile content back in front of the cached history. It is never persisted and
   never rendered by the UI; the agent prompt tells the model what it is. Memory, the skills
   manifest, and the MCP names manifest may all change per request at zero cache cost here.
+- **AGENTS.md** (workspace root, `AgentsFileInjection`) is read once per send
+  (`MainForm.BeginToolSend`) and handed to the orchestrator as a fixed string
+  (`ProjectInstructions`), so it cannot change between a turn's loop iterations — even if the
+  model edits the file through its own tools. An on-disk edit takes effect on the next turn at
+  the cost of one prefix re-write (see §6); absent or empty, it leaves no trace in context.
 - **Breakpoints** are `ChatMessage.CacheControl` flags, placed by
   `McpChatOrchestrator.ApplyCacheBreakpoints`. Zone A's flag goes on a request-local head
   message; Zone B's goes on a `WithCacheControl()` clone so the flag never lands in persisted
@@ -142,6 +148,7 @@ So requests on cache-supported models carry `provider.order = [<cache-warm provi
 |---|---|---|
 | reveal_tools / gate flip / cap eviction | one full prefix re-write | occasional, implies new work anyway |
 | workspace or model change mid-conversation | one full re-write / cold cache | rare |
+| AGENTS.md edit between turns | one full prefix re-write | rare (documentation cadence) |
 | memory write, skills change, manifest change | nothing (Zone C) | — |
 | loop iteration, normal user turn | incremental read + small write | the common case |
 | > provider TTL (~5 min) between turns | one re-write | normal chat pacing |


### PR DESCRIPTION
## Summary

When a conversation has a working directory, the workspace root's `AGENTS.md` (the cross-tool convention for per-project agent instructions) is now read and injected into context as the last stable-head system message.

## Why Zone A

- `AGENTS.md` changes on a documentation cadence, so within a conversation it is effectively constant. An edit between turns costs one full prefix re-write — the same class of invalidation event as a workspace change (added to the §6 table).
- The file can be large; in the cached Zone A prefix it bills once per conversation, while Zone C would re-bill it on every request.

## How

- New host-side `AgentsFileInjection` (mirrors `MemoryInjection`): reads `<workdir>/AGENTS.md`, returns a framed block or null — a project without one leaves no trace in context. Capped at 32 KB with a truncation marker.
- The orchestrator gets a plain `ProjectInstructions` string property (not a provider delegate): `MainForm.BeginToolSend` reads the file once per send on the worker thread, so the head stays byte-identical across a turn's loop iterations even if the model edits `AGENTS.md` through its own file tools. Edits take effect on the next turn.
- `BuildStableHead` appends the block after the workspace message, so cache breakpoint #1 rides it automatically; the cap wrap-up path reuses the same head.
- `docs/prompt-caching-design.md` updated: zone diagram, §2 bullet, §6 invalidation row.

## Tests

- `AgentsFileInjectionTests`: framing + content, null for missing/empty file or no workspace, truncation marker on oversized files.
- Orchestrator test: `ProjectInstructions` lands as the last stable-head message and carries cache breakpoint #1, with history starting right after.

Not built locally (no .NET SDK available in the sandbox) — relying on this PR's CI run for verification.

https://claude.ai/code/session_0137ghkrFnHKyEKMXfWVLcSU

---
_Generated by [Claude Code](https://claude.ai/code/session_0137ghkrFnHKyEKMXfWVLcSU)_