### PR TITLE
Refactor ISlashCommandContext into focused facet interfaces

### DIFF
--- a/GxPT.Tests/Commands/ClientCommandsTests.cs
+++ b/GxPT.Tests/Commands/ClientCommandsTests.cs
@@ -12,7 +12,7 @@ namespace GxPT.Tests.Commands
         private static FakeSlashCommandContext CtxWithModels()
         {
             var ctx = new FakeSlashCommandContext("/work");
-            ctx.Models.AddRange(new[]
+            ctx.ModelStore.Models.AddRange(new[]
             {
                 "openai/gpt-4o", "openai/gpt-4o-mini", "anthropic/claude-3.5-sonnet"
             });
@@ -69,7 +69,7 @@ namespace GxPT.Tests.Commands
             var result = new ModelCommand().Invoke("openai/gpt-4o", ctx);
             Assert.False(result.SendToModel);
             Assert.Null(result.Error);
-            Assert.Equal("openai/gpt-4o", ctx.LastModelSet);
+            Assert.Equal("openai/gpt-4o", ctx.ModelStore.LastModelSet);
         }
 
         [Fact]
@@ -84,9 +84,9 @@ namespace GxPT.Tests.Commands
         private static FakeSlashCommandContext CtxWithServers()
         {
             var ctx = new FakeSlashCommandContext("/work");
-            ctx.ServerStates["git"] = true;
-            ctx.ServerStates["files"] = false;
-            ctx.ServerStates["command"] = false;
+            ctx.ServerStore.ServerStates["git"] = true;
+            ctx.ServerStore.ServerStates["files"] = false;
+            ctx.ServerStore.ServerStates["command"] = false;
             return ctx;
         }
 
@@ -108,10 +108,10 @@ namespace GxPT.Tests.Commands
         {
             var ctx = CtxWithServers();
             new ToolCommand().Invoke("files on", ctx);
-            Assert.True(ctx.ServerStates["files"]);
+            Assert.True(ctx.ServerStore.ServerStates["files"]);
 
             new ToolCommand().Invoke("git off", ctx);
-            Assert.False(ctx.ServerStates["git"]);
+            Assert.False(ctx.ServerStore.ServerStates["git"]);
         }
 
         [Fact]
@@ -119,9 +119,9 @@ namespace GxPT.Tests.Commands
         {
             var ctx = CtxWithServers(); // git starts on
             new ToolCommand().Invoke("git", ctx);
-            Assert.False(ctx.ServerStates["git"]);
+            Assert.False(ctx.ServerStore.ServerStates["git"]);
             new ToolCommand().Invoke("git", ctx);
-            Assert.True(ctx.ServerStates["git"]);
+            Assert.True(ctx.ServerStore.ServerStates["git"]);
         }
 
         [Fact]
@@ -244,7 +244,7 @@ namespace GxPT.Tests.Commands
             var result = processor.Process("/model openai/gpt-4o", ctx);
             Assert.NotNull(result);
             Assert.False(result.SendToModel);     // client command: not sent to the model
-            Assert.Equal("openai/gpt-4o", ctx.LastModelSet);
+            Assert.Equal("openai/gpt-4o", ctx.ModelStore.LastModelSet);
         }
     }
 }

--- a/GxPT.Tests/Commands/FakeSlashCommandContext.cs
+++ b/GxPT.Tests/Commands/FakeSlashCommandContext.cs
@@ -5,7 +5,8 @@ using GxPT;
 namespace GxPT.Tests.Commands
 {
     // ISlashCommandContext for tests. The HasServer/WorkingDir bits drive prompt-command gating tests;
-    // the model/server collections and recorded actions drive client-command tests.
+    // the clustered facets (ModelStore/ServerStore/SkillStore) carry the recorded state and actions the
+    // client-command tests assert against.
     internal sealed class FakeSlashCommandContext : ISlashCommandContext
     {
         private readonly HashSet<string> _servers =
@@ -28,20 +29,47 @@ namespace GxPT.Tests.Commands
             return !string.IsNullOrEmpty(serverName) && _servers.Contains(serverName);
         }
 
-        // ---- configurable state / recorded actions for client-command tests ----
-        public List<string> Models = new List<string>();
-        public Dictionary<string, bool> ServerStates =
-            new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        // ---- clustered facets (state + recorded actions live on the stores) ----
+        public readonly FakeModelControl ModelStore = new FakeModelControl();
+        public readonly FakeServerControl ServerStore = new FakeServerControl();
+        public readonly FakeSkillEnablementStore SkillStore = new FakeSkillEnablementStore();
+
+        public IModelControl Models { get { return ModelStore; } }
+        public IServerControl Servers { get { return ServerStore; } }
+        public ISkillEnablementStore Skills { get { return SkillStore; } }
+
+        // ---- top-level state / recorded actions ----
         public List<string> Infos = new List<string>();
-        public string LastModelSet;
         public int NewConversationCount;
         public int ExportCount;
+        public int CompactCount;
+        public List<Skill> ExportedSkills = new List<Skill>();
+        public int ImportCount;
 
         public void WriteInfo(string text) { Infos.Add(text); }
+        public void NewConversation() { NewConversationCount++; }
+        public void ExportConversations() { ExportCount++; }
+        public void ExportSkill(Skill skill) { ExportedSkills.Add(skill); }
+        public void ImportArchive() { ImportCount++; }
+        public void Compact() { CompactCount++; }
+    }
+
+    // Records the model the /model command selects and serves the configurable model list to completion.
+    internal sealed class FakeModelControl : IModelControl
+    {
+        public List<string> Models = new List<string>();
+        public string LastModelSet;
 
         public IList<string> GetModels() { return Models; }
         public string GetActiveModel() { return LastModelSet; }
         public void SetModel(string slug) { LastModelSet = slug; }
+    }
+
+    // Backs the /tool command: configurable server states, mutated in place by SetServerEnabled.
+    internal sealed class FakeServerControl : IServerControl
+    {
+        public Dictionary<string, bool> ServerStates =
+            new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         public IList<string> GetServerNames() { return new List<string>(ServerStates.Keys); }
         public bool GetServerEnabled(string serverName)
@@ -54,11 +82,15 @@ namespace GxPT.Tests.Commands
             ServerStates[serverName] = enabled;
             return null;
         }
