### PR TITLE
Fix duplicate-open / usage-cost clobbering and related tab/status-bar bugs

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -994,9 +994,9 @@ namespace GxPT
                 ctx.Conversation.WorkingDir = dir;
                 ctx.Conversation.WorkspaceStripDismissed = false;
             }
-            PersistWorkingDir(ctx);
+            PersistWorkingDir(ctx); // holds the folder in memory; a blank tab isn't written until first send
             // (The tab is already registered in the open-by-id dedup map from when its conversation was
-            // assigned - see TabManager.WireConversationTracking - and it persists under that same id.)
+            // assigned - see TabManager.WireConversationTracking - under the id it will save with.)
             ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
             try { SelectTab(ctx.Page); } catch { }
         }
@@ -1024,8 +1024,18 @@ namespace GxPT
         private void PersistWorkingDir(TabManager.ChatTabContext ctx)
         {
             if (ctx == null || ctx.Conversation == null) return;
+            // Always hold the folder in memory; the first user send persists the conversation (with this
+            // folder) like any other blank tab.
             ctx.Conversation.WorkingDir = ctx.WorkingDir;
-            try { if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation); }
+            // Don't write a blank, never-sent conversation to disk just because a workspace folder was
+            // set - that littered the history sidebar with empty "New Conversation" entries (and created
+            // invisible empty files on the strip path, which doesn't refresh the sidebar). A conversation
+            // that already has messages still persists the folder change immediately.
+            try
+            {
+                if (!ctx.NoSaveUntilUserSend && ctx.Conversation.History.Count > 0)
+                    ConversationStore.Save(ctx.Conversation);
+            }
             catch { }
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -995,9 +995,8 @@ namespace GxPT
                 ctx.Conversation.WorkspaceStripDismissed = false;
             }
             PersistWorkingDir(ctx);
-            // PersistWorkingDir just wrote this conversation to disk, so it now shows in the sidebar:
-            // track it so re-opening it from there focuses this tab instead of forking a duplicate.
-            TrackOpenConversationForTab(ctx);
+            // (The tab is already registered in the open-by-id dedup map from when its conversation was
+            // assigned - see TabManager.WireConversationTracking - and it persists under that same id.)
             ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
             try { SelectTab(ctx.Page); } catch { }
         }
@@ -1030,17 +1029,28 @@ namespace GxPT
             catch { }
         }
 
-        // Register a tab's conversation in the sidebar's open-by-id map once it has a file on disk,
-        // so double-clicking its sidebar entry focuses THIS tab instead of loading a duplicate copy.
-        // Conversations created in-app (a new tab's first send, /new, opening a recent workspace) were
-        // previously tracked only when opened FROM the sidebar, so they slipped the dedup: a second
-        // copy would open in a blank tab, and the two same-id tabs would then clobber each other's
-        // saves (usage/cost included). Idempotent; skips conversations not yet persisted (no sidebar
-        // entry exists to dedup against) and the initial/help tabs already tracked elsewhere.
+        // Single point that registers a tab's conversation in the sidebar's open-by-id dedup map, so
+        // re-opening that conversation focuses THIS tab instead of loading a duplicate copy. Driven by
+        // ChatTabContext.ConversationAssigned (wired in TabManager.WireConversationTracking), so it runs
+        // for EVERY way a conversation is put on a tab - new tab, /new, recycle, opening from the
+        // sidebar/history, help, or opening a recent workspace - and any future path gets it for free.
+        // Tracking an id before its file exists is harmless: the dedup only ever looks up ids that have a
+        // saved sidebar entry, and a brand-new conversation keeps the same id through to its first save.
+        // Idempotent (overwrites the id->page entry). The id is ensured at creation/load before the
+        // assignment fires, so it is non-empty here in practice; guarded anyway.
+        internal void OnTabConversationAssigned(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            // Atomic re-point: drop whatever id this page mapped to before (e.g. the blank conversation
+            // a reused tab started with) and register the new one, so the page maps to exactly its
+            // current conversation and no stale entries accumulate.
+            UntrackOpenConversation(ctx.Page);
+            TrackOpenConversationForTab(ctx);
+        }
+
         private void TrackOpenConversationForTab(TabManager.ChatTabContext ctx)
         {
             if (_sidebarManager == null || ctx == null || ctx.Conversation == null) return;
-            if (ctx.NoSaveUntilUserSend) return;
             if (string.IsNullOrEmpty(ctx.Conversation.Id)) return;
             _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
         }
