### PR TITLE
Pause status bar marquee and show "Awaiting user..." during tool approval

### DIFF
--- a/GxPT/Controls/StopGenerationItem.cs
+++ b/GxPT/Controls/StopGenerationItem.cs
@@ -24,7 +24,7 @@ namespace GxPT
         public const int ItemHeight = 15;  // tspGenProgress's height
 
         private const string StopText = "Stop";
-        private const string AwaitingText = "awaiting user...";
+        private const string AwaitingText = "Awaiting user...";
 
         public StopGenerationItem()
         {
@@ -86,10 +86,11 @@ namespace GxPT
             Rectangle bounds = new Rectangle(0, 0, this.Width, this.Height);
 
             // Awaiting state: a flat status label, no border/fill, so it reads as passive text rather
-            // than a clickable Stop button.
+            // than a clickable Stop button. Uses ControlText (like the strip's other labels) rather
+            // than the lighter GrayText, which next to them reads as thinner/smaller.
             if (_awaiting)
             {
-                TextRenderer.DrawText(g, this.Text, this.Font, bounds, SystemColors.GrayText,
+                TextRenderer.DrawText(g, this.Text, this.Font, bounds, SystemColors.ControlText,
                     TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
                     TextFormatFlags.SingleLine | TextFormatFlags.NoPadding);
                 return;

--- a/GxPT/Controls/StopGenerationItem.cs
+++ b/GxPT/Controls/StopGenerationItem.cs
@@ -18,15 +18,39 @@ namespace GxPT
     {
         private bool _hover;
         private bool _pressed;
+        private bool _awaiting;
 
         private const int PadX = 8;        // horizontal label padding, matching RetryBtnPadX
         public const int ItemHeight = 15;  // tspGenProgress's height
 
+        private const string StopText = "Stop";
+        private const string AwaitingText = "awaiting user...";
+
         public StopGenerationItem()
         {
             this.AutoSize = false;
-            this.Text = "Stop";
+            this.Text = StopText;
             this.Size = new Size(PreferredWidth(), ItemHeight);
+        }
+
+        // While a tool-approval (or continuation) prompt awaits the user's decision, the turn is
+        // paused at the gate: there is nothing to "Stop", so this item drops its button chrome and
+        // shows a passive "awaiting user..." status label instead. The host pauses the marquee and
+        // ignores clicks on this item in that state.
+        public bool Awaiting
+        {
+            get { return _awaiting; }
+            set
+            {
+                if (_awaiting == value) return;
+                _awaiting = value;
+                _hover = false;
+                _pressed = false;
+                this.Text = value ? AwaitingText : StopText;
+                try { this.Width = PreferredWidth(); }
+                catch { }
+                Invalidate();
+            }
         }
 
         protected override Size DefaultSize
@@ -49,9 +73,9 @@ namespace GxPT
             catch { }
         }
 
-        protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
+        protected override void OnMouseEnter(EventArgs e) { if (!_awaiting) { _hover = true; Invalidate(); } base.OnMouseEnter(e); }
         protected override void OnMouseLeave(EventArgs e) { _hover = false; _pressed = false; Invalidate(); base.OnMouseLeave(e); }
-        protected override void OnMouseDown(MouseEventArgs e) { if (e.Button == MouseButtons.Left) { _pressed = true; Invalidate(); } base.OnMouseDown(e); }
+        protected override void OnMouseDown(MouseEventArgs e) { if (!_awaiting && e.Button == MouseButtons.Left) { _pressed = true; Invalidate(); } base.OnMouseDown(e); }
         protected override void OnMouseUp(MouseEventArgs e) { _pressed = false; Invalidate(); base.OnMouseUp(e); }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -60,6 +84,17 @@ namespace GxPT
             Graphics g = e.Graphics;
 
             Rectangle bounds = new Rectangle(0, 0, this.Width, this.Height);
+
+            // Awaiting state: a flat status label, no border/fill, so it reads as passive text rather
+            // than a clickable Stop button.
+            if (_awaiting)
+            {
+                TextRenderer.DrawText(g, this.Text, this.Font, bounds, SystemColors.GrayText,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |
+                    TextFormatFlags.SingleLine | TextFormatFlags.NoPadding);
+                return;
+            }
+
             Rectangle border = new Rectangle(0, 0, this.Width - 1, this.Height - 1);
 
             Color fill = _pressed ? Color.FromArgb(210, 210, 210)

--- a/GxPT/Controls/StopGenerationItem.cs
+++ b/GxPT/Controls/StopGenerationItem.cs
@@ -26,6 +26,9 @@ namespace GxPT
         private const string StopText = "Stop";
         private const string AwaitingText = "Awaiting user...";
 
+        private const string StopTip = "Stop generating";
+        private const string AwaitingTip = "Waiting for tool approval";
+
         public StopGenerationItem()
         {
             this.AutoSize = false;
@@ -47,6 +50,7 @@ namespace GxPT
                 _hover = false;
                 _pressed = false;
                 this.Text = value ? AwaitingText : StopText;
+                this.ToolTipText = value ? AwaitingTip : StopTip;
                 try { this.Width = PreferredWidth(); }
                 catch { }
                 Invalidate();

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -26,6 +26,13 @@ namespace GxPT
         private Action<ApprovalChoice> _onChoose;
         private Action<bool> _onContinue;   // set instead of _onChoose for the iteration-cap prompt
 
+        // Raised (on the UI thread) when a prompt starts or stops awaiting the user's decision, so the
+        // host can reflect it in the status bar: pause the generation marquee and swap the Stop button
+        // for an "awaiting user..." label while a prompt is up. IsPromptVisible is the current state.
+        public event EventHandler PromptVisibleChanged;
+        private bool _promptVisible;
+        public bool IsPromptVisible { get { return _promptVisible; } }
+
         // Supplies the active workspace root so an edit approval can show a few lines of real file
         // context around the change. Set by the host (MainForm); null disables context (bare diff).
         public Func<string> WorkingDirProvider;
@@ -397,6 +404,7 @@ namespace GxPT
             // transcript to shrink *above* it (rather than the panel overlaying the transcript's
             // bottom edge and its right-docked scrollbar). BringToFront would cause exactly that.
             this.SendToBack();
+            SetPromptVisible(true);
         }
 
         // Iteration-cap confirmation, reusing this docked panel so it reads like the tool-approval
@@ -428,6 +436,7 @@ namespace GxPT
 
             this.Visible = true;
             this.SendToBack();
+            SetPromptVisible(true);
         }
 
         public void HidePanel()
@@ -435,6 +444,20 @@ namespace GxPT
             this.Visible = false;
             _onChoose = null;
             _onContinue = null;
+            SetPromptVisible(false);
+        }
+
+        // Track and broadcast whether a prompt is currently awaiting the user.
+        private void SetPromptVisible(bool v)
+        {
+            if (_promptVisible == v) return;
+            _promptVisible = v;
+            EventHandler h = PromptVisibleChanged;
+            if (h != null)
+            {
+                try { h(this, EventArgs.Empty); }
+                catch { }
+            }
         }
 
         // Resolve any pending prompt as if the user had declined (Deny / Stop), then hide. Used when

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -743,6 +743,9 @@ namespace GxPT
                 ctx.ApprovalPanel = panel;
                 var ctxRef = ctx;
                 panel.WorkingDirProvider = delegate { return ctxRef.WorkingDir; };
+                // While this tab's prompt awaits the user, pause the status-bar marquee and swap the
+                // Stop button for an "awaiting user..." label (only when this is the active tab).
+                panel.PromptVisibleChanged += delegate { SyncGenerationIndicatorFromActiveTab(); };
                 ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
@@ -777,7 +780,7 @@ namespace GxPT
             {
                 var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
                 if (act != null && ReferenceEquals(act, ctx))
-                    SetGenerationIndicatorVisible(true);
+                    SyncGenerationIndicatorFromActiveTab();
             }
             catch { }
         }
