### PR TITLE
Scope-first skills toggles, /reset-skills, and arg-hint cleanup

### DIFF
--- a/GxPT.Tests/Commands/SlashCommandConfigTests.cs
+++ b/GxPT.Tests/Commands/SlashCommandConfigTests.cs
@@ -29,7 +29,7 @@ namespace GxPT.Tests.Commands
 
             Assert.True(explain.TakesPathArgument);
             Assert.Contains("files", explain.Requires);
-            Assert.Equal("[path]", explain.ArgumentHint);
+            Assert.Equal("<path>", explain.ArgumentHint);
         }
 
         [Fact]

--- a/GxPT.Tests/SkillCommandsTests.cs
+++ b/GxPT.Tests/SkillCommandsTests.cs
@@ -129,22 +129,23 @@ namespace GxPT.Tests
         }
 
         [Fact]
-        public void Skills_OffGlobal_ThenReset()
+        public void Skills_Global_OnOff_TogglesMaster()
         {
+            // The global on/off master is controlled only by /toggle-skills global on|off.
             new ToggleSkillsCommand().Invoke("global off", _ctx);
             Assert.True(SkillEnablement.LoadGlobal().FeatureOff);
 
-            new ResetSkillsCommand().Invoke("global", _ctx);
+            new ToggleSkillsCommand().Invoke("global on", _ctx);
             Assert.False(SkillEnablement.LoadGlobal().FeatureOff);
         }
 
         [Fact]
-        public void Skills_GlobalInherit_Fails_AndPointsToReset()
+        public void Skills_GlobalInherit_Fails()
         {
             // The global feature toggle has no upstream to inherit from, so "inherit" is rejected.
             SlashCommandResult r = new ToggleSkillsCommand().Invoke("global inherit", _ctx);
             Assert.NotNull(r.Error);
-            Assert.Contains("reset-skills", r.Error);
+            Assert.False(SkillEnablement.LoadGlobal().FeatureOff); // nothing applied
         }
 
         [Fact]
@@ -384,7 +385,7 @@ namespace GxPT.Tests
         }
 
         [Fact]
-        public void ResetSkills_Global_ClearsAllGlobalSettings()
+        public void ResetSkills_Global_ClearsPerSkillSettings_LeavesMaster()
         {
             WriteSkill("greeting", "Be a pirate.", "b");
             new ToggleSkillsCommand().Invoke("global off", _ctx);
@@ -393,8 +394,8 @@ namespace GxPT.Tests
             new ResetSkillsCommand().Invoke("global", _ctx);
 
             SkillEnablement g = SkillEnablement.LoadGlobal();
-            Assert.False(g.FeatureOff);
-            Assert.Null(g.GetSkillOverride("greeting"));
+            Assert.True(g.FeatureOff);                       // on/off master left as-is
+            Assert.Null(g.GetSkillOverride("greeting"));     // per-skill override cleared
         }
 
         [Fact]

