### PR TITLE
Use deepseek-v4-flash for conversation compaction

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1585,8 +1585,10 @@ namespace GxPT
             "The following is a summary of an earlier conversation, provided as context so you can "
             + "continue it seamlessly:\n\n";
 
-        // Compaction always summarizes with gemini-flash (fast/cheap), regardless of the chat model.
-        private const string CompactionModel = "~google/gemini-flash-latest";
+        // Compaction always summarizes with deepseek-v4-flash (an order of magnitude cheaper than
+        // comparable models, which matters when summarizing very long conversations), regardless of
+        // the chat model.
+        private const string CompactionModel = "deepseek/deepseek-v4-flash";
 
         // Chromeless marker shown atop a conversation that /compact created. Persisted via
         // Conversation.ContinuedFromCompaction, so it re-renders on reopen (see RebuildTranscriptAsync).


### PR DESCRIPTION
## Summary

Switches the `/compact` summarization model from `~google/gemini-flash-latest` to `deepseek/deepseek-v4-flash`.

## Why

DeepSeek v4 Flash is an order of magnitude cheaper than Gemini Flash. Compaction sends the entire conversation transcript to the model, so on very long conversations the input token cost adds up quickly — making this the most price-sensitive call in the app. Speed and summarization quality are comparable.

## Changes

- `GxPT/Forms/MainForm.cs`: `CompactionModel` constant now points at `deepseek/deepseek-v4-flash` (a concrete OpenRouter ID already present in the default model catalog, so no `~` alias prefix), with the comment updated to match.

The gemini-flash entry in `ModelDefaults.cs` is untouched — it remains available as a regular chat model; only compaction switches.

https://claude.ai/code/session_0157JjHiDyxTC7GSAvENFgVn

---
_Generated by [Claude Code](https://claude.ai/code/session_0157JjHiDyxTC7GSAvENFgVn)_