### PR TITLE
Add opt-in scratch dir for the command server when no workspace is set

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -56,6 +56,57 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Scratch_workingdir_resolves_command_tool_and_injects_scratch_note_not_workspace()
+        {
+            // No user workspace, but a per-conversation scratch dir runs the command server. The
+            // orchestrator resolves the scratch-bound tool via ScratchWorkingDir (not WorkingDir) and
+            // tells the model about the scratch sandbox - never presenting it as a real workspace.
+            RegistryFakeTransport ft;
+            var conn = FakeConn.Ready("command", out ft, new ToolDef("run"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn, "C:\\scratch\\abc"); // scoped to the scratch dir
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("ran"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "command__run", "{\"cmd\":\"echo hi\"}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg);
+            orch.WorkingDir = null;
+            orch.ScratchWorkingDir = "C:\\scratch\\abc";
+            orch.RevealedToolNames = new List<string> { "command__run" }; // pre-revealed so it's exposed
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "run echo", ui);
+
+            // The call routed to the scratch-bound connection (not "[Unknown tool]").
+            Assert.Equal(new[] { "command__run" }, ui.ToolCalls.ToArray());
+            Assert.Contains("ran", ui.ToolResults[0]);
+            Assert.False(ui.ToolErrors[0]);
+
+            // Stable head carries the scratch note and NO workspace block.
+            var msgs = streamer.SeenMessages[0];
+            Assert.Equal("system", msgs[0].Role);
+            Assert.Contains("operating as an agent", msgs[0].Content);
+            Assert.Equal("system", msgs[1].Role);
+            Assert.Contains("temporary scratch directory", msgs[1].Content);
+            Assert.Contains("C:\\scratch\\abc", msgs[1].Content);
+            foreach (var m in msgs)
+                if (m.Role == "system" && m.Content != null)
+                    Assert.DoesNotContain("running in this workspace directory", m.Content);
+            // The manifest tail advertises the scratch command tool.
+            Assert.Contains("command__run", msgs[msgs.Count - 1].Content);
+        }
+
+        [Fact]
+        public void Scratch_note_is_absent_when_no_scratch_dir()
+        {
+            Assert.Null(McpChatOrchestrator.ScratchSystemMessage(null));
+            Assert.Null(McpChatOrchestrator.ScratchSystemMessage(""));
+            Assert.Contains("C:\\scratch\\x", McpChatOrchestrator.ScratchSystemMessage("C:\\scratch\\x"));
+        }
+
+        [Fact]
         public void Passes_manifest_tail_and_tools_to_streamer()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/Mcp/McpConfigTests.cs
+++ b/GxPT.Tests/Mcp/McpConfigTests.cs
@@ -154,6 +154,14 @@ namespace GxPT.Tests.Mcp
 
             Assert.Equal("cmd.exe", byName["command"].Env[McpConfig.EnvCmdShell]);
             Assert.True(byName["command"].WorkdirScoped);
+            // The command server is the only scratch-eligible scoped built-in (runs in a per-
+            // conversation scratch dir when no workspace is set); the others stay workspace-only.
+            Assert.True(byName["command"].RunsInScratch);
+            Assert.False(byName["files"].RunsInScratch);
+            Assert.False(byName["git"].RunsInScratch);
+            Assert.False(byName["msbuild"].RunsInScratch);
+            Assert.False(byName["memory"].RunsInScratch);
+            Assert.False(byName["skills"].RunsInScratch);
 
             // msbuild — workdir-scoped, engines discovered (no extra env baked in).
             var msbuild = byName["msbuild"];

--- a/GxPT.Tests/Mcp/McpHostTests.cs
+++ b/GxPT.Tests/Mcp/McpHostTests.cs
@@ -101,6 +101,49 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void EnsureScratchDir_opens_only_scratch_eligible_scoped_specs()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            var command = Specs.Scoped("command", true);
+            command.RunsInScratch = true;
+            host.Start(new[] { Specs.Scoped("files", true), command, Specs.Scoped("git", true) });
+
+            host.EnsureScratchDir("C:\\scratch\\abc");
+
+            // Only the command server (RunsInScratch) launched in the scratch dir; files/git stayed off.
+            Assert.Equal(new[] { "command" }, c.CreatedNames.ToArray());
+            Assert.True(c.Workdirs.All(w => w == "C:\\scratch\\abc"));
+            var m = Manifest(reg);
+            Assert.Contains("command__command_tool", m);
+            Assert.DoesNotContain("files__files_tool", m);
+            Assert.DoesNotContain("git__git_tool", m);
+            Assert.Contains("C:\\scratch\\abc", host.ActiveWorkingDirs);
+
+            // The command tool routes to the scratch-bound connection.
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("command__command_tool", "C:\\scratch\\abc", out r, out tool));
+            Assert.Same(c.Created.Last(), r);
+        }
+
+        [Fact]
+        public void EnsureScratchDir_set_is_torn_down_by_RetainOnly_when_unreferenced()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            var command = Specs.Scoped("command", true);
+            command.RunsInScratch = true;
+            host.Start(new[] { command });
+            host.EnsureScratchDir("C:\\scratch\\abc");
+            var conn = c.Created.Last();
+
+            host.RetainOnly(new string[0]); // no open tab references it anymore
+
+            Assert.Equal(ConnectionState.Closed, conn.State);
+            Assert.DoesNotContain("C:\\scratch\\abc", host.ActiveWorkingDirs);
+        }
+
+        [Fact]
         public void EnsureWorkingDir_is_idempotent_for_the_same_folder()
         {
             FakeServerConnector c; McpToolRegistry reg;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -299,6 +299,12 @@ namespace GxPT
             // Shut down MCP servers (close stdio children / HTTP sessions).
             try { if (_mcpHost != null) _mcpHost.Dispose(); }
             catch { }
+
+            // Remove every per-conversation scratch directory this process created. Done AFTER the host
+            // is disposed so the command children (which had a scratch dir as their CWD) have exited and
+            // no longer hold it open.
+            try { ScratchWorkspace.DeleteAllCreated(); }
+            catch { }
         }
 
         private List<string> GetOpenConversationIdsInOrder()
@@ -650,6 +656,53 @@ namespace GxPT
             if (_inputManager != null) _inputManager.FocusInputSoon();
         }
 
+        // The per-conversation scratch directory used to run the command server when this conversation
+        // has no workspace and the scratch-command feature is enabled (opt-in); null otherwise (a real
+        // workspace takes precedence, or the feature is off). When create is true the directory — and
+        // the conversation id it is keyed by — is materialized; when false a missing id/dir yields a
+        // path without side effects (for read-only callers like the tab reconcile / status bar).
+        private string ScratchDirForContext(TabManager.ChatTabContext ctx, bool create)
+        {
+            if (ctx == null || ctx.Conversation == null) return null;
+            if (!string.IsNullOrEmpty(ctx.WorkingDir)) return null;     // a real workspace wins
+            if (!ScratchWorkspace.IsEnabled()) return null;
+            string id = ctx.Conversation.Id;
+            if (string.IsNullOrEmpty(id))
+            {
+                if (!create) return null;
+                id = ConversationStore.EnsureConversationId(ctx.Conversation);
+            }
+            return create ? ScratchWorkspace.EnsureDir(id) : ScratchWorkspace.PathFor(id);
+        }
+
+        // The working directory used to RESOLVE workdir-scoped MCP tools for a tab (status bar count,
+        // turn routing): the user workspace if set, else this conversation's already-created scratch dir
+        // (command server only). Null when neither applies. Read-only — never creates a dir or an id, so
+        // the scratch path counts only once a turn has actually materialized it.
+        private string ResolutionWorkdirForContext(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null) return null;
+            if (!string.IsNullOrEmpty(ctx.WorkingDir)) return ctx.WorkingDir;
+            string s = ScratchDirForContext(ctx, false);
+            return (!string.IsNullOrEmpty(s) && System.IO.Directory.Exists(s)) ? s : null;
+        }
+
+        // Release and delete a conversation's scratch working directory (if any). Stops the scratch
+        // command server bound to it first so the directory isn't held open, then removes it. Safe for
+        // conversations that never used a scratch dir. Used when a conversation is deleted.
+        internal void DeleteScratchForConversation(string conversationId)
+        {
+            if (string.IsNullOrEmpty(conversationId)) return;
+            try
+            {
+                string path = ScratchWorkspace.PathFor(conversationId);
+                if (string.IsNullOrEmpty(path)) return;
+                if (_mcpHost != null) _mcpHost.ReleaseWorkingDir(path); // tear down the command server holding it
+                ScratchWorkspace.DeletePath(path);
+            }
+            catch { }
+        }
+
         // Reconcile the MCP host's workdir-scoped servers (files/git/command) with the open tabs:
         // pre-warm the active conversation's folder and tear down any folder no longer referenced by an
         // open tab. Each distinct working directory runs its own server set, kept alive across tab
