### PR TITLE
Add a Retry button to error notices in the chat transcript

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -72,6 +72,11 @@ namespace GxPT
         private const int InlineCodePaddingX = 3;
         private const int InlineCodePaddingY = 1;
 
+        // Retry button drawn under a trailing error notice (re-runs the failed turn)
+        private const int RetryBtnPadX = 8;   // horizontal padding around the label
+        private const int RetryBtnPadY = 3;   // vertical padding around the label
+        private const int RetryBtnGapTop = 4; // gap between the error text and the button
+
         // Bounded central content area width (designer-configurable)
         private int _maxContentWidth = 1000; // default maximum central area width
 
@@ -204,11 +209,16 @@ namespace GxPT
 
         // Raised when the user selects Edit… on a user message via context menu
         public event Action<int, string> UserMessageEditRequested;
+        // Raised when the user clicks the Retry button on a trailing error notice
+        public event Action RetryRequested;
         // Hover/drag state for code block UI
         private MessageItem _hoverCopyItem;
         private int _hoverCopyCodeIndex = -1;
         private MessageItem _copyPressedItem;
         private int _copyPressedCodeIndex = -1;
+        // Hover/pressed state for the Retry button on a trailing error notice
+        private MessageItem _hoverRetryItem;
+        private MessageItem _retryPressedItem;
         private bool _draggingHScroll;
         private MessageItem _dragScrollItem;
         private int _dragScrollCodeIndex = -1;
@@ -251,6 +261,8 @@ namespace GxPT
             // When true, a tiny "zdr" tag is drawn in the bubble's top-right corner (zero-retention
             // message). Only meaningful for User/Assistant bubbles; tool blocks never show it.
             public bool ShowZdrTag;
+            // Retry button rect captured at draw time (virtual coords); Empty when not drawn
+            public Rectangle RetryRect;
 
         }
 
@@ -729,6 +741,49 @@ namespace GxPT
             ReflowSoon();
         }
 
+        // Remove trailing error-notice messages (sentinel-only messages added by the form when a turn
+        // fails) so a retried turn streams in their place. Safe no-op when none.
+        public void RemoveTrailingErrorNotices()
+        {
+            bool removed = false;
+            while (_items.Count > 0 && IsErrorNoticeItem(_items[_items.Count - 1]))
+            {
+                _items.RemoveAt(_items.Count - 1);
+                removed = true;
+            }
+            if (removed)
+            {
+                Invalidate();
+                ReflowSoon();
+            }
+        }
+
+        // True when every block in the message is an error notice — the shape ShowTranscriptError
+        // produces (a Tool-role message whose markdown is a single error sentinel line).
+        private static bool IsErrorNoticeItem(MessageItem it)
+        {
+            if (it == null || it.Blocks == null || it.Blocks.Count == 0) return false;
+            for (int i = 0; i < it.Blocks.Count; i++)
+                if (it.Blocks[i] == null || it.Blocks[i].Type != BlockType.Error) return false;
+            return true;
+        }
+
+        // The Retry button appears only on the transcript's last message and only when that message
+        // is an error notice: retrying re-runs the turn that just failed, so once the conversation
+        // moves on (or when no handler is wired) older notices never offer it.
+        private bool IsRetryTarget(MessageItem it)
+        {
+            if (RetryRequested == null) return false;
+            if (it == null || _items.Count == 0 || _items[_items.Count - 1] != it) return false;
+            return IsErrorNoticeItem(it);
+        }
+
+        private Size GetRetryButtonSize()
+        {
+            Size txt = TextRenderer.MeasureText("Retry", _baseFont);
+            return new Size(txt.Width + 2 * RetryBtnPadX, _baseFont.Height + 2 * RetryBtnPadY);
+        }
+
         // Replace the content of the last message if it exists
         public void UpdateLastMessage(string markdown)
         {
@@ -1014,6 +1069,14 @@ namespace GxPT
                 // Lists don't add extra spacing after themselves
 
                 wUsed = Math.Max(wUsed, sz.Width);
+            }
+
+            // Trailing error notice: reserve room for the Retry button drawn under the red text
+            if (IsRetryTarget(it))
+            {
+                Size btn = GetRetryButtonSize();
+                h += RetryBtnGapTop + btn.Height;
+                wUsed = Math.Max(wUsed, btn.Width);
             }
 
             h += BubblePadding; // bottom padding
