### PR TITLE
Fix inline code background drifting on lines with multiple spans

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -2556,12 +2556,17 @@ namespace GxPT
                         g.DrawRectangle(pen, bg);
                     }
 
-                    // Skip the segments we just processed
+                    // Advance past the entire run we just consumed. We must add the
+                    // full run width (endX - startX), not just the last segment's
+                    // width: otherwise currentX is left short by the rest of the run
+                    // and any later inline-code background on the same line is shifted
+                    // left, overlapping preceding text and ending mid-word.
+                    currentX = endX;
                     i = j - 1; // -1 because the loop will increment
+                    continue;
                 }
 
-                if (i < lineEnd)
-                    currentX += segments[i].Rect.Width;
+                currentX += seg.Rect.Width;
             }
         }
 


### PR DESCRIPTION
## Problem

Occasionally an inline code span's grey background rectangle is drawn too short and/or shifted left, so the tail of the code text renders outside the box and an adjacent normal word can end up *inside* the box.

This is rare: it only triggers when a single visual line contains a **multi-word** inline-code span followed by **another** inline-code span.

## Root cause

`ChatTranscriptControl.DrawInlineCodeBackgrounds` walks the laid-out segments and advances a running X cursor (`currentX`) so each inline-code background lands at the right position. For a code run it groups consecutive code segments and computes the full extent into `endX` correctly — but after consuming the run it set `i = j - 1` and then fell through to `currentX += segments[i].Rect.Width`, adding back **only the last segment's width** instead of the whole run.

So after a multi-word inline-code span, `currentX` was left short by `(run width - last segment width)`, shifting every subsequent inline-code background on that line to the left — overlapping preceding text and ending mid-word.

## Example

Line: `` `fibonacci.bat -5` `` and `` `:test_invalid_arg_neg` ``

The first multi-word span under-counts the cursor, so the second span's box shifts left, swallowing the word "and" and ending inside `:test_i`, leaving `nvalid_arg_neg` rendered outside the box.

## Fix

Advance the cursor by the full run extent (`currentX = endX`) and `continue`, so a multi-segment inline-code run no longer leaves the cursor short.

## Testing notes

This is a .NET Framework WinForms project; I was unable to compile/run it in the Linux container (no Windows/.NET toolchain available). The change is small and self-contained, but has not been exercised against an actual render — worth a quick visual check on a line with two inline-code spans where the first is multi-word.

https://claude.ai/code/session_01TEzgEEo7JADHrZ2bBhTBhN