@@ -668,27 +721,51 @@ namespace GxPT
             // the status bar's tool count is workdir-scoped — refresh it alongside the servers.
             UpdateToolSkillCounts();
             string active = null;
+            bool activeScratch = false;
             var inUse = new List<string>();
             try
             {
                 var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
-                if (act != null) active = act.WorkingDir;
+                if (act != null)
+                {
+                    if (!string.IsNullOrEmpty(act.WorkingDir)) active = act.WorkingDir;
+                    else
+                    {
+                        // Folderless active tab: pre-warm its scratch command server, but only once a
+                        // turn has created the dir (the first send creates + connects it). Connecting a
+                        // not-yet-created dir would launch the child with a missing CWD.
+                        string s = ResolutionWorkdirForContext(act);
+                        if (!string.IsNullOrEmpty(s)) { active = s; activeScratch = true; }
+                    }
+                }
                 if (_tabManager != null)
                 {
                     foreach (var c in _tabManager.TabContexts.Values)
-                        if (c != null && !string.IsNullOrEmpty(c.WorkingDir)) inUse.Add(c.WorkingDir);
+                    {
+                        if (c == null) continue;
+                        if (!string.IsNullOrEmpty(c.WorkingDir)) { inUse.Add(c.WorkingDir); continue; }
+                        // Keep a folderless tab's scratch server alive across tab switches by listing its
+                        // scratch dir among the retained workdirs.
+                        string s = ResolutionWorkdirForContext(c);
+                        if (!string.IsNullOrEmpty(s)) inUse.Add(s);
+                    }
                 }
             }
             catch { }
 
             McpHost hostRef = _mcpHost;
             string activeRef = active;
+            bool activeScratchRef = activeScratch;
             string[] inUseArr = inUse.ToArray();
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
                 try
                 {
-                    if (!string.IsNullOrEmpty(activeRef)) hostRef.EnsureWorkingDir(activeRef);
+                    if (!string.IsNullOrEmpty(activeRef))
+                    {
+                        if (activeScratchRef) hostRef.EnsureScratchDir(activeRef);
+                        else hostRef.EnsureWorkingDir(activeRef);
+                    }
                     hostRef.RetainOnly(inUseArr); // release folders whose last tab closed
                 }
                 catch (Exception ex) { try { Logger.Log("mcp", "MCP workdir reconcile failed: " + ex.Message); } catch { } }