+    }
 
-        // ---- skills: per-conversation override state ----
+    // Backs /skills and /skill: per-conversation override state plus the RefreshSkillsServer call count.
+    internal sealed class FakeSkillEnablementStore : ISkillEnablementStore
+    {
         public bool? ConvFeatureOff;
         public Dictionary<string, bool> ConvOverrides =
             new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        public int RefreshSkillsServerCount;
 
         public bool? GetConversationSkillsFeatureOff() { return ConvFeatureOff; }
         public void SetConversationSkillsFeatureOff(bool? value) { ConvFeatureOff = value; }
@@ -67,17 +99,6 @@ namespace GxPT.Tests.Commands
         public void SetConversationSkillOverride(string slug, bool? value)
         { if (value.HasValue) ConvOverrides[slug] = value.Value; else ConvOverrides.Remove(slug); }
         public void ResetConversationSkills() { ConvFeatureOff = null; ConvOverrides.Clear(); }
-
-        public int RefreshSkillsServerCount;
         public void RefreshSkillsServer() { RefreshSkillsServerCount++; }
-
-        public int CompactCount;
-        public List<Skill> ExportedSkills = new List<Skill>();
-        public int ImportCount;
-        public void NewConversation() { NewConversationCount++; }
-        public void ExportConversations() { ExportCount++; }
-        public void ExportSkill(Skill skill) { ExportedSkills.Add(skill); }
-        public void ImportArchive() { ImportCount++; }
-        public void Compact() { CompactCount++; }
     }
 }

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\GxPT\Services\Mcp\MemoryInjection.cs" Link="Linked\Mcp\MemoryInjection.cs" />
     <Compile Include="..\GxPT\Services\Mcp\AgentsFileInjection.cs" Link="Linked\Mcp\AgentsFileInjection.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillInjection.cs" Link="Linked\Skills\SkillInjection.cs" />
+    <Compile Include="..\GxPT\Services\Skills\SkillRoots.cs" Link="Linked\Skills\SkillRoots.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillTools.cs" Link="Linked\Skills\SkillTools.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillEnablement.cs" Link="Linked\Skills\SkillEnablement.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillResolve.cs" Link="Linked\Skills\SkillResolve.cs" />
@@ -72,6 +73,9 @@
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />
     <Compile Include="..\GxPT\Services\Commands\ISlashCommandContext.cs" Link="Linked\Commands\ISlashCommandContext.cs" />
+    <Compile Include="..\GxPT\Services\Commands\IModelControl.cs" Link="Linked\Commands\IModelControl.cs" />
+    <Compile Include="..\GxPT\Services\Commands\IServerControl.cs" Link="Linked\Commands\IServerControl.cs" />
+    <Compile Include="..\GxPT\Services\Commands\ISkillEnablementStore.cs" Link="Linked\Commands\ISkillEnablementStore.cs" />
     <Compile Include="..\GxPT\Services\Commands\ISlashCommand.cs" Link="Linked\Commands\ISlashCommand.cs" />
     <Compile Include="..\GxPT\Services\Commands\WorkspacePath.cs" Link="Linked\Commands\WorkspacePath.cs" />
     <Compile Include="..\GxPT\Services\Commands\IArgumentCompleter.cs" Link="Linked\Commands\IArgumentCompleter.cs" />

--- a/GxPT.Tests/SkillCommandsTests.cs
+++ b/GxPT.Tests/SkillCommandsTests.cs
@@ -69,7 +69,7 @@ namespace GxPT.Tests
             SlashCommandResult r = new SkillCommand().Invoke("greeting off", _ctx);
 
             Assert.False(r.SendToModel);
-            Assert.False(_ctx.ConvOverrides["greeting"]);   // forced off for this conversation
+            Assert.False(_ctx.SkillStore.ConvOverrides["greeting"]);   // forced off for this conversation
         }
 
         [Fact]
@@ -78,10 +78,10 @@ namespace GxPT.Tests
             WriteSkill("greeting", "Be a pirate.", "b");
 
             new SkillCommand().Invoke("greeting", _ctx);     // on by default -> toggles off
-            Assert.False(_ctx.ConvOverrides["greeting"]);
+            Assert.False(_ctx.SkillStore.ConvOverrides["greeting"]);
 
             new SkillCommand().Invoke("greeting", _ctx);     // now off -> toggles on
-            Assert.True(_ctx.ConvOverrides["greeting"]);
+            Assert.True(_ctx.SkillStore.ConvOverrides["greeting"]);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace GxPT.Tests
             new SkillCommand().Invoke("greeting off global", _ctx);
 
             Assert.Equal((bool?)false, SkillEnablement.LoadGlobal().GetSkillOverride("greeting"));
-            Assert.Empty(_ctx.ConvOverrides);   // global scope must not touch the conversation
+            Assert.Empty(_ctx.SkillStore.ConvOverrides);   // global scope must not touch the conversation
         }
 
         // The transcript scenario: /skills off then /skill greeting on -> greeting still listed ON.
@@ -164,7 +164,7 @@ namespace GxPT.Tests
             new SkillsCommand().Invoke("reset global", _ctx);
             new SkillsCommand().Invoke("off here", _ctx);
             new SkillsCommand().Invoke("reset", _ctx);
-            Assert.Equal(5, _ctx.RefreshSkillsServerCount);
+            Assert.Equal(5, _ctx.SkillStore.RefreshSkillsServerCount);
         }
 
         [Fact]