--- a/GxPT.Tests/SkillCommandsTests.cs
+++ b/GxPT.Tests/SkillCommandsTests.cs
@@ -66,7 +66,7 @@ namespace GxPT.Tests
         {
             WriteSkill("greeting", "Be a pirate.", "b");
 
-            SlashCommandResult r = new ToggleSkillCommand().Invoke("greeting off", _ctx);
+            SlashCommandResult r = new ToggleSkillCommand().Invoke("greeting here off", _ctx);
 
             Assert.False(r.SendToModel);
             Assert.False(_ctx.SkillStore.ConvOverrides["greeting"]);   // forced off for this conversation
@@ -89,20 +89,21 @@ namespace GxPT.Tests
         {
             WriteSkill("greeting", "Be a pirate.", "b");
 
-            new ToggleSkillCommand().Invoke("greeting off global", _ctx);
+            new ToggleSkillCommand().Invoke("greeting global off", _ctx);
 
             Assert.Equal((bool?)false, SkillEnablement.LoadGlobal().GetSkillOverride("greeting"));
             Assert.Empty(_ctx.SkillStore.ConvOverrides);   // global scope must not touch the conversation
         }
 
-        // The transcript scenario: /skills off then /skill greeting on -> greeting still listed ON.
+        // The transcript scenario: /toggle-skills here off then /toggle-skill greeting here on
+        // -> greeting still listed ON.
         [Fact]
         public void SkillOnHere_OverridesSkillsOffHere_InList()
         {
             WriteSkill("greeting", "Be a pirate.", "b");
 
-            new ToggleSkillsCommand().Invoke("off", _ctx);          // all skills off here
-            new ToggleSkillCommand().Invoke("greeting on", _ctx);   // but this one on here
+            new ToggleSkillsCommand().Invoke("here off", _ctx);          // all skills off here
+            new ToggleSkillCommand().Invoke("greeting here on", _ctx);   // but this one on here
             new ListSkillsCommand().Invoke("", _ctx);             // list
 
             Assert.Contains("greeting", LastInfo());
@@ -114,8 +115,8 @@ namespace GxPT.Tests
         {
             WriteSkill("pirate", "Always pirate.", "b");
 
-            new ToggleSkillsCommand().Invoke("off global", _ctx);   // feature off globally
-            new ToggleSkillCommand().Invoke("pirate on global", _ctx);
+            new ToggleSkillsCommand().Invoke("global off", _ctx);   // feature off globally
+            new ToggleSkillCommand().Invoke("pirate global on", _ctx);
 
             Assert.Equal((bool?)true, SkillEnablement.LoadGlobal().GetSkillOverride("pirate"));
         }
@@ -123,24 +124,33 @@ namespace GxPT.Tests
         [Fact]
         public void Skill_UnknownSlug_Fails()
         {
-            SlashCommandResult r = new ToggleSkillCommand().Invoke("nope off", _ctx);
+            SlashCommandResult r = new ToggleSkillCommand().Invoke("nope global off", _ctx);
             Assert.NotNull(r.Error);
         }
 
         [Fact]
         public void Skills_OffGlobal_ThenReset()
         {
-            new ToggleSkillsCommand().Invoke("off global", _ctx);
+            new ToggleSkillsCommand().Invoke("global off", _ctx);
             Assert.True(SkillEnablement.LoadGlobal().FeatureOff);
 
-            new ToggleSkillsCommand().Invoke("reset global", _ctx);
+            new ResetSkillsCommand().Invoke("global", _ctx);
             Assert.False(SkillEnablement.LoadGlobal().FeatureOff);
+        }
+
+        [Fact]
+        public void Skills_GlobalInherit_Fails_AndPointsToReset()
+        {
+            // The global feature toggle has no upstream to inherit from, so "inherit" is rejected.
+            SlashCommandResult r = new ToggleSkillsCommand().Invoke("global inherit", _ctx);
+            Assert.NotNull(r.Error);
+            Assert.Contains("reset-skills", r.Error);
         }
 
         [Fact]
         public void Skills_TrailingTokens_Fail()
         {
-            SlashCommandResult r = new ToggleSkillsCommand().Invoke("on here garbage", _ctx);
+            SlashCommandResult r = new ToggleSkillsCommand().Invoke("here on garbage", _ctx);
             Assert.NotNull(r.Error);
             Assert.False(SkillEnablement.LoadGlobal().FeatureOff); // nothing applied
         }
@@ -149,7 +159,7 @@ namespace GxPT.Tests
         public void Skill_TrailingTokens_Fail()
         {
             WriteSkill("greeting", "Be a pirate.", "b");
-            SlashCommandResult r = new ToggleSkillCommand().Invoke("greeting on global junk", _ctx);
+            SlashCommandResult r = new ToggleSkillCommand().Invoke("greeting global on junk", _ctx);
             Assert.NotNull(r.Error);
             Assert.Null(SkillEnablement.LoadGlobal().GetSkillOverride("greeting")); // nothing applied
         }
@@ -159,11 +169,11 @@ namespace GxPT.Tests
         {
             // The Skills MCP server follows skill enablement, so every enablement change - global OR
             // per-conversation - asks the host to bring it into line (a no-op unless it crosses on/off).
-            new ToggleSkillsCommand().Invoke("off global", _ctx);
-            new ToggleSkillsCommand().Invoke("on global", _ctx);
-            new ToggleSkillsCommand().Invoke("reset global", _ctx);
-            new ToggleSkillsCommand().Invoke("off here", _ctx);
-            new ToggleSkillsCommand().Invoke("reset", _ctx);
+            new ToggleSkillsCommand().Invoke("global off", _ctx);
+            new ToggleSkillsCommand().Invoke("global on", _ctx);
+            new ResetSkillsCommand().Invoke("global", _ctx);
+            new ToggleSkillsCommand().Invoke("here off", _ctx);
+            new ResetSkillsCommand().Invoke("here", _ctx);
             Assert.Equal(5, _ctx.SkillStore.RefreshSkillsServerCount);
         }
 
@@ -171,26 +181,26 @@ namespace GxPT.Tests
         public void Skill_EnablementChange_RefreshesSkillsServer()
         {
             WriteSkill("greeting", "Be a pirate.", "b");
-            new ToggleSkillCommand().Invoke("greeting on here", _ctx);
-            new ToggleSkillCommand().Invoke("greeting off global", _ctx);
-            new ToggleSkillCommand().Invoke("greeting reset", _ctx);
+            new ToggleSkillCommand().Invoke("greeting here on", _ctx);
+            new ToggleSkillCommand().Invoke("greeting global off", _ctx);
+            new ToggleSkillCommand().Invoke("greeting here inherit", _ctx);
             Assert.Equal(3, _ctx.SkillStore.RefreshSkillsServerCount);
         }
 
         [Fact]
         public void Skills_OffHere_AndReset()
         {
-            new ToggleSkillsCommand().Invoke("off", _ctx);
+            new ToggleSkillsCommand().Invoke("here off", _ctx);
             Assert.Equal(true, _ctx.SkillStore.ConvFeatureOff);
 
-            new ToggleSkillsCommand().Invoke("reset", _ctx);
+            new ResetSkillsCommand().Invoke("here", _ctx);
             Assert.Null(_ctx.SkillStore.ConvFeatureOff);
         }
 
         [Fact]
         public void Skills_UnknownScope_Fails()
         {
-            SlashCommandResult r = new ToggleSkillsCommand().Invoke("off nowhere", _ctx);
+            SlashCommandResult r = new ToggleSkillsCommand().Invoke("nowhere off", _ctx);
             Assert.NotNull(r.Error);
         }
 
@@ -225,11 +235,11 @@ namespace GxPT.Tests
         public void Use_DisabledSkill_StillWorks()
         {
             WriteSkill("greeting", "Be a pirate.", "ARRR");
-            new ToggleSkillCommand().Invoke("greeting off global", _ctx);   // disable globally
+            new ToggleSkillCommand().Invoke("greeting global off", _ctx);   // disable globally
 
             SlashCommandResult r = new UseSkillCommand().Invoke("greeting", _ctx);
 
-            Assert.True(r.SendToModel);   // explicit /use ignores enablement
+            Assert.True(r.SendToModel);   // explicit /use-skill ignores enablement
             Assert.Contains("ARRR", r.SystemContext); // body still attached
         }
 
@@ -312,36 +322,86 @@ namespace GxPT.Tests
         }
 
         [Fact]
-        public void Complete_Skills_Empty_OffersVerbsThatAdvance()
+        public void Complete_Skills_Empty_OffersScopesThatAdvance()
         {
             IList<ArgCompletion> c = new ToggleSkillsCommand().CompleteArgument("", _ctx);
 
-            // No bare-command entry: a verb is required (listing is /list-skills).
-            Assert.Null(Find(c, "(toggle skills for this conversation)"));
-
-            ArgCompletion on = Find(c, "on");
-            Assert.NotNull(on);
-            Assert.Equal("on ", on.InsertArg);   // trailing space so the scope level populates next
-            Assert.True(on.ContinueCompleting);
-        }
-
-        [Fact]
-        public void Complete_Skills_AfterVerb_OffersScope()
-        {
-            IList<ArgCompletion> c = new ToggleSkillsCommand().CompleteArgument("on ", _ctx);
-
-            Assert.NotNull(Find(c, "here"));
-            Assert.Equal("on here", Find(c, "here").InsertArg);
+            ArgCompletion here = Find(c, "here");
+            Assert.NotNull(here);
+            Assert.Equal("here ", here.InsertArg);   // trailing space so the verb level populates next
+            Assert.True(here.ContinueCompleting);
             Assert.NotNull(Find(c, "global"));
         }
 
         [Fact]
-        public void Complete_Skill_AfterVerb_OffersScope()
+        public void Complete_Skills_AfterHere_OffersOnOffInherit()
         {
-            IList<ArgCompletion> c = new ToggleSkillCommand().CompleteArgument("greeting on ", _ctx);
+            IList<ArgCompletion> c = new ToggleSkillsCommand().CompleteArgument("here ", _ctx);
+
+            Assert.NotNull(Find(c, "on"));
+            Assert.Equal("here on", Find(c, "on").InsertArg);
+            Assert.NotNull(Find(c, "off"));
+            Assert.NotNull(Find(c, "inherit"));
+        }
+
+        [Fact]
+        public void Complete_Skills_AfterGlobal_OffersOnlyOnOff()
+        {
+            IList<ArgCompletion> c = new ToggleSkillsCommand().CompleteArgument("global ", _ctx);
+
+            Assert.NotNull(Find(c, "on"));
+            Assert.NotNull(Find(c, "off"));
+            Assert.Null(Find(c, "inherit"));   // global feature toggle has no inherit
+        }
+
+        [Fact]
+        public void Complete_Skill_AfterScope_OffersOnOffInherit()
+        {
+            // global scope still offers inherit for a single skill (per-skill global is tri-state).
+            IList<ArgCompletion> c = new ToggleSkillCommand().CompleteArgument("greeting global ", _ctx);
+
+            Assert.NotNull(Find(c, "on"));
+            Assert.Equal("greeting global on", Find(c, "on").InsertArg);
+            Assert.NotNull(Find(c, "inherit"));
+        }
+
+        [Fact]
+        public void Complete_ResetSkills_OffersScopes()
+        {
+            IList<ArgCompletion> c = new ResetSkillsCommand().CompleteArgument("", _ctx);
 
             Assert.NotNull(Find(c, "here"));
-            Assert.Equal("greeting on here", Find(c, "here").InsertArg);
+            Assert.Equal("here", Find(c, "here").InsertArg);   // terminal: no trailing space
+            Assert.NotNull(Find(c, "global"));
+        }
+
+        [Fact]
+        public void ResetSkills_Here_ClearsConversation()
+        {
+            new ToggleSkillsCommand().Invoke("here off", _ctx);
+            new ResetSkillsCommand().Invoke("here", _ctx);
+            Assert.Null(_ctx.SkillStore.ConvFeatureOff);
+        }
+
+        [Fact]
+        public void ResetSkills_Global_ClearsAllGlobalSettings()
+        {
+            WriteSkill("greeting", "Be a pirate.", "b");
+            new ToggleSkillsCommand().Invoke("global off", _ctx);
+            new ToggleSkillCommand().Invoke("greeting global off", _ctx);
+
+            new ResetSkillsCommand().Invoke("global", _ctx);
+
+            SkillEnablement g = SkillEnablement.LoadGlobal();
+            Assert.False(g.FeatureOff);
+            Assert.Null(g.GetSkillOverride("greeting"));
+        }
+
+        [Fact]
+        public void ResetSkills_UnknownScope_Fails()
+        {
+            SlashCommandResult r = new ResetSkillsCommand().Invoke("nowhere", _ctx);
+            Assert.NotNull(r.Error);
         }
     }
 }

