### PR TITLE
Add workspace-wide file approval and a flag-insensitive command pattern rule

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -266,6 +266,63 @@ namespace GxPT.Tests.Mcp
             Assert.Equal(2, prompt.Calls);
         }
 
+        // ---- command "pattern" signature (flag-insensitive, target-sensitive) ----
+
+        [Fact]
+        public void Command_signature_keeps_subcommand_when_second_token_is_not_a_flag()
+        {
+            Assert.Equal("git status", ToolApprovalPolicy.CommandSignature("git status -s"));
+            Assert.Equal("npm install", ToolApprovalPolicy.CommandSignature("npm install react --save"));
+            Assert.Equal("del foo.txt", ToolApprovalPolicy.CommandSignature("del foo.txt"));
+            Assert.Equal("git", ToolApprovalPolicy.CommandSignature("git"));
+        }
+
+        [Fact]
+        public void Command_signature_drops_flags_and_keys_on_the_file()
+        {
+            // 2nd token is a flag -> signature is command + first file/path operand, flags dropped.
+            Assert.Equal("powershell hello.ps1",
+                ToolApprovalPolicy.CommandSignature("powershell -File hello.ps1 -Name \"Blackbeard\""));
+            // Space-valued leading flags (-ExecutionPolicy Bypass) don't fool it: "Bypass" isn't
+            // path-shaped, so it's skipped in favor of the .ps1 file.
+            Assert.Equal("powershell hello.ps1",
+                ToolApprovalPolicy.CommandSignature("powershell -ExecutionPolicy Bypass -File hello.ps1"));
+            // No flags before the script at all -> same signature.
+            Assert.Equal("powershell hello.ps1",
+                ToolApprovalPolicy.CommandSignature("powershell hello.ps1"));
+            // Path separators also mark the operand.
+            Assert.Equal("python scripts/run.py",
+                ToolApprovalPolicy.CommandSignature("python -u scripts/run.py --verbose"));
+        }
+
+        [Fact]
+        public void Command_signature_falls_back_to_command_plus_first_flag()
+        {
+            // Flag present but no file/path operand -> command + first flag (today's behavior).
+            Assert.Equal("dir /s", ToolApprovalPolicy.CommandSignature("dir /s /b"));
+            Assert.Equal("powershell -Command",
+                ToolApprovalPolicy.CommandSignature("powershell -Command \"Get-Process\""));
+        }
+
+        [Fact]
+        public void Command_pattern_rule_is_flag_insensitive_but_file_sensitive()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("command__run", Args("{\"command\":\"powershell -File hello.ps1 -Name Anne\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // Same script, different flags/args -> covered, no re-prompt (flag-insensitive).
+            Assert.Equal(ApprovalDecision.Allow,
+                pol.Check("command__run", Args("{\"command\":\"powershell -ExecutionPolicy Bypass -File hello.ps1\"}")));
+            Assert.Equal(1, prompt.Calls);
+
+            // A different script -> prompts again (file-sensitive).
+            pol.Check("command__run", Args("{\"command\":\"powershell -File goodbye.ps1\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
         [Fact]
         public void Prefix_path_rule_is_directory_boundary_aware()
         {

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -347,6 +347,97 @@ namespace GxPT.Tests.Mcp
             Assert.False(ToolApprovalPolicy.PrefixMatches("a/bc/y.txt", "a\\b", true));
         }
 
+        // ---- "all edits in this workspace" blanket approval ----
+
+        [Fact]
+        public void Workspace_approval_covers_all_write_tier_files_tools_in_the_same_workdir()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberWorkdirWrites };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.WorkingDir = "/work/project";
+
+            // Approving the blanket on a write call...
+            pol.Check("files__write", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // ...a later write in a different folder is covered (whole workspace, not just one dir)...
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__write", Args("{\"path\":\"deep/nested/b.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+
+            // ...and so is files__edit, even though it's a different function name (spans write tools).
+            Assert.Equal(ApprovalDecision.Allow, pol.Check("files__edit", Args("{\"path\":\"c.txt\"}")));
+            Assert.Equal(1, prompt.Calls);
+        }
+
+        [Fact]
+        public void Workspace_approval_does_not_leak_to_a_different_workdir()
+        {
+            // The store is shared app-wide; workspace-relative paths would collide across tabs, so the
+            // approval must be scoped to the canonical working directory.
+            var store = new InMemoryApprovalStore();
+
+            var p1 = new ScriptedPrompt { Next = ApprovalChoice.RememberWorkdirWrites };
+            var pol1 = Policy(p1, store);
+            pol1.WorkingDir = "/work/project-a";
+            pol1.Check("files__edit", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(1, p1.Calls);
+
+            // A turn in a different workspace (same shared store) is NOT covered -> prompts.
+            var p2 = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol2 = Policy(p2, store);
+            pol2.WorkingDir = "/work/project-b";
+            pol2.Check("files__edit", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(1, p2.Calls);
+        }
+
+        [Fact]
+        public void Workspace_approval_is_separator_and_case_insensitive_for_the_workdir()
+        {
+            var store = new InMemoryApprovalStore();
+
+            var p1 = new ScriptedPrompt { Next = ApprovalChoice.RememberWorkdirWrites };
+            var pol1 = Policy(p1, store);
+            pol1.WorkingDir = "/Work/Project/";
+            pol1.Check("files__write", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(1, p1.Calls);
+
+            // Same folder, different separators/casing/trailing-slash -> still matches the canonical key.
+            var p2 = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol2 = Policy(p2, store);
+            pol2.WorkingDir = "\\work\\project";
+            Assert.Equal(ApprovalDecision.Allow, pol2.Check("files__write", Args("{\"path\":\"a.txt\"}")));
+            Assert.Equal(0, p2.Calls);
+        }
+
+        [Fact]
+        public void Workspace_approval_does_not_sweep_in_destructive_files_delete()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberWorkdirWrites };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.WorkingDir = "/work/project";
+
+            pol.Check("files__write", Args("{\"path\":\"a.txt\"}")); // grants the blanket
+            Assert.Equal(1, prompt.Calls);
+
+            // files__delete is Destructive (Scope=None) -> never covered by the write blanket.
+            pol.Check("files__delete", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Workspace_approval_persists_nothing_without_a_workdir()
+        {
+            // No active workspace -> the blanket has nothing to scope to; the next call still prompts.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberWorkdirWrites };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            // WorkingDir intentionally left unset (null).
+
+            pol.Check("files__write", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(1, prompt.Calls);
+            pol.Check("files__write", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
         [Fact]
         public void Prefix_command_boundary_helper()
         {

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -21,6 +21,7 @@ namespace GxPT
         private readonly DiffPreviewPanel _diffPanel;   // shown instead of _preview for files__edit
         private readonly Font _monoFont;
         private readonly FlowLayoutPanel _buttons;
+        private readonly ToolTip _toolTip;
 
         private Action<ApprovalChoice> _onChoose;
         private Action<bool> _onContinue;   // set instead of _onChoose for the iteration-cap prompt
@@ -94,6 +95,9 @@ namespace GxPT
             _buttons.AutoSize = true;
             _buttons.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             _buttons.MinimumSize = new Size(0, 34);
+
+            _toolTip = new ToolTip();
+            _toolTip.AutoPopDelay = 15000; // keep the multi-line rule explanation visible long enough to read
 
             // Order added (Fill must be added before docked siblings to lay out correctly):
             this.Controls.Add(_diffPanel);
@@ -545,6 +549,12 @@ namespace GxPT
                     try { cc(false); }
                     catch { }
                 }
+
+                if (_toolTip != null)
+                {
+                    try { _toolTip.Dispose(); }
+                    catch { }
+                }
             }
             base.Dispose(disposing);
         }
@@ -560,8 +570,11 @@ namespace GxPT
             }
             else if (scope == RememberScope.Argument && argPath == "command")
             {
-                AddButton("Always allow this base command", ApprovalChoice.RememberPrefixArg, false);
-                AddButton("Always allow this exact command", ApprovalChoice.RememberExactArg, false);
+                AddButton("Always allow this command pattern", ApprovalChoice.RememberPrefixArg, false,
+                    CommandPatternTooltip(req));
+                AddButton("Always allow this exact command", ApprovalChoice.RememberExactArg, false,
+                    "Allows only this exact command line. Any change to the command — including its "
+                    + "flags or arguments — prompts again.");
             }
             else if (scope == RememberScope.Argument && argPath == "path")
             {
@@ -574,7 +587,28 @@ namespace GxPT
             // Scope == None: no remember buttons (Allow once / Deny only).
         }
 
+        // Summarizes what "Always allow this command pattern" will permit, showing the concrete
+        // signature this command reduces to (e.g. "powershell hello.ps1") so the user sees exactly
+        // what future commands will match.
+        private static string CommandPatternTooltip(ApprovalRequest req)
+        {
+            string cmd = (req != null && req.Arguments != null) ? req.Arguments.Value<string>("command") : null;
+            string sig = ToolApprovalPolicy.CommandSignature(cmd);
+            string body =
+                "Allows future commands matching the program and its main target (a subcommand or "
+                + "file), while ignoring other flags and arguments. A different program, file, or "
+                + "subcommand prompts again.";
+            if (!string.IsNullOrEmpty(sig))
+                body = "Allows:  " + sig + "  (any flags or arguments)\r\n\r\n" + body;
+            return body;
+        }
+
         private void AddButton(string text, ApprovalChoice choice, bool defaultFocus)
+        {
+            AddButton(text, choice, defaultFocus, null);
+        }
+
+        private void AddButton(string text, ApprovalChoice choice, bool defaultFocus, string tooltip)
         {
             Button b = new Button();
             b.Text = text;
@@ -588,6 +622,11 @@ namespace GxPT
                 if (cb != null) cb(choice);
             };
             _buttons.Controls.Add(b);
+            if (!string.IsNullOrEmpty(tooltip) && _toolTip != null)
+            {
+                try { _toolTip.SetToolTip(b, tooltip); }
+                catch { }
+            }
             if (defaultFocus) { try { b.Select(); } catch { } }
         }
 

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -224,7 +224,14 @@ namespace GxPT
                     if (cmd.Trim().Length > 0)
                     {
                         _diffPanel.SetContent(string.Empty, cmd, "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
-                        _previewLabel.Text = "Command:";
+                        // Surface the "command pattern" signature next to the command when it differs
+                        // from the full line (i.e. flags/args were dropped), so the broader allow-scope
+                        // is visible without hovering the button's tooltip.
+                        string sig = ToolApprovalPolicy.CommandSignature(cmd);
+                        _previewLabel.Text =
+                            (!string.IsNullOrEmpty(sig) && !string.Equals(sig, cmd.Trim(), StringComparison.Ordinal))
+                            ? "Command   (pattern: " + sig + ")"
+                            : "Command:";
                         handled = true;
                     }
                 }

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -560,8 +560,8 @@ namespace GxPT
             }
             else if (scope == RememberScope.Argument && argPath == "command")
             {
-                AddButton("Always allow this exact command", ApprovalChoice.RememberExactArg, false);
                 AddButton("Always allow this base command", ApprovalChoice.RememberPrefixArg, false);
+                AddButton("Always allow this exact command", ApprovalChoice.RememberExactArg, false);
             }
             else if (scope == RememberScope.Argument && argPath == "path")
             {

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -565,8 +565,11 @@ namespace GxPT
             }
             else if (scope == RememberScope.Argument && argPath == "path")
             {
-                AddButton("Always allow this directory", ApprovalChoice.RememberPrefixArg, false);
+                // "this file" (exact) and a workspace-wide blanket for all write-tier files tools. The
+                // per-folder prefix option is intentionally omitted to keep the strip to four buttons;
+                // the workspace blanket covers the "trust this working area" case more broadly.
                 AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
+                AddButton("Allow all edits in this workspace", ApprovalChoice.RememberWorkdirWrites, false);
             }
             // Scope == None: no remember buttons (Allow once / Deny only).
         }

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -568,8 +568,8 @@ namespace GxPT
                 // "this file" (exact) and a workspace-wide blanket for all write-tier files tools. The
                 // per-folder prefix option is intentionally omitted to keep the strip to four buttons;
                 // the workspace blanket covers the "trust this working area" case more broadly.
-                AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
                 AddButton("Allow all edits in this workspace", ApprovalChoice.RememberWorkdirWrites, false);
+                AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
             }
             // Scope == None: no remember buttons (Allow once / Deny only).
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2778,6 +2778,10 @@ namespace GxPT
                             _approvalStore,
                             _mcpRegistry) // classify third-party tools by their declared readOnly/destructive hints
                         : (IToolApprovalPolicy)new AllowAllApprovalPolicy();
+                    // Scope this turn's "all edits in this workspace" approvals to the active folder
+                    // (same workdir the orchestrator routes tool calls to, below).
+                    ToolApprovalPolicy realPolicy = approval as ToolApprovalPolicy;
+                    if (realPolicy != null) realPolicy.WorkingDir = ctx.WorkingDir;
                     var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);
                     orch.WorkingDir = ctx.WorkingDir;

--- a/GxPT/Services/Mcp/ApprovalStore.cs
+++ b/GxPT/Services/Mcp/ApprovalStore.cs
@@ -12,6 +12,11 @@ namespace GxPT
         void AddApprovedTool(string functionName);
         IList<ApprovalRule> RulesFor(string functionName);
         void AddRule(ApprovalRule rule);
+        // Workdir-scoped blanket approval for a server's Write-tier tools (e.g. "all files__ edits in
+        // this workspace"). Keyed by (server, canonical working directory) so it never leaks across
+        // tabs whose file paths — being workspace-relative — would otherwise collide.
+        bool IsWorkdirApproved(string server, string workdir);
+        void AddApprovedWorkdir(string server, string workdir);
     }
 
     // In-memory store: remembered approvals live for the app session only.
