### PR TITLE
Slow status-bar marquee on Windows XP

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -810,7 +810,12 @@ namespace GxPT
                 if (this.tspGenProgress != null)
                 {
                     // Run the marquee only while shown (no point animating an invisible bar).
-                    this.tspGenProgress.MarqueeAnimationSpeed = busy ? 30 : 0;
+                    // MarqueeAnimationSpeed is the native PBM_SETMARQUEE interval (ms between
+                    // updates), which XP/Luna honors literally while Vista+/Aero drives the
+                    // animation from the theme engine and effectively ignores it. A short interval
+                    // therefore scrolls far too fast on XP; 120ms reads like the Win7 pace there and
+                    // leaves the (ignored) Aero animation unchanged.
+                    this.tspGenProgress.MarqueeAnimationSpeed = busy ? 120 : 0;
                     this.tspGenProgress.Visible = busy;
                 }
                 if (this.tsiStopGen != null) this.tsiStopGen.Visible = busy;


### PR DESCRIPTION
## Summary

The conversation progress marquee in the status bar animated far too fast on Windows XP, while looking normal on Windows 7.

The bar's only speed knob, `MarqueeAnimationSpeed`, is passed straight through to the native common control as the `PBM_SETMARQUEE` `lParam` — the **milliseconds between marquee updates**, not a traversal duration. XP/Luna honors that interval literally, so the `30ms` value scrolled the block very quickly. Vista+/Aero drives the marquee from the theme animation engine and effectively ignores the value, which is why the same `30` looked fine on Win7.

This bumps the interval to `120ms`, which reads like the Win7 pace on XP and leaves the (ignored) Aero animation unchanged.

## Changes

- `GxPT/Forms/MainForm.cs`: `MarqueeAnimationSpeed` while busy changed from `30` → `120`, with a comment explaining the cross-platform behavior.

https://claude.ai/code/session_01XkEcQ6mp6aeKK9omy4xN4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkEcQ6mp6aeKK9omy4xN4Y)_