### PR TITLE
Fix detached turn handling when tabs are recycled mid-flight

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -426,6 +426,20 @@ namespace GxPT
             _onContinue = null;
         }
 
+        // Resolve any pending prompt as if the user had declined (Deny / Stop), then hide. Used when
+        // the prompting turn detaches from this panel's tab (the tab closed or was recycled
+        // mid-prompt): the worker blocked in TranscriptApprovalPrompt/TranscriptContinuationPrompt
+        // must be released - HidePanel alone clears the callbacks WITHOUT invoking them, which would
+        // leave that turn waiting forever (and its conversation never saved).
+        public void DenyPending()
+        {
+            Action<ApprovalChoice> choose = _onChoose;
+            Action<bool> cont = _onContinue;
+            HidePanel();
+            if (choose != null) choose(ApprovalChoice.Deny);
+            if (cont != null) cont(false);
+        }
+
         // The clamped natural height of the current details control's content, in [Min,Max].
         private int ClampedDetailsHeight(bool handled)
         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2226,6 +2226,12 @@ namespace GxPT
                 return;
             }
 
+            // The turn's conversation, snapshotted NOW (UI thread, send start). Closing the last tab
+            // recycles the page and REPLACES ctx.Conversation with a fresh one mid-flight; this turn
+            // must keep appending to - and finally save - the conversation it was started for, and
+            // must stop painting into the recycled tab's transcript (#141).
+            Conversation convo = ctx.Conversation;
+
             // Add placeholder assistant message to stream into and capture its index
             int assistantIndex = ctx.Transcript.AddMessageGetIndex(MessageRole.Assistant, string.Empty);
             if (zdrForSend) ctx.Transcript.SetMessageZdrTag(assistantIndex, true);