@@ -19,6 +24,9 @@ namespace GxPT
     {
         protected readonly Dictionary<string, bool> _approvedTools = new Dictionary<string, bool>(StringComparer.Ordinal);
         protected readonly List<ApprovalRule> _rules = new List<ApprovalRule>();
+        // Approved (server, workdir) pairs; the key is server + '\0' + canonical workdir (the policy
+        // supplies the canonical form, so this stays an opaque-string lookup).
+        protected readonly Dictionary<string, bool> _approvedWorkdirs = new Dictionary<string, bool>(StringComparer.Ordinal);
 
         public bool IsToolApproved(string functionName)
         {
@@ -49,6 +57,18 @@ namespace GxPT
                     r.ArgPath == rule.ArgPath && r.Pattern == rule.Pattern) return;
             }
             _rules.Add(rule);
+        }
+
+        public bool IsWorkdirApproved(string server, string workdir)
+        {
+            if (string.IsNullOrEmpty(server) || string.IsNullOrEmpty(workdir)) return false;
+            return _approvedWorkdirs.ContainsKey(server + "\0" + workdir);
+        }
+
+        public virtual void AddApprovedWorkdir(string server, string workdir)
+        {
+            if (string.IsNullOrEmpty(server) || string.IsNullOrEmpty(workdir)) return;
+            _approvedWorkdirs[server + "\0" + workdir] = true;
         }
     }
 }

