### PR TITLE
Omit message contents from request-body logging

### DIFF
--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -291,12 +291,10 @@ namespace GxPT.Tests.Mcp
             Assert.Null(OpenRouterClient.ExtractGenerationStats(null));
         }
 
-        // ---- log truncation: only the last two messages survive, with an omission marker ----
-        // (two, not one: the orchestrator appends an ephemeral context tail after the real user
-        // message, so keeping a single entry would log only that tail)
+        // ---- log truncation: the messages array collapses to a single omission marker ----
 
         [Fact]
-        public void TruncateMessagesForLog_keeps_last_two_messages_and_marks_omissions()
+        public void TruncateMessagesForLog_replaces_messages_with_count_marker()
         {
             var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>
             {
@@ -308,34 +306,17 @@ namespace GxPT.Tests.Mcp
             var logged = JObject.Parse(OpenRouterClient.TruncateMessagesForLog(body));
             var msgs = (JArray)logged["messages"];
 
-            // 4 originals (emoji system message + 3) collapse to marker + last two
-            Assert.Equal(3, msgs.Count);
-            Assert.Equal("... 2 earlier message(s) omitted ...", (string)msgs[0]);
-            Assert.Equal("assistant", (string)msgs[1]["role"]);
-            Assert.Equal("second", (string)msgs[1]["content"]);
-            Assert.Equal("user", (string)msgs[2]["role"]);
-            Assert.Equal("last", (string)msgs[2]["content"]);
+            // 4 originals (emoji system message + 3) collapse to the marker alone
+            Assert.Equal(1, msgs.Count);
+            Assert.Equal("... 4 message(s) omitted ...", (string)msgs[0]);
 
             // everything outside messages is untouched
             Assert.Equal("m", (string)logged["model"]);
         }
 
         [Fact]
-        public void TruncateMessagesForLog_leaves_short_arrays_and_bad_json_alone()
+        public void TruncateMessagesForLog_leaves_bad_json_alone()
         {
-            // emoji system message only
-            var one = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, new ClientProperties());
-            Assert.Equal(1, ((JArray)JObject.Parse(OpenRouterClient.TruncateMessagesForLog(one))["messages"]).Count);
-
-            // emoji system message + one user message: still no truncation
-            var two = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>
-            {
-                new ChatMessage("user", "hi"),
-            }, null, new ClientProperties());
-            var msgs = (JArray)JObject.Parse(OpenRouterClient.TruncateMessagesForLog(two))["messages"];
-            Assert.Equal(2, msgs.Count);
-            Assert.Equal("hi", (string)msgs[1]["content"]);
-
             Assert.Equal("not json", OpenRouterClient.TruncateMessagesForLog("not json"));
             Assert.Null(OpenRouterClient.TruncateMessagesForLog(null));
         }

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -291,6 +291,42 @@ namespace GxPT.Tests.Mcp
             Assert.Null(OpenRouterClient.ExtractGenerationStats(null));
         }
 
+        // ---- log truncation: only the last message survives, with an omission marker ----
+
+        [Fact]
+        public void TruncateMessagesForLog_keeps_last_message_and_marks_omissions()
+        {
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>
+            {
+                new ChatMessage("user", "first"),
+                new ChatMessage("assistant", "second"),
+                new ChatMessage("user", "last"),
+            }, null, new ClientProperties());
+
+            var logged = JObject.Parse(OpenRouterClient.TruncateMessagesForLog(body));
+            var msgs = (JArray)logged["messages"];
+
+            // 4 originals (emoji system message + 3) collapse to marker + last
+            Assert.Equal(2, msgs.Count);
+            Assert.Equal("... 3 earlier message(s) omitted ...", (string)msgs[0]);
+            Assert.Equal("user", (string)msgs[1]["role"]);
+            Assert.Equal("last", (string)msgs[1]["content"]);
+
+            // everything outside messages is untouched
+            Assert.Equal("m", (string)logged["model"]);
+        }
+
+        [Fact]
+        public void TruncateMessagesForLog_leaves_single_message_and_bad_json_alone()
+        {
+            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, new ClientProperties());
+            var logged = JObject.Parse(OpenRouterClient.TruncateMessagesForLog(body));
+            Assert.Equal(1, ((JArray)logged["messages"]).Count);
+
+            Assert.Equal("not json", OpenRouterClient.TruncateMessagesForLog("not json"));
+            Assert.Null(OpenRouterClient.TruncateMessagesForLog(null));
+        }
+
         // ---- streaming chunk parsing under Newtonsoft ----
 
         [Fact]

--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -291,10 +291,12 @@ namespace GxPT.Tests.Mcp
             Assert.Null(OpenRouterClient.ExtractGenerationStats(null));
         }
 