--- a/GxPT/Services/Commands/SkillCommands.cs
+++ b/GxPT/Services/Commands/SkillCommands.cs
@@ -163,7 +163,7 @@ namespace GxPT
     {
         public override string Name { get { return "toggle-skills"; } }
         public override string Description { get { return "Turn the skills feature on/off"; } }
-        public override string ArgumentHint { get { return "[on|off|reset] [here|global]"; } }
+        public override string ArgumentHint { get { return "<on|off|reset> [here|global]"; } }
 
         public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
         {

--- a/GxPT/Services/Commands/SkillCommands.cs
+++ b/GxPT/Services/Commands/SkillCommands.cs
@@ -5,14 +5,18 @@ using System.Text;
 namespace GxPT
 {
     // Slash commands for the skills feature (design sec.6), built on the existing ISlashCommand framework:
-    //   /list-skills                                    -- list skills and their effective on/off state
-    //   /toggle-skills [on|off|reset] [here|global]     -- toggle/reset the whole feature at that scope
-    //   /toggle-skill <slug> [on|off|reset] [here|global] -- toggle/reset one skill (bare slug toggles)
-    //   /use-skill <slug> [text]                        -- use a skill (body attached as hidden context)
+    //   /list-skills                                          -- list skills and their effective on/off state
+    //   /toggle-skills <here|global> <on|off|inherit>         -- set the whole feature at that scope
+    //   /toggle-skill <slug> <here|global> <on|off|inherit>   -- set one skill (bare slug toggles here)
+    //   /reset-skills <here|global>                           -- clear all skill settings at that scope
+    //   /use-skill <slug> [text]                              -- use a skill (body attached as hidden context)
+    // Scope comes first and is required: it picks the layer the change lands on, and the autocomplete then
+    // offers only the verbs that layer accepts. "inherit" unsets a layer so it falls through to the one
+    // upstream; the global feature toggle is the most upstream layer (a plain bool, always on or off), so
+    // it has no "inherit" -- bulk-clearing global per-skill settings is /reset-skills global instead.
     // Management commands are Client (local, no LLM send); /use-skill sends a short "Use the X skill" ask
-    // and attaches the skill body as a hidden system message (it never enters the transcript). Scope
-    // defaults to "here" (this conversation); "global" edits skills.json. Conversation overrides are
-    // read/written through ISlashCommandContext; the global default through SkillEnablement directly.
+    // and attaches the skill body as a hidden system message (it never enters the transcript). "global"
+    // edits skills.json; conversation overrides are read/written through ISlashCommandContext.
     internal static class SkillCommandShared
     {
         public static IList<ISlashCommand> BuiltIns()
@@ -21,6 +25,7 @@ namespace GxPT
             list.Add(new ListSkillsCommand());
             list.Add(new ToggleSkillsCommand());
             list.Add(new ToggleSkillCommand());
+            list.Add(new ResetSkillsCommand());
             list.Add(new UseSkillCommand());
             return list;
         }
@@ -46,7 +51,7 @@ namespace GxPT
             return SlashArgs.ParseOnOff(token);
         }
 
-        // Recognizes the trailing scope word. Returns false for anything that isn't here/global.
+        // Recognizes the scope word. Returns false for anything that isn't here/global.
         internal static bool TryScope(string token, out bool isGlobal)
         {
             isGlobal = false;
@@ -55,6 +60,26 @@ namespace GxPT
             if (t == "global") { isGlobal = true; return true; }
             if (t == "here") { isGlobal = false; return true; }
             return false;
+        }
+
+        // Parses a mutation verb: on/off yield onOff with a value (isInherit false); "inherit" yields
+        // isInherit true (onOff null). Returns false for anything else.
+        internal static bool TryParseVerb(string token, out bool? onOff, out bool isInherit)
+        {
+            onOff = null;
+            isInherit = false;
+            if (string.IsNullOrEmpty(token)) return false;
+            if (string.Equals(token.Trim(), "inherit", StringComparison.OrdinalIgnoreCase)) { isInherit = true; return true; }
+            onOff = ParseOnOff(token);
+            return onOff.HasValue;
+        }
+
+        // The verbs a scope accepts: global feature settings are a plain on/off, every other layer is
+        // tri-state and also takes "inherit". Drives both validation and autocomplete.
+        internal static string[] VerbsForScope(bool isGlobal, bool isFeature)
+        {
+            if (isGlobal && isFeature) return new string[] { "on", "off" };
+            return new string[] { "on", "off", "inherit" };
         }
 
         // Resolve a user-typed slug (exact, else kebab-normalized) against the catalog.
@@ -158,50 +183,41 @@ namespace GxPT
         }
     }
 