@@ -1493,6 +1556,8 @@ namespace GxPT
             if (it.EditDiffScrollHits == null) it.EditDiffScrollHits = new List<EditDiffScrollHit>(); else it.EditDiffScrollHits.Clear();
             // Reset drawn text segments list (for selection)
             if (it.DrawnSegments == null) it.DrawnSegments = new List<DrawnSeg>(); else it.DrawnSegments.Clear();
+            // Reset the retry button hit rect; the error-block draw re-captures it when shown
+            it.RetryRect = Rectangle.Empty;
             // Reset link run sequence
             it.LinkRunSeq = 0;
             DrawBlocks(g, content, it.Blocks, it);
@@ -1799,6 +1864,30 @@ namespace GxPT
                                              new InlineCopyContext { ForeOverride = _clrError });
                     y += 2;
                     if (owner != null) { if (owner.DrawnSegments == null) owner.DrawnSegments = new List<DrawnSeg>(); owner.DrawnSegments.Add(new DrawnSeg { IsNewLine = true, IsHardBreak = true, Rect = new Rectangle(x0, y, 0, 0), Text = null, Font = _baseFont }); }
+                    // Trailing error notice: a small bordered Retry button under the red text re-runs
+                    // the failed turn (the form wires RetryRequested to restart the send).
+                    if (owner != null && blk == blocks[blocks.Count - 1] && IsRetryTarget(owner))
+                    {
+                        y += RetryBtnGapTop;
+                        Size btnSz = GetRetryButtonSize();
+                        Rectangle btn = new Rectangle(x0, y, btnSz.Width, btnSz.Height);
+                        bool retryPressed = (owner == _retryPressedItem);
+                        bool retryHover = (owner == _hoverRetryItem);
+                        using (var sb = new SolidBrush(retryPressed ? _clrCopyPressed : (retryHover ? _clrCopyHover : _clrCodeBack)))
+                        using (var pen = new Pen(_clrCodeBorder))
+                        {
+                            g.FillRectangle(sb, btn);
+                            g.DrawRectangle(pen, btn);
+                        }
+                        using (var brush = new SolidBrush(_clrLink))
+                        using (var fmt = StringFormat.GenericTypographic)
+                        {
+                            fmt.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
+                            g.DrawString("Retry", _baseFont, brush, new PointF(btn.X + RetryBtnPadX, btn.Y + RetryBtnPadY), fmt);
+                        }
+                        owner.RetryRect = btn;
+                        y += btnSz.Height;
+                    }
                     numberedCounters.Clear();
                 }
                 else if (blk.Type == BlockType.CodeBlock)
@@ -2657,6 +2746,17 @@ namespace GxPT
                     Invalidate();
                     return;
                 }
+                // Retry button click → re-run the failed turn
+                var retryUp = HitTestRetry(e.Location);
+                if (retryUp != null && _retryPressedItem == retryUp)
+                {
+                    _retryPressedItem = null;
+                    Invalidate();
+                    var retryHandler = RetryRequested;
+                    if (retryHandler != null) retryHandler();
+                    return;
+                }
+                if (_retryPressedItem != null) { _retryPressedItem = null; Invalidate(); }
                 // Copy button click
                 var ui = HitTestCodeUI(e.Location);
                 if (ui.Hit && ui.Which == CodeUiHit.CopyButton && ui.Item != null)
@@ -2736,6 +2836,14 @@ namespace GxPT
                     _dragEditDiffStartMouseX = e.X;
                     _dragEditDiffStartScroll = GetEditDiffScroll(edh.Key);
                     Capture = true;
+                    Invalidate();
+                    return;
+                }
+                // Retry button press on a trailing error notice
+                var retryDown = HitTestRetry(e.Location);
+                if (retryDown != null)
+                {
+                    _retryPressedItem = retryDown;
                     Invalidate();
                     return;
                 }
@@ -2906,6 +3014,17 @@ namespace GxPT
                 _hoverScrollItem = null; _hoverScrollCodeIndex = -1; _hoverScrollIsTable = false; _hoverScrollTableIndex = -1;
             }
 
+            // Hover over the Retry button on a trailing error notice
+            var retryHover = HitTestRetry(e.Location);
+            if (retryHover != null)
+            {
+                _hoverRetryItem = retryHover; Cursor = Cursors.Hand; Invalidate(); return;
+            }
+            else
+            {
+                _hoverRetryItem = null;
+            }
+
             // Hover over attachment pill
             var pillHit = HitTestAttachmentPill(e.Location);
             if (pillHit.Item != null)