@@ -788,7 +791,7 @@ namespace GxPT
             {
                 var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
                 if (act != null && ReferenceEquals(act, ctx))
-                    SetGenerationIndicatorVisible(false);
+                    SyncGenerationIndicatorFromActiveTab();
             }
             catch { }
         }
@@ -798,27 +801,35 @@ namespace GxPT
             try
             {
                 var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
-                SetGenerationIndicatorVisible(act != null && act.IsSending && !act.SendDetached);
+                bool busy = act != null && act.IsSending && !act.SendDetached;
+                // The turn is paused at an approval/continuation gate when the active tab's prompt is
+                // up: pause the marquee and show "awaiting user..." in place of the Stop button.
+                bool awaiting = busy && act.ApprovalPanel != null && act.ApprovalPanel.IsPromptVisible;
+                SetGenerationIndicatorVisible(busy, awaiting);
             }
             catch { }
         }
 
-        private void SetGenerationIndicatorVisible(bool busy)
+        private void SetGenerationIndicatorVisible(bool busy, bool awaiting)
         {
             try
             {
                 if (this.tspGenProgress != null)
                 {
-                    // Run the marquee only while shown (no point animating an invisible bar).
-                    // MarqueeAnimationSpeed is the native PBM_SETMARQUEE interval (ms between
-                    // updates), which XP/Luna honors literally while Vista+/Aero drives the
-                    // animation from the theme engine and effectively ignores it. A short interval
-                    // therefore scrolls far too fast on XP; 120ms reads like the Win7 pace there and
-                    // leaves the (ignored) Aero animation unchanged.
-                    this.tspGenProgress.MarqueeAnimationSpeed = busy ? 120 : 0;
+                    // Run the marquee only while shown and not paused at a prompt (no point animating
+                    // an invisible or stalled bar). MarqueeAnimationSpeed is the native PBM_SETMARQUEE
+                    // interval (ms between updates), which XP/Luna honors literally while Vista+/Aero
+                    // drives the animation from the theme engine and effectively ignores it. A short
+                    // interval therefore scrolls far too fast on XP; 120ms reads like the Win7 pace
+                    // there and leaves the (ignored) Aero animation unchanged. 0 freezes the marquee.
+                    this.tspGenProgress.MarqueeAnimationSpeed = (busy && !awaiting) ? 120 : 0;
                     this.tspGenProgress.Visible = busy;
                 }
-                if (this.tsiStopGen != null) this.tsiStopGen.Visible = busy;
+                if (this.tsiStopGen != null)
+                {
+                    this.tsiStopGen.Awaiting = awaiting;
+                    this.tsiStopGen.Visible = busy;
+                }
                 // The slot's idle face: the active conversation's tool/skill counts. Refresh before
                 // showing so a turn's side effects (a server faulting, a skill the model authored)
                 // are reflected the moment the indicator yields the slot back.
@@ -891,6 +902,9 @@ namespace GxPT
         // cancel the active tab's request.
         private void tsiStopGen_Click(object sender, EventArgs e)
         {
+            // While the item shows "awaiting user...", there's nothing to stop (the turn is paused at
+            // an approval gate); ignore clicks so it behaves as a passive label.
+            if (this.tsiStopGen != null && this.tsiStopGen.Awaiting) return;
             try { CancelActiveRequest(_tabManager != null ? _tabManager.GetActiveContext() : null); }
             catch { }
         }


### PR DESCRIPTION
## Summary

While a tool-approval (or continuation) prompt is up, the turn is genuinely paused at the gate, so the status-bar generation indicator now reflects that:

- **Marquee pauses** — `MarqueeAnimationSpeed` is set to `0` (sends `PBM_SETMARQUEE FALSE`, freezing the animation) while the bar stays visible.
- **Stop → "Awaiting user..."** — `StopGenerationItem` gains an `Awaiting` mode that drops the button chrome (border/fill/hover), paints a passive label, ignores clicks, and swaps its tooltip to "Waiting for tool approval". The label uses `ControlText` to match the weight of the strip's other labels.

## How it's wired

- `ToolApprovalPanel` exposes `IsPromptVisible` and raises `PromptVisibleChanged` when a prompt starts/stops awaiting a decision (covering both `ShowFor` and the iteration-cap `ShowContinuation`, plus `HidePanel`/`DenyPending`).
- `MainForm` subscribes per-tab in `AttachApprovalPanel` and re-syncs the indicator from that event and from tab switches. The awaiting state is computed from the **active** tab's panel, so a background tab's prompt never touches the foreground indicator, and a tab switch restores the correct state.

## Notes

This is a .NET Framework / Visual Studio project and there's no `msbuild`/`dotnet` in the dev container, so the changes were verified by inspection rather than a compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CotDJk2mgDXzAZ9DHF1qSu)_