-        // ---- log truncation: only the last message survives, with an omission marker ----
+        // ---- log truncation: only the last two messages survive, with an omission marker ----
+        // (two, not one: the orchestrator appends an ephemeral context tail after the real user
+        // message, so keeping a single entry would log only that tail)
 
         [Fact]
-        public void TruncateMessagesForLog_keeps_last_message_and_marks_omissions()
+        public void TruncateMessagesForLog_keeps_last_two_messages_and_marks_omissions()
         {
             var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>
             {
@@ -306,22 +308,33 @@ namespace GxPT.Tests.Mcp
             var logged = JObject.Parse(OpenRouterClient.TruncateMessagesForLog(body));
             var msgs = (JArray)logged["messages"];
 
-            // 4 originals (emoji system message + 3) collapse to marker + last
-            Assert.Equal(2, msgs.Count);
-            Assert.Equal("... 3 earlier message(s) omitted ...", (string)msgs[0]);
-            Assert.Equal("user", (string)msgs[1]["role"]);
-            Assert.Equal("last", (string)msgs[1]["content"]);
+            // 4 originals (emoji system message + 3) collapse to marker + last two
+            Assert.Equal(3, msgs.Count);
+            Assert.Equal("... 2 earlier message(s) omitted ...", (string)msgs[0]);
+            Assert.Equal("assistant", (string)msgs[1]["role"]);
+            Assert.Equal("second", (string)msgs[1]["content"]);
+            Assert.Equal("user", (string)msgs[2]["role"]);
+            Assert.Equal("last", (string)msgs[2]["content"]);
 
             // everything outside messages is untouched
             Assert.Equal("m", (string)logged["model"]);
         }
 
         [Fact]
-        public void TruncateMessagesForLog_leaves_single_message_and_bad_json_alone()
+        public void TruncateMessagesForLog_leaves_short_arrays_and_bad_json_alone()
         {
-            var body = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, new ClientProperties());
-            var logged = JObject.Parse(OpenRouterClient.TruncateMessagesForLog(body));
-            Assert.Equal(1, ((JArray)logged["messages"]).Count);
+            // emoji system message only
+            var one = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>(), null, new ClientProperties());
+            Assert.Equal(1, ((JArray)JObject.Parse(OpenRouterClient.TruncateMessagesForLog(one))["messages"]).Count);
+
+            // emoji system message + one user message: still no truncation
+            var two = OpenRouterClient.BuildRequestBody("m", new List<ChatMessage>
+            {
+                new ChatMessage("user", "hi"),
+            }, null, new ClientProperties());
+            var msgs = (JArray)JObject.Parse(OpenRouterClient.TruncateMessagesForLog(two))["messages"];
+            Assert.Equal(2, msgs.Count);
+            Assert.Equal("hi", (string)msgs[1]["content"]);
 
             Assert.Equal("not json", OpenRouterClient.TruncateMessagesForLog("not json"));
             Assert.Null(OpenRouterClient.TruncateMessagesForLog(null));

--- a/GxPT/Services/Logger.cs
+++ b/GxPT/Services/Logger.cs
@@ -42,6 +42,13 @@ namespace GxPT
             catch { return false; }
         }
 
+        // For callers that build expensive log messages: lets them skip the work entirely
+        // when logging is off.
+        public static bool Enabled
+        {
+            get { return IsEnabled(); }
+        }
+
         public static void Log(string category, string message)
         {
             if (!IsEnabled()) return;

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -687,11 +687,9 @@ namespace GxPT
             }
         }
 