-    // /toggle-skills [on|off|reset] [here|global]   (a verb is required; listing is /list-skills)
+    // /toggle-skills <here|global> <on|off|inherit>   (scope first; global takes only on|off)
     internal sealed class ToggleSkillsCommand : ClientCommandBase, IArgumentCompleter
     {
         public override string Name { get { return "toggle-skills"; } }
         public override string Description { get { return "Turn the skills feature on/off"; } }
-        public override string ArgumentHint { get { return "<on|off|reset> [here|global]"; } }
+        public override string ArgumentHint { get { return "<here|global> <on|off|inherit>"; } }
 
         public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
         {
             string[] tok = SkillCommandShared.Tokens(args);
+            if (tok.Length != 2) // scope + verb, both required; listing is /list-skills
+                return SlashCommandResult.Fail("Usage: /toggle-skills <here|global> <on|off|inherit>");
+
+            bool isGlobal;
+            if (!SkillCommandShared.TryScope(tok[0], out isGlobal))
+                return SlashCommandResult.Fail("Unknown scope '" + tok[0] + "'. Use 'here' or 'global'.");
+
+            bool? onoff;
+            bool isInherit;
+            if (!SkillCommandShared.TryParseVerb(tok[1], out onoff, out isInherit))
+                return SlashCommandResult.Fail("Usage: /toggle-skills <here|global> <on|off|inherit>");
+
             SkillEnablement global = SkillEnablement.LoadGlobal();
-
-            // A verb is required; trailing junk past verb + optional scope is rejected too. (Listing is
-            // /list-skills, not a bare invocation here.)
-            if (tok.Length == 0 || tok.Length > 2)
-                return SlashCommandResult.Fail("Usage: /toggle-skills [on|off|reset] [here|global]");
-
-            bool isGlobal = false;
-            if (tok.Length >= 2 && !SkillCommandShared.TryScope(tok[1], out isGlobal))
-                return SlashCommandResult.Fail("Unknown scope '" + tok[1] + "'. Use 'here' or 'global'.");
-
-            string verb = tok[0].ToLowerInvariant();
             string info;
-            if (verb == "reset")
+            if (isInherit)
             {
+                // The global feature toggle is the most upstream layer (a plain bool), so it has nothing to
+                // inherit from -- there's no "inherit" for it; bulk-clearing is /reset-skills global.
                 if (isGlobal)
-                {
-                    global.FeatureOff = false;
-                    global.ClearSkillOverrides();
-                    global.SaveGlobal();
-                    info = "Skills: global defaults reset (feature on, no per-skill settings).";
-                }
-                else
-                {
-                    ctx.Skills.ResetConversationSkills();
-                    info = "Skills: cleared this conversation's overrides.";
-                }
+                    return SlashCommandResult.Fail("Global skills are always on or off. Use '/reset-skills global' to clear per-skill settings.");
+                ctx.Skills.SetConversationSkillsFeatureOff(null);
+                info = "Skills: this conversation now follows the global default.";
             }
             else
             {
-                bool? onoff = SkillCommandShared.ParseOnOff(verb);
-                if (!onoff.HasValue)
-                    return SlashCommandResult.Fail("Usage: /toggle-skills [on|off|reset] [here|global]");
-
                 bool on = onoff.Value;
                 if (isGlobal) { global.FeatureOff = !on; global.SaveGlobal(); }
                 else { ctx.Skills.SetConversationSkillsFeatureOff(on ? (bool?)false : (bool?)true); }
@@ -220,31 +236,34 @@ namespace GxPT
             int sp = a.IndexOf(' ');
             if (sp < 0)
             {
-                SkillCommandShared.AddMatching(result, new string[] { "on", "off", "reset" }, a, "", true);
+                // First token: the scope, which then narrows the verb choices.
+                SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, a, "", true);
             }
             else
             {
-                string first = a.Substring(0, sp);
+                string scopeTok = a.Substring(0, sp);
                 string rest = a.Substring(sp + 1).TrimStart();
-                SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, rest, first + " ", false);
+                bool isGlobal;
+                if (!SkillCommandShared.TryScope(scopeTok, out isGlobal)) return result; // unknown scope: nothing
+                SkillCommandShared.AddMatching(result, SkillCommandShared.VerbsForScope(isGlobal, true), rest, scopeTok + " ", false);
             }
             return result;
         }
     }
 