@@ -865,7 +942,9 @@ namespace GxPT
                 int toolCount = 0;
                 if (_mcpRegistry != null)
                 {
-                    IList<string> names = _mcpRegistry.NamesForWorkdir(workdir);
+                    // Tools may include a folderless conversation's scratch command server; skills/project
+                    // discovery above stays on the real workspace (scratch has no project skills).
+                    IList<string> names = _mcpRegistry.NamesForWorkdir(ResolutionWorkdirForContext(ctx));
                     ICollection<string> hidden = SkillToolGate.HiddenTools(enabledSkills);
                     for (int i = 0; i < names.Count; i++)
                         if (!hidden.Contains(names[i])) toolCount++;
@@ -1364,23 +1443,40 @@ namespace GxPT
                 // rebuilt after a Settings save starts with no active workdir and those servers never
                 // launch even though the current conversation has a folder set.
                 string activeWorkdir = null;
+                bool activeScratch = false;
                 try
                 {
                     var actCtx = _tabManager != null ? _tabManager.GetActiveContext() : null;
-                    if (actCtx != null) activeWorkdir = actCtx.WorkingDir;
+                    if (actCtx != null)
+                    {
+                        if (!string.IsNullOrEmpty(actCtx.WorkingDir)) activeWorkdir = actCtx.WorkingDir;
+                        else
+                        {
+                            // Folderless active tab with an already-created scratch dir: re-bind its
+                            // command-only set after the rebuild.
+                            string s = ResolutionWorkdirForContext(actCtx);
+                            if (!string.IsNullOrEmpty(s)) { activeWorkdir = s; activeScratch = true; }
+                        }
+                    }
                 }
                 catch { }
 
                 // Connecting (handshakes / process spawns) can block — do it off the UI thread.
                 McpHost hostRef = _mcpHost;
                 string wd = activeWorkdir;
+                bool wdScratch = activeScratch;
                 System.Threading.ThreadPool.QueueUserWorkItem(delegate
                 {
                     try
                     {
                         hostRef.Start(specs);
-                        // Launch the workdir-scoped servers for the active conversation's folder.
-                        if (!string.IsNullOrEmpty(wd)) hostRef.EnsureWorkingDir(wd);
+                        // Launch the workdir-scoped servers for the active conversation's folder (or the
+                        // command-only set for its scratch dir when folderless).
+                        if (!string.IsNullOrEmpty(wd))
+                        {
+                            if (wdScratch) hostRef.EnsureScratchDir(wd);
+                            else hostRef.EnsureWorkingDir(wd);
+                        }
                     }
                     catch (Exception ex) { try { Logger.Log("mcp", "host start failed: " + ex.Message); } catch { } }
                 });
@@ -2294,7 +2390,12 @@ namespace GxPT
             // Skills also route through the tool loop (they inject a manifest and expose open_skill),
             // so a conversation with skills but no MCP tools still takes this path.
             bool hasMcpTools = _mcpRegistry != null && _mcpRegistry.HasToolsForWorkdir(ctx.WorkingDir);
-            if (hasMcpTools || ConversationHasSkills(ctx))
+            // Folderless conversations can still route through the tool loop for the command server in a
+            // scratch dir (opt-in). The scratch server may not be connected yet at this point - it is
+            // launched in BeginToolSend - so gate on the feature/settings, not the live registry.
+            bool scratchCommand = string.IsNullOrEmpty(ctx.WorkingDir)
+                && ctx.Conversation != null && ScratchWorkspace.IsEnabled();
+            if (hasMcpTools || ConversationHasSkills(ctx) || scratchCommand)
             {
                 BeginToolSend(ctx, modelToUse, zdrForSend);
                 return;
@@ -2767,9 +2868,18 @@ namespace GxPT
                 {
                     // Make sure THIS conversation's folder has its own scoped server set before the
                     // turn runs (idempotent; no-op if already connected), and route the turn's tool
-                    // calls to that folder so a concurrent turn in another tab can't interfere.
-                    if (_mcpHost != null && !string.IsNullOrEmpty(ctx.WorkingDir))
-                        _mcpHost.EnsureWorkingDir(ctx.WorkingDir);
+                    // calls to that folder so a concurrent turn in another tab can't interfere. A
+                    // folderless conversation with the opt-in scratch-command feature instead gets a
+                    // per-conversation scratch dir (command server only); compute it once here (creates
+                    // the dir + ensures the id), launch its command-only set, and route the turn at it.
+                    string scratchDir = ScratchDirForContext(ctx, true);
+                    if (_mcpHost != null)
+                    {
+                        if (!string.IsNullOrEmpty(ctx.WorkingDir))
+                            _mcpHost.EnsureWorkingDir(ctx.WorkingDir);
+                        else if (!string.IsNullOrEmpty(scratchDir))
+                            _mcpHost.EnsureScratchDir(scratchDir);
+                    }
 
                     // Per-turn approval policy bound to THIS tab's panel, so the prompt appears on the
                     // conversation that requested the tool. The remembered-choice store is shared
@@ -2799,6 +2909,9 @@ namespace GxPT
                     var orch = new McpChatOrchestrator(_client, _mcpRegistry, approval,
                                                        model, LoggerSink.Instance);
                     orch.WorkingDir = ctx.WorkingDir;
+                    // Route scoped-tool resolution at the scratch dir when folderless (null otherwise);
+                    // the prompt's workspace block stays absent and a scratch-sandbox note is used instead.
+                    orch.ScratchWorkingDir = string.IsNullOrEmpty(ctx.WorkingDir) ? scratchDir : null;
                     orch.Zdr = zdr ? true : (bool?)null;
                     // Reveal state is per-conversation (recency-ordered; persisted with the
                     // conversation) so concurrent tabs don't churn each other's tools array - the

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -658,8 +658,8 @@ namespace GxPT
 
         // The per-conversation scratch directory used to run the command server when this conversation
         // has no workspace and the scratch-command feature is enabled (opt-in); null otherwise (a real
-        // workspace takes precedence, or the feature is off). When create is true the directory — and
-        // the conversation id it is keyed by — is materialized; when false a missing id/dir yields a
+        // workspace takes precedence, or the feature is off). When create is true the directory - and
+        // the conversation id it is keyed by - is materialized; when false a missing id/dir yields a
         // path without side effects (for read-only callers like the tab reconcile / status bar).
         private string ScratchDirForContext(TabManager.ChatTabContext ctx, bool create)
         {
@@ -677,7 +677,7 @@ namespace GxPT
 
         // The working directory used to RESOLVE workdir-scoped MCP tools for a tab (status bar count,
         // turn routing): the user workspace if set, else this conversation's already-created scratch dir
-        // (command server only). Null when neither applies. Read-only — never creates a dir or an id, so
+        // (command server only). Null when neither applies. Read-only - never creates a dir or an id, so
         // the scratch path counts only once a turn has actually materialized it.
         private string ResolutionWorkdirForContext(TabManager.ChatTabContext ctx)
         {

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -76,7 +76,6 @@
             this.txtGithubPat = new System.Windows.Forms.TextBox();
             this.grpMcpWorkspace = new System.Windows.Forms.GroupBox();
             this.tblMcpWorkspace = new System.Windows.Forms.TableLayoutPanel();
-            this.lblMcpWorkspaceHint = new System.Windows.Forms.Label();
             this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpFiles = new System.Windows.Forms.CheckBox();
             this.chkMcpCommand = new System.Windows.Forms.CheckBox();
@@ -85,7 +84,6 @@
             this.chkMcpCommandScratch = new System.Windows.Forms.CheckBox();
             this.grpMcpCustom = new System.Windows.Forms.GroupBox();
             this.tblMcpCustom = new System.Windows.Forms.TableLayoutPanel();
-            this.lblMcpCustom = new System.Windows.Forms.Label();
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
             this.tblSettings.SuspendLayout();
@@ -612,7 +610,7 @@
             this.tblMcp.Name = "tblMcp";
             this.tblMcp.RowCount = 3;
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 84F));
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
@@ -656,7 +654,7 @@
             this.grpMcpWorkspace.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.grpMcpWorkspace.Name = "grpMcpWorkspace";
             this.grpMcpWorkspace.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
-            this.grpMcpWorkspace.Size = new System.Drawing.Size(584, 94);
+            this.grpMcpWorkspace.Size = new System.Drawing.Size(584, 78);
             this.grpMcpWorkspace.TabIndex = 1;
             this.grpMcpWorkspace.TabStop = false;
             this.grpMcpWorkspace.Text = "Workspace tools";
@@ -665,29 +663,16 @@
             //
             this.tblMcpWorkspace.ColumnCount = 1;
             this.tblMcpWorkspace.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tblMcpWorkspace.Controls.Add(this.lblMcpWorkspaceHint, 0, 0);
-            this.tblMcpWorkspace.Controls.Add(this.tblMcpKeyless, 0, 1);
-            this.tblMcpWorkspace.Controls.Add(this.chkMcpCommandScratch, 0, 2);
+            this.tblMcpWorkspace.Controls.Add(this.tblMcpKeyless, 0, 0);
+            this.tblMcpWorkspace.Controls.Add(this.chkMcpCommandScratch, 0, 1);
             this.tblMcpWorkspace.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcpWorkspace.Location = new System.Drawing.Point(6, 13);
             this.tblMcpWorkspace.Name = "tblMcpWorkspace";
-            this.tblMcpWorkspace.RowCount = 3;
+            this.tblMcpWorkspace.RowCount = 2;
             this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcpWorkspace.Size = new System.Drawing.Size(572, 65);
+            this.tblMcpWorkspace.Size = new System.Drawing.Size(572, 59);
             this.tblMcpWorkspace.TabIndex = 0;
-            //
-            // lblMcpWorkspaceHint
-            //
-            this.lblMcpWorkspaceHint.AutoSize = true;
-            this.lblMcpWorkspaceHint.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblMcpWorkspaceHint.Location = new System.Drawing.Point(3, 0);
-            this.lblMcpWorkspaceHint.Margin = new System.Windows.Forms.Padding(3, 0, 3, 4);
-            this.lblMcpWorkspaceHint.Name = "lblMcpWorkspaceHint";
-            this.lblMcpWorkspaceHint.Size = new System.Drawing.Size(317, 13);
-            this.lblMcpWorkspaceHint.TabIndex = 0;
-            this.lblMcpWorkspaceHint.Text = "These tools act on the conversation\'s workspace folder when one is set.";
             //
             // chkMcpWeb
             // 
@@ -826,27 +811,14 @@
             //
             this.tblMcpCustom.ColumnCount = 1;
             this.tblMcpCustom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tblMcpCustom.Controls.Add(this.lblMcpCustom, 0, 0);
-            this.tblMcpCustom.Controls.Add(this.rtbMcpJson, 0, 1);
+            this.tblMcpCustom.Controls.Add(this.rtbMcpJson, 0, 0);
             this.tblMcpCustom.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcpCustom.Location = new System.Drawing.Point(6, 13);
             this.tblMcpCustom.Name = "tblMcpCustom";
-            this.tblMcpCustom.RowCount = 2;
-            this.tblMcpCustom.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpCustom.RowCount = 1;
             this.tblMcpCustom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblMcpCustom.Size = new System.Drawing.Size(572, 168);
             this.tblMcpCustom.TabIndex = 0;
-            //
-            // lblMcpCustom
-            //
-            this.lblMcpCustom.AutoSize = true;
-            this.lblMcpCustom.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblMcpCustom.Location = new System.Drawing.Point(3, 0);
-            this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 0, 3, 4);
-            this.lblMcpCustom.Name = "lblMcpCustom";
-            this.lblMcpCustom.Size = new System.Drawing.Size(323, 13);
-            this.lblMcpCustom.TabIndex = 0;
-            this.lblMcpCustom.Text = "Add MCP servers by editing this JSON. GitHub is configured above.";
             //
             // rtbMcpJson
             //
@@ -902,7 +874,6 @@
             this.tblMcpKeyless.PerformLayout();
             this.grpMcpCustom.ResumeLayout(false);
             this.tblMcpCustom.ResumeLayout(false);
-            this.tblMcpCustom.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -953,7 +924,6 @@
         private System.Windows.Forms.TableLayoutPanel tblMcpWeb;
         private System.Windows.Forms.GroupBox grpMcpWorkspace;
         private System.Windows.Forms.TableLayoutPanel tblMcpWorkspace;
-        private System.Windows.Forms.Label lblMcpWorkspaceHint;
         private System.Windows.Forms.TableLayoutPanel tblMcpKeyless;
         private System.Windows.Forms.GroupBox grpMcpCustom;
         private System.Windows.Forms.TableLayoutPanel tblMcpCustom;
@@ -966,7 +936,6 @@
         private System.Windows.Forms.CheckBox chkMcpCommand;
         private System.Windows.Forms.CheckBox chkMcpCommandScratch;
         private System.Windows.Forms.CheckBox chkMcpMsBuild;
-        private System.Windows.Forms.Label lblMcpCustom;
         private System.Windows.Forms.RichTextBox rtbMcpJson;
     }
 }

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -68,16 +68,23 @@
             this.tabJson = new System.Windows.Forms.TabPage();
             this.tabMcp = new System.Windows.Forms.TabPage();
             this.tblMcp = new System.Windows.Forms.TableLayoutPanel();
+            this.grpMcpWeb = new System.Windows.Forms.GroupBox();
+            this.tblMcpWeb = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpWeb = new System.Windows.Forms.CheckBox();
             this.txtWebSearchKey = new System.Windows.Forms.TextBox();
             this.chkMcpGithub = new System.Windows.Forms.CheckBox();
             this.txtGithubPat = new System.Windows.Forms.TextBox();
+            this.grpMcpWorkspace = new System.Windows.Forms.GroupBox();
+            this.tblMcpWorkspace = new System.Windows.Forms.TableLayoutPanel();
+            this.lblMcpWorkspaceHint = new System.Windows.Forms.Label();
             this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpFiles = new System.Windows.Forms.CheckBox();
             this.chkMcpCommand = new System.Windows.Forms.CheckBox();
-            this.chkMcpCommandScratch = new System.Windows.Forms.CheckBox();
             this.chkMcpGit = new System.Windows.Forms.CheckBox();
             this.chkMcpMsBuild = new System.Windows.Forms.CheckBox();
+            this.chkMcpCommandScratch = new System.Windows.Forms.CheckBox();
+            this.grpMcpCustom = new System.Windows.Forms.GroupBox();
+            this.tblMcpCustom = new System.Windows.Forms.TableLayoutPanel();
             this.lblMcpCustom = new System.Windows.Forms.Label();
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
@@ -94,7 +101,13 @@
             this.tabJson.SuspendLayout();
             this.tabMcp.SuspendLayout();
             this.tblMcp.SuspendLayout();