@@ -2208,10 +2218,8 @@ namespace GxPT
                     ctx.NoSaveUntilUserSend = false;
                 }
                 ConversationStore.Save(ctx.Conversation); // save when a new user message starts/continues a convo
-                // Now that this conversation has a file (and a sidebar entry), make sure the sidebar's
-                // open-by-id dedup knows it's open here - new-tab/in-app conversations were never tracked,
-                // so re-opening one from the sidebar would fork it into a duplicate tab.
-                TrackOpenConversationForTab(ctx);
+                // (No explicit open-by-id tracking here: the tab was registered when its conversation was
+                // assigned - see TabManager.WireConversationTracking - under the same id it saves with.)
                 Logger.Log("Send", "User message added. HistoryCount=" + ctx.Conversation.History.Count);
                 if (_inputManager != null)
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -354,10 +354,15 @@ namespace GxPT
                 {
                 // We'll reuse the initial blank tab for the first item if suitable
                 bool firstUsed = false;
+                // A conversation must not open into two tabs: duplicates fork the in-memory copy and
+                // their saves clobber each other (a prior bug could already have written the same id
+                // twice into session.json), so skip ids we've already opened this restore.
+                var seenIds = new HashSet<string>(StringComparer.Ordinal);
                 for (int i = 0; i < ids.Count; i++)
                 {
                     string id = ids[i];
                     if (string.IsNullOrEmpty(id)) continue;
+                    if (!seenIds.Add(id)) continue;
                     try
                     {
                         if (IsHelpConversationId(id))
@@ -990,6 +995,9 @@ namespace GxPT
                 ctx.Conversation.WorkspaceStripDismissed = false;
             }
             PersistWorkingDir(ctx);
+            // PersistWorkingDir just wrote this conversation to disk, so it now shows in the sidebar:
+            // track it so re-opening it from there focuses this tab instead of forking a duplicate.
+            TrackOpenConversationForTab(ctx);
             ApplyLoadedWorkingDir(ctx); // shows the workspace strip + binds MCP; also re-adds to recents
             try { SelectTab(ctx.Page); } catch { }
         }
@@ -1020,6 +1028,21 @@ namespace GxPT
             ctx.Conversation.WorkingDir = ctx.WorkingDir;
             try { if (!ctx.NoSaveUntilUserSend) ConversationStore.Save(ctx.Conversation); }
             catch { }
+        }
+
+        // Register a tab's conversation in the sidebar's open-by-id map once it has a file on disk,
+        // so double-clicking its sidebar entry focuses THIS tab instead of loading a duplicate copy.
+        // Conversations created in-app (a new tab's first send, /new, opening a recent workspace) were
+        // previously tracked only when opened FROM the sidebar, so they slipped the dedup: a second
+        // copy would open in a blank tab, and the two same-id tabs would then clobber each other's
+        // saves (usage/cost included). Idempotent; skips conversations not yet persisted (no sidebar
+        // entry exists to dedup against) and the initial/help tabs already tracked elsewhere.
+        private void TrackOpenConversationForTab(TabManager.ChatTabContext ctx)
+        {
+            if (_sidebarManager == null || ctx == null || ctx.Conversation == null) return;
+            if (ctx.NoSaveUntilUserSend) return;
+            if (string.IsNullOrEmpty(ctx.Conversation.Id)) return;
+            _sidebarManager.TrackOpenConversation(ctx.Conversation.Id, ctx.Page);
         }
 
         private void OnTabsChanged()
@@ -2185,6 +2208,10 @@ namespace GxPT
                     ctx.NoSaveUntilUserSend = false;
                 }
                 ConversationStore.Save(ctx.Conversation); // save when a new user message starts/continues a convo
+                // Now that this conversation has a file (and a sidebar entry), make sure the sidebar's
+                // open-by-id dedup knows it's open here - new-tab/in-app conversations were never tracked,
+                // so re-opening one from the sidebar would fork it into a duplicate tab.
+                TrackOpenConversationForTab(ctx);
                 Logger.Log("Send", "User message added. HistoryCount=" + ctx.Conversation.History.Count);
                 if (_inputManager != null)
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -969,6 +969,10 @@ namespace GxPT
             // to is gone. The flag also keeps later tab-switch syncs from re-showing it.
             ctx.SendDetached = ctx.IsSending;
             SyncGenerationIndicatorFromActiveTab();