-    // /toggle-skill <slug> [on|off|reset] [here|global]   (bare "/toggle-skill <slug>" toggles for this
-    // conversation)
+    // /toggle-skill <slug> <here|global> <on|off|inherit>   (bare "/toggle-skill <slug>" toggles here)
     internal sealed class ToggleSkillCommand : ClientCommandBase, IArgumentCompleter
     {
         public override string Name { get { return "toggle-skill"; } }
         public override string Description { get { return "Enable or disable one skill"; } }
-        public override string ArgumentHint { get { return "<slug> [on|off|reset] [here|global]"; } }
+        public override string ArgumentHint { get { return "<slug> <here|global> <on|off|inherit>"; } }
 
         public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
         {
             string[] tok = SkillCommandShared.Tokens(args);
-            if (tok.Length == 0 || tok.Length > 3) // slug + optional verb + optional scope; no trailing junk
-                return SlashCommandResult.Fail("Usage: /toggle-skill <slug> [on|off|reset] [here|global]");
+            // Either a bare slug (toggle here) or the full slug + scope + verb; nothing in between.
+            if (tok.Length != 1 && tok.Length != 3)
+                return SlashCommandResult.Fail("Usage: /toggle-skill <slug> <here|global> <on|off|inherit>");
 
             SkillCatalog cat = SkillCommandShared.BuildCatalog(ctx);
             Skill skill;
@@ -265,22 +284,22 @@ namespace GxPT
             }
             else
             {
-                bool isGlobal = false;
-                if (tok.Length >= 3 && !SkillCommandShared.TryScope(tok[2], out isGlobal))
-                    return SlashCommandResult.Fail("Unknown scope '" + tok[2] + "'. Use 'here' or 'global'.");
+                bool isGlobal;
+                if (!SkillCommandShared.TryScope(tok[1], out isGlobal))
+                    return SlashCommandResult.Fail("Unknown scope '" + tok[1] + "'. Use 'here' or 'global'.");
 
-                string verb = tok[1].ToLowerInvariant();
-                if (verb == "reset")
+                bool? onoff;
+                bool isInherit;
+                if (!SkillCommandShared.TryParseVerb(tok[2], out onoff, out isInherit))
+                    return SlashCommandResult.Fail("Usage: /toggle-skill <slug> <here|global> <on|off|inherit>");
+
+                if (isInherit)
                 {
-                    if (isGlobal) { global.SetSkillOverride(slug, null); global.SaveGlobal(); info = "Skill '" + slug + "': global setting cleared."; }
-                    else { ctx.Skills.SetConversationSkillOverride(slug, null); info = "Skill '" + slug + "': conversation override cleared."; }
+                    if (isGlobal) { global.SetSkillOverride(slug, null); global.SaveGlobal(); info = "Skill '" + slug + "': global setting cleared (inherits the feature default)."; }
+                    else { ctx.Skills.SetConversationSkillOverride(slug, null); info = "Skill '" + slug + "': conversation setting cleared (inherits the global default)."; }
                 }
                 else
                 {
-                    bool? onoff = SkillCommandShared.ParseOnOff(verb);
-                    if (!onoff.HasValue)
-                        return SlashCommandResult.Fail("Usage: /toggle-skill <slug> [on|off|reset] [here|global]");
-
                     bool on = onoff.Value;
                     if (isGlobal) { global.SetSkillOverride(slug, on); global.SaveGlobal(); }
                     else { ctx.Skills.SetConversationSkillOverride(slug, on); }
@@ -318,17 +337,70 @@ namespace GxPT
                 int sp2 = a.IndexOf(' ', sp + 1);
                 if (sp2 < 0)
                 {
+                    // Second token: the scope, which then narrows the verb choices.
                     string slug = a.Substring(0, sp);
                     string rest = a.Substring(sp + 1).TrimStart();
-                    SkillCommandShared.AddMatching(result, new string[] { "on", "off", "reset" }, rest, slug + " ", true);
+                    SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, rest, slug + " ", true);
                 }
                 else
                 {
-                    string head = a.Substring(0, sp2);
+                    string head = a.Substring(0, sp2);            // "<slug> <scope>"
+                    string scopeTok = a.Substring(sp + 1, sp2 - sp - 1);
                     string rest = a.Substring(sp2 + 1).TrimStart();
-                    SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, rest, head + " ", false);
+                    bool isGlobal;
+                    if (!SkillCommandShared.TryScope(scopeTok, out isGlobal)) return result; // unknown scope: nothing
+                    SkillCommandShared.AddMatching(result, SkillCommandShared.VerbsForScope(isGlobal, false), rest, head + " ", false);
                 }
             }