+            this.grpMcpWeb.SuspendLayout();
+            this.tblMcpWeb.SuspendLayout();
+            this.grpMcpWorkspace.SuspendLayout();
+            this.tblMcpWorkspace.SuspendLayout();
             this.tblMcpKeyless.SuspendLayout();
+            this.grpMcpCustom.SuspendLayout();
+            this.tblMcpCustom.SuspendLayout();
             this.SuspendLayout();
             // 
             // flowLayoutPanel1
@@ -589,28 +602,93 @@
             // 
             // tblMcp
             // 
-            this.tblMcp.ColumnCount = 2;
-            this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcp.ColumnCount = 1;
             this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tblMcp.Controls.Add(this.chkMcpWeb, 0, 0);
-            this.tblMcp.Controls.Add(this.txtWebSearchKey, 1, 0);
-            this.tblMcp.Controls.Add(this.chkMcpGithub, 0, 1);
-            this.tblMcp.Controls.Add(this.txtGithubPat, 1, 1);
-            this.tblMcp.Controls.Add(this.tblMcpKeyless, 0, 2);
-            this.tblMcp.Controls.Add(this.lblMcpCustom, 0, 3);
-            this.tblMcp.Controls.Add(this.rtbMcpJson, 0, 4);
+            this.tblMcp.Controls.Add(this.grpMcpWeb, 0, 0);
+            this.tblMcp.Controls.Add(this.grpMcpWorkspace, 0, 1);
+            this.tblMcp.Controls.Add(this.grpMcpCustom, 0, 2);
             this.tblMcp.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcp.Location = new System.Drawing.Point(3, 3);
             this.tblMcp.Name = "tblMcp";
-            this.tblMcp.RowCount = 5;
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcp.RowCount = 3;
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100F));
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
-            // 
+            //
+            // grpMcpWeb
+            //
+            this.grpMcpWeb.Controls.Add(this.tblMcpWeb);
+            this.grpMcpWeb.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpMcpWeb.Location = new System.Drawing.Point(3, 3);
+            this.grpMcpWeb.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.grpMcpWeb.Name = "grpMcpWeb";
+            this.grpMcpWeb.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
+            this.grpMcpWeb.Size = new System.Drawing.Size(584, 80);
+            this.grpMcpWeb.TabIndex = 0;
+            this.grpMcpWeb.TabStop = false;
+            this.grpMcpWeb.Text = "Web && integrations";
+            //
+            // tblMcpWeb
+            //
+            this.tblMcpWeb.ColumnCount = 2;
+            this.tblMcpWeb.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcpWeb.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcpWeb.Controls.Add(this.chkMcpWeb, 0, 0);
+            this.tblMcpWeb.Controls.Add(this.txtWebSearchKey, 1, 0);
+            this.tblMcpWeb.Controls.Add(this.chkMcpGithub, 0, 1);
+            this.tblMcpWeb.Controls.Add(this.txtGithubPat, 1, 1);
+            this.tblMcpWeb.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tblMcpWeb.Location = new System.Drawing.Point(6, 13);
+            this.tblMcpWeb.Name = "tblMcpWeb";
+            this.tblMcpWeb.RowCount = 2;
+            this.tblMcpWeb.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpWeb.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpWeb.Size = new System.Drawing.Size(572, 49);
+            this.tblMcpWeb.TabIndex = 0;
+            //
+            // grpMcpWorkspace
+            //
+            this.grpMcpWorkspace.Controls.Add(this.tblMcpWorkspace);
+            this.grpMcpWorkspace.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpMcpWorkspace.Location = new System.Drawing.Point(3, 77);
+            this.grpMcpWorkspace.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.grpMcpWorkspace.Name = "grpMcpWorkspace";
+            this.grpMcpWorkspace.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
+            this.grpMcpWorkspace.Size = new System.Drawing.Size(584, 94);
+            this.grpMcpWorkspace.TabIndex = 1;
+            this.grpMcpWorkspace.TabStop = false;
+            this.grpMcpWorkspace.Text = "Workspace tools";
+            //
+            // tblMcpWorkspace
+            //
+            this.tblMcpWorkspace.ColumnCount = 1;
+            this.tblMcpWorkspace.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcpWorkspace.Controls.Add(this.lblMcpWorkspaceHint, 0, 0);
+            this.tblMcpWorkspace.Controls.Add(this.tblMcpKeyless, 0, 1);
+            this.tblMcpWorkspace.Controls.Add(this.chkMcpCommandScratch, 0, 2);
+            this.tblMcpWorkspace.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tblMcpWorkspace.Location = new System.Drawing.Point(6, 13);
+            this.tblMcpWorkspace.Name = "tblMcpWorkspace";
+            this.tblMcpWorkspace.RowCount = 3;
+            this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpWorkspace.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpWorkspace.Size = new System.Drawing.Size(572, 65);
+            this.tblMcpWorkspace.TabIndex = 0;
+            //
+            // lblMcpWorkspaceHint
+            //
+            this.lblMcpWorkspaceHint.AutoSize = true;
+            this.lblMcpWorkspaceHint.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblMcpWorkspaceHint.Location = new System.Drawing.Point(3, 0);
+            this.lblMcpWorkspaceHint.Margin = new System.Windows.Forms.Padding(3, 0, 3, 4);
+            this.lblMcpWorkspaceHint.Name = "lblMcpWorkspaceHint";
+            this.lblMcpWorkspaceHint.Size = new System.Drawing.Size(317, 13);
+            this.lblMcpWorkspaceHint.TabIndex = 0;
+            this.lblMcpWorkspaceHint.Text = "These tools act on the conversation\'s workspace folder when one is set.";
+            //
             // chkMcpWeb
             // 
             this.chkMcpWeb.Anchor = System.Windows.Forms.AnchorStyles.Left;
@@ -654,9 +732,7 @@
             // tblMcpKeyless
             // 
             this.tblMcpKeyless.AutoSize = true;
-            this.tblMcpKeyless.ColumnCount = 5;
-            this.tblMcp.SetColumnSpan(this.tblMcpKeyless, 2);
-            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tblMcpKeyless.ColumnCount = 4;
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
@@ -665,14 +741,13 @@
             this.tblMcpKeyless.Controls.Add(this.chkMcpCommand, 1, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 2, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 3, 0);
-            this.tblMcpKeyless.Controls.Add(this.chkMcpCommandScratch, 4, 0);
-            this.tblMcpKeyless.Location = new System.Drawing.Point(0, 52);
+            this.tblMcpKeyless.Location = new System.Drawing.Point(0, 16);
             this.tblMcpKeyless.Margin = new System.Windows.Forms.Padding(0);
             this.tblMcpKeyless.Name = "tblMcpKeyless";
             this.tblMcpKeyless.RowCount = 1;
             this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcpKeyless.Size = new System.Drawing.Size(380, 25);
-            this.tblMcpKeyless.TabIndex = 4;
+            this.tblMcpKeyless.Size = new System.Drawing.Size(258, 25);
+            this.tblMcpKeyless.TabIndex = 1;
             // 
             // chkMcpFiles
             // 
@@ -726,41 +801,68 @@
             //
             this.chkMcpCommandScratch.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkMcpCommandScratch.AutoSize = true;
-            this.chkMcpCommandScratch.Location = new System.Drawing.Point(251, 4);
-            this.chkMcpCommandScratch.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpCommandScratch.Location = new System.Drawing.Point(3, 45);
+            this.chkMcpCommandScratch.Margin = new System.Windows.Forms.Padding(3, 4, 3, 2);
             this.chkMcpCommandScratch.Name = "chkMcpCommandScratch";
-            this.chkMcpCommandScratch.Size = new System.Drawing.Size(122, 17);
-            this.chkMcpCommandScratch.TabIndex = 8;
-            this.chkMcpCommandScratch.Text = "Command scratch dir";
+            this.chkMcpCommandScratch.Size = new System.Drawing.Size(355, 17);
+            this.chkMcpCommandScratch.TabIndex = 2;
+            this.chkMcpCommandScratch.Text = "Run Command in a temporary scratch folder when no workspace is set";
             this.chkMcpCommandScratch.UseVisualStyleBackColor = true;
             //
