### PR TITLE
Register document icon for .gxsk file extension

### DIFF
--- a/GxPT.Setup/GxPT.Setup.vdproj
+++ b/GxPT.Setup/GxPT.Setup.vdproj
@@ -1025,14 +1025,14 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:GxPT"
-        "ProductCode" = "8:{6D7BD0F1-9659-4E19-BE5E-7B443CE7FB82}"
-        "PackageCode" = "8:{668350B5-011F-4B58-AE9A-7BBA76FF4401}"
+        "ProductCode" = "8:{A9E9164F-AB0D-4EDF-A51E-D4FC1C42F031}"
+        "PackageCode" = "8:{4765389D-6248-42DA-A119-1242D5AC961D}"
         "UpgradeCode" = "8:{18C05863-8BD9-4273-B9E8-061F771066DF}"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:0.19.3"
+        "ProductVersion" = "8:0.19.4"
         "Manufacturer" = "8:IFM Innovations"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:"
@@ -1125,42 +1125,6 @@
             {
                 "Keys"
                 {
-                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_C8F3673929CB408CB17B01685CCCFBC1"
-                    {
-                    "Name" = "8:GxPT Archive"
-                    "Condition" = "8:"
-                    "AlwaysCreate" = "11:FALSE"
-                    "DeleteAtUninstall" = "11:FALSE"
-                    "Transitive" = "11:FALSE"
-                        "Keys"
-                        {
-                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_7D1691CE7AFB45F39153FDA79BA66EA1"
-                            {
-                            "Name" = "8:DefaultIcon"
-                            "Condition" = "8:"
-                            "AlwaysCreate" = "11:FALSE"
-                            "DeleteAtUninstall" = "11:FALSE"
-                            "Transitive" = "11:FALSE"
-                                "Keys"
-                                {
-                                }
-                                "Values"
-                                {
-                                    "{ADCFDA98-8FDD-45E4-90BC-E3D20B029870}:_666FD256DCAE4842992849729B2EC0C3"
-                                    {
-                                    "Name" = "8:"
-                                    "Condition" = "8:"
-                                    "Transitive" = "11:FALSE"
-                                    "ValueTypes" = "3:1"
-                                    "Value" = "8:[#gxpt-document.ico]"
-                                    }
-                                }
-                            }
-                        }
-                        "Values"
-                        {
-                        }
-                    }
                     "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_A1B2C3D4E5F60718293A4B5C6D7E8F90"
                     {
                     "Name" = "8:GxPT Skill"
@@ -1183,6 +1147,42 @@
                                 "Values"
                                 {
                                     "{ADCFDA98-8FDD-45E4-90BC-E3D20B029870}:_C3D4E5F60718293A4B5C6D7E8F901234"
+                                    {
+                                    "Name" = "8:"
+                                    "Condition" = "8:"
+                                    "Transitive" = "11:FALSE"
+                                    "ValueTypes" = "3:1"
+                                    "Value" = "8:[#gxpt-document.ico]"
+                                    }
+                                }
+                            }
+                        }
+                        "Values"
+                        {
+                        }
+                    }
+                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_C8F3673929CB408CB17B01685CCCFBC1"
+                    {
+                    "Name" = "8:GxPT Archive"
+                    "Condition" = "8:"
+                    "AlwaysCreate" = "11:FALSE"
+                    "DeleteAtUninstall" = "11:FALSE"
+                    "Transitive" = "11:FALSE"
+                        "Keys"
+                        {
+                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_7D1691CE7AFB45F39153FDA79BA66EA1"
+                            {
+                            "Name" = "8:DefaultIcon"
+                            "Condition" = "8:"
+                            "AlwaysCreate" = "11:FALSE"
+                            "DeleteAtUninstall" = "11:FALSE"
+                            "Transitive" = "11:FALSE"
+                                "Keys"
+                                {
+                                }
+                                "Values"
+                                {
+                                    "{ADCFDA98-8FDD-45E4-90BC-E3D20B029870}:_666FD256DCAE4842992849729B2EC0C3"
                                     {
                                     "Name" = "8:"
                                     "Condition" = "8:"

--- a/GxPT.Setup/GxPT.Setup.vdproj
+++ b/GxPT.Setup/GxPT.Setup.vdproj
@@ -1161,6 +1161,42 @@
                         {
                         }
                     }
+                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_A1B2C3D4E5F60718293A4B5C6D7E8F90"
+                    {
+                    "Name" = "8:GxPT Skill"
+                    "Condition" = "8:"
+                    "AlwaysCreate" = "11:FALSE"
+                    "DeleteAtUninstall" = "11:FALSE"
+                    "Transitive" = "11:FALSE"
+                        "Keys"
+                        {
+                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_B2C3D4E5F6071829304A5B6C7D8E9F01"
+                            {
+                            "Name" = "8:DefaultIcon"
+                            "Condition" = "8:"
+                            "AlwaysCreate" = "11:FALSE"
+                            "DeleteAtUninstall" = "11:FALSE"
+                            "Transitive" = "11:FALSE"
+                                "Keys"
+                                {
+                                }
+                                "Values"
+                                {
+                                    "{ADCFDA98-8FDD-45E4-90BC-E3D20B029870}:_C3D4E5F60718293A4B5C6D7E8F901234"
+                                    {
+                                    "Name" = "8:"
+                                    "Condition" = "8:"
+                                    "Transitive" = "11:FALSE"
+                                    "ValueTypes" = "3:1"
+                                    "Value" = "8:[#gxpt-document.ico]"
+                                    }
+                                }
+                            }
+                        }
+                        "Values"
+                        {
+                        }
+                    }
                 }
             }
             "HKU"

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -26,7 +26,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.19.3.%2a</ApplicationVersion>
+    <ApplicationVersion>0.19.4.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/GxPT/Properties/AssemblyInfo.cs
+++ b/GxPT/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.19.3.0")]
-[assembly: AssemblyFileVersion("0.19.3.0")]
+[assembly: AssemblyVersion("0.19.4.0")]
+[assembly: AssemblyFileVersion("0.19.4.0")]


### PR DESCRIPTION
## Summary

The document icon was registered in the OS for `.gxcv` files but not for `.gxsk` files, even though the `Import` action was registered for both.

### Root cause

In `GxPT.Setup/GxPT.Setup.vdproj`, both file types are defined symmetrically in the `FileType` section — `.gxcv` (`GxPT Archive`) and `.gxsk` (`GxPT Skill`) both reference `gxpt-document.ico` and both register the `&Import` verb (which is why the import action worked for `.gxsk`).

However, the icon is actually applied via an explicit `HKCR` registry override in the `Registry` section, and that override existed **only** for the `.gxcv` ProgID (`HKCR\GxPT Archive\DefaultIcon = [#gxpt-document.ico]`). There was no parallel `HKCR\GxPT Skill\DefaultIcon` key, so the icon never applied to `.gxsk` files.

### Fix

Added a matching `HKCR\GxPT Skill\DefaultIcon` registry key pointing at `[#gxpt-document.ico]`, mirroring the existing `GxPT Archive` entry.

## Notes

This is a Visual Studio setup (`.vdproj`) change, which can only be built/verified by compiling the installer in Visual Studio on Windows. After building the new MSI, the `.gxsk` icon should appear once Explorer's icon cache refreshes (a reinstall on a clean machine, or clearing the icon cache, avoids stale-cache confusion during testing).

Also includes a version bump to 0.19.4.

https://claude.ai/code/session_011ypoFahpY8NzA8gJ5AJdWh

---
_Generated by [Claude Code](https://claude.ai/code/session_011ypoFahpY8NzA8gJ5AJdWh)_