### PR TITLE
Scale expanded history sidebar width with font size setting

### DIFF
--- a/GxPT/Managers/SidebarManager.cs
+++ b/GxPT/Managers/SidebarManager.cs
@@ -61,6 +61,23 @@ namespace GxPT
             get { return _sidebarExpanded; }
         }
 
+        // Expanded width grows 5% per font point above the default size so longer
+        // row text at larger fonts still fits. Default mirrors GetChatDefaultFontSize
+        // in SettingsForm: an unparented control's font, i.e. Control.DefaultFont.
+        private static int GetExpandedWidth()
+        {
+            int width = SidebarMaxWidth;
+            try
+            {
+                double fs = AppSettings.GetDouble("font_size", 0);
+                double def = Control.DefaultFont.Size;
+                if (fs > def)
+                    width = (int)Math.Round(SidebarMaxWidth * (1.0 + 0.05 * (fs - def)));
+            }
+            catch { }
+            return width;
+        }
+
         private void InitializeSidebar()
         {
             if (_splitContainer != null)
@@ -127,7 +144,7 @@ namespace GxPT
             if (_splitContainer == null || _sidebarAnimating) return;
 
             _sidebarStartWidth = _splitContainer.SplitterDistance;
-            _sidebarTargetWidth = _sidebarExpanded ? SidebarMinWidth : SidebarMaxWidth;
+            _sidebarTargetWidth = _sidebarExpanded ? SidebarMinWidth : GetExpandedWidth();
             _sidebarAnimating = true;
 
             try
@@ -191,7 +208,7 @@ namespace GxPT
                     _sidebarTimer.Stop();
                     _sidebarAnimWatch.Stop();
                     _sidebarAnimating = false;
-                    _sidebarExpanded = (_sidebarTargetWidth >= SidebarMaxWidth);
+                    _sidebarExpanded = (_sidebarTargetWidth > SidebarMinWidth);
 
                     if (_sidebarArrowPanel != null)
                         _sidebarArrowPanel.Invalidate();
@@ -849,6 +866,21 @@ namespace GxPT
                     var current = _lvConversations.SmallImageList;
                     _lvConversations.SmallImageList = null;
                     _lvConversations.SmallImageList = _lvRowHeightImages;
+                }
+                catch { }
+
+                // Re-apply the font-scaled expanded width if currently expanded
+                try
+                {
+                    if (_sidebarExpanded && !_sidebarAnimating && _splitContainer != null)
+                    {
+                        int expandedW = GetExpandedWidth();
+                        if (_splitContainer.SplitterDistance != expandedW)
+                        {
+                            _splitContainer.SplitterDistance = expandedW;
+                            LayoutSidebarChildren();
+                        }
+                    }
                 }
                 catch { }
 


### PR DESCRIPTION
## Summary
- Grow the conversation history sidebar's expanded width by 5% per font point above the default control font size (8.25pt, read from `Control.DefaultFont` so it stays in sync with how `GetChatDefaultFontSize()` derives the settings default)
- At or below the default font size the width stays at the original 240px; e.g. at 12pt it expands to roughly 285px
- Re-apply the scaled width live in `ApplyFontSetting()` when the font setting changes while the sidebar is expanded
- The end-of-animation "is expanded" check now compares against `SidebarMinWidth` since the expanded target is no longer a constant

## Testing
- Not compiled: this environment has no .NET Framework 3.5 toolchain. The change is confined to `SidebarManager.cs` and uses only constructs already present in the file, but a local build is recommended to confirm.

https://claude.ai/code/session_017kWHom8o3d7ZfaSVWzZXS4

---
_Generated by [Claude Code](https://claude.ai/code/session_017kWHom8o3d7ZfaSVWzZXS4)_