+            // grpMcpCustom
+            //
+            this.grpMcpCustom.Controls.Add(this.tblMcpCustom);
+            this.grpMcpCustom.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpMcpCustom.Location = new System.Drawing.Point(3, 167);
+            this.grpMcpCustom.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.grpMcpCustom.Name = "grpMcpCustom";
+            this.grpMcpCustom.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
+            this.grpMcpCustom.Size = new System.Drawing.Size(584, 187);
+            this.grpMcpCustom.TabIndex = 2;
+            this.grpMcpCustom.TabStop = false;
+            this.grpMcpCustom.Text = "Custom servers (mcp.json)";
+            //
+            // tblMcpCustom
+            //
+            this.tblMcpCustom.ColumnCount = 1;
+            this.tblMcpCustom.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcpCustom.Controls.Add(this.lblMcpCustom, 0, 0);
+            this.tblMcpCustom.Controls.Add(this.rtbMcpJson, 0, 1);
+            this.tblMcpCustom.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tblMcpCustom.Location = new System.Drawing.Point(6, 13);
+            this.tblMcpCustom.Name = "tblMcpCustom";
+            this.tblMcpCustom.RowCount = 2;
+            this.tblMcpCustom.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tblMcpCustom.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblMcpCustom.Size = new System.Drawing.Size(572, 168);
+            this.tblMcpCustom.TabIndex = 0;
+            //
             // lblMcpCustom
-            // 
+            //
             this.lblMcpCustom.AutoSize = true;
-            this.tblMcp.SetColumnSpan(this.lblMcpCustom, 2);
-            this.lblMcpCustom.Location = new System.Drawing.Point(3, 85);
-            this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
+            this.lblMcpCustom.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblMcpCustom.Location = new System.Drawing.Point(3, 0);
+            this.lblMcpCustom.Margin = new System.Windows.Forms.Padding(3, 0, 3, 4);
             this.lblMcpCustom.Name = "lblMcpCustom";
-            this.lblMcpCustom.Size = new System.Drawing.Size(133, 13);
-            this.lblMcpCustom.TabIndex = 8;
-            this.lblMcpCustom.Text = "Custom servers (mcp.json):";
-            // 
+            this.lblMcpCustom.Size = new System.Drawing.Size(323, 13);
+            this.lblMcpCustom.TabIndex = 0;
+            this.lblMcpCustom.Text = "Add MCP servers by editing this JSON. GitHub is configured above.";
+            //
             // rtbMcpJson
-            // 
+            //
             this.rtbMcpJson.AcceptsTab = true;
             this.rtbMcpJson.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.tblMcp.SetColumnSpan(this.rtbMcpJson, 2);
             this.rtbMcpJson.DetectUrls = false;
             this.rtbMcpJson.Dock = System.Windows.Forms.DockStyle.Fill;
             this.rtbMcpJson.Font = new System.Drawing.Font("Consolas", 9F);
             this.rtbMcpJson.HideSelection = false;
-            this.rtbMcpJson.Location = new System.Drawing.Point(3, 104);
+            this.rtbMcpJson.Location = new System.Drawing.Point(3, 20);
             this.rtbMcpJson.Name = "rtbMcpJson";
-            this.rtbMcpJson.Size = new System.Drawing.Size(584, 250);
-            this.rtbMcpJson.TabIndex = 8;
+            this.rtbMcpJson.Size = new System.Drawing.Size(566, 145);
+            this.rtbMcpJson.TabIndex = 1;
             this.rtbMcpJson.Text = "";
             this.rtbMcpJson.WordWrap = false;
-            // 
+            //
             // SettingsForm
             // 
             this.AcceptButton = this.btnSave;
@@ -790,9 +892,17 @@
             this.tabJson.ResumeLayout(false);
             this.tabMcp.ResumeLayout(false);
             this.tblMcp.ResumeLayout(false);
-            this.tblMcp.PerformLayout();
+            this.grpMcpWeb.ResumeLayout(false);
+            this.tblMcpWeb.ResumeLayout(false);
+            this.tblMcpWeb.PerformLayout();
+            this.grpMcpWorkspace.ResumeLayout(false);
+            this.tblMcpWorkspace.ResumeLayout(false);
+            this.tblMcpWorkspace.PerformLayout();
             this.tblMcpKeyless.ResumeLayout(false);
             this.tblMcpKeyless.PerformLayout();
+            this.grpMcpCustom.ResumeLayout(false);
+            this.tblMcpCustom.ResumeLayout(false);
+            this.tblMcpCustom.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -839,7 +949,14 @@
         private System.Windows.Forms.ComboBox cmbColor;
         private System.Windows.Forms.TabPage tabMcp;
         private System.Windows.Forms.TableLayoutPanel tblMcp;
+        private System.Windows.Forms.GroupBox grpMcpWeb;
+        private System.Windows.Forms.TableLayoutPanel tblMcpWeb;
+        private System.Windows.Forms.GroupBox grpMcpWorkspace;
+        private System.Windows.Forms.TableLayoutPanel tblMcpWorkspace;
+        private System.Windows.Forms.Label lblMcpWorkspaceHint;
         private System.Windows.Forms.TableLayoutPanel tblMcpKeyless;
+        private System.Windows.Forms.GroupBox grpMcpCustom;
+        private System.Windows.Forms.TableLayoutPanel tblMcpCustom;
         private System.Windows.Forms.CheckBox chkMcpWeb;
         private System.Windows.Forms.TextBox txtWebSearchKey;
         private System.Windows.Forms.CheckBox chkMcpGithub;

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -75,6 +75,7 @@
             this.tblMcpKeyless = new System.Windows.Forms.TableLayoutPanel();
             this.chkMcpFiles = new System.Windows.Forms.CheckBox();
             this.chkMcpCommand = new System.Windows.Forms.CheckBox();
+            this.chkMcpCommandScratch = new System.Windows.Forms.CheckBox();
             this.chkMcpGit = new System.Windows.Forms.CheckBox();
             this.chkMcpMsBuild = new System.Windows.Forms.CheckBox();
             this.lblMcpCustom = new System.Windows.Forms.Label();
@@ -653,8 +654,9 @@
             // tblMcpKeyless
             // 
             this.tblMcpKeyless.AutoSize = true;
-            this.tblMcpKeyless.ColumnCount = 4;
+            this.tblMcpKeyless.ColumnCount = 5;
             this.tblMcp.SetColumnSpan(this.tblMcpKeyless, 2);
+            this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tblMcpKeyless.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
@@ -663,12 +665,13 @@
             this.tblMcpKeyless.Controls.Add(this.chkMcpCommand, 1, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpGit, 2, 0);
             this.tblMcpKeyless.Controls.Add(this.chkMcpMsBuild, 3, 0);
+            this.tblMcpKeyless.Controls.Add(this.chkMcpCommandScratch, 4, 0);
             this.tblMcpKeyless.Location = new System.Drawing.Point(0, 52);
             this.tblMcpKeyless.Margin = new System.Windows.Forms.Padding(0);
             this.tblMcpKeyless.Name = "tblMcpKeyless";
             this.tblMcpKeyless.RowCount = 1;
             this.tblMcpKeyless.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tblMcpKeyless.Size = new System.Drawing.Size(248, 25);
+            this.tblMcpKeyless.Size = new System.Drawing.Size(380, 25);
             this.tblMcpKeyless.TabIndex = 4;
             // 
             // chkMcpFiles
@@ -718,7 +721,19 @@
             this.chkMcpMsBuild.TabIndex = 7;
             this.chkMcpMsBuild.Text = "MSBuild";
             this.chkMcpMsBuild.UseVisualStyleBackColor = true;
-            // 
+            //
+            // chkMcpCommandScratch
+            //
+            this.chkMcpCommandScratch.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkMcpCommandScratch.AutoSize = true;
+            this.chkMcpCommandScratch.Location = new System.Drawing.Point(251, 4);
+            this.chkMcpCommandScratch.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkMcpCommandScratch.Name = "chkMcpCommandScratch";
+            this.chkMcpCommandScratch.Size = new System.Drawing.Size(122, 17);
+            this.chkMcpCommandScratch.TabIndex = 8;
+            this.chkMcpCommandScratch.Text = "Command scratch dir";
+            this.chkMcpCommandScratch.UseVisualStyleBackColor = true;
+            //
             // lblMcpCustom
             // 
             this.lblMcpCustom.AutoSize = true;
@@ -832,6 +847,7 @@
         private System.Windows.Forms.CheckBox chkMcpFiles;
         private System.Windows.Forms.CheckBox chkMcpGit;
         private System.Windows.Forms.CheckBox chkMcpCommand;
+        private System.Windows.Forms.CheckBox chkMcpCommandScratch;
         private System.Windows.Forms.CheckBox chkMcpMsBuild;
         private System.Windows.Forms.Label lblMcpCustom;
         private System.Windows.Forms.RichTextBox rtbMcpJson;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1471,15 +1471,6 @@ namespace GxPT
             bool commandOn = this.chkMcpCommand.Checked;
             this.chkMcpCommandScratch.Enabled = commandOn;
             if (!commandOn) this.chkMcpCommandScratch.Checked = false;