@@ -2940,6 +3059,7 @@ namespace GxPT
             _hoverCopyItem = null; _hoverCopyCodeIndex = -1;
             _hoverScrollItem = null; _hoverScrollCodeIndex = -1;
             _copyPressedItem = null; _copyPressedCodeIndex = -1;
+            _hoverRetryItem = null; _retryPressedItem = null;
             _hoverAttachItem = null; _hoverAttachIndex = -1; _pressAttachItem = null; _pressAttachIndex = -1;
             Invalidate();
         }
@@ -3029,6 +3149,17 @@ namespace GxPT
         }
 
         // Returns true and the diff key if the point is over an edit-diff header row.
+        // Hit test the Retry button on a trailing error notice. Only the last message can carry the
+        // button (rect captured at draw time, virtual coords), so only it is checked.
+        private MessageItem HitTestRetry(Point clientPt)
+        {
+            if (_items.Count == 0) return null;
+            var it = _items[_items.Count - 1];
+            if (it.RetryRect.Width <= 0 || !IsRetryTarget(it)) return null;
+            Point virt = new Point(clientPt.X, clientPt.Y + _scrollOffset);
+            return it.RetryRect.Contains(virt) ? it : null;
+        }
+
         private bool HitTestEditDiff(Point clientPt, out string key)
         {
             key = null;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2026,211 +2026,267 @@ namespace GxPT
                 }
                 ClearAttachmentsBanner();
 