--- a/GxPT/Services/Mcp/ToolApproval.cs
+++ b/GxPT/Services/Mcp/ToolApproval.cs
@@ -56,7 +56,8 @@ namespace GxPT
         AllowOnce,
         RememberTool,        // Tool scope: remember the whole function name
         RememberExactArg,    // Argument scope: ExactArgs rule on ScopeArgPath
-        RememberPrefixArg    // Argument scope: Prefix rule (base+sub / directory-and-below)
+        RememberPrefixArg,   // Argument scope: Prefix rule (base+sub / directory-and-below)
+        RememberWorkdirWrites // Workdir scope: every Write-tier files__ tool in the active workspace
     }
 
     // The confirmation surface the policy invokes when a call isn't already allowed. Implemented by

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -27,6 +27,16 @@ namespace GxPT
         private readonly IToolApprovalPrompt _prompt;
         private readonly IApprovalStore _store;
         private readonly IToolAnnotationSource _annotations;
+        private string _workdirKey; // canonical working dir for this turn (null = no workspace)
+
+        // The working directory of the turn this policy serves, set per-turn by the host (mirrors
+        // McpChatOrchestrator.WorkingDir). Stored canonicalized so a "all edits in this workspace"
+        // approval matches the same folder regardless of separator/case/trailing-slash differences,
+        // and never matches a different workspace. Null/empty clears it (no workdir-scoped approvals).
+        public string WorkingDir
+        {
+            set { _workdirKey = CanonicalWorkdir(value); }
+        }
 
         public ToolApprovalPolicy(IToolClassifier classifier, IToolApprovalPrompt prompt, IApprovalStore store)
             : this(classifier, prompt, store, null)