@@ -2242,6 +2248,9 @@ namespace GxPT
             renderTimer.Interval = 75; // ~13 fps; adjust between 50-150ms if needed
             renderTimer.Tick += (s2, e2) =>
             {
+                // The recycled tab's transcript is not this turn's to draw on (the placeholder
+                // index points into a cleared list).
+                if (!ReferenceEquals(ctx.Conversation, convo)) return;
                 string snapshot;
                 int len;
                 lock (sbLock)
@@ -2266,7 +2275,7 @@ namespace GxPT
                 {
                     // Snapshot the history and log it
                     // Build a model snapshot where attachments are appended to content on-the-fly
-                    var snapshot = BuildMessagesForModel(ctx.Conversation.History);
+                    var snapshot = BuildMessagesForModel(convo.History);
                     // Prompt caching: the newest message carries the cache breakpoint, so each
                     // turn re-reads the prior turn's prefix and extends it. Snapshot messages are
                     // request-local clones - the flag never lands in persisted history.
@@ -2295,7 +2304,7 @@ namespace GxPT
                     // cache activity (a read or a write) sets or moves the preference; merely
                     // serving a request proves nothing. Usage/cost accounting (status bar)
                     // records on every model.
-                    Conversation usageConvo = ctx.Conversation;
+                    Conversation usageConvo = convo;
                     bool cachingModel = OpenRouterClient.ModelSupportsPromptCaching(modelToUse);
                     if (usageConvo != null)
                     {
@@ -2329,26 +2338,40 @@ namespace GxPT
                             {
                                 try { renderTimer.Stop(); renderTimer.Dispose(); }
                                 catch { }
-                                try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                                catch { }
+                                // Detached = the tab was recycled mid-flight: the transcript is not
+                                // this turn's to touch, but the response still belongs in the turn's
+                                // conversation (and its file).
+                                bool attached = ReferenceEquals(ctx.Conversation, convo);
+                                if (attached)
+                                {
+                                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                                    catch { }
+                                }
                                 // A user stop ends the stream via onDone (no error). If nothing
                                 // streamed yet, drop the empty placeholder rather than committing an
                                 // empty assistant message; otherwise keep the partial text as normal.
                                 bool cancelled = (cancel != null && cancel.IsCancelled);
                                 if (cancelled && finalText.Trim().Length == 0)
                                 {
-                                    if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                    if (attached && assistantIndex == ctx.Transcript.MessageCount - 1)
                                         ctx.Transcript.RemoveLastMessage();
                                     Logger.Log("Send", "Stream stopped by user before any output at index=" + assistantIndex);
                                 }
                                 else
                                 {
-                                    ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
-                                    ctx.Conversation.AddAssistantMessage(finalText);
-                                    ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                                    // Save assistant completion if allowed
-                                    if (!ctx.NoSaveUntilUserSend)
-                                        ConversationStore.Save(ctx.Conversation); // save only after streaming completes
+                                    if (attached) ctx.Transcript.UpdateMessageAt(assistantIndex, finalText);
+                                    convo.AddAssistantMessage(finalText);
+                                    if (attached)
+                                    {
+                                        convo.SelectedModel = ctx.SelectedModel;
+                                        // Save assistant completion if allowed
+                                        if (!ctx.NoSaveUntilUserSend)
+                                            ConversationStore.Save(convo); // save only after streaming completes
+                                    }
+                                    else
+                                    {
+                                        SaveDetachedTurnConversation(convo);
+                                    }
                                     try { Logger.Log("Transcript", "Final assistant message at index=" + assistantIndex + ":\n" + (finalText ?? string.Empty)); }
                                     catch { }
                                     Logger.Log("Send", "Assistant finalized at index=" + assistantIndex + ", chars=" + (finalText != null ? finalText.Length : 0) + (cancelled ? " (stopped by user)" : string.Empty));
@@ -2368,15 +2391,20 @@ namespace GxPT
                             {
                                 try { renderTimer.Stop(); renderTimer.Dispose(); }
                                 catch { }
-                                try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                                catch { }
-                                // Keep any partial text in the assistant bubble; otherwise drop the
-                                // empty placeholder so only the red error notice shows.
-                                if (partial.Trim().Length > 0)
-                                    ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
-                                else if (assistantIndex == ctx.Transcript.MessageCount - 1)
-                                    ctx.Transcript.RemoveLastMessage();
-                                ShowTranscriptError(ctx.Transcript, err);
+                                // Transcript writes only while the tab still hosts this turn's
+                                // conversation (see the success path).
+                                if (ReferenceEquals(ctx.Conversation, convo))
+                                {
+                                    try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                                    catch { }
+                                    // Keep any partial text in the assistant bubble; otherwise drop the
+                                    // empty placeholder so only the red error notice shows.
+                                    if (partial.Trim().Length > 0)
+                                        ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                                    else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                        ctx.Transcript.RemoveLastMessage();
+                                    ShowTranscriptError(ctx.Transcript, err);
+                                }
                                 Logger.Log("Send", "Stream error at index=" + assistantIndex + ": " + err);
                                 ctx.IsSending = false;
                                 ctx.Cancellation = null;
@@ -2395,13 +2423,17 @@ namespace GxPT
                     {
                         try { renderTimer.Stop(); renderTimer.Dispose(); }
                         catch { }
-                        try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-                        catch { }
-                        if (partial.Trim().Length > 0)
-                            ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
-                        else if (assistantIndex == ctx.Transcript.MessageCount - 1)
-                            ctx.Transcript.RemoveLastMessage();
-                        ShowTranscriptError(ctx.Transcript, ex.Message);
+                        // Transcript writes only while the tab still hosts this turn's conversation.
+                        if (ReferenceEquals(ctx.Conversation, convo))
+                        {
+                            try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                            catch { }
+                            if (partial.Trim().Length > 0)
+                                ctx.Transcript.UpdateMessageAt(assistantIndex, partial);
+                            else if (assistantIndex == ctx.Transcript.MessageCount - 1)
+                                ctx.Transcript.RemoveLastMessage();
+                            ShowTranscriptError(ctx.Transcript, ex.Message);
+                        }
                         Logger.Log("Send", "Exception in streaming worker: " + ex.Message);
                         ctx.IsSending = false;
                         ctx.Cancellation = null;
@@ -2629,6 +2661,12 @@ namespace GxPT
 
         private void BeginToolSend(TabManager.ChatTabContext ctx, string model, bool zdr)
         {
+            // The turn's conversation, snapshotted NOW (UI thread, send start). Closing the last tab
+            // recycles the page and REPLACES ctx.Conversation with a fresh one mid-flight; this turn
+            // must keep appending to - and finally save - the conversation it was started for, and
+            // must stop painting into the recycled tab's transcript (#141).
+            Conversation convo = ctx.Conversation;
+
             // Ordered transcript segments for this turn: assistant-text bubbles and chrome-less
             // tool-activity blocks, interleaved in arrival order so the view reads chronologically
             // (text, then the tools it triggered, then the next text, ...). A segment only becomes a
@@ -2639,7 +2677,12 @@ namespace GxPT
 
             var renderTimer = new System.Windows.Forms.Timer();
             renderTimer.Interval = 75;
-            renderTimer.Tick += delegate { MaterializeLiveSegs(ctx, sbLock, segs); };
+            // Stop materializing once the tab no longer hosts this turn's conversation (recycled):
+            // unmaterialized segments would otherwise ADD bubbles to the new blank transcript.
+            renderTimer.Tick += delegate
+            {
+                if (ReferenceEquals(ctx.Conversation, convo)) MaterializeLiveSegs(ctx, sbLock, segs);
+            };
             try { ctx.Transcript.StickToBottomDuringStreaming = true; }
             catch { }
             renderTimer.Start();
@@ -2671,7 +2714,7 @@ namespace GxPT
                     // Reveal state is per-conversation (recency-ordered; persisted with the
                     // conversation) so concurrent tabs don't churn each other's tools array - the
                     // array must stay byte-stable across requests for prompt caching to hit.
-                    Conversation revealConvo = ctx.Conversation;
+                    Conversation revealConvo = convo;
                     if (revealConvo != null)
                     {
                         if (revealConvo.RevealedTools == null)
@@ -2728,7 +2771,7 @@ namespace GxPT
                     // the enabled set. Rebuilt per send, so on-disk edits take effect on the next turn.
                     SkillCatalog skillCatalog =
                         SkillInjection.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
-                    Conversation skillConvo = ctx.Conversation;
+                    Conversation skillConvo = convo;
                     List<Skill> enabledSkills = SkillResolve.EnabledSkills(
                         skillCatalog.Skills, SkillEnablement.LoadGlobal(),
                         skillConvo != null ? skillConvo.SkillsFeatureOff : null,
@@ -2827,16 +2870,16 @@ namespace GxPT
                     Action onComplete = delegate
                     {
                         BeginInvoke((MethodInvoker)delegate
-                        { FinalizeToolSend(ctx, renderTimer, sbLock, segs, null); });
+                        { FinalizeToolSend(ctx, convo, renderTimer, sbLock, segs, null); });
                     };
                     Action<string> onErr = delegate(string err)
                     {
                         string e2 = string.IsNullOrEmpty(err) ? "Unknown error." : err;
                         BeginInvoke((MethodInvoker)delegate
-                        { FinalizeToolSend(ctx, renderTimer, sbLock, segs, e2); });
+                        { FinalizeToolSend(ctx, convo, renderTimer, sbLock, segs, e2); });
                     };
 
-                    orch.RunTurn(ctx.Conversation.History, new DelegateToolLoopUi(onAppend, onToolCall, onToolResult, onComplete, onErr));
+                    orch.RunTurn(convo.History, new DelegateToolLoopUi(onAppend, onToolCall, onToolResult, onComplete, onErr));
                 }
                 catch (Exception ex)
                 {
@@ -2847,39 +2890,69 @@ namespace GxPT
                     catch { }
                     string msg = ex.Message;
                     BeginInvoke((MethodInvoker)delegate
-                    { FinalizeToolSend(ctx, renderTimer, sbLock, segs, msg); });
+                    { FinalizeToolSend(ctx, convo, renderTimer, sbLock, segs, msg); });
                 }
             });
         }
 
         // Finalize a tool turn on the UI thread. error == null means success. The orchestrator has
         // already appended the structured assistant/tool messages to history, so we only flush the
-        // transcript bubbles and save.
-        private void FinalizeToolSend(TabManager.ChatTabContext ctx, System.Windows.Forms.Timer renderTimer,
+        // transcript bubbles and save. convo is the conversation the turn was STARTED for - when the
+        // tab was recycled mid-flight (last tab closed) it differs from ctx.Conversation, and the
+        // turn finishes detached: no transcript writes, but the response still reaches its file.
+        private void FinalizeToolSend(TabManager.ChatTabContext ctx, Conversation convo,
+                                      System.Windows.Forms.Timer renderTimer,
                                       object sbLock, List<LiveSeg> segs, string error)
         {
             try { renderTimer.Stop(); renderTimer.Dispose(); }
             catch { }
-            try { ctx.Transcript.StickToBottomDuringStreaming = false; }
-            catch { }
 
-            // Flush any pending segment content (final delta the timer may not have rendered yet).
-            MaterializeLiveSegs(ctx, sbLock, segs);
-
-            // A failed turn surfaces as a chrome-less red notice below whatever (if anything) the model
-            // managed to produce — never baked into a bubble.
-            if (error != null)
-                ShowTranscriptError(ctx.Transcript, error);
-
-            if (error == null)
+            bool attached = ReferenceEquals(ctx.Conversation, convo);
+            if (attached)
             {
-                ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation);
+                try { ctx.Transcript.StickToBottomDuringStreaming = false; }
+                catch { }
+
+                // Flush any pending segment content (final delta the timer may not have rendered yet).
+                MaterializeLiveSegs(ctx, sbLock, segs);
+
+                // A failed turn surfaces as a chrome-less red notice below whatever (if anything) the
+                // model managed to produce — never baked into a bubble.
+                if (error != null)
+                    ShowTranscriptError(ctx.Transcript, error);
+            }
+
+            if (error == null && convo != null)
+            {
+                if (attached)
+                {
+                    convo.SelectedModel = ctx.SelectedModel;
+                    if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(convo);
+                }
+                else
+                {
+                    SaveDetachedTurnConversation(convo);
+                }
             }
             ctx.IsSending = false;
             ctx.Cancellation = null;
             HideGenerationBar(ctx);
             if (_sidebarManager != null) _sidebarManager.RefreshSidebarList();
+        }
+
+        // Persist a detached turn's conversation (its tab was recycled out from under it). Update-only:
+        // never re-create a file the user deleted while the turn was running - the tab Delete action
+        // also routes through the recycle path, and its delete must stick.
+        private static void SaveDetachedTurnConversation(Conversation convo)
+        {
+            if (convo == null) return;
+            try
+            {
+                string path = ConversationStore.GetPathForId(convo.Id);
+                if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
+                    ConversationStore.Save(convo);
+            }
+            catch { }
         }
 
         // Create/update the transcript messages backing the ordered live segments. Each segment becomes

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -964,6 +964,12 @@ namespace GxPT
             // to is gone. The flag also keeps later tab-switch syncs from re-showing it.
             ctx.SendDetached = ctx.IsSending;
             SyncGenerationIndicatorFromActiveTab();
+            // A tool-approval / continuation prompt may already be showing for the closed
+            // conversation's now-detached turn: resolve it as Deny/Stop so the blocked worker is
+            // released and the turn wraps up and saves. (Prompts the turn raises AFTER detaching are
+            // auto-denied by the send path's panel gate.)
+            try { if (ctx.ApprovalPanel != null) ctx.ApprovalPanel.DenyPending(); }
+            catch { }
         }
 
         // Opens a conversation tab whose working folder is preset to 'dir'. Mirrors the
@@ -2700,10 +2706,21 @@ namespace GxPT
                     // Per-turn approval policy bound to THIS tab's panel, so the prompt appears on the
                     // conversation that requested the tool. The remembered-choice store is shared
                     // across tabs. Falls back to allow-all only if approvals couldn't be set up.
+                    // The panel resolver yields null once the tab no longer hosts this turn's
+                    // conversation (recycled mid-flight): a detached turn's prompts AUTO-DENY instead
+                    // of appearing on the new blank tab, and the turn wraps up and saves.
                     IToolApprovalPolicy approval = (_approvalStore != null && ctx.ApprovalPanel != null)
                         ? new ToolApprovalPolicy(
                             new ToolClassifier(),
-                            new TranscriptApprovalPrompt(this, delegate { return ctx.ApprovalPanel; }),
+                            new TranscriptApprovalPrompt(this, delegate
+                            {
+                                // Null (=> deny) when the tab was recycled away from this turn's
+                                // conversation, or closed outright (panel disposed with the page).
+                                ToolApprovalPanel p = ctx.ApprovalPanel;
+                                bool usable = ReferenceEquals(ctx.Conversation, convo)
+                                    && p != null && !p.IsDisposed;
+                                return usable ? p : null;
+                            }),
                             _approvalStore,
                             _mcpRegistry) // classify third-party tools by their declared readOnly/destructive hints
                         : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
@@ -2742,7 +2759,14 @@ namespace GxPT
                     // wraps up by default.
                     if (ctx.ApprovalPanel != null)
                     {
-                        var contPrompt = new TranscriptContinuationPrompt(this, delegate { return ctx.ApprovalPanel; });
+                        var contPrompt = new TranscriptContinuationPrompt(this, delegate
+                        {
+                            // Same gate as the approval prompt: null (=> stop/wrap up) once detached.
+                            ToolApprovalPanel p = ctx.ApprovalPanel;
+                            bool usable = ReferenceEquals(ctx.Conversation, convo)
+                                && p != null && !p.IsDisposed;
+                            return usable ? p : null;
+                        });
                         orch.ContinuationDecider = delegate(int n) { return contPrompt.Ask(n); };
                     }
                     orch.RequestMessageTransform = delegate(IList<ChatMessage> h)

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -451,6 +451,13 @@ namespace GxPT
 
             try
             {
+                // A pending approval/continuation prompt would be disposed with the page WITHOUT its
+                // callback firing, stranding the closed conversation's turn on its blocked worker
+                // forever (it would never finalize or save). Resolve it as Deny/Stop first; the
+                // now-detached turn then wraps up on its own.
+                try { if (ctx != null && ctx.ApprovalPanel != null) ctx.ApprovalPanel.DenyPending(); }
+                catch { }
+
                 int desiredIndex = -1;
                 if (_tabControl != null)
                 {

--- a/GxPT/Services/Mcp/TranscriptApprovalPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptApprovalPrompt.cs
@@ -29,13 +29,19 @@ namespace GxPT
                 {
                     _uiMarshal.BeginInvoke((MethodInvoker)delegate
                     {
-                        ToolApprovalPanel panel = _getPanel();
-                        if (panel == null) { done.Set(); return; }
-                        panel.ShowFor(req, delegate(ApprovalChoice choice)
+                        // Any UI failure (panel resolver, a disposed panel mid-show) must still
+                        // signal the waiting worker - an unset event strands the turn forever.
+                        try
                         {
-                            result[0] = choice;
-                            done.Set();
-                        });
+                            ToolApprovalPanel panel = _getPanel();
+                            if (panel == null) { done.Set(); return; }
+                            panel.ShowFor(req, delegate(ApprovalChoice choice)
+                            {
+                                result[0] = choice;
+                                done.Set();
+                            });
+                        }
+                        catch { done.Set(); }
                     });
                 }
                 catch

--- a/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
@@ -32,13 +32,19 @@ namespace GxPT
                 {
                     _uiMarshal.BeginInvoke((MethodInvoker)delegate
                     {
-                        ToolApprovalPanel panel = _getPanel();
-                        if (panel == null) { done.Set(); return; }
-                        panel.ShowContinuation(iterationsSoFar, delegate(bool cont)
+                        // Any UI failure (panel resolver, a disposed panel mid-show) must still
+                        // signal the waiting worker - an unset event strands the turn forever.
+                        try
                         {
-                            result[0] = cont;
-                            done.Set();
-                        });
+                            ToolApprovalPanel panel = _getPanel();
+                            if (panel == null) { done.Set(); return; }
+                            panel.ShowContinuation(iterationsSoFar, delegate(bool cont)
+                            {
+                                result[0] = cont;
+                                done.Set();
+                            });
+                        }
+                        catch { done.Set(); }
                     });
                 }
                 catch


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where closing the last conversation tab while a model turn is in-flight causes the turn to become detached from its original conversation. The changes ensure that detached turns properly complete, save their responses, and don't corrupt the recycled tab's transcript.

## Key Changes

- **Snapshot conversation at turn start**: Both `StartModelTurn()` and `BeginToolSend()` now capture `ctx.Conversation` at the moment the turn begins (UI thread). This ensures the turn always appends to and saves the correct conversation, even if the tab is recycled mid-flight.

- **Guard transcript writes**: Added `ReferenceEquals(ctx.Conversation, convo)` checks before all transcript updates (rendering, error display, message updates). When a tab is recycled, the transcript is cleared and repurposed for a new conversation, so detached turns must not write to it.

- **Detached turn finalization**: 
  - Model turn responses are saved via new `SaveDetachedTurnConversation()` helper (update-only, respects user deletes)
  - Tool turn responses use the same detached path in `FinalizeToolSend()`
  - Both paths skip transcript updates but persist the conversation to disk

- **Approval/continuation prompt handling**:
  - Added `DenyPending()` method to `ToolApprovalPanel` to resolve pending prompts as Deny/Stop
  - Integrated prompt resolution in `ResetRecycledTabWorkspaceState()` and `TabManager.CloseConversationTab()`
  - Modified approval/continuation prompt delegates to return null (auto-deny) when the tab no longer hosts the turn's conversation
  - Added try-catch guards in `TranscriptApprovalPrompt` and `TranscriptContinuationPrompt` to ensure worker threads are always released

- **Render timer safety**: Render timers in both model and tool turns now check conversation identity before materializing segments, preventing stale content from appearing on recycled tabs.

## Implementation Details

The core issue is that `ctx.Conversation` can be replaced when the last tab closes and triggers workspace recycling. By snapshotting the conversation reference at turn start, the turn can:
1. Continue appending to the correct conversation object
2. Detect when it's been detached (identity check fails)
3. Skip UI updates but still persist results
4. Properly release any blocked approval/continuation prompts

This maintains data integrity while preventing UI corruption and worker thread deadlocks.

https://claude.ai/code/session_01MdN3x6d59FQ1vuyePRMu2r