-                var modelToUse = GetSelectedModel();
-
-                // Effective ZDR for this send (global default OR the per-conversation toggle); engages
-                // the one-way latch on the first ZDR send and tags the message bubbles just added.
-                bool zdrForSend = ResolveZdrForSend(ctx);
-                if (zdrForSend) MarkActiveTurnZdrBubbles(ctx);
-
-                // Tool-enabled turn: tool activity renders as a separate chrome-less message above the
-                // answer bubble. BeginToolSend owns the whole turn; the plain path below is unchanged.
-                // Skills also route through the tool loop (they inject a manifest and expose open_skill),
-                // so a conversation with skills but no MCP tools still takes this path.
-                bool hasMcpTools = _mcpRegistry != null && _mcpRegistry.HasToolsForWorkdir(ctx.WorkingDir);
-                if (hasMcpTools || ConversationHasSkills(ctx))
-                {
-                    BeginToolSend(ctx, modelToUse, zdrForSend);
-                    return;
-                }
-
-                // Add placeholder assistant message to stream into and capture its index
-                int assistantIndex = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
-                if (zdrForSend) ctx.Transcript.SetMessageZdrTag(assistantIndex, true);
-                Logger.Log("Send", "Assistant placeholder index=" + assistantIndex);
-                var assistantBuilder = new StringBuilder();
-                // Capture this turn's cancellation handle for the streaming callbacks (the field is
-                // cleared to null when the turn finalizes).
-                RequestCancellation cancel = ctx.Cancellation;
-
-                // Throttle UI updates with a WinForms timer (coalesces rapid deltas)
-                var sbLock = new object();
-                int lastRenderedLen = 0;
-                var renderTimer = new System.Windows.Forms.Timer();
-                renderTimer.Interval = 75; // ~13 fps; adjust between 50-150ms if needed
-                renderTimer.Tick += (s2, e2) =>
-                {
-                    string snapshot;
-                    int len;
-                    lock (sbLock)
-                    {
-                        len = assistantBuilder.Length;
-                        if (len == lastRenderedLen) return; // nothing new
-                        snapshot = assistantBuilder.ToString();
-                        lastRenderedLen = len;
-                    }
-                    // Update on UI thread (timer runs on UI thread)
-                    ctx.Transcript.UpdateMessageAt(assistantIndex, snapshot);
-                };
-                // Keep view pinned to bottom while streaming
-                try { ctx.Transcript.StickToBottomDuringStreaming = true; }
-                catch { }
-                renderTimer.Start();
-
-                // Kick off streaming in background
-                System.Threading.ThreadPool.QueueUserWorkItem(delegate
-                {
-                    try
-                    {
-                        // Snapshot the history and log it
-                        // Build a model snapshot where attachments are appended to content on-the-fly
-                        var snapshot = BuildMessagesForModel(ctx.Conversation.History);
-                        // Prompt caching: the newest message carries the cache breakpoint, so each
-                        // turn re-reads the prior turn's prefix and extends it. Snapshot messages are
-                        // request-local clones - the flag never lands in persisted history.
-                        if (snapshot.Count > 0)
-                            snapshot[snapshot.Count - 1].CacheControl = true;
-                        try
-                        {
-                            var sbSnap = new StringBuilder();
-                            sbSnap.Append("Sending ").Append(snapshot.Count).Append(" messages:\n");
-                            for (int i = 0; i < snapshot.Count; i++)
-                            {
-                                var m = snapshot[i];
-                                string content = m.Content ?? string.Empty;
-                                content = content.Replace("\r", " ").Replace("\n", " ");
-                                if (content.Length > 200) content = content.Substring(0, 200) + "...";
-                                sbSnap.Append("  ").Append(i).Append(": ").Append(m.Role).Append(" | ").Append(content).Append('\n');
-                            }
-                            Logger.Log("Send", sbSnap.ToString());
-                        }
-                        catch { }
-
-                        var sendProps = new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null };
-                        // Sticky provider routing on cache-supported models: prefer (provider.order,
-                        // preference with fallback) the endpoint holding this conversation's warm
-                        // prompt cache. Stickiness is confirmation-gated - only a response reporting
-                        // cache activity (a read or a write) sets or moves the preference; merely
-                        // serving a request proves nothing. Usage/cost accounting (status bar)
-                        // records on every model.
-                        Conversation usageConvo = ctx.Conversation;
-                        bool cachingModel = OpenRouterClient.ModelSupportsPromptCaching(modelToUse);
-                        if (usageConvo != null)
-                        {
-                            if (cachingModel && !string.IsNullOrEmpty(usageConvo.CacheWarmProvider))
-                                sendProps.ProviderOrder = new List<string> { usageConvo.CacheWarmProvider };
-                            sendProps.ResponseUsageCallback = delegate(ResponseUsage u)
-                            {
-                                if (u == null) return;
-                                if (cachingModel && !string.IsNullOrEmpty(u.Provider)
-                                    && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
-                                    usageConvo.CacheWarmProvider = u.Provider;
-                                RecordUsageAndReconcile(usageConvo, u, cachingModel);
-                            };
-                        }
-                        _client.CreateCompletionStream(
-                            modelToUse,
-                            snapshot,
-                            sendProps,
-                            delegate(string d)
-                            {
-                                if (string.IsNullOrEmpty(d)) return;
-                                lock (sbLock) { assistantBuilder.Append(d); }
-                                // no per-delta BeginInvoke; timer will render
-                            },
-                            delegate
-                            {
-                                // finalize on UI thread (update history and unlock send)
-                                string finalText;
-                                lock (sbLock) { finalText = assistantBuilder.ToString(); }
-                                BeginInvoke((MethodInvoker)delegate
-                                {
-                                    try { renderTimer.Stop(); renderTimer.Dispose(); }
-                                    catch { }
-                                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                                    catch { }
-                                    // A user stop ends the stream via onDone (no error). If nothing
-                                    // streamed yet, drop the empty placeholder rather than committing an
-                                    // empty assistant message; otherwise keep the partial text as normal.
-                                    bool cancelled = (cancel != null && cancel.IsCancelled);
-                                    if (cancelled && finalText.Trim().Length == 0)
-                                    {
-                                        if (assistantIndex == ctx.Transcript.MessageCount - 1)
-                                            ctx.Transcript.RemoveLastMessage();
-                                        Logger.Log("Send", "Stream stopped by user before any output at index=" + assistantIndex);
-                                    }
-                                    else
-                                    {
-                                        ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
-                                        ctx.Conversation.AddAssistantMessage(finalText);
-                                        ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                                        // Save assistant completion if allowed
-                                        if (!ctx.NoSaveUntilUserSend)
-                                            ConversationStore.Save(ctx.Conversation); // save only after streaming completes
-                                        try { Logger.Log("Transcript", "Final assistant message at index=" + assistantIndex + ":\n" + (finalText ?? string.Empty)); }
-                                        catch { }
-                                        Logger.Log("Send", "Assistant finalized at index=" + assistantIndex + ", chars=" + (finalText != null ? finalText.Length : 0) + (cancelled ? " (stopped by user)" : string.Empty));
-                                    }
-                                    ctx.IsSending = false;
-                                    ctx.Cancellation = null;
-                                    HideGenerationBar(ctx);
-                                    if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
-                                });
-                            },
-                            delegate(string err)
-                            {
-                                if (string.IsNullOrEmpty(err)) err = "Unknown error.";
-                                string partial;
-                                lock (sbLock) { partial = assistantBuilder.ToString(); }
-                                BeginInvoke((MethodInvoker)delegate
-                                {
-                                    try { renderTimer.Stop(); renderTimer.Dispose(); }
-                                    catch { }
-                                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                                    catch { }
-                                    // Keep any partial text in the assistant bubble; otherwise drop the
-                                    // empty placeholder so only the red error notice shows.
-                                    if (partial.Trim().Length > 0)
-                                        ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
-                                    else if (assistantIndex == ctx.Transcript.MessageCount - 1)
-                                        ctx.Transcript.RemoveLastMessage();
-                                    ShowTranscriptError(ctx.Transcript, err);
-                                    Logger.Log("Send", "Stream error at index=" + assistantIndex + ": " + err);
-                                    ctx.IsSending = false;
-                                    ctx.Cancellation = null;
-                                    HideGenerationBar(ctx);
-                                    // don't save on failure; no new assistant content
-                                });
-                            },
-                            cancel
-                        );
-                    }
-                    catch (Exception ex)
-                    {
-                        string partial;
-                        lock (sbLock) { partial = assistantBuilder.ToString(); }
-                        BeginInvoke((MethodInvoker)delegate
-                        {
-                            try { renderTimer.Stop(); renderTimer.Dispose(); }
-                            catch { }
-                            try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                            catch { }
-                            if (partial.Trim().Length > 0)
-                                ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
-                            else if (assistantIndex == ctx.Transcript.MessageCount - 1)
-                                ctx.Transcript.RemoveLastMessage();
-                            ShowTranscriptError(ctx.Transcript, ex.Message);
-                            Logger.Log("Send", "Exception in streaming worker: " + ex.Message);
-                            ctx.IsSending = false;
-                            ctx.Cancellation = null;
-                            HideGenerationBar(ctx);
-                        });
-                    }
-                });
+                StartModelTurn(ctx);
             }
             catch
             {
                 Logger.Log("Send", "Send failed unexpectedly; unlocking.");
+                ctx.IsSending = false;
+                ctx.Cancellation = null;
+                HideGenerationBar(ctx);
+                throw;
+            }
+        }
+
+        // Kick off the model turn for the conversation's current history: routes to the tool loop
+        // when MCP tools or skills apply, otherwise streams a plain completion into a new assistant
+        // bubble. Callers own the send lock — ctx.IsSending is already true, ctx.Cancellation is
+        // fresh and the generation bar is showing. Used by the normal send path and by
+        // RetryLastTurn, which re-runs the turn over unchanged history after a failure.
+        private void StartModelTurn(TabManager.ChatTabContext ctx)
+        {
+            var modelToUse = GetSelectedModel();
+
+            // Effective ZDR for this send (global default OR the per-conversation toggle); engages
+            // the one-way latch on the first ZDR send and tags the message bubbles just added.
+            bool zdrForSend = ResolveZdrForSend(ctx);
+            if (zdrForSend) MarkActiveTurnZdrBubbles(ctx);
+
+            // Tool-enabled turn: tool activity renders as a separate chrome-less message above the
+            // answer bubble. BeginToolSend owns the whole turn; the plain path below is unchanged.
+            // Skills also route through the tool loop (they inject a manifest and expose open_skill),
+            // so a conversation with skills but no MCP tools still takes this path.
+            bool hasMcpTools = _mcpRegistry != null && _mcpRegistry.HasToolsForWorkdir(ctx.WorkingDir);
+            if (hasMcpTools || ConversationHasSkills(ctx))
+            {
+                BeginToolSend(ctx, modelToUse, zdrForSend);
+                return;
+            }
+
+            // Add placeholder assistant message to stream into and capture its index
+            int assistantIndex = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
+            if (zdrForSend) ctx.Transcript.SetMessageZdrTag(assistantIndex, true);
+            Logger.Log("Send", "Assistant placeholder index=" + assistantIndex);
+            var assistantBuilder = new StringBuilder();
+            // Capture this turn's cancellation handle for the streaming callbacks (the field is
+            // cleared to null when the turn finalizes).
+            RequestCancellation cancel = ctx.Cancellation;
+
+            // Throttle UI updates with a WinForms timer (coalesces rapid deltas)
+            var sbLock = new object();
+            int lastRenderedLen = 0;
+            var renderTimer = new System.Windows.Forms.Timer();
+            renderTimer.Interval = 75; // ~13 fps; adjust between 50-150ms if needed
+            renderTimer.Tick += (s2, e2) =>
+            {
+                string snapshot;
+                int len;
+                lock (sbLock)
+                {
+                    len = assistantBuilder.Length;
+                    if (len == lastRenderedLen) return; // nothing new
+                    snapshot = assistantBuilder.ToString();
+                    lastRenderedLen = len;
+                }
+                // Update on UI thread (timer runs on UI thread)
+                ctx.Transcript.UpdateMessageAt(assistantIndex, snapshot);
+            };
+            // Keep view pinned to bottom while streaming
+            try { ctx.Transcript.StickToBottomDuringStreaming = true; }
+            catch { }
+            renderTimer.Start();
+
+            // Kick off streaming in background
+            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            {
+                try
+                {
+                    // Snapshot the history and log it
+                    // Build a model snapshot where attachments are appended to content on-the-fly
+                    var snapshot = BuildMessagesForModel(ctx.Conversation.History);
+                    // Prompt caching: the newest message carries the cache breakpoint, so each
+                    // turn re-reads the prior turn's prefix and extends it. Snapshot messages are
+                    // request-local clones - the flag never lands in persisted history.
+                    if (snapshot.Count > 0)
+                        snapshot[snapshot.Count - 1].CacheControl = true;
+                    try
+                    {
+                        var sbSnap = new StringBuilder();
+                        sbSnap.Append("Sending ").Append(snapshot.Count).Append(" messages:\n");
+                        for (int i = 0; i < snapshot.Count; i++)
+                        {
+                            var m = snapshot[i];
+                            string content = m.Content ?? string.Empty;
+                            content = content.Replace("\r", " ").Replace("\n", " ");
+                            if (content.Length > 200) content = content.Substring(0, 200) + "...";
+                            sbSnap.Append("  ").Append(i).Append(": ").Append(m.Role).Append(" | ").Append(content).Append('\n');
+                        }
+                        Logger.Log("Send", sbSnap.ToString());
+                    }
+                    catch { }
+
+                    var sendProps = new ClientProperties { Stream = true, Zdr = zdrForSend ? true : (bool?)null };
+                    // Sticky provider routing on cache-supported models: prefer (provider.order,
+                    // preference with fallback) the endpoint holding this conversation's warm
+                    // prompt cache. Stickiness is confirmation-gated - only a response reporting
+                    // cache activity (a read or a write) sets or moves the preference; merely
+                    // serving a request proves nothing. Usage/cost accounting (status bar)
+                    // records on every model.
+                    Conversation usageConvo = ctx.Conversation;
+                    bool cachingModel = OpenRouterClient.ModelSupportsPromptCaching(modelToUse);
+                    if (usageConvo != null)
+                    {
+                        if (cachingModel && !string.IsNullOrEmpty(usageConvo.CacheWarmProvider))
+                            sendProps.ProviderOrder = new List<string> { usageConvo.CacheWarmProvider };
+                        sendProps.ResponseUsageCallback = delegate(ResponseUsage u)
+                        {
+                            if (u == null) return;
+                            if (cachingModel && !string.IsNullOrEmpty(u.Provider)
+                                && (u.CachedTokens > 0 || u.CacheWriteTokens > 0))
+                                usageConvo.CacheWarmProvider = u.Provider;
+                            RecordUsageAndReconcile(usageConvo, u, cachingModel);
+                        };
+                    }
+                    _client.CreateCompletionStream(
+                        modelToUse,
+                        snapshot,
+                        sendProps,
+                        delegate(string d)
+                        {
+                            if (string.IsNullOrEmpty(d)) return;
+                            lock (sbLock) { assistantBuilder.Append(d); }
+                            // no per-delta BeginInvoke; timer will render
+                        },
+                        delegate
+                        {
+                            // finalize on UI thread (update history and unlock send)
+                            string finalText;
+                            lock (sbLock) { finalText = assistantBuilder.ToString(); }
+                            BeginInvoke((MethodInvoker)delegate
+                            {
+                                try { renderTimer.Stop(); renderTimer.Dispose(); }
+                                catch { }
+                                try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                                catch { }
+                                // A user stop ends the stream via onDone (no error). If nothing
+                                // streamed yet, drop the empty placeholder rather than committing an
+                                // empty assistant message; otherwise keep the partial text as normal.
+                                bool cancelled = (cancel != null && cancel.IsCancelled);
+                                if (cancelled && finalText.Trim().Length == 0)
+                                {
+                                    if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                        ctx.Transcript.RemoveLastMessage();
+                                    Logger.Log("Send", "Stream stopped by user before any output at index=" + assistantIndex);
+                                }
+                                else
+                                {
+                                    ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
+                                    ctx.Conversation.AddAssistantMessage(finalText);
+                                    ctx.Conversation.SelectedModel = ctx.SelectedModel;
+                                    // Save assistant completion if allowed
+                                    if (!ctx.NoSaveUntilUserSend)
+                                        ConversationStore.Save(ctx.Conversation); // save only after streaming completes
+                                    try { Logger.Log("Transcript", "Final assistant message at index=" + assistantIndex + ":\n" + (finalText ?? string.Empty)); }
+                                    catch { }
+                                    Logger.Log("Send", "Assistant finalized at index=" + assistantIndex + ", chars=" + (finalText != null ? finalText.Length : 0) + (cancelled ? " (stopped by user)" : string.Empty));
+                                }
+                                ctx.IsSending = false;
+                                ctx.Cancellation = null;
+                                HideGenerationBar(ctx);
+                                if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
+                            });
+                        },
+                        delegate(string err)
+                        {
+                            if (string.IsNullOrEmpty(err)) err = "Unknown error.";
+                            string partial;
+                            lock (sbLock) { partial = assistantBuilder.ToString(); }
+                            BeginInvoke((MethodInvoker)delegate
+                            {
+                                try { renderTimer.Stop(); renderTimer.Dispose(); }
+                                catch { }
+                                try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                                catch { }
+                                // Keep any partial text in the assistant bubble; otherwise drop the
+                                // empty placeholder so only the red error notice shows.
+                                if (partial.Trim().Length > 0)
+                                    ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                                else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                    ctx.Transcript.RemoveLastMessage();
+                                ShowTranscriptError(ctx.Transcript, err);
+                                Logger.Log("Send", "Stream error at index=" + assistantIndex + ": " + err);
+                                ctx.IsSending = false;
+                                ctx.Cancellation = null;
+                                HideGenerationBar(ctx);
+                                // don't save on failure; no new assistant content
+                            });
+                        },
+                        cancel
+                    );
+                }
+                catch (Exception ex)
+                {
+                    string partial;
+                    lock (sbLock) { partial = assistantBuilder.ToString(); }
+                    BeginInvoke((MethodInvoker)delegate
+                    {
+                        try { renderTimer.Stop(); renderTimer.Dispose(); }
+                        catch { }
+                        try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                        catch { }
+                        if (partial.Trim().Length > 0)
+                            ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                        else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                            ctx.Transcript.RemoveLastMessage();
+                        ShowTranscriptError(ctx.Transcript, ex.Message);
+                        Logger.Log("Send", "Exception in streaming worker: " + ex.Message);
+                        ctx.IsSending = false;
+                        ctx.Cancellation = null;
+                        HideGenerationBar(ctx);
+                    });
+                }
+            });
+        }
+
+        // Re-run the turn that just failed (the Retry button on a trailing error notice). The failed
+        // turn's input is already in history, so nothing is appended: the error notice is removed and
+        // the turn restarts over the unchanged history — this holds for both the plain stream (the
+        // user message is committed before the request) and the tool loop (the orchestrator's partial
+        // progress stays in history, same as when the user keeps typing after a failure).
+        internal void RetryLastTurn(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Conversation == null || ctx.Transcript == null) return;
+            if (ctx.IsSending) return;
+            if (ctx.Conversation.History == null || LastUserHistoryIndex(ctx.Conversation) < 0)
+                return; // no turn to re-run
+
+            if (_client == null || !_client.IsConfigured)
+            {
+                string reason = _client == null
+                    ? "Client not initialized."
+                    : (!System.IO.File.Exists(System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Lib\\curl.exe"))
+                        ? "curl.exe could not be found."
+                        : "Missing API key in settings.");
+                ctx.Transcript.AddMessage(MessageRole.Assistant, "Error: " + reason);
+                Logger.Log("Send", "Retry blocked: " + reason);
+                return;
+            }
+
+            // Drop the trailing error notice so the retried turn streams in its place; a repeat
+            // failure surfaces a fresh notice (with a fresh Retry button).
+            ctx.Transcript.RemoveTrailingErrorNotices();
+
+            ctx.IsSending = true;
+            ctx.Cancellation = new RequestCancellation();
+            ShowGenerationBar(ctx);
+            try
+            {
+                Logger.Log("Send", "Retry turn. Model=" + GetSelectedModel());
+                StartModelTurn(ctx);
+            }
+            catch
+            {
+                Logger.Log("Send", "Retry failed unexpectedly; unlocking.");
                 ctx.IsSending = false;
                 ctx.Cancellation = null;
                 HideGenerationBar(ctx);

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -174,8 +174,9 @@ namespace GxPT
                 };
                 ctx.Conversation.SelectedModel = ctx.SelectedModel;
                 _mainForm.EnsureConversationId(ctx.Conversation);
-                // Wire edit-request and name-generated handlers for this tab
+                // Wire edit-request, retry and name-generated handlers for this tab
                 HookEditRequest(ctx);
+                HookRetryRequest(ctx);
                 HookNameGenerated(ctx);
 
                 try { ctx.Page.Text = "New Conversation"; }
@@ -216,8 +217,9 @@ namespace GxPT
             ctx.Conversation.SelectedModel = ctx.SelectedModel;
             _mainForm.EnsureConversationId(ctx.Conversation);
 
-            // Wire edit-request and name-generated handlers for this tab
+            // Wire edit-request, retry and name-generated handlers for this tab
             HookEditRequest(ctx);
+            HookRetryRequest(ctx);
             HookNameGenerated(ctx);
 
             _tabContexts[page] = ctx;
@@ -584,6 +586,18 @@ namespace GxPT
                 }
             }
             catch { }
