### PR TITLE
Enable a disabled skill when invoked via /use-skill

### DIFF
--- a/GxPT/Services/Commands/SkillCommands.cs
+++ b/GxPT/Services/Commands/SkillCommands.cs
@@ -410,6 +410,9 @@ namespace GxPT
     // short user message ("Use the <slug> skill. [text]") and attaches the skill's full instructions as a
     // HIDDEN system message (context the model sees but the transcript never shows) - so the body never
     // clutters the user transcript. Custom behavior, not a generic prompt expansion.
+    // If the skill is currently disabled, this also enables it for the conversation (and brings the Skills
+    // MCP server up): a disabled skill's tools are gated off, so without this the skill-writer skill (and
+    // any other tool-backed skill) would load its body but have no tools to actually run.
     internal sealed class UseSkillCommand : ClientCommandBase, IArgumentCompleter
     {
         public override string Name { get { return "use-skill"; } }
@@ -430,6 +433,19 @@ namespace GxPT
             Skill skill;
             if (!SkillCommandShared.ResolveSkill(cat, slugArg, out skill))
                 return SlashCommandResult.Fail("Unknown skill: " + slugArg);
+
+            // A disabled skill's MCP server is gated off, so /use-skill alone would load the body but leave
+            // its tools unavailable. Enable it for this conversation and bring the Skills MCP server into
+            // line so the skill can actually be used (mirrors /toggle-skill <slug> on for this scope).
+            SkillEnablement global = SkillEnablement.LoadGlobal();
+            bool enabled = SkillResolve.IsEnabled(global, skill.Slug,
+                SkillCommandShared.ConvOverrideFor(ctx, skill.Slug), ctx.Skills.GetConversationSkillsFeatureOff());
+            if (!enabled)
+            {
+                ctx.Skills.SetConversationSkillOverride(skill.Slug, true);
+                ctx.Skills.RefreshSkillsServer();
+                ctx.WriteInfo("Skill '" + skill.Slug + "' was disabled; enabled it for this conversation.");
+            }
 
             // The skill body rides as a hidden system message (committed at send, not now), so the
             // transcript shows only the short ask and an early return can't orphan it.


### PR DESCRIPTION
## Summary

`/use-skill <slug>` now **enables a disabled skill for the conversation** before sending, instead of only loading its body as hidden context.

### Why

`/use-skill` attaches the skill's instructions as a hidden system message but never changed the skill's enablement. For tool-backed skills — most notably **skill-writer** — this was a dead end: a disabled skill keeps its associated MCP server gated off, so the model got the instructions but had **none of the tools the skill actually needs**. The user couldn't really use the skill.

### What changed

In `UseSkillCommand.Invoke`, after resolving the skill:
- Compute its effective enabled state (`SkillResolve.IsEnabled`, same ladder the send path uses).
- If it's **not** enabled, set a per-conversation override to ON (`SetConversationSkillOverride(slug, true)` — same mechanism as `/toggle-skill <slug> on`), call `RefreshSkillsServer()` so the Skills MCP server comes online, and write an info line: *"Skill 'X' was disabled; enabled it for this conversation."*
- Skills that are already enabled are untouched (no info line, no server churn).

Scope is per-conversation, matching the wording of the request ("enable it for the conversation"); global settings are left alone.

### Notes

- The Skills MCP server connects on a background thread (as it does for any `/toggle-skill` change), so tools become available as it finishes connecting; the override is persisted on the conversation regardless.
- Only `GxPT/Services/Commands/SkillCommands.cs` changed.

## Verification

⚠️ Not compiled here — the project targets .NET Framework 3.5 and no build tooling is available in this environment. The change uses only C#3-compatible syntax and existing APIs (`SkillEnablement.LoadGlobal`, `SkillResolve.IsEnabled`, `ISkillEnablementStore.SetConversationSkillOverride/RefreshSkillsServer`, `WriteInfo`). Suggested manual check: disable `skill-writer`, run `/use-skill skill-writer`, and confirm it reports being enabled and its MCP tools become available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKDizozyyrbLf23deddkGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKDizozyyrbLf23deddkGQ)_