-            try
-            {
-                this._mcpTip.SetToolTip(this.chkMcpCommandScratch,
-                    "When no workspace folder is set, let the command server run in a temporary "
-                    + "per-conversation scratch directory (%AppData%\\GxPT\\scratch\\<id>). Files, Git "
-                    + "and MSBuild stay disabled without a workspace. Scratch dirs are deleted when the "
-                    + "conversation is deleted or the app closes.");
-            }
-            catch { }
         }
 
         // Tavily keys look like "tvly-dev-XXXXXXXX" (or "tvly-XXXXXXXX"). Lenient prefix + length check.

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -164,6 +164,8 @@ namespace GxPT
             {
                 this.txtWebSearchKey.TextChanged += McpCredential_TextChanged;
                 this.txtGithubPat.TextChanged += McpCredential_TextChanged;
+                // Toggling the command server enables/disables its dependent scratch-dir option.
+                this.chkMcpCommand.CheckedChanged += McpCredential_TextChanged;
             }
             catch { }
         }
@@ -1402,6 +1404,7 @@ namespace GxPT
             // disabled below) when git isn't on PATH.
             this.chkMcpGit.Checked = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
             this.chkMcpCommand.Checked = s.mcp_command_enabled;
+            this.chkMcpCommandScratch.Checked = s.mcp_command_scratch_enabled;
             // MSBuild, like Git, defaults ON when a build engine is found and the user hasn't chosen
             // otherwise; OFF (and disabled below) when no MSBuild is present.
             this.chkMcpMsBuild.Checked = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled", true);
@@ -1418,6 +1421,9 @@ namespace GxPT
             target.mcp_files_enabled = this.chkMcpFiles.Checked;
             target.mcp_git_enabled = this.chkMcpGit.Checked;
             target.mcp_command_enabled = this.chkMcpCommand.Checked;
+            // Only meaningful when the command server itself is on; force-off otherwise so a stale
+            // setting can't enable scratch behavior for a disabled command server.
+            target.mcp_command_scratch_enabled = this.chkMcpCommand.Checked && this.chkMcpCommandScratch.Checked;
             target.mcp_msbuild_enabled = this.chkMcpMsBuild.Checked;
             target.mcp_github_enabled = this.chkMcpGithub.Checked;
             target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
@@ -1457,6 +1463,21 @@ namespace GxPT
                 this._mcpTip.SetToolTip(this.chkMcpMsBuild, msbuildInstalled
                     ? string.Empty
                     : "No MSBuild was found on this system. Install the .NET Framework or Visual Studio/Build Tools to enable these tools.");
+            }
+            catch { }
+
+            // The scratch-dir option only applies to the command server, so it's enableable only while
+            // the command server itself is on; unchecked-and-disabled otherwise.
+            bool commandOn = this.chkMcpCommand.Checked;
+            this.chkMcpCommandScratch.Enabled = commandOn;
+            if (!commandOn) this.chkMcpCommandScratch.Checked = false;
+            try
+            {
+                this._mcpTip.SetToolTip(this.chkMcpCommandScratch,
+                    "When no workspace folder is set, let the command server run in a temporary "
+                    + "per-conversation scratch directory (%AppData%\\GxPT\\scratch\\<id>). Files, Git "
+                    + "and MSBuild stay disabled without a workspace. Scratch dirs are deleted when the "
+                    + "conversation is deleted or the app closes.");
             }
             catch { }
         }
@@ -1539,6 +1560,8 @@ namespace GxPT
             public bool mcp_files_enabled { get; set; }
             public bool mcp_git_enabled { get; set; }
             public bool mcp_command_enabled { get; set; }
+            // Opt-in: run the command server in a per-conversation scratch dir when no workspace is set.
+            public bool mcp_command_scratch_enabled { get; set; }
             public bool mcp_msbuild_enabled { get; set; }
             public bool mcp_github_enabled { get; set; }
             public bool mcp_memory_enabled { get; set; }

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Managers\SkillImportExportManager.cs" />
     <Compile Include="Services\AppSettings.cs" />
     <Compile Include="Services\RecentWorkDirs.cs" />
+    <Compile Include="Services\ScratchWorkspace.cs" />
     <Compile Include="Services\Skills\SkillSlug.cs" />
     <Compile Include="Services\Skills\SkillFrontmatter.cs" />
     <Compile Include="Services\Skills\Skill.cs" />

--- a/GxPT/Managers/SidebarManager.cs
+++ b/GxPT/Managers/SidebarManager.cs
@@ -546,6 +546,10 @@ namespace GxPT
                 }
 
                 ConversationStore.DeletePath(info.Path);
+                // Remove the conversation's scratch working directory (if any), stopping its command
+                // server first so the directory isn't held open.
+                try { if (!string.IsNullOrEmpty(info.Id)) _mainForm.DeleteScratchForConversation(info.Id); }
+                catch { }
                 RefreshSidebarList();
             }
             catch { }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -65,6 +65,23 @@ namespace GxPT
                 + "mean this workspace - look here first.";
         }
 
+        // Per-turn scratch-sandbox block, injected only when there is no workspace but the command
+        // server is running in a per-conversation scratch directory (the opt-in scratch-command
+        // feature). Tells the model it has a throwaway working directory for running commands (the
+        // command server's CWD) and that it is NOT a project: there are no workspace files to read, and
+        // it is deleted when the conversation is deleted or the app closes. Kept separate from the
+        // workspace block so a scratch turn is never presented as a real workspace. Null/empty scratch
+        // dir => no block, leaving a folderless turn with no trace of one.
+        internal static string ScratchSystemMessage(string scratchDir)
+        {
+            if (string.IsNullOrEmpty(scratchDir)) return null;
+            return "No workspace folder is set for this conversation. A temporary scratch directory has "
+                + "been created at `" + scratchDir + "` and is the working directory for any commands "
+                + "you run. It starts empty and is not a project - there are no workspace files to read - "
+                + "and it is deleted when this conversation is deleted or the app closes. Use it only for "
+                + "transient work.";
+        }
+
         private readonly IChatStreamer _streamer;
         private readonly McpToolRegistry _registry;
         private readonly IToolApprovalPolicy _approval;
@@ -183,6 +200,22 @@ namespace GxPT
         // resolve); workdir-independent tools (web/github/custom) resolve regardless.
         public string WorkingDir { get; set; }
 
+        // When there is no user WorkingDir, the per-conversation SCRATCH directory the command server
+        // runs in (folderless conversations with the opt-in scratch-command feature). Used ONLY to
+        // resolve and expose workdir-scoped tools (the command server) — never for the workspace prompt
+        // block, which stays absent so a scratch turn is not presented as a real workspace. Instead a
+        // distinct scratch-sandbox note (ScratchSystemMessage) tells the model about the temp dir. Null
+        // when not applicable (a real workspace is set, or the feature is off).
+        public string ScratchWorkingDir { get; set; }
+
+        // The working directory used to resolve/expose workdir-scoped MCP tools for this turn: the user
+        // workspace when set, else the scratch dir (command server only). Distinct from WorkingDir, which
+        // drives the prompt's workspace block and is left null for a scratch turn.
+        private string ResolutionWorkdir
+        {
+            get { return !string.IsNullOrEmpty(WorkingDir) ? WorkingDir : ScratchWorkingDir; }
+        }
+
         public McpChatOrchestrator(IChatStreamer streamer, McpToolRegistry registry,
                                    IToolApprovalPolicy approval, string model, ILogSink log)
             : this(streamer, registry, approval, model, log, DefaultMaxIterations, DefaultCallTimeoutMs)
@@ -276,10 +309,11 @@ namespace GxPT
                 // actually contributes tools; a skills-only turn skips both and offers just open_skill.
                 // Filter by THIS turn's workdir so a folderless turn never advertises another folder's
                 // scoped tools (files/git/run_skill_script, ...) that it couldn't actually call.
-                bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(WorkingDir);
+                string resolveDir = ResolutionWorkdir;
+                bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(resolveDir);
                 IList<JObject> tools = hasMcpTools