@@ -174,17 +174,17 @@ namespace GxPT.Tests
             new SkillCommand().Invoke("greeting on here", _ctx);
             new SkillCommand().Invoke("greeting off global", _ctx);
             new SkillCommand().Invoke("greeting reset", _ctx);
-            Assert.Equal(3, _ctx.RefreshSkillsServerCount);
+            Assert.Equal(3, _ctx.SkillStore.RefreshSkillsServerCount);
         }
 
         [Fact]
         public void Skills_OffHere_AndReset()
         {
             new SkillsCommand().Invoke("off", _ctx);
-            Assert.Equal(true, _ctx.ConvFeatureOff);
+            Assert.Equal(true, _ctx.SkillStore.ConvFeatureOff);
 
             new SkillsCommand().Invoke("reset", _ctx);
-            Assert.Null(_ctx.ConvFeatureOff);
+            Assert.Null(_ctx.SkillStore.ConvFeatureOff);
         }
 
         [Fact]
@@ -252,7 +252,7 @@ namespace GxPT.Tests
             SkillEnablement g = SkillEnablement.LoadGlobal();
             g.SetSkillOverride("release-notes", false);   // off globally
             g.SaveGlobal();
-            _ctx.ConvOverrides["greeting"] = true;        // on here
+            _ctx.SkillStore.ConvOverrides["greeting"] = true;        // on here
         }
 
         // Feature OFF here: unset skills fall through to rung 3 -> "all skills off here" (NOT "default").
@@ -260,7 +260,7 @@ namespace GxPT.Tests
         public void List_FeatureOffHere_UnsetSkillsAreAllSkillsOffHere_NotDefault()
         {
             SeedFourSkills();
-            _ctx.ConvFeatureOff = true;
+            _ctx.SkillStore.ConvFeatureOff = true;
 
             new SkillsCommand().Invoke("", _ctx);
             string info = LastInfo();
@@ -291,7 +291,7 @@ namespace GxPT.Tests
         [Fact]
         public void List_FeatureUnsetHere_UnsetSkillsAreDefault()
         {
-            SeedFourSkills();   // _ctx.ConvFeatureOff stays null
+            SeedFourSkills();   // _ctx.SkillStore.ConvFeatureOff stays null
 
             new SkillsCommand().Invoke("", _ctx);
             string info = LastInfo();

--- a/GxPT.Tests/SkillInjectionTests.cs
+++ b/GxPT.Tests/SkillInjectionTests.cs
@@ -23,21 +23,6 @@ namespace GxPT.Tests
         }
 
         [Fact]
-        public void BundledRoot_AppendsSkillsDir()
-        {
-            Assert.Equal(Path.Combine("base", "skills"), SkillInjection.BundledRoot("base"));
-            Assert.Null(SkillInjection.BundledRoot(null));
-        }
-
-        [Fact]
-        public void ProjectRoot_IsUnderDotGxpt_OrNull()
-        {
-            string expected = Path.Combine(Path.Combine("work", ".gxpt"), "skills");
-            Assert.Equal(expected, SkillInjection.ProjectRoot("work"));
-            Assert.Null(SkillInjection.ProjectRoot(null));
-        }
-
-        [Fact]
         public void BuildManifestMessage_EmptyCatalog_ReturnsNull()
         {
             SkillCatalog empty = SkillCatalog.Build(_root, null);   // _root has no skill folders
@@ -61,21 +46,6 @@ namespace GxPT.Tests
             Assert.Contains("open_skill", msg);
             Assert.Contains("release-notes", msg);
             Assert.Contains("Draft notes.", msg);
-        }
-
-        [Fact]
-        public void BuildCatalog_DiscoversProjectSkillsUnderDotGxpt()
-        {
-            string skillDir = Path.Combine(Path.Combine(Path.Combine(_root, ".gxpt"), "skills"), "proj-skill");
-            Directory.CreateDirectory(skillDir);
-            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
-                "---\ndescription: A project skill.\n---\nbody\n", new UTF8Encoding(false));
-
-            SkillCatalog cat = SkillInjection.BuildCatalog("no-such-exe-dir", _root);
-
-            Skill s;
-            Assert.True(cat.TryGet("proj-skill", out s));
-            Assert.Equal(SkillSource.Project, s.Source);
         }
     }
 }