+            return result;
+        }
+    }
+
+    // /reset-skills <here|global> -- clear every skill setting at that scope (the bulk action that used to
+    // ride on the feature command's "reset"). "here" drops all of this conversation's overrides so it
+    // follows global again; "global" resets the feature to on and removes every per-skill global setting.
+    internal sealed class ResetSkillsCommand : ClientCommandBase, IArgumentCompleter
+    {
+        public override string Name { get { return "reset-skills"; } }
+        public override string Description { get { return "Clear all skill settings at a scope"; } }
+        public override string ArgumentHint { get { return "<here|global>"; } }
+
+        public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
+        {
+            string[] tok = SkillCommandShared.Tokens(args);
+            if (tok.Length != 1)
+                return SlashCommandResult.Fail("Usage: /reset-skills <here|global>");
+
+            bool isGlobal;
+            if (!SkillCommandShared.TryScope(tok[0], out isGlobal))
+                return SlashCommandResult.Fail("Unknown scope '" + tok[0] + "'. Use 'here' or 'global'.");
+
+            string info;
+            if (isGlobal)
+            {
+                SkillEnablement global = SkillEnablement.LoadGlobal();
+                global.FeatureOff = false;
+                global.ClearSkillOverrides();
+                global.SaveGlobal();
+                info = "Skills: global settings reset (feature on, no per-skill settings).";
+            }
+            else
+            {
+                ctx.Skills.ResetConversationSkills();
+                info = "Skills: cleared all of this conversation's overrides.";
+            }
+
+            ctx.Skills.RefreshSkillsServer();
+            ctx.WriteInfo(info);
+            return SlashCommandResult.Handled();
+        }
+
+        public IList<ArgCompletion> CompleteArgument(string argText, ISlashCommandContext ctx)
+        {
+            List<ArgCompletion> result = new List<ArgCompletion>();
+            string a = argText ?? string.Empty;
+            if (a.IndexOf(' ') >= 0) return result; // single argument
+            SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, a, "", false);
             return result;
         }
     }

--- a/GxPT/Services/Commands/SkillCommands.cs
+++ b/GxPT/Services/Commands/SkillCommands.cs
@@ -210,9 +210,9 @@ namespace GxPT
             if (isInherit)
             {
                 // The global feature toggle is the most upstream layer (a plain bool), so it has nothing to
-                // inherit from -- there's no "inherit" for it; bulk-clearing is /reset-skills global.
+                // inherit from -- there's no "inherit" for it, only on/off.
                 if (isGlobal)
-                    return SlashCommandResult.Fail("Global skills are always on or off. Use '/reset-skills global' to clear per-skill settings.");
+                    return SlashCommandResult.Fail("Global skills are always on or off; use 'on' or 'off'.");
                 ctx.Skills.SetConversationSkillsFeatureOff(null);
                 info = "Skills: this conversation now follows the global default.";
             }
@@ -356,9 +356,10 @@ namespace GxPT
         }
     }
 