@@ -69,6 +79,12 @@ namespace GxPT
 
             // Already-remembered fast paths.
             if (pol.Scope == RememberScope.Tool && _store.IsToolApproved(functionName))
+                return ApprovalDecision.Allow;
+            // Blanket "all edits in this workspace" approval: covers every Write-tier path-scoped files
+            // tool (write/edit) for the active workspace. Gated on Tier==Write so Destructive path tools
+            // (files__delete) are never swept in, and on a non-null workdir so it can't match globally.
+            if (IsWorkdirWriteEligible(pol) && _workdirKey != null
+                && _store.IsWorkdirApproved(server, _workdirKey))
                 return ApprovalDecision.Allow;
             if (pol.Scope == RememberScope.Argument && MatchesAnyRule(functionName, pol, args))
                 return ApprovalDecision.Allow;
@@ -173,6 +189,11 @@ namespace GxPT
                     _store.AddRule(new ApprovalRule(req.FunctionName, RuleKind.Prefix,
                         req.Policy.ScopeArgPath, PrefixPattern(req)));
                     break;
+                case ApprovalChoice.RememberWorkdirWrites:
+                    // Approve every Write-tier files tool in the active workspace. No-op without a
+                    // workdir (nothing to scope the blanket approval to).
+                    if (_workdirKey != null) _store.AddApprovedWorkdir(req.ServerName, _workdirKey);
+                    break;
                 // AllowOnce / Deny: nothing persisted.
             }
         }