--- a/GxPT.Tests/SkillRootsTests.cs
+++ b/GxPT.Tests/SkillRootsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Text;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Root/catalog resolution, split out of SkillInjection into SkillRoots (issue #119).
+    public sealed class SkillRootsTests : IDisposable
+    {
+        private readonly string _root;
+
+        public SkillRootsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_skillroots_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void BundledRoot_AppendsSkillsDir()
+        {
+            Assert.Equal(Path.Combine("base", "skills"), SkillRoots.BundledRoot("base"));
+            Assert.Null(SkillRoots.BundledRoot(null));
+        }
+
+        [Fact]
+        public void ProjectRoot_IsUnderDotGxpt_OrNull()
+        {
+            string expected = Path.Combine(Path.Combine("work", ".gxpt"), "skills");
+            Assert.Equal(expected, SkillRoots.ProjectRoot("work"));
+            Assert.Null(SkillRoots.ProjectRoot(null));
+        }
+
+        [Fact]
+        public void BuildCatalog_DiscoversProjectSkillsUnderDotGxpt()
+        {
+            string skillDir = Path.Combine(Path.Combine(Path.Combine(_root, ".gxpt"), "skills"), "proj-skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+                "---\ndescription: A project skill.\n---\nbody\n", new UTF8Encoding(false));
+
+            SkillCatalog cat = SkillRoots.BuildCatalog("no-such-exe-dir", _root);
+
+            Skill s;
+            Assert.True(cat.TryGet("proj-skill", out s));
+            Assert.Equal(SkillSource.Project, s.Source);
+        }
+    }
+}

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -845,7 +845,7 @@ namespace GxPT
                 string workdir = (ctx != null) ? ctx.WorkingDir : null;
 
                 SkillCatalog catalog =
-                    SkillInjection.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, workdir);
+                    SkillRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, workdir);
                 List<Skill> enabledSkills = SkillResolve.EnabledSkills(
                     catalog.Skills, SkillEnablement.LoadGlobal(),
                     (convo != null) ? convo.SkillsFeatureOff : null,
@@ -1305,8 +1305,8 @@ namespace GxPT
                 // Skill roots the server resolves scripts against: bundled (<exe>/skills, shipped with the
                 // app) and user-global (%AppData%/GxPT/skills). The project root is derived from
                 // GXPT_WORKDIR inside the server. These mirror the read-side roots (SkillInjection).
-                opts.SkillsBundledRoot = SkillInjection.BundledRoot(baseDir);
-                opts.SkillsUserRoot = SkillInjection.UserRoot();
+                opts.SkillsBundledRoot = SkillRoots.BundledRoot(baseDir);
+                opts.SkillsUserRoot = SkillRoots.UserRoot();
                 opts.WebSearchKey = AppSettings.GetString("mcp_websearch_key");
                 opts.CurlPath = curlPath;
                 // Server exes: dev builds deploy them to a 'mcp-servers' subfolder (AfterBuild copy);
@@ -2848,7 +2848,7 @@ namespace GxPT
                     // override layer), then inject the manifest and expose open_skill over
                     // the enabled set. Rebuilt per send, so on-disk edits take effect on the next turn.
                     SkillCatalog skillCatalog =
-                        SkillInjection.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
+                        SkillRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
                     Conversation skillConvo = convo;
                     List<Skill> enabledSkills = SkillResolve.EnabledSkills(
                         skillCatalog.Skills, SkillEnablement.LoadGlobal(),

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Services\Skills\Skill.cs" />
     <Compile Include="Services\Skills\SkillCatalog.cs" />
     <Compile Include="Services\Skills\SkillInjection.cs" />
+    <Compile Include="Services\Skills\SkillRoots.cs" />
     <Compile Include="Services\Skills\SkillTools.cs" />
     <Compile Include="Services\Skills\SkillEnablement.cs" />
     <Compile Include="Services\Skills\SkillResolve.cs" />
@@ -116,6 +117,9 @@
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />
     <Compile Include="Services\Commands\ISlashCommandContext.cs" />
+    <Compile Include="Services\Commands\IModelControl.cs" />
+    <Compile Include="Services\Commands\IServerControl.cs" />
+    <Compile Include="Services\Commands\ISkillEnablementStore.cs" />
     <Compile Include="Services\Commands\ISlashCommand.cs" />
     <Compile Include="Services\Commands\WorkspacePath.cs" />
     <Compile Include="Services\Commands\IArgumentCompleter.cs" />
@@ -387,7 +391,7 @@
     </ItemGroup>
     <Copy SourceFiles="@(McpServerFiles)" DestinationFiles="@(McpServerFiles->'$(OutDir)mcp-servers\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" ContinueOnError="true" />
     <!-- Ship the bundled (first-party) skills next to GxPT.exe in a 'skills' folder. The host's
-         SkillInjection.BundledRoot resolves <exe>/skills, and SkillsMcpServer gets the same path as
+         SkillRoots.BundledRoot resolves <exe>/skills, and SkillsMcpServer gets the same path as
          GXPT_SKILLS_BUNDLED_ROOT, so a shipped skill (e.g. skill-writer) is discoverable and its
          scripts runnable. Mirrors the mcp-servers copy above. -->
     <ItemGroup>

--- a/GxPT/Managers/SkillImportExportManager.cs
+++ b/GxPT/Managers/SkillImportExportManager.cs
@@ -48,7 +48,7 @@ namespace GxPT
 
         public static bool ImportSkillFromFile(IWin32Window owner, string archivePath)
         {
-            string targetRoot = SkillInjection.UserRoot();
+            string targetRoot = SkillRoots.UserRoot();
             if (string.IsNullOrEmpty(targetRoot))
             {
                 try { MessageBox.Show(owner, "Could not resolve the user skills folder.", "Import Skill", MessageBoxButtons.OK, MessageBoxIcon.Error); }

--- a/GxPT/Services/Commands/ClientCommands.cs
+++ b/GxPT/Services/Commands/ClientCommands.cs
@@ -48,7 +48,7 @@ namespace GxPT
         {
             string slug = (args ?? string.Empty).Trim();
             if (slug.Length == 0) return SlashCommandResult.Fail("Usage: /model <author/model>");
-            ctx.SetModel(slug);
+            ctx.Models.SetModel(slug);
             ctx.WriteInfo("Model set to " + slug + ".");
             return SlashCommandResult.Handled();
         }
@@ -56,7 +56,7 @@ namespace GxPT
         public IList<ArgCompletion> CompleteArgument(string argText, ISlashCommandContext ctx)
         {
             List<ArgCompletion> result = new List<ArgCompletion>();
-            IList<string> models = ctx != null ? ctx.GetModels() : null;
+            IList<string> models = ctx != null ? ctx.Models.GetModels() : null;
             if (models == null) return result;
 
             string a = argText ?? string.Empty;
@@ -116,7 +116,7 @@ namespace GxPT
             else { name = a.Substring(0, sp); rest = a.Substring(sp + 1).Trim(); }
 
             // Match (and canonicalize) the name against the known servers.
-            IList<string> names = ctx.GetServerNames();
+            IList<string> names = ctx.Servers.GetServerNames();
             bool known = false;
             if (names != null)
             {
@@ -128,12 +128,12 @@ namespace GxPT
             if (!known) return SlashCommandResult.Fail("Unknown server: " + name);
 
             bool target;
-            if (rest.Length == 0) target = !ctx.GetServerEnabled(name); // toggle
+            if (rest.Length == 0) target = !ctx.Servers.GetServerEnabled(name); // toggle
             else if (IsOn(rest)) target = true;
             else if (IsOff(rest)) target = false;
             else return SlashCommandResult.Fail("Use 'on' or 'off' (or omit to toggle).");
 
-            string err = ctx.SetServerEnabled(name, target);
+            string err = ctx.Servers.SetServerEnabled(name, target);
             if (err != null) return SlashCommandResult.Fail(err);
             ctx.WriteInfo(name + " server " + (target ? "enabled" : "disabled") + ".");
             return SlashCommandResult.Handled();
@@ -149,14 +149,14 @@ namespace GxPT
             if (sp < 0)
             {
                 // First token: server names, annotated with their current state.
-                IList<string> names = ctx.GetServerNames();
+                IList<string> names = ctx.Servers.GetServerNames();
                 if (names == null) return result;
                 for (int i = 0; i < names.Count; i++)
                 {
                     string n = names[i];
                     if (string.IsNullOrEmpty(n)) continue;
                     if (a.Length > 0 && !n.StartsWith(a, StringComparison.OrdinalIgnoreCase)) continue;
-                    string state = ctx.GetServerEnabled(n) ? "on" : "off";
+                    string state = ctx.Servers.GetServerEnabled(n) ? "on" : "off";
                     result.Add(new ArgCompletion(n + "  (" + state + ")", n + " ", true));
                 }
             }

--- a/GxPT/Services/Commands/IModelControl.cs
+++ b/GxPT/Services/Commands/IModelControl.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // The active tab's model selection, split out of ISlashCommandContext (issue #119) so /model depends
+    // only on this surface rather than the whole host facade.
+    internal interface IModelControl
+    {
+        IList<string> GetModels();      // known "author/model" slugs (for completion)
+        string GetActiveModel();        // the active tab's current model
+        void SetModel(string slug);     // switch the active tab's model
+    }
+}

--- a/GxPT/Services/Commands/IServerControl.cs
+++ b/GxPT/Services/Commands/IServerControl.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Built-in toggleable MCP servers, split out of ISlashCommandContext (issue #119) so /tool depends
+    // only on this surface rather than the whole host facade. (Availability gating - HasServer - stays on
+    // ISlashCommandContext, since every command is gated on it.)
+    internal interface IServerControl
+    {
+        IList<string> GetServerNames();           // names that can be toggled
+        bool GetServerEnabled(string serverName); // effective current state
+        // Apply a new enabled state. Returns null on success, or a message explaining why it didn't
+        // change (e.g. the tool isn't installed).
+        string SetServerEnabled(string serverName, bool enabled);
+    }
+}

--- a/GxPT/Services/Commands/ISkillEnablementStore.cs
+++ b/GxPT/Services/Commands/ISkillEnablementStore.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Per-conversation skills enablement, split out of ISlashCommandContext (issue #119) so the skills
+    // commands depend only on the skills surface rather than the whole host facade. Tri-state overrides
+    // (null = inherit the global default in skills.json); global-scope changes go straight to
+    // SkillEnablement, not through here.
+    internal interface ISkillEnablementStore
+    {
+        bool? GetConversationSkillsFeatureOff();            // null = inherit, true = off, false = on
+        void SetConversationSkillsFeatureOff(bool? value);  // persists the active conversation
+        IDictionary<string, bool> GetConversationSkillOverrides(); // copy; slug -> force on/off
+        void SetConversationSkillOverride(string slug, bool? value); // null clears the slug; persists
+        void ResetConversationSkills();                     // clear feature override + all per-skill overrides
+
+        // Bring the Skills MCP server into line with skill enablement (it runs iff any skill is enabled).
+        // Call after any skills enablement change - global or per-conversation. A no-op unless the change
+        // crosses the on/off boundary.
+        void RefreshSkillsServer();
+    }
+}

--- a/GxPT/Services/Commands/ISlashCommandContext.cs
+++ b/GxPT/Services/Commands/ISlashCommandContext.cs
@@ -1,10 +1,12 @@
-using System.Collections.Generic;
-
 namespace GxPT
 {
     // The host surface a slash command may consult or drive. Kept free of WinForms types so the command
     // core compiles into the unit-test assembly; the app provides a MainForm-backed implementation and
     // tests provide a fake. Prompt commands use only WorkingDir/HasServer; client commands use the rest.
+    //
+    // The cohesive clusters that had grown this into a god-interface are split into dedicated facets
+    // (issue #119): model selection (Models), MCP-server toggles (Servers), and skills enablement
+    // (Skills). What remains here is genuinely cross-cutting host state plus one-off app actions.
     internal interface ISlashCommandContext
     {
         // The conversation's working folder (may be null/empty when none is set). Path arguments are
@@ -18,30 +20,14 @@ namespace GxPT
         // Show a short status line in the active transcript (UI only; not saved to history).
         void WriteInfo(string text);
 
-        // ---- model control ----
-        IList<string> GetModels();      // known "author/model" slugs (for completion)
-        string GetActiveModel();        // the active tab's current model
-        void SetModel(string slug);     // switch the active tab's model
+        // Model selection for the active tab (used by /model).
+        IModelControl Models { get; }
 
-        // ---- MCP server control (built-in toggleable servers) ----
-        IList<string> GetServerNames();          // names that can be toggled
-        bool GetServerEnabled(string serverName); // effective current state
-        // Apply a new enabled state. Returns null on success, or a message explaining why it didn't
-        // change (e.g. the tool isn't installed).
-        string SetServerEnabled(string serverName, bool enabled);
+        // Built-in toggleable MCP servers (used by /tool).
+        IServerControl Servers { get; }
 
-        // ---- skills: per-conversation enablement overrides (tri-state; null = inherit the global
-        // default in skills.json). Global-scope changes go straight to SkillEnablement, not through here.
-        bool? GetConversationSkillsFeatureOff();            // null = inherit, true = off, false = on
-        void SetConversationSkillsFeatureOff(bool? value);  // persists the active conversation
-        IDictionary<string, bool> GetConversationSkillOverrides(); // copy; slug -> force on/off
-        void SetConversationSkillOverride(string slug, bool? value); // null clears the slug; persists
-        void ResetConversationSkills();                     // clear feature override + all per-skill overrides
-
-        // Bring the Skills MCP server into line with skill enablement (it runs iff any skill is enabled).
-        // Call after any skills enablement change - global or per-conversation. A no-op unless the change
-        // crosses the on/off boundary.
-        void RefreshSkillsServer();
+        // Per-conversation skills enablement (used by /skills and /skill).
+        ISkillEnablementStore Skills { get; }
 
         // ---- conversation / app actions ----
         void NewConversation();

--- a/GxPT/Services/Commands/MainFormSlashContext.cs
+++ b/GxPT/Services/Commands/MainFormSlashContext.cs
@@ -4,24 +4,62 @@ namespace GxPT
 {
     // ISlashCommandContext implementation backed by MainForm. It forwards to MainForm's internal Slash*
     // helpers (which read live state -- active tab, model combo, MCP registry/host), so commands never
-    // hold stale references and stay decoupled from MainForm itself.
+    // hold stale references and stay decoupled from MainForm itself. The clustered facets (Models,
+    // Servers, Skills) are thin adapters over the same helpers.
     internal sealed class MainFormSlashContext : ISlashCommandContext
     {
         private readonly MainForm _form;
+        private readonly IModelControl _models;
+        private readonly IServerControl _servers;
+        private readonly ISkillEnablementStore _skills;
 
-        public MainFormSlashContext(MainForm form) { _form = form; }
+        public MainFormSlashContext(MainForm form)
+        {
+            _form = form;
+            _models = new MainFormModelControl(form);
+            _servers = new MainFormServerControl(form);
+            _skills = new MainFormSkillStore(form);
+        }
 
         public string WorkingDir { get { return _form.SlashWorkingDir(); } }
         public bool HasServer(string serverName) { return _form.SlashHasServer(serverName); }
         public void WriteInfo(string text) { _form.SlashWriteInfo(text); }
 
+        public IModelControl Models { get { return _models; } }
+        public IServerControl Servers { get { return _servers; } }
+        public ISkillEnablementStore Skills { get { return _skills; } }
+
+        public void NewConversation() { _form.SlashNewConversation(); }
+        public void ExportConversations() { _form.SlashExportConversations(); }
+        public void ExportSkill(Skill skill) { _form.SlashExportSkill(skill); }
+        public void ImportArchive() { _form.SlashImportArchive(); }
+        public void Compact() { _form.SlashCompact(); }
+    }
+
+    internal sealed class MainFormModelControl : IModelControl
+    {
+        private readonly MainForm _form;
+        public MainFormModelControl(MainForm form) { _form = form; }
+
         public IList<string> GetModels() { return _form.SlashGetModels(); }
         public string GetActiveModel() { return _form.SlashGetActiveModel(); }
         public void SetModel(string slug) { _form.SlashSetModel(slug); }
+    }
+
+    internal sealed class MainFormServerControl : IServerControl
+    {
+        private readonly MainForm _form;
+        public MainFormServerControl(MainForm form) { _form = form; }
 
         public IList<string> GetServerNames() { return _form.SlashGetServerNames(); }
         public bool GetServerEnabled(string serverName) { return _form.SlashGetServerEnabled(serverName); }
         public string SetServerEnabled(string serverName, bool enabled) { return _form.SlashSetServerEnabled(serverName, enabled); }
+    }
+
+    internal sealed class MainFormSkillStore : ISkillEnablementStore
+    {
+        private readonly MainForm _form;
+        public MainFormSkillStore(MainForm form) { _form = form; }
 
         public bool? GetConversationSkillsFeatureOff() { return _form.SlashGetConversationSkillsFeatureOff(); }
         public void SetConversationSkillsFeatureOff(bool? value) { _form.SlashSetConversationSkillsFeatureOff(value); }
@@ -29,11 +67,5 @@ namespace GxPT
         public void SetConversationSkillOverride(string slug, bool? value) { _form.SlashSetConversationSkillOverride(slug, value); }
         public void ResetConversationSkills() { _form.SlashResetConversationSkills(); }
         public void RefreshSkillsServer() { _form.SlashRefreshSkillsServer(); }
-
-        public void NewConversation() { _form.SlashNewConversation(); }
-        public void ExportConversations() { _form.SlashExportConversations(); }
-        public void ExportSkill(Skill skill) { _form.SlashExportSkill(skill); }
-        public void ImportArchive() { _form.SlashImportArchive(); }
-        public void Compact() { _form.SlashCompact(); }
     }
 }

--- a/GxPT/Services/Commands/SkillCommands.cs
+++ b/GxPT/Services/Commands/SkillCommands.cs
@@ -28,7 +28,7 @@ namespace GxPT
         internal static SkillCatalog BuildCatalog(ISlashCommandContext ctx)
         {
             string workdir = ctx != null ? ctx.WorkingDir : null;
-            return SkillInjection.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, workdir);
+            return SkillRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, workdir);
         }
 
         // Splits raw args on whitespace into non-empty tokens.
@@ -67,7 +67,7 @@ namespace GxPT
 
         internal static bool? ConvOverrideFor(ISlashCommandContext ctx, string slug)
         {
-            IDictionary<string, bool> ov = ctx.GetConversationSkillOverrides();
+            IDictionary<string, bool> ov = ctx.Skills.GetConversationSkillOverrides();
             bool v;
             if (ov != null && slug != null && ov.TryGetValue(slug, out v)) return v;
             return null;
@@ -112,7 +112,7 @@ namespace GxPT
                 }
                 else
                 {
-                    ctx.ResetConversationSkills();
+                    ctx.Skills.ResetConversationSkills();
                     info = "Skills: cleared this conversation's overrides.";
                 }
             }
@@ -124,19 +124,19 @@ namespace GxPT
 
                 bool on = onoff.Value;
                 if (isGlobal) { global.FeatureOff = !on; global.SaveGlobal(); }
-                else { ctx.SetConversationSkillsFeatureOff(on ? (bool?)false : (bool?)true); }
+                else { ctx.Skills.SetConversationSkillsFeatureOff(on ? (bool?)false : (bool?)true); }
                 info = "Skills turned " + (on ? "on" : "off") + " " + (isGlobal ? "globally" : "for this conversation") + ".";
             }
 
-            ctx.RefreshSkillsServer(); // once, after a successful mutation - the server follows enablement
+            ctx.Skills.RefreshSkillsServer(); // once, after a successful mutation - the server follows enablement
             ctx.WriteInfo(info);
             return SlashCommandResult.Handled();
         }
 
         private static string BuildList(SkillCatalog cat, SkillEnablement global, ISlashCommandContext ctx)
         {
-            bool? convFeatureOff = ctx.GetConversationSkillsFeatureOff();
-            IDictionary<string, bool> convOv = ctx.GetConversationSkillOverrides();
+            bool? convFeatureOff = ctx.Skills.GetConversationSkillsFeatureOff();
+            IDictionary<string, bool> convOv = ctx.Skills.GetConversationSkillOverrides();
 
             StringBuilder sb = new StringBuilder();
             sb.Append("Skills \u2014 most specific setting wins.");
@@ -248,8 +248,8 @@ namespace GxPT
             if (tok.Length == 1)
             {
                 bool current = SkillResolve.IsEnabled(global, slug,
-                    SkillCommandShared.ConvOverrideFor(ctx, slug), ctx.GetConversationSkillsFeatureOff());
-                ctx.SetConversationSkillOverride(slug, !current);
+                    SkillCommandShared.ConvOverrideFor(ctx, slug), ctx.Skills.GetConversationSkillsFeatureOff());
+                ctx.Skills.SetConversationSkillOverride(slug, !current);
                 info = "Skill '" + slug + "' " + (!current ? "enabled" : "disabled") + " for this conversation.";
             }
             else
@@ -262,7 +262,7 @@ namespace GxPT
                 if (verb == "reset")
                 {
                     if (isGlobal) { global.SetSkillOverride(slug, null); global.SaveGlobal(); info = "Skill '" + slug + "': global setting cleared."; }
-                    else { ctx.SetConversationSkillOverride(slug, null); info = "Skill '" + slug + "': conversation override cleared."; }
+                    else { ctx.Skills.SetConversationSkillOverride(slug, null); info = "Skill '" + slug + "': conversation override cleared."; }
                 }
                 else
                 {
@@ -272,12 +272,12 @@ namespace GxPT
 
                     bool on = onoff.Value;
                     if (isGlobal) { global.SetSkillOverride(slug, on); global.SaveGlobal(); }
-                    else { ctx.SetConversationSkillOverride(slug, on); }
+                    else { ctx.Skills.SetConversationSkillOverride(slug, on); }
                     info = "Skill '" + slug + "' " + (on ? "enabled" : "disabled") + " " + (isGlobal ? "globally" : "for this conversation") + ".";
                 }
             }
 
-            ctx.RefreshSkillsServer(); // once, after a successful mutation - the server follows enablement
+            ctx.Skills.RefreshSkillsServer(); // once, after a successful mutation - the server follows enablement
             ctx.WriteInfo(info);
             return SlashCommandResult.Handled();
         }