-                    ? _registry.ExposedFunctionDefs(WorkingDir, RevealedToolNames) : null;
-                string manifest = hasMcpTools ? _registry.NamesManifestSystemMessage(WorkingDir) : null;
+                    ? _registry.ExposedFunctionDefs(resolveDir, RevealedToolNames) : null;
+                string manifest = hasMcpTools ? _registry.NamesManifestSystemMessage(resolveDir) : null;
                 if (SkillTools != null && SkillTools.HasSkills)
                 {
                     if (tools == null) tools = new List<JObject>();
@@ -580,6 +614,14 @@ namespace GxPT
             string workspaceBlock = WorkspaceSystemMessage(WorkingDir);
             if (!string.IsNullOrEmpty(workspaceBlock))
                 head.Add(new ChatMessage("system", workspaceBlock));
+            else
+            {
+                // No workspace, but the command server may be running in a per-conversation scratch
+                // sandbox: tell the model about that temp dir (kept distinct from the workspace block).
+                string scratchBlock = ScratchSystemMessage(ScratchWorkingDir);
+                if (!string.IsNullOrEmpty(scratchBlock))
+                    head.Add(new ChatMessage("system", scratchBlock));
+            }
             if (!string.IsNullOrEmpty(ProjectInstructions))
                 head.Add(new ChatMessage("system", ProjectInstructions));
             return head;
@@ -647,7 +689,7 @@ namespace GxPT
             {
                 string[] names = ParseRevealNames(call.ArgumentsJson);
                 _log.Log("mcp", "[turn " + turnId + "] reveal_tools: " + names.Length + " name(s)");
-                return _registry.Reveal(names, WorkingDir, RevealedToolNames);
+                return _registry.Reveal(names, ResolutionWorkdir, RevealedToolNames);
             }
 
             // open_skill is a host meta-tool (no MCP round-trip): load skill bodies by slug. Same
@@ -679,11 +721,12 @@ namespace GxPT
 
             McpServerConnection conn;
             string toolName;
-            if (_registry == null || !_registry.TryResolve(call.Name, WorkingDir, out conn, out toolName))
+            string resolveDir = ResolutionWorkdir;
+            if (_registry == null || !_registry.TryResolve(call.Name, resolveDir, out conn, out toolName))
             {
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] unresolved tool '" + call.Name + "' (workdir="
-                    + (string.IsNullOrEmpty(WorkingDir) ? "(none)" : WorkingDir) + ")");
+                    + (string.IsNullOrEmpty(resolveDir) ? "(none)" : resolveDir) + ")");
                 return "[Unknown tool: " + call.Name + "]";
             }
 

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -202,7 +202,7 @@ namespace GxPT
 
         // When there is no user WorkingDir, the per-conversation SCRATCH directory the command server
         // runs in (folderless conversations with the opt-in scratch-command feature). Used ONLY to
-        // resolve and expose workdir-scoped tools (the command server) — never for the workspace prompt
+        // resolve and expose workdir-scoped tools (the command server) - never for the workspace prompt
         // block, which stays absent so a scratch turn is not presented as a real workspace. Instead a
         // distinct scratch-sandbox note (ScratchSystemMessage) tells the model about the temp dir. Null
         // when not applicable (a real workspace is set, or the feature is off).

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -113,6 +113,10 @@ namespace GxPT
             // command — runs approved commands via the shell, in GXPT_WORKDIR.
             McpServerSpec cmd = NewBuiltIn(CommandName, "CommandMcpServer.exe", o.ServerDir, true, o.CommandEnabled);
             if (!string.IsNullOrEmpty(o.CmdShell)) cmd.Env[EnvCmdShell] = o.CmdShell;
+            // The command server is the only workdir-scoped built-in allowed to run in a per-conversation
+            // scratch dir when no workspace is set (files/git/msbuild require a real workspace). The host
+            // gates whether scratch dirs are used at all on an opt-in setting.
+            cmd.RunsInScratch = true;
             list.Add(cmd);
 
             // msbuild — discovers installed MSBuild versions and builds the project at GXPT_WORKDIR.

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -170,7 +170,7 @@ namespace GxPT
         }
 
         // Ensure the SCRATCH server set for `workdir` is running: like EnsureWorkingDir, but only the
-        // scratch-eligible scoped specs (the command server) launch here — files/git/msbuild require a
+        // scratch-eligible scoped specs (the command server) launch here - files/git/msbuild require a
         // real workspace and are skipped. Used for folderless conversations whose command server runs in
         // a per-conversation scratch dir. The directory must already exist (it becomes the child's CWD).
         // Idempotent; a null/empty workdir is a no-op.

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -45,6 +45,13 @@ namespace GxPT
         // event instead of launching a duplicate set.
         private readonly Dictionary<string, ManualResetEvent> _connecting =
             new Dictionary<string, ManualResetEvent>(StringComparer.OrdinalIgnoreCase);
+        // Working dirs that are SCRATCH sandboxes (no user workspace): only RunsInScratch scoped specs
+        // (the command server) launch for these; files/git/msbuild are skipped. Recorded before the
+        // (unlocked) connect so ConnectScoped filters the spec set, and pruned alongside the scoped set
+        // on teardown. A scratch path and a real-workspace path never collide (scratch lives under a
+        // dedicated %AppData% subfolder), so a given key is only ever one kind.
+        private readonly Dictionary<string, bool> _scratchWorkdirs =
+            new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private List<McpServerSpec> _scopedSpecs = new List<McpServerSpec>();
         private bool _started;
         // Volatile: the connect loops (which run OUTSIDE _lock) poll this to bail out promptly once
@@ -162,6 +169,22 @@ namespace GxPT
             ConnectScoped(workdir);
         }
 
+        // Ensure the SCRATCH server set for `workdir` is running: like EnsureWorkingDir, but only the
+        // scratch-eligible scoped specs (the command server) launch here — files/git/msbuild require a
+        // real workspace and are skipped. Used for folderless conversations whose command server runs in
+        // a per-conversation scratch dir. The directory must already exist (it becomes the child's CWD).
+        // Idempotent; a null/empty workdir is a no-op.
+        public void EnsureScratchDir(string workdir)
+        {
+            if (string.IsNullOrEmpty(workdir)) return;
+            lock (_lock)
+            {
+                if (_disposed) return;
+                _scratchWorkdirs[workdir] = true; // mark BEFORE connecting so ConnectScoped filters
+            }
+            ConnectScoped(workdir);
+        }
+
         // Ensure the scoped set for `workdir` is running, connecting it if needed. The blocking Open()
         // handshakes run WITHOUT _lock held (so Dispose never waits on them); the lock is taken only
         // briefly to reserve the workdir and again to publish the result. A second caller for a
@@ -171,12 +194,14 @@ namespace GxPT
             if (string.IsNullOrEmpty(workdir)) return;
 
             List<McpServerSpec> specs;