-        // Log-friendly copy of the request body: only the last two entries of the messages array
-        // are kept (a long transcript would otherwise dominate the log), with a placeholder string
-        // recording how many earlier messages were dropped. Two because the orchestrator appends an
-        // ephemeral context tail after the real user message - keeping just one would log only that
-        // tail. Everything else is left intact.
+        // Log-friendly copy of the request body: the messages array is replaced wholesale with a
+        // one-string placeholder recording how many messages it held - even one transcript message
+        // bloats the log too much to be worth keeping. Everything else is left intact.
         internal static string TruncateMessagesForLog(string jsonBody)
         {
             if (string.IsNullOrEmpty(jsonBody)) return jsonBody;
@@ -699,12 +697,10 @@ namespace GxPT
             {
                 var obj = JObject.Parse(jsonBody);
                 var msgs = obj["messages"] as JArray;
-                if (msgs != null && msgs.Count > 2)
+                if (msgs != null && msgs.Count > 0)
                 {
                     var truncated = new JArray();
-                    truncated.Add("... " + (msgs.Count - 2) + " earlier message(s) omitted ...");
-                    truncated.Add(msgs[msgs.Count - 2]);
-                    truncated.Add(msgs[msgs.Count - 1]);
+                    truncated.Add("... " + msgs.Count + " message(s) omitted ...");
                     obj["messages"] = truncated;
                 }
                 return obj.ToString(Formatting.None);
@@ -720,7 +716,7 @@ namespace GxPT
         {
             tempFiles = new List<string>();
 
-            try { if (Logger.Enabled) Logger.Log("Stream", "Request JSON (older messages omitted): " + TruncateMessagesForLog(jsonBody)); }
+            try { if (Logger.Enabled) Logger.Log("Stream", "Request JSON (messages omitted): " + TruncateMessagesForLog(jsonBody)); }
             catch { }
             try { Logger.Log("Stream", "Request JSON length=" + (jsonBody != null ? jsonBody.Length : 0)); }
             catch { }

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -687,9 +687,11 @@ namespace GxPT
             }
         }
 
-        // Log-friendly copy of the request body: only the last entry of the messages array is
-        // kept (a long transcript would otherwise dominate the log), with a placeholder string
-        // recording how many earlier messages were dropped. Everything else is left intact.
+        // Log-friendly copy of the request body: only the last two entries of the messages array
+        // are kept (a long transcript would otherwise dominate the log), with a placeholder string
+        // recording how many earlier messages were dropped. Two because the orchestrator appends an
+        // ephemeral context tail after the real user message - keeping just one would log only that
+        // tail. Everything else is left intact.
         internal static string TruncateMessagesForLog(string jsonBody)
         {
             if (string.IsNullOrEmpty(jsonBody)) return jsonBody;
@@ -697,10 +699,11 @@ namespace GxPT
             {
                 var obj = JObject.Parse(jsonBody);
                 var msgs = obj["messages"] as JArray;
-                if (msgs != null && msgs.Count > 1)
+                if (msgs != null && msgs.Count > 2)
                 {
                     var truncated = new JArray();
-                    truncated.Add("... " + (msgs.Count - 1) + " earlier message(s) omitted ...");
+                    truncated.Add("... " + (msgs.Count - 2) + " earlier message(s) omitted ...");
+                    truncated.Add(msgs[msgs.Count - 2]);
                     truncated.Add(msgs[msgs.Count - 1]);
                     obj["messages"] = truncated;
                 }

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -687,11 +687,37 @@ namespace GxPT
             }
         }
 
+        // Log-friendly copy of the request body: only the last entry of the messages array is
+        // kept (a long transcript would otherwise dominate the log), with a placeholder string
+        // recording how many earlier messages were dropped. Everything else is left intact.
+        internal static string TruncateMessagesForLog(string jsonBody)
+        {
+            if (string.IsNullOrEmpty(jsonBody)) return jsonBody;
+            try
+            {
+                var obj = JObject.Parse(jsonBody);
+                var msgs = obj["messages"] as JArray;
+                if (msgs != null && msgs.Count > 1)
+                {
+                    var truncated = new JArray();
+                    truncated.Add("... " + (msgs.Count - 1) + " earlier message(s) omitted ...");
+                    truncated.Add(msgs[msgs.Count - 1]);
+                    obj["messages"] = truncated;
+                }
+                return obj.ToString(Formatting.None);
+            }
+            catch
+            {
+                // Unparseable body: better an oversized log line than none at all.
+                return jsonBody;
+            }
+        }
+
         private string BuildCurlArgs(string jsonBody, out List<string> tempFiles)
         {
             tempFiles = new List<string>();
 
-            try { Logger.Log("Stream", "Request JSON: " + jsonBody); }
+            try { if (Logger.Enabled) Logger.Log("Stream", "Request JSON (older messages omitted): " + TruncateMessagesForLog(jsonBody)); }
             catch { }
             try { Logger.Log("Stream", "Request JSON length=" + (jsonBody != null ? jsonBody.Length : 0)); }
             catch { }


### PR DESCRIPTION
## Summary

The `Stream`-category "Request JSON" log line previously dumped the full serialized request body, so on long conversations every turn re-logged the entire transcript. This blew through the 2 MB log-rotation cap in just a few requests, which is why almost everything kept ending up in `gxpt.log.old`.

The logged copy of the request now replaces the `messages` array with a single count marker:

```
Request JSON (messages omitted): {"model":"...","stream":true,"messages":["... 14 message(s) omitted ..."],"tools":[...],...}
```

- Everything outside `messages` (model, stream flag, usage options, tools, provider options) is still logged intact, and the existing `Request JSON length=` line still records the true body size.
- The actual request sent to OpenRouter is untouched — only the log line changes.
- New `Logger.Enabled` property lets the caller skip the JSON parse entirely when logging is off.
- Unparseable bodies fall back to logging as-is rather than logging nothing.

## Testing

Added `TruncateMessagesForLog` tests covering the collapse-to-marker case (rest of payload untouched) and the bad-JSON/null fallbacks. Note: this container has no .NET toolchain, so the suite was not run here — please run it locally before merging.

https://claude.ai/code/session_01UzEwCt4SJqeQFKYukioVYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzEwCt4SJqeQFKYukioVYC)_