-    // /reset-skills <here|global> -- clear every skill setting at that scope (the bulk action that used to
-    // ride on the feature command's "reset"). "here" drops all of this conversation's overrides so it
-    // follows global again; "global" resets the feature to on and removes every per-skill global setting.
+    // /reset-skills <here|global> -- clear skill settings at that scope (the bulk action that used to ride
+    // on the feature command's "reset"). "here" drops all of this conversation's overrides -- its feature
+    // on/off and every per-skill override -- so it follows global again; "global" removes every per-skill
+    // global override. Neither touches the global on/off master; that is only /toggle-skills global on|off.
     internal sealed class ResetSkillsCommand : ClientCommandBase, IArgumentCompleter
     {
         public override string Name { get { return "reset-skills"; } }
@@ -378,11 +379,11 @@ namespace GxPT
             string info;
             if (isGlobal)
             {
+                // Per-skill global overrides only; the on/off master (FeatureOff) is left as-is.
                 SkillEnablement global = SkillEnablement.LoadGlobal();
-                global.FeatureOff = false;
                 global.ClearSkillOverrides();
                 global.SaveGlobal();
-                info = "Skills: global settings reset (feature on, no per-skill settings).";
+                info = "Skills: all per-skill global settings cleared.";
             }
             else
             {

--- a/GxPT/Services/Commands/SlashCommandConfig.cs
+++ b/GxPT/Services/Commands/SlashCommandConfig.cs
@@ -43,7 +43,7 @@ namespace GxPT
       ""type"": ""prompt"",
       ""name"": ""explain"",
       ""description"": ""Read a file or folder and explain what it does"",
-      ""argument_hint"": ""[path]"",
+      ""argument_hint"": ""<path>"",
       ""arg_type"": ""path"",
       ""requires"": [""files""],
       ""template"": ""Read `{args}` and explain what it does, its key types, and how it fits into the rest of the project.""

--- a/GxPT/Services/Skills/SkillEnablement.cs
+++ b/GxPT/Services/Skills/SkillEnablement.cs
@@ -56,7 +56,7 @@ namespace GxPT
             else _skills.Remove(slug);
         }
 
-        // Clears every per-skill global setting (used by `/toggle-skills reset global`); leaves FeatureOff.
+        // Clears every per-skill global setting (used by `/reset-skills global`); leaves FeatureOff.
         public void ClearSkillOverrides()
         {
             _skills.Clear();

--- a/docs/skills-design.md
+++ b/docs/skills-design.md
@@ -276,13 +276,19 @@ Registered in `SkillCommands.BuiltIns()` alongside the other built-ins.
 | Command | Kind | Effect |
 |---------|------|--------|
 | `/list-skills` | Client | List skills with effective on/off state and source (global default vs. this conversation) |
-| `/toggle-skills [on\|off\|reset] [here\|global]` | Client | Toggle/reset the **whole feature** at that scope (default `here`); a verb is required |
-| `/toggle-skill <slug> [on\|off\|reset] [here\|global]` | Client | Toggle/reset **one skill**; bare `/toggle-skill <slug>` toggles for this conversation |
+| `/toggle-skills <here\|global> <on\|off\|inherit>` | Client | Set the **whole feature** at that scope. `global` takes only `on\|off` (it is the most upstream layer); `here` also takes `inherit` (unset → follow global) |
+| `/toggle-skill <slug> <here\|global> <on\|off\|inherit>` | Client | Set **one skill** at that scope (both scopes tri-state, so both take `inherit`); bare `/toggle-skill <slug>` toggles for this conversation |
+| `/reset-skills <here\|global>` | Client | Clear **all** skill settings at that scope: `here` drops every conversation override; `global` resets the feature to on and removes every per-skill global setting |
 | `/use-skill <slug> [text]` | Client | **Invoke**: resolve `<slug>`, carry its rendered `SKILL.md` block on the result as `SystemContext` (committed to history as a **hidden system message** at the send, so an early return can't orphan it), and send the short user ask `Use the <slug> skill. [text]` |
 
-- **Slug-first** for `/toggle-skill`, mirroring `/toggle-tool <name> [on|off]`; the verb
-  (`on|off|reset`) is the optional second token, scope (`here`/`global`) the optional
-  third. Scope defaults to `here`; `global` edits `skills.json`.
+- **Scope-first, required.** The scope (`here`/`global`) is the first token and picks the
+  layer the change lands on; the verb follows. This lets autocomplete offer only the verbs
+  that layer accepts — `global` on the feature toggle is `on|off` (no `inherit`, since the
+  global feature flag is a plain bool with nothing upstream to inherit from), every other
+  layer adds `inherit`. `global` edits `skills.json`.
+- **`inherit` vs. `/reset-skills`.** `inherit` unsets a *single* layer so it falls through
+  to the one upstream. The bulk "clear everything at this scope" action lives in
+  `/reset-skills <here|global>` — that is where the old `reset` verb's behavior moved.
 - **Invocation is `/use-skill <slug>`**, not a per-skill `/<slug>` command — the framework's
   registry is built once at startup, so one command per dynamically-discovered skill
   doesn't fit (decision in §11). `/use-skill` attaches the rendered skill body as a **hidden
@@ -297,11 +303,11 @@ Registered in `SkillCommands.BuiltIns()` alongside the other built-ins.
   changes go straight to `SkillEnablement` (`skills.json`). Both take effect on the
   next message (the manifest/enabled set is recomputed per send).
 - **Autocomplete:** `/toggle-skill` and `/use-skill` complete slugs (annotated with state)
-  via `IArgumentCompleter`; `/toggle-skill`/`/toggle-skills` then complete `on|off|reset`
-  and `here|global`. Each level's accepted value carries a trailing space so the popup
-  advances to the next level immediately (no manual space needed).
-  Command-name completion is hyphen-aware: a typed prefix anchors at the start of a name
-  or just after any `-`, so `/skill` surfaces `/toggle-skill`, `/toggle-skills`, etc.
+  via `IArgumentCompleter`; `/toggle-skills`/`/toggle-skill` then complete `here|global`
+  and, scoped to that choice, `on|off[|inherit]`. Each level's accepted value carries a
+  trailing space so the popup advances to the next level immediately (no manual space
+  needed). Command-name completion is hyphen-aware: a typed prefix anchors at the start of
+  a name or just after any `-`, so `/skill` surfaces `/toggle-skill`, `/toggle-skills`, etc.
 
 ---
 
@@ -315,11 +321,13 @@ which was the bug). Everything defaults to **on**.
 ### The controls (2×2)
 |  | **Global** (`skills.json`) | **This conversation** (`Conversation`) |
 |---|---|---|
-| **All skills** | `/toggle-skills on\|off global` → `feature_off` | `/toggle-skills on\|off` → `SkillsFeatureOff` |
-| **One skill** | `/toggle-skill X on\|off global` → `skills[X]` | `/toggle-skill X on\|off` → `SkillOverrides[X]` |
+| **All skills** | `/toggle-skills global on\|off` → `feature_off` | `/toggle-skills here on\|off\|inherit` → `SkillsFeatureOff` |
+| **One skill** | `/toggle-skill X global on\|off\|inherit` → `skills[X]` | `/toggle-skill X here on\|off\|inherit` → `SkillOverrides[X]` |
 
-All four are **tri-state where applicable** (set / unset = inherit). `reset` clears a
-cell so it falls through to the next rule.
+Three of the four cells are **tri-state** (set / unset = inherit); `inherit` clears that one
+cell so it falls through to the next rule. The exception is **all-skills / global**
+(`feature_off`), a plain bool that is the most upstream layer — it is always `on` or `off`,
+with no `inherit`. Clearing a whole scope at once is `/reset-skills <here|global>`.
 
 ### Resolution ladder (effective state of skill X in conversation C)
 Take the first rule that has been set:
@@ -391,10 +399,11 @@ Same dual-world pattern as the rest of the repo (net48 linked-source via
 - **`SkillCatalog` + frontmatter parser** — discovery, project-over-bundled
   shadowing, malformed frontmatter, manifest assembly for a given enabled set.
 - **Skills slash commands** (`SkillCommands`, against a fake `ISlashCommandContext`) —
-  `/list-skills` list, `/toggle-skills` toggle/reset, and `/toggle-skill <slug>` toggle/reset
-  across `here`/`global` scopes; conversation overrides vs. `skills.json`; bare-slug toggle;
-  unknown slug/scope failures; `/use-skill` attaches the body as hidden context + sends a short ask,
-  and works even when disabled.
+  `/list-skills` list; `/toggle-skills` and `/toggle-skill <slug>` set on/off/inherit across
+  `here`/`global` scopes (scope-first); `/reset-skills` bulk-clears each scope; `global inherit`
+  on the feature toggle is rejected and points at `/reset-skills`; conversation overrides vs.
+  `skills.json`; bare-slug toggle; per-scope verb completion; unknown slug/scope failures;
+  `/use-skill` attaches the body as hidden context + sends a short ask, and works even when disabled.
 - **Conversation override persistence** — `SkillsFeatureOff` + `SkillOverrides`
   round-trip through `ConversationStore`; missing fields default to inherit/empty.
 - **Enablement resolution** — the two-layer precedence: conversation override beats
@@ -422,7 +431,7 @@ Same dual-world pattern as the rest of the repo (net48 linked-source via
    asset listing as the tool result.
 4. **`read_skill_file` meta-tool** (ReadOnly) for Level-3 assets.
 5. **Skills slash commands** on the existing `ISlashCommand` framework
-   (`SkillCommands`: `/list-skills`, `/toggle-skills`, `/toggle-skill <slug>`, `/use-skill <slug>`) + per-conversation
+   (`SkillCommands`: `/list-skills`, `/toggle-skills`, `/toggle-skill <slug>`, `/reset-skills`, `/use-skill <slug>`) + per-conversation
    override fields on `Conversation`/`ConversationStore` + global `skills.json`
    enablement. *(Split: 4a = enablement core + gating; 4b = the commands.)*
 6. **`SkillsMcpServer` scaffold + `run_skill_script`**: batch-only entry, handle

--- a/docs/skills-design.md
+++ b/docs/skills-design.md
@@ -278,7 +278,7 @@ Registered in `SkillCommands.BuiltIns()` alongside the other built-ins.
 | `/list-skills` | Client | List skills with effective on/off state and source (global default vs. this conversation) |
 | `/toggle-skills <here\|global> <on\|off\|inherit>` | Client | Set the **whole feature** at that scope. `global` takes only `on\|off` (it is the most upstream layer); `here` also takes `inherit` (unset → follow global) |
 | `/toggle-skill <slug> <here\|global> <on\|off\|inherit>` | Client | Set **one skill** at that scope (both scopes tri-state, so both take `inherit`); bare `/toggle-skill <slug>` toggles for this conversation |
-| `/reset-skills <here\|global>` | Client | Clear **all** skill settings at that scope: `here` drops every conversation override; `global` resets the feature to on and removes every per-skill global setting |
+| `/reset-skills <here\|global>` | Client | Clear skill settings at that scope: `here` drops every conversation override (its feature on/off and all per-skill); `global` removes every per-skill global override. Neither touches the global on/off master (only `/toggle-skills global on\|off` does) |
 | `/use-skill <slug> [text]` | Client | **Invoke**: resolve `<slug>`, carry its rendered `SKILL.md` block on the result as `SystemContext` (committed to history as a **hidden system message** at the send, so an early return can't orphan it), and send the short user ask `Use the <slug> skill. [text]` |
 
 - **Scope-first, required.** The scope (`here`/`global`) is the first token and picks the
@@ -287,8 +287,10 @@ Registered in `SkillCommands.BuiltIns()` alongside the other built-ins.
   global feature flag is a plain bool with nothing upstream to inherit from), every other
   layer adds `inherit`. `global` edits `skills.json`.
 - **`inherit` vs. `/reset-skills`.** `inherit` unsets a *single* layer so it falls through
-  to the one upstream. The bulk "clear everything at this scope" action lives in
-  `/reset-skills <here|global>` — that is where the old `reset` verb's behavior moved.
+  to the one upstream. The bulk "clear the overrides at this scope" action lives in
+  `/reset-skills <here|global>` — that is where the old `reset` verb's behavior moved. It
+  clears per-skill overrides (and, for `here`, the conversation feature toggle) but never the
+  global on/off master, which only `/toggle-skills global on|off` changes.
 - **Invocation is `/use-skill <slug>`**, not a per-skill `/<slug>` command — the framework's
   registry is built once at startup, so one command per dynamically-discovered skill
   doesn't fit (decision in §11). `/use-skill` attaches the rendered skill body as a **hidden
@@ -400,8 +402,8 @@ Same dual-world pattern as the rest of the repo (net48 linked-source via
   shadowing, malformed frontmatter, manifest assembly for a given enabled set.
 - **Skills slash commands** (`SkillCommands`, against a fake `ISlashCommandContext`) —
   `/list-skills` list; `/toggle-skills` and `/toggle-skill <slug>` set on/off/inherit across
-  `here`/`global` scopes (scope-first); `/reset-skills` bulk-clears each scope; `global inherit`
-  on the feature toggle is rejected and points at `/reset-skills`; conversation overrides vs.
+  `here`/`global` scopes (scope-first); `/reset-skills` bulk-clears each scope (leaving the global
+  on/off master alone); `global inherit` on the feature toggle is rejected; conversation overrides vs.
   `skills.json`; bare-slug toggle; per-scope verb completion; unknown slug/scope failures;
   `/use-skill` attaches the body as hidden context + sends a short ask, and works even when disabled.
 - **Conversation override persistence** — `SkillsFeatureOff` + `SkillOverrides`

--- a/skills/skill-writer/SKILL.md
+++ b/skills/skill-writer/SKILL.md
@@ -109,5 +109,5 @@ is what makes the skill discoverable).
 ## 6. Hand off
 
 Tell the user what you created and where. Note that the skill is available on their next
-message, that they can turn it on or off with `/toggle-skill <slug> on|off`, and run it directly with
+message, that they can turn it on or off with `/toggle-skill <slug> here on|off`, and run it directly with
 `/use-skill <slug>`. Offer to refine it after they've tried it - skills get better with use.


### PR DESCRIPTION
Follow-up tweaks to the slash-command rework from #156.

## Arg-hint convention
Audited every autocomplete hint so `<>` marks required arguments and `[]` optional:
- `/toggle-skills` verb is mandatory → `<here|global> <on|off|inherit>`
- `/explain` refuses to run without a path → `<path>`

## Skills toggles are now scope-first
The global feature flag (`skills.json` `feature_off`) is the most upstream layer and a plain bool, so it has no meaningful "unset". The toggle commands are reworked around that:

- **Scope first and required:**
  - `/toggle-skills <here|global> <on|off|inherit>`
  - `/toggle-skill <slug> <here|global> <on|off|inherit>`
  - Autocomplete offers the scope first, then only the verbs that scope accepts — `global` on the feature toggle is `on|off` (no `inherit`), every other layer adds `inherit`. Bare `/toggle-skill <slug>` still quick-toggles the conversation.
- **`reset` verb renamed to `inherit`** — unsets a single layer so it falls through to the one upstream. `/toggle-skills global inherit` is rejected (the master is always on/off).
- **New `/reset-skills <here|global>`** for the bulk clear that used to ride on the feature command's `reset`:
  - `here` → drops the conversation's feature on/off **and** all its per-skill overrides
  - `global` → clears **only** the per-skill global overrides; the on/off master is left alone (changed solely by `/toggle-skills global on|off`)

The resolution ladder, persistence format, and tri-state semantics are unchanged — this is purely a command-surface change.

Tests, the bundled skill-writer guidance, README, the docs site, and the skills design doc are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LL2coUBnfsdvUJr27WxDP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL2coUBnfsdvUJr27WxDP1)_