+            // Usage status bar (context / cost / savings): recycling reuses the same selected tab, so
+            // no tab-switch fires to refresh it - without this the bar keeps showing the closed
+            // conversation's totals. The fresh conversation's totals are zero, so the bar clears.
+            SyncUsageStatusFromActiveTab();
             // A tool-approval / continuation prompt may already be showing for the closed
             // conversation's now-detached turn: resolve it as Deny/Stop so the blocked worker is
             // released and the turn wraps up and saves. (Prompts the turn raises AFTER detaching are

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -35,7 +35,26 @@ namespace GxPT
         {
             public TabPage Page;
             public ChatTranscriptControl Transcript;
-            public Conversation Conversation;
+            // Backing field for Conversation. Assignment goes through the property so that putting a
+            // conversation on a tab is the SAME action as registering it in the sidebar's open-by-id
+            // dedup map - no open-path can do one without the other. See ConversationAssigned.
+            private Conversation _conversation;
+            public Conversation Conversation
+            {
+                get { return _conversation; }
+                set
+                {
+                    _conversation = value;
+                    Action<ChatTabContext> h = ConversationAssigned;
+                    if (h != null) h(this);
+                }
+            }
+            // Fired whenever this tab's Conversation reference is (re)assigned. TabManager wires this
+            // (WireConversationTracking) to the host's open-by-id tracking, so every current and future
+            // way of opening a tab keeps the dedup map in sync just by assigning the property. Set after
+            // construction, so the object-initializer assignment in the creators does not fire it -
+            // those assign the conversation explicitly once the callback is wired.
+            internal Action<ChatTabContext> ConversationAssigned;
             public bool IsSending;
             public string SelectedModel;
             public bool NoSaveUntilUserSend;
@@ -162,6 +181,16 @@ namespace GxPT
             catch { }
         }
 