@@ -201,6 +222,29 @@ namespace GxPT
         }
 
         // ---- helpers ----
+
+        // The shape a "all edits in this workspace" approval covers: a remember-eligible Write-tier
+        // path-scoped tool (files__write / files__edit). Tier==Write deliberately excludes the
+        // Destructive files__delete, which shares the same Argument/path scope.
+        private static bool IsWorkdirWriteEligible(ToolPolicy pol)
+        {
+            return pol != null && pol.Tier == ToolTier.Write
+                && pol.Scope == RememberScope.Argument && pol.ScopeArgPath == "path";
+        }
+
+        // Canonical key for a working directory: '/'-separated, no trailing slash, lowercased (Windows
+        // paths compare case-insensitively, matching the OrdinalIgnoreCase path rules above). Used as
+        // the stable lookup key for workdir-scoped approvals so the same folder always matches and
+        // different folders never collide. The host supplies an already-absolute path (ctx.WorkingDir),
+        // so this only reconciles separator/case/trailing-slash spelling — no filesystem resolution
+        // (which would be platform-dependent for drive rooting).
+        private static string CanonicalWorkdir(string workdir)
+        {
+            if (string.IsNullOrEmpty(workdir)) return null;
+            string p = workdir.Replace('\\', '/');
+            while (p.Length > 1 && p[p.Length - 1] == '/') p = p.Substring(0, p.Length - 1);
+            return p.ToLowerInvariant();
+        }
 
         private static string BuildPreview(string functionName, ToolPolicy pol, JObject args)
         {

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -123,8 +123,17 @@ namespace GxPT
                 }
                 else // Prefix
                 {
-                    bool isPath = pol.ScopeArgPath == "path";
-                    if (PrefixMatches(val, r.Pattern, isPath)) return true;
+                    if (pol.ScopeArgPath == "path")
+                    {
+                        if (PrefixMatches(val, r.Pattern, true)) return true;
+                    }
+                    else
+                    {
+                        // Command "pattern" rule: match by normalized signature (command + its
+                        // subcommand/file/first-flag, flags otherwise ignored), computed identically
+                        // for the stored rule and the candidate. NOT a prefix — see CommandSignature.
+                        if (string.Equals(CommandSignature(val), r.Pattern, StringComparison.Ordinal)) return true;
+                    }
                 }
             }
             return false;