@@ -292,7 +292,7 @@ namespace GxPT
                 // First token: skill slugs, annotated with their effective state.
                 SkillCatalog cat = SkillCommandShared.BuildCatalog(ctx);
                 SkillEnablement global = SkillEnablement.LoadGlobal();
-                bool? convFeatureOff = ctx.GetConversationSkillsFeatureOff();
+                bool? convFeatureOff = ctx.Skills.GetConversationSkillsFeatureOff();
                 IList<Skill> skills = cat.Skills;
                 for (int i = 0; i < skills.Count; i++)
                 {

--- a/GxPT/Services/Skills/SkillInjection.cs
+++ b/GxPT/Services/Skills/SkillInjection.cs
@@ -1,49 +1,16 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
 namespace GxPT
 {
-    // Host side of the skills feature (phase 2): resolves the bundled (<exe>/skills) and project
-    // (<workdir>/.gxpt/skills) roots, builds the SkillCatalog, and frames the always-on skills manifest
-    // for injection as an ephemeral system message (McpChatOrchestrator.SkillsManifestSystemMessageProvider),
-    // ordered right after the memory block and before the MCP names manifest (design sec.5). All skills
-    // framing lives here, so when no skills are present nothing is injected and the feature leaves no
-    // trace in context.
+    // Host side of the skills feature (phase 2): frames the always-on skills manifest for injection as an
+    // ephemeral system message (McpChatOrchestrator.SkillsManifestSystemMessageProvider), ordered right
+    // after the memory block and before the MCP names manifest (design sec.5). All skills framing lives
+    // here, so when no skills are present nothing is injected and the feature leaves no trace in context.
+    // Root/catalog resolution lives in SkillRoots; this type owns the injection framing plus the shared
+    // "is any skill enabled here" enablement helper.
     internal static class SkillInjection
     {
-        public const string SkillsDirName = "skills";
-
-        // Bundled skills ship beside GxPT.exe (deployed by the AfterBuild copy like mcp-servers).
-        public static string BundledRoot(string exeDir)
-        {
-            if (string.IsNullOrEmpty(exeDir)) return null;
-            return Path.Combine(exeDir, SkillsDirName);
-        }
-
-        // Project skills live under the conversation's working folder, reusing the memory system's .gxpt.
-        public static string ProjectRoot(string workingDir)
-        {
-            if (string.IsNullOrEmpty(workingDir)) return null;
-            return Path.Combine(Path.Combine(workingDir, MemoryInjection.MemoryDirName), SkillsDirName);
-        }
-
-        // User-global skills live under %AppData%/GxPT/skills - one set per Windows user, independent of
-        // workspace. The SkillsMcpServer writes/runs them at the same path (GXPT_SKILLS_USER_ROOT), so
-        // read and write stay in sync. Returns null if %AppData% can't be resolved.
-        public static string UserRoot()
-        {
-            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            if (string.IsNullOrEmpty(appData)) return null;
-            return Path.Combine(Path.Combine(appData, "GxPT"), SkillsDirName);
-        }
-
-        public static SkillCatalog BuildCatalog(string exeDir, string workingDir)
-        {
-            return SkillCatalog.Build(BundledRoot(exeDir), UserRoot(), ProjectRoot(workingDir));
-        }
-
         // True when the conversation (its feature/skill overrides) has at least one enabled skill for the
         // given roots: build the catalog, apply the global default + conversation overrides, count > 0.
         // The single shared "is any skill enabled here" check - used by the send-path gate and by the
@@ -51,7 +18,7 @@ namespace GxPT
         public static bool HasAnyEnabledSkills(string exeDir, string workingDir,
             bool? convFeatureOff, IDictionary<string, bool> convOverrides)
         {
-            SkillCatalog cat = BuildCatalog(exeDir, workingDir);
+            SkillCatalog cat = SkillRoots.BuildCatalog(exeDir, workingDir);
             return SkillResolve.EnabledSkills(
                 cat.Skills, SkillEnablement.LoadGlobal(), convFeatureOff, convOverrides).Count > 0;
         }

--- a/GxPT/Services/Skills/SkillRoots.cs
+++ b/GxPT/Services/Skills/SkillRoots.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+
+namespace GxPT
+{
+    // Resolves the three skill roots - bundled (<exe>/skills), user-global (%AppData%/GxPT/skills), and
+    // project (<workdir>/.gxpt/skills) - and builds the SkillCatalog over them. Split out of SkillInjection
+    // (issue #119) so the path/root resolution - consumed independently by the /skill commands and the
+    // host's enablement checks that do no injection - is named for what it does; SkillInjection keeps the
+    // injection framing and the enablement helper.
+    internal static class SkillRoots
+    {
+        public const string SkillsDirName = "skills";
+
+        // Bundled skills ship beside GxPT.exe (deployed by the AfterBuild copy like mcp-servers).
+        public static string BundledRoot(string exeDir)
+        {
+            if (string.IsNullOrEmpty(exeDir)) return null;
+            return Path.Combine(exeDir, SkillsDirName);
+        }
+
+        // Project skills live under the conversation's working folder, reusing the memory system's .gxpt.
+        public static string ProjectRoot(string workingDir)
+        {
+            if (string.IsNullOrEmpty(workingDir)) return null;
+            return Path.Combine(Path.Combine(workingDir, MemoryInjection.MemoryDirName), SkillsDirName);
+        }
+
+        // User-global skills live under %AppData%/GxPT/skills - one set per Windows user, independent of
+        // workspace. The SkillsMcpServer writes/runs them at the same path (GXPT_SKILLS_USER_ROOT), so
+        // read and write stay in sync. Returns null if %AppData% can't be resolved.
+        public static string UserRoot()
+        {
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (string.IsNullOrEmpty(appData)) return null;
+            return Path.Combine(Path.Combine(appData, "GxPT"), SkillsDirName);
+        }
+
+        public static SkillCatalog BuildCatalog(string exeDir, string workingDir)
+        {
+            return SkillCatalog.Build(BundledRoot(exeDir), UserRoot(), ProjectRoot(workingDir));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Split the monolithic `ISlashCommandContext` interface into focused, single-responsibility facets to improve separation of concerns and reduce coupling between command implementations and the host facade. This addresses issue #119.

## Key Changes

- **New facet interfaces** extracted from `ISlashCommandContext`:
  - `IModelControl`: Model selection for the active tab (used by `/model`)
  - `IServerControl`: Built-in toggleable MCP servers (used by `/tool`)
  - `ISkillEnablementStore`: Per-conversation skills enablement (used by `/skills` and `/skill`)

- **Refactored `ISlashCommandContext`**: Now exposes the three facets as properties (`Models`, `Servers`, `Skills`) while retaining cross-cutting concerns (working directory, server availability checks, info output, and app actions like conversation/export/import/compact)

- **Updated implementations**:
  - `MainFormSlashContext`: Creates thin adapter classes (`MainFormModelControl`, `MainFormServerControl`, `MainFormSkillStore`) that delegate to MainForm's internal helpers
  - `FakeSlashCommandContext`: Refactored to use concrete fake implementations (`FakeModelControl`, `FakeServerControl`, `FakeSkillEnablementStore`) for better test organization

- **Extracted skill root resolution**: Moved `BundledRoot()`, `ProjectRoot()`, `UserRoot()`, and `BuildCatalog()` from `SkillInjection` to new `SkillRoots` class, keeping injection framing and enablement helpers in `SkillInjection`

- **Updated all command implementations**: Modified `ClientCommands.cs` and `SkillCommands.cs` to use the new facet interfaces (e.g., `ctx.Models.SetModel()` instead of `ctx.SetModel()`)

- **New test class**: `SkillRootsTests` covers the extracted root/catalog resolution logic

## Implementation Details

- The facet interfaces maintain the same method signatures as before, ensuring no behavioral changes
- `ISlashCommandContext` retains `HasServer()` for availability gating since all commands depend on it
- Test infrastructure updated to access facet state through the new store properties (e.g., `ctx.ModelStore.LastModelSet` instead of `ctx.LastModelSet`)
- Project files updated to include new source files and linked references in test project

https://claude.ai/code/session_01A9fTE96X7pU9Gr6rq5u7J2