+        // Wire a context so any (re)assignment of its Conversation keeps the host's sidebar open-by-id
+        // dedup map in sync. This is the single chokepoint: every path that puts a conversation on a tab
+        // does so through the Conversation property, so none can open a tab without registering it - the
+        // class of bug where a new open-path silently forks a duplicate becomes structurally impossible.
+        private void WireConversationTracking(ChatTabContext ctx)
+        {
+            if (ctx == null) return;
+            ctx.ConversationAssigned = delegate(ChatTabContext c) { _mainForm.OnTabConversationAssigned(c); };
+        }
+
         public ChatTabContext SetupInitialConversationTab(TabPage initialTab, ChatTranscriptControl initialTranscript)
         {
             try
@@ -176,12 +205,16 @@ namespace GxPT
                 {
                     Page = initialTab,
                     Transcript = initialTranscript,
-                    Conversation = new Conversation(_mainForm.GetClient()),
                     IsSending = false,
                     SelectedModel = _mainForm.GetConfiguredDefaultModel()
                 };
-                ctx.Conversation.SelectedModel = ctx.SelectedModel;
-                _mainForm.EnsureConversationId(ctx.Conversation);
+                WireConversationTracking(ctx);
+                // Ensure the id before assigning, so the property setter registers a real id in the
+                // dedup map (a brand-new Conversation has no id until EnsureConversationId runs).
+                var initialConvo = new Conversation(_mainForm.GetClient());
+                initialConvo.SelectedModel = ctx.SelectedModel;
+                _mainForm.EnsureConversationId(initialConvo);
+                ctx.Conversation = initialConvo;
                 // Wire edit-request, retry and name-generated handlers for this tab
                 HookEditRequest(ctx);
                 HookRetryRequest(ctx);
@@ -218,12 +251,16 @@ namespace GxPT
             {
                 Page = page,
                 Transcript = transcript,
-                Conversation = new Conversation(_mainForm.GetClient()),
                 IsSending = false,
                 SelectedModel = _mainForm.GetConfiguredDefaultModel()
             };
-            ctx.Conversation.SelectedModel = ctx.SelectedModel;
-            _mainForm.EnsureConversationId(ctx.Conversation);
+            WireConversationTracking(ctx);
+            // Ensure the id before assigning, so the property setter registers a real id in the dedup
+            // map (a brand-new Conversation has no id until EnsureConversationId runs).
+            var convo = new Conversation(_mainForm.GetClient());
+            convo.SelectedModel = ctx.SelectedModel;
+            _mainForm.EnsureConversationId(convo);
+            ctx.Conversation = convo;
 
             // Wire edit-request, retry and name-generated handlers for this tab
             HookEditRequest(ctx);
@@ -424,7 +461,11 @@ namespace GxPT
                         try { _mainForm.UntrackOpenConversation(page); }
                         catch { }
                         if (ctx.Transcript != null) ctx.Transcript.ClearMessages();
-                        ctx.Conversation = new Conversation(_mainForm.GetClient());
+                        // Fresh blank conversation for the recycled tab; ensure its id before assigning
+                        // so the property setter re-registers this page under the new id.
+                        var recycled = new Conversation(_mainForm.GetClient());
+                        _mainForm.EnsureConversationId(recycled);
+                        ctx.Conversation = recycled;
                         // Reset model to default on a fresh blank tab
                         try
                         {


### PR DESCRIPTION
## Summary

A chain of related fixes around tab ↔ conversation association, sidebar dedup, and the usage status bar. The headline bug: a conversation created in-app could be opened a second time, producing two tabs backed by the same id and file whose saves clobber each other — including the per-conversation usage/cost totals.

## The bugs

1. **Duplicate-open / usage-cost clobbering.** Conversations created inside the app (a new tab's first send, `/new`, opening a recent workspace) were registered in the sidebar's open-by-id dedup map only when opened *from* the sidebar. Created in-app, they slipped the dedup, so double-clicking such a conversation in the sidebar missed the "already open" lookup and loaded a fresh copy into the active blank tab instead of focusing the open one. The result is two tabs with the same conversation id and file, each accruing usage on its own in-memory copy, then clobbering each other on every save (sends, the late usage reconcile, model/ZDR/working-folder changes) — last writer wins, so one tab's totals silently overwrite the other's. The two same-named tabs are a symptom of this fork, not the cause.

2. **Last-tab close didn't clear the status bar.** Closing the last tab recycles it into a fresh blank conversation *in place* rather than switching tabs, so `OnTabSelected` never fires and the usage status bar kept showing the closed conversation's context/cost/savings.

3. **Empty workspace tabs littered history.** Opening a recent workspace (and, less visibly, setting a folder via the workspace strip) wrote the still-empty conversation to disk immediately, creating never-used "New Conversation" entries in the sidebar.

## The fixes

- **Track in-app conversations** in the open-by-id map, and de-duplicate ids during session restore so an already-poisoned `session.json` can't reopen the same conversation into two tabs.
- **Consolidate tracking into a single, unforgettable chokepoint.** `ChatTabContext.Conversation` becomes a notifying property whose setter fires a `ConversationAssigned` callback wired to the open-by-id tracking. Putting a conversation on a tab is now the *same action* as registering it, so no current or future open-path can do one without the other — the "a new way to open a tab forgot to track" bug class is structurally prevented. The three creation sites (initial tab, new tab, last-tab recycle) ensure the conversation id before assigning so the setter registers a real id, and the callback re-points the page's map entry atomically so reusing a blank tab leaves no stale entry.
- **Clear the usage status bar on last-tab recycle** by adding the usage sync alongside the existing workspace/ZDR/generation re-syncs in the recycle reset.
- **Defer persistence of blank workspace tabs.** Gate `PersistWorkingDir`'s save on the conversation having messages (`History.Count > 0`), matching the existing model-combo and ZDR save sites. A blank workspace tab is now written on first send like any other blank tab; setting/clearing a folder on a conversation that already has messages still saves immediately.

## Trade-off

An opened-but-unsent workspace tab is no longer restored after an app restart — which matches how an empty new tab already behaves (its id may be in `session.json`, but with no file on disk the restore loop skips it).

## Related

Same last-writer-wins mechanism as #144 (detached-turn fork), reached without an in-flight turn.

## Testing notes

No local .NET toolchain in the dev environment (net35 WinForms; CI is the first compile). Changes were verified by reading the source: the field→property conversion is safe (no `ref`/`out` usage of `Conversation`), referenced APIs and imports check out, and the key flows (new-tab/first-send, the reported open-blank-tab repro, recent-workspace, recycle, help/load-into-blank, last-tab status clear) were traced against the final code. The touched paths live in `MainForm`/`TabManager` (WinForms), which have no existing unit-test coverage.

https://claude.ai/code/session_01RxZDnPjPhoVzA134hZW3zr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxZDnPjPhoVzA134hZW3zr)_