@@ -198,8 +207,9 @@ namespace GxPT
             }
         }
 
-        // The structured prefix for a "base+subcommand" command rule or a "directory and below" path
-        // rule, derived from the actual argument (no free-form entry — spec §3/§4).
+        // The structured pattern remembered for a RememberPrefixArg choice, derived from the actual
+        // argument (no free-form entry — spec §3/§4): a "directory and below" prefix for a path rule,
+        // or the normalized command signature (see CommandSignature) for a command rule.
         private static string PrefixPattern(ApprovalRequest req)
         {
             string val = ArgValue(req.Arguments, req.Policy.ScopeArgPath);
@@ -214,11 +224,64 @@ namespace GxPT
                 int slash = norm.LastIndexOf('/');
                 return slash < 0 ? string.Empty : norm.Substring(0, slash);
             }
-            // command: base + first subcommand (first two whitespace tokens)
-            string trimmed = val.Trim();
-            string[] parts = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length <= 1) return parts.Length == 1 ? parts[0] : trimmed;
-            return parts[0] + " " + parts[1];
+            // command: the normalized signature (see CommandSignature).
+            return CommandSignature(val);
+        }
+
+        // The "command pattern" signature: the invariant identity of a command, ignoring incidental
+        // flags/arguments so re-runs that differ only in options still match. Computed identically when
+        // a rule is stored and when a candidate is checked, then compared for equality (NOT a prefix).
+        //
+        //   command + 2nd token            when the 2nd token is NOT a flag   (git status, del foo.txt)
+        //   command + first file/path tok  when the 2nd token IS a flag       (powershell hello.ps1)
+        //   command + first flag           fallback: flag, no file/path found (dir /s, powershell -Command)
+        //
+        // Rationale and limits (flag arity is unknowable without per-tool grammar) are discussed in the
+        // approval design notes; the file/path heuristic only shifts where the signature ends, so a
+        // misdetection is benign (re-prompt), never a silent widening.
+        internal static string CommandSignature(string command)
+        {
+            if (command == null) return string.Empty;
+            string trimmed = command.Trim();
+            if (trimmed.Length == 0) return string.Empty;
+            string[] t = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            if (t.Length == 1) return t[0];
+
+            if (!IsFlagToken(t[1])) return t[0] + " " + t[1];
+
+            // 2nd token is a flag: prefer the first file/path-shaped operand (skipping flags and their
+            // space-separated values, which aren't path-shaped).
+            for (int i = 1; i < t.Length; i++)
+            {
+                if (!IsFlagToken(t[i]) && LooksLikePath(t[i])) return t[0] + " " + t[i];
+            }
+            // No concrete operand -> keep today's behavior (command + first flag).
+            return t[0] + " " + t[1];
+        }
+
+        private static bool IsFlagToken(string tok)
+        {
+            if (string.IsNullOrEmpty(tok)) return false;
+            char c = tok[0];
+            return c == '-' || c == '/';
+        }
+
+        // Recognized script/executable extensions (case-insensitive). Kept deliberately small; extend
+        // as needed. A token is also treated as a path if it contains a separator.
+        private static readonly string[] _scriptExtensions =
+            { ".ps1", ".bat", ".cmd", ".sh", ".py", ".js", ".ts", ".rb", ".pl", ".php", ".lua",
+              ".exe", ".com", ".sln", ".csproj", ".vbs", ".psm1" };
+
+        private static bool LooksLikePath(string tok)
+        {
+            if (string.IsNullOrEmpty(tok)) return false;
+            // Strip a wrapping/ trailing quote so e.g. hello.ps1" still reads as a script.
+            string s = tok.Trim('"', '\'');
+            if (s.Length == 0) return false;
+            if (s.IndexOf('/') >= 0 || s.IndexOf('\\') >= 0) return true;
+            for (int i = 0; i < _scriptExtensions.Length; i++)
+                if (s.EndsWith(_scriptExtensions[i], StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
         }
 
         // ---- helpers ----


### PR DESCRIPTION
## Summary

Two improvements to the tool-approval prompt:

1. **"Allow all edits in this workspace"** — a new approval option on write-scoped `files__` tools (`files__write` / `files__edit`). Choosing it remembers approval for every Write-tier `files__` tool targeting the current working directory, for the rest of the session.
2. **Command "pattern" rule** — the old two-token "base command" allow option is now a flag-insensitive command *signature*, so re-runs that differ only in flags/arguments stop re-prompting while a different target still prompts.

## Workspace-wide file approval

- New `ApprovalChoice.RememberWorkdirWrites` plus a workdir-scoped approval set on `IApprovalStore`, keyed by `server + canonical workdir`. Because the store is shared app-wide and file paths are workspace-relative, the approval is scoped to the canonical working directory so it never leaks across tabs/workspaces.
- `ToolApprovalPolicy` gains a per-turn `WorkingDir`, a fast-path that allows Write-tier path-scoped files tools when the workspace is approved (Destructive `files__delete` is excluded), and persistence of the choice. Wired from `MainForm` at the same point the orchestrator's `WorkingDir` is set.
- Panel: the per-folder prefix button is replaced by the workspace blanket, keeping the strip to four buttons (*Allow once · Always allow this file · Allow all edits in this workspace · Deny*).

## Command pattern rule

The stored rule and each live command are reduced to the same signature and matched by **equality** (not contiguous prefix):

| command | signature |
|---|---|
| `git status -s` | `git status` (2nd token not a flag) |
| `powershell -File hello.ps1 -Name "Anne"` | `powershell hello.ps1` |
| `powershell -ExecutionPolicy Bypass -File hello.ps1` | `powershell hello.ps1` (same → no re-prompt) |
| `powershell -File goodbye.ps1` | `powershell goodbye.ps1` (different file → re-prompts) |
| `dir /s /b` | `dir /s` (fallback: command + first flag) |

The operand is detected by shape (path separator or known extension), which sidesteps space-valued flags like `-ExecutionPolicy Bypass`. Detection only shifts where the signature ends, so a miss is benign (re-prompt), never a silent widening.

**Known limitation:** a path-valued flag *before* a subcommand can still mislead it (`git -C ./repo status` → `git ./repo`, collapsing `status`/`log`). Narrow case; the user opts into the breadth by choosing the pattern rule.

## UI

- The command button is relabeled **"Always allow this command pattern"** (the old "base" undersold that the file/subcommand is pinned), with a tooltip explaining the rule and showing the concrete signature. The "exact command" button gains a clarifying tooltip too.
- The resolved signature is also shown in the visible preview label next to the command line (e.g. `Command (pattern: powershell hello.ps1)`), shown only when it differs from the full command.

## Tests

- Workspace approval: cross-tool coverage, no cross-workspace leak, separator/case insensitivity, `files__delete` exclusion, no-workdir no-op.
- Command signature: subcommand/file/fallback cases plus an end-to-end flag-insensitive, file-sensitive check. Existing command behavior still holds (`git status` ≡ `git status -s`, not `git status-hack`).

Note: the app targets .NET 3.5 (WinForms) and isn't buildable on a stock runner; the policy/store logic and tests are linked into the net48 `GxPT.Tests` project and run via `dotnet test`. The panel changes were kept C# 3.0-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01She1gMyn252ad5CV5sUmn3)_