+        }
+
+        // Wire a tab's transcript Retry button (shown on a trailing error notice) to re-run the
+        // failed turn.
+        private void HookRetryRequest(ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Transcript == null) return;
+            ctx.Transcript.RetryRequested += delegate
+            {
+                try { _mainForm.RetryLastTurn(ctx); }
+                catch { }
+            };
         }
 
         // Wire a tab's transcript edit-request to populate the input box and enter edit mode.


### PR DESCRIPTION
## Summary

A failed turn's red error notice now offers a small **Retry** button drawn under the error text, so a transient stream failure can be re-run with one click instead of re-typing the message.

- **`ChatTranscriptControl`**: draws a bordered Retry button beneath the error text, with hover/pressed states and a hand cursor matching the code-block Copy button. The button appears only on the transcript's *trailing* error notice — retrying re-runs the turn that just failed, so once the conversation moves on, older notices stay plain text. Clicking raises a new `RetryRequested` event; a new `RemoveTrailingErrorNotices()` clears the notice so the retried turn streams in its place.
- **`MainForm`**: the turn-start half of the send path (model selection, ZDR, tool-loop vs. plain streaming routing) is extracted into `StartModelTurn(ctx)`, shared by the normal send and the new `RetryLastTurn(ctx)`. Retry guards against an in-flight send, removes the trailing notice, takes the send lock, and re-runs the turn over unchanged history — the failed turn's user message was committed before the request, so nothing is re-appended, and this holds for both the plain stream and the MCP tool loop. A repeat failure surfaces a fresh notice with a fresh Retry button.
- **`TabManager`**: wires `RetryRequested` → `RetryLastTurn` for every tab, alongside the existing edit-request hook.

## Testing

- Compiled the full GxPT source tree (plus the Mcp35.Core/Mcp35.Client project references) with Mono `mcs` — clean, with only the five warnings that already exist on `main`. CI only builds the test projects, which don't include these UI sources.
- Not yet exercised by hand: a quick manual check on Windows (e.g., disconnect the network, send a message, click Retry; also a retry in a tool-enabled conversation) would be a good final pass.

https://claude.ai/code/session_01YR1LwD7Rvpp5nzh2sJ1YLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR1LwD7Rvpp5nzh2sJ1YLW)_