+            bool scratch = false;
             ManualResetEvent reservation;
             ManualResetEvent waitFor;
             lock (_lock)
             {
                 if (_disposed) return;
                 if (_scopedByWorkdir.ContainsKey(workdir)) return;      // already connected
+                scratch = _scratchWorkdirs.ContainsKey(workdir);
                 if (!_started)
                 {
                     if (!_pendingWorkdirs.Contains(workdir)) _pendingWorkdirs.Add(workdir);
@@ -213,6 +238,9 @@ namespace GxPT
                     if (_disposed) break;
                     McpServerSpec spec = specs[i];
                     if (spec == null || !spec.Enabled) continue;
+                    // A scratch sandbox runs only the scratch-eligible scoped specs (command); the
+                    // workspace-only servers (files/git/msbuild/memory/skills) are skipped there.
+                    if (scratch && !spec.RunsInScratch) continue;
                     McpServerConnection conn = CreateAndOpen(spec, workdir);
                     if (conn != null) conns.Add(conn);
                 }
@@ -247,6 +275,7 @@ namespace GxPT
             lock (_lock)
             {
                 _pendingWorkdirs.Remove(workdir);
+                _scratchWorkdirs.Remove(workdir);
                 List<McpServerConnection> conns;
                 if (_scopedByWorkdir.TryGetValue(workdir, out conns))
                 {
@@ -271,6 +300,14 @@ namespace GxPT
                 if (_disposed) return;
                 for (int i = _pendingWorkdirs.Count - 1; i >= 0; i--)
                     if (!keepSet.ContainsKey(_pendingWorkdirs[i])) _pendingWorkdirs.RemoveAt(i);
+
+                // Forget scratch markers for folders no longer referenced by an open tab (their scoped
+                // set is torn down below); a re-ensure later re-marks them.
+                List<string> dropScratch = null;
+                foreach (string wd in _scratchWorkdirs.Keys)
+                    if (!keepSet.ContainsKey(wd)) (dropScratch ?? (dropScratch = new List<string>())).Add(wd);
+                if (dropScratch != null)
+                    for (int i = 0; i < dropScratch.Count; i++) _scratchWorkdirs.Remove(dropScratch[i]);
 
                 List<string> drop = null;
                 foreach (string wd in _scopedByWorkdir.Keys)
@@ -380,6 +417,7 @@ namespace GxPT
                     all.AddRange(conns);
                 _scopedByWorkdir.Clear();
                 _pendingWorkdirs.Clear();
+                _scratchWorkdirs.Clear();
                 all.AddRange(_eager);
                 _eager.Clear();
             }

--- a/GxPT/Services/Mcp/McpServerSpec.cs
+++ b/GxPT/Services/Mcp/McpServerSpec.cs
@@ -30,7 +30,7 @@ namespace GxPT
 
         // For a WorkdirScoped server, eligible to run in a per-conversation SCRATCH working directory
         // when the user has no workspace set (the command server uses this). A scratch dir launches
-        // ONLY the scoped specs flagged here — files/git/msbuild require a real workspace and stay off.
+        // ONLY the scoped specs flagged here - files/git/msbuild require a real workspace and stay off.
         // Ignored when not WorkdirScoped. The host decides whether scratch dirs are used at all (opt-in
         // setting); this flag only says "this server is allowed there".
         public bool RunsInScratch;

--- a/GxPT/Services/Mcp/McpServerSpec.cs
+++ b/GxPT/Services/Mcp/McpServerSpec.cs
@@ -28,6 +28,13 @@ namespace GxPT
         // the per-workdir instances handle project authoring + run_skill_script. Ignored when not scoped.
         public bool RunsWithoutWorkdir;
 
+        // For a WorkdirScoped server, eligible to run in a per-conversation SCRATCH working directory
+        // when the user has no workspace set (the command server uses this). A scratch dir launches
+        // ONLY the scoped specs flagged here — files/git/msbuild require a real workspace and stay off.
+        // Ignored when not WorkdirScoped. The host decides whether scratch dirs are used at all (opt-in
+        // setting); this flag only says "this server is allowed there".
+        public bool RunsInScratch;
+
         // True for the four bundled first-party servers (hardcoded launch, never in mcp.json, D15).
         public bool BuiltIn;
 

--- a/GxPT/Services/ScratchWorkspace.cs
+++ b/GxPT/Services/ScratchWorkspace.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GxPT
+{
+    // Per-conversation scratch working directories for the command MCP server when no workspace is
+    // set. Each folderless conversation that uses the command server gets its own sandbox at
+    // %AppData%/GxPT/scratch/<conversation_id>, which becomes the command server's GXPT_WORKDIR. Only
+    // the command server runs here — files/git/msbuild require a real workspace and stay off. Scratch
+    // directories are transient: they are removed when the conversation is deleted or when the
+    // application closes (whichever comes first), so nothing here is meant to persist. The "scratch"
+    // parent folder keeps these dirs from colliding with real GxPT data (Conversations/skills/mcp.json)
+    // and lets shutdown wipe them as a group.
+    internal static class ScratchWorkspace
+    {
+        private const string FolderName = "scratch";
+
+        // Directories this process created, so they can all be removed on shutdown. Keyed by full
+        // path (OrdinalIgnoreCase) to dedupe repeated EnsureDir calls for the same conversation.
+        private static readonly object _gate = new object();
+        private static readonly HashSet<string> _created =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // True when the scratch-command feature is on: the command server is enabled AND the user has
+        // opted into running it in a scratch dir when no workspace is set. Both gates matter — a
+        // scratch dir is only useful if the command server will actually launch in it.
+        public static bool IsEnabled()
+        {
+            try
+            {
+                return AppSettings.GetBool("mcp_command_enabled", false)
+                    && AppSettings.GetBool("mcp_command_scratch_enabled", false);
+            }
+            catch { return false; }
+        }
+
+        // %AppData%/GxPT/scratch (the parent of every conversation's scratch dir).
+        public static string Root()
+        {
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(Path.Combine(appData, "GxPT"), FolderName);
+        }
+
+        // The scratch path for a conversation id (NOT created). Null for an empty id.
+        public static string PathFor(string conversationId)
+        {
+            string id = Sanitize(conversationId);
+            if (string.IsNullOrEmpty(id)) return null;
+            return Path.Combine(Root(), id);
+        }
+
+        // The scratch path for a conversation id, creating the directory (and remembering it for
+        // shutdown cleanup) if needed. Null when the id is empty or the directory can't be created.
+        public static string EnsureDir(string conversationId)
+        {
+            string path = PathFor(conversationId);
+            if (string.IsNullOrEmpty(path)) return null;
+            try
+            {
+                if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+                lock (_gate) { _created.Add(path); }
+                return path;
+            }
+            catch { return null; }
+        }
+
+        // Delete one conversation's scratch directory (best-effort). Safe when it doesn't exist. The
+        // caller must first stop the command server bound to it so the directory isn't held open.
+        public static void Delete(string conversationId)
+        {
+            DeletePath(PathFor(conversationId));
+        }
+
+        public static void DeletePath(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return;
+            try { if (Directory.Exists(path)) Directory.Delete(path, true); }
+            catch { }
+            lock (_gate) { _created.Remove(path); }
+        }
+
+        // Remove every scratch directory this process created (application shutdown). Best-effort: a
+        // directory still held open by a not-yet-exited child is skipped rather than throwing. Only
+        // this process's dirs are touched, so a second running instance's scratch dirs are left alone.
+        public static void DeleteAllCreated()
+        {
+            List<string> paths;
+            lock (_gate) { paths = new List<string>(_created); _created.Clear(); }
+            for (int i = 0; i < paths.Count; i++)
+            {
+                try { if (Directory.Exists(paths[i])) Directory.Delete(paths[i], true); }
+                catch { }
+            }
+        }
+
+        private static string Sanitize(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return null;
+            foreach (char c in Path.GetInvalidFileNameChars()) id = id.Replace(c, '_');
+            return id;
+        }
+    }
+}

--- a/GxPT/Services/ScratchWorkspace.cs
+++ b/GxPT/Services/ScratchWorkspace.cs
@@ -7,7 +7,7 @@ namespace GxPT
     // Per-conversation scratch working directories for the command MCP server when no workspace is
     // set. Each folderless conversation that uses the command server gets its own sandbox at
     // %AppData%/GxPT/scratch/<conversation_id>, which becomes the command server's GXPT_WORKDIR. Only
-    // the command server runs here — files/git/msbuild require a real workspace and stay off. Scratch
+    // the command server runs here - files/git/msbuild require a real workspace and stay off. Scratch
     // directories are transient: they are removed when the conversation is deleted or when the
     // application closes (whichever comes first), so nothing here is meant to persist. The "scratch"
     // parent folder keeps these dirs from colliding with real GxPT data (Conversations/skills/mcp.json)
@@ -23,7 +23,7 @@ namespace GxPT
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // True when the scratch-command feature is on: the command server is enabled AND the user has
-        // opted into running it in a scratch dir when no workspace is set. Both gates matter — a
+        // opted into running it in a scratch dir when no workspace is set. Both gates matter - a
         // scratch dir is only useful if the command server will actually launch in it.
         public static bool IsEnabled()
         {


### PR DESCRIPTION
## Summary

Lets a folderless conversation still run the **command** MCP server, in a per-conversation throwaway sandbox, without exposing the workspace-only tools.

- When no workspace is set, the command server can run in a scratch directory at `%AppData%\GxPT\scratch\<conversation_uuid>` (its `GXPT_WORKDIR`/CWD).
- Files / Git / MSBuild (and memory/project skills) still require a real workspace and stay off there.
- Opt-in via a new setting, **off by default**, and only usable while the command server itself is enabled.
- Scratch dirs are deleted when the conversation is deleted or when the app closes — whichever comes first.

## How it works

- `McpServerSpec.RunsInScratch` flags the command server as the only scoped built-in allowed in a scratch dir. `McpHost.EnsureScratchDir(dir)` launches just the scratch-eligible scoped specs for that folder (reusing the existing per-workdir connection / `RetainOnly` teardown machinery).
- The orchestrator resolves and exposes workdir-scoped tools off a new `ScratchWorkingDir` when there is no `WorkingDir`. The prompt keeps **no** workspace block; instead a distinct scratch-sandbox note tells the model it has a temp dir for commands, so a scratch turn is never presented as a real workspace.
- `MainForm` threads the scratch dir through tab reconcile (so it survives tab switches), turn routing, `BeginToolSend`, and host rebuild. `ScratchWorkspace` owns path/create/delete + tracks this process's dirs for shutdown cleanup; only this process's dirs are touched, so a second running instance is unaffected.

## Settings UI

Reworked the **Tools** tab into three group boxes — **Web & integrations**, **Workspace tools** (Files/Command/Git/MSBuild on one row + the new scratch toggle on its own full-width row), and **Custom servers (mcp.json)**.

## Tests

Added coverage for the host (scratch launches only the command server; torn down by `RetainOnly`), config (`RunsInScratch` only on command), and orchestrator (scratch tool resolves; scratch note injected, no workspace block).

## Notes

- This is a .NET Framework / WinForms app and could not be compiled in the authoring environment. Please build locally and open the Settings → Tools dialog once to confirm the group-box spacing; the heights are hand-tuned and easy to nudge.
- All added source is pure ASCII (an earlier VS2008 source-open error from a UTF-8 em-dash was fixed in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKDizozyyrbLf23deddkGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKDizozyyrbLf23deddkGQ)_