### PR TITLE
Sub-agents: design doc + phase 1 (AgentCatalog + frontmatter parser)

### DIFF
--- a/GxPT.Setup/GxPT.Setup.vdproj
+++ b/GxPT.Setup/GxPT.Setup.vdproj
@@ -21,6 +21,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_1F1A270D5F354EDABFA1CD331F34382A"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_1F515FDCDCC54A81B1A7984BE9561853"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -147,6 +153,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_7961BD5F3E0C47969977BB0BFB50492F"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_7E3A6FA0A21D2C2AFAC5DA8698579058"
         "OwnerKey" = "8:_10650E4BA14F4EB39F7DB44C8656F217"
         "MsmSig" = "8:_UNDEFINED"
@@ -207,7 +219,25 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_91940A2915C34361BB01A6C38959BA12"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_A180D69227FE4B7083CE9AD87CFDF823"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_A1AA60E296554DD6B8DB52DBD30131E6"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_A4DE60DFE825402FA09CB42E708DAA91"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -244,6 +274,12 @@
         "Entry"
         {
         "MsmKey" = "8:_E3F2F30D7728454C8C5BE99120DD163F"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_E4A6A191855C4BBC80883994653B31B8"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -460,6 +496,26 @@
         }
         "File"
         {
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_1F1A270D5F354EDABFA1CD331F34382A"
+            {
+            "SourcePath" = "8:..\\agents\\code-reviewer.md"
+            "TargetName" = "8:code-reviewer.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_233A41B509EE377D3539F831E7F0C67D"
             {
             "AssemblyRegister" = "3:1"
@@ -664,6 +720,26 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_7961BD5F3E0C47969977BB0BFB50492F"
+            {
+            "SourcePath" = "8:..\\agents\\plan.md"
+            "TargetName" = "8:plan.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_7E3A6FA0A21D2C2AFAC5DA8698579058"
             {
             "AssemblyRegister" = "3:1"
@@ -701,6 +777,26 @@
             "TargetName" = "8:gxpt-document.ico"
             "Tag" = "8:"
             "Folder" = "8:_DF13B4C475D44F26AB5A285F0E29B7C7"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_91940A2915C34361BB01A6C38959BA12"
+            {
+            "SourcePath" = "8:..\\agents\\general-purpose.md"
+            "TargetName" = "8:general-purpose.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -755,6 +851,46 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_A1AA60E296554DD6B8DB52DBD30131E6"
+            {
+            "SourcePath" = "8:..\\agents\\web-research.md"
+            "TargetName" = "8:web-research.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_A4DE60DFE825402FA09CB42E708DAA91"
+            {
+            "SourcePath" = "8:..\\agents\\explore.md"
+            "TargetName" = "8:explore.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_AEAD08493BAD4918B056AED37CBD650F"
             {
             "SourcePath" = "8:..\\skills\\skill-writer\\SKILL.md"
@@ -804,6 +940,26 @@
             "Register" = "3:1"
             "Exclude" = "11:FALSE"
             "IsDependency" = "11:TRUE"
+            "IsolateTo" = "8:"
+            }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_E4A6A191855C4BBC80883994653B31B8"
+            {
+            "SourcePath" = "8:..\\agents\\verify.md"
+            "TargetName" = "8:verify.md"
+            "Tag" = "8:"
+            "Folder" = "8:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_E523A35055A0475C83166684BAE74635"
@@ -941,6 +1097,17 @@
             "Property" = "8:TARGETDIR"
                 "Folders"
                 {
+                    "{9EF0B969-E518-4E46-987F-47570745A589}:_0B0AC2A83AD1489C8B1E8F5E1410070B"
+                    {
+                    "Name" = "8:agents"
+                    "AlwaysCreate" = "11:FALSE"
+                    "Condition" = "8:"
+                    "Transitive" = "11:FALSE"
+                    "Property" = "8:_A3FFDBD47A53424396125CF6E50726ED"
+                        "Folders"
+                        {
+                        }
+                    }
                     "{9EF0B969-E518-4E46-987F-47570745A589}:_24C4BCC179A740BFBC5D45DDB8D16A6D"
                     {
                     "Name" = "8:Resources"

--- a/GxPT.Tests/AgentAvailabilityTests.cs
+++ b/GxPT.Tests/AgentAvailabilityTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public class AgentAvailabilityTests
+    {
+        // Real first-party tiers for the tools used here.
+        private static ToolTier TierOf(string name)
+        {
+            switch (name)
+            {
+                case "files__read":
+                case "files__list":
+                case "files__search":
+                case "web__search":
+                case "web__extract":
+                    return ToolTier.ReadOnly;
+                case "files__edit":
+                    return ToolTier.Write;
+                case "command__run":
+                    return ToolTier.Destructive;
+                default:
+                    return ToolTier.Write;
+            }
+        }
+
+        private static Agent ReadOnlyAgent(string slug, string[] tools)
+        {
+            return new Agent(slug, slug, "d", tools, AgentMaxTier.ReadOnly, AgentAutonomy.AutoReadOnly,
+                null, 0, null, AgentSource.Bundled);
+        }
+
+        [Fact]
+        public void Available_WhenAtLeastOneToolPresent()
+        {
+            Agent a = ReadOnlyAgent("explore", new string[] { "files__read", "files__search" });
+            string[] parent = new string[] { "files__read", "files__list" };
+            Assert.True(AgentAvailability.IsAvailable(a, parent, TierOf));
+        }
+
+        [Fact]
+        public void Unavailable_WhenNoRequiredToolPresent()
+        {
+            Agent a = ReadOnlyAgent("web-research", new string[] { "web__search", "web__extract" });
+            string[] parent = new string[] { "files__read", "files__list" };   // no web tools
+            Assert.False(AgentAvailability.IsAvailable(a, parent, TierOf));
+
+            List<string> missing = AgentAvailability.MissingTools(a, parent);
+            Assert.Contains("web__search", missing);
+            Assert.Contains("web__extract", missing);
+        }
+
+        [Fact]
+        public void MissingTools_ListsOnlyTheUnavailableOnes()
+        {
+            Agent a = ReadOnlyAgent("explore", new string[] { "files__read", "web__search" });
+            string[] parent = new string[] { "files__read" };   // web missing, files present
+            List<string> missing = AgentAvailability.MissingTools(a, parent);
+            Assert.Contains("web__search", missing);
+            Assert.DoesNotContain("files__read", missing);
+        }
+
+        [Fact]
+        public void Unavailable_WhenToolsExceedTierCeiling()
+        {
+            // A read-only agent that only lists a write tool resolves to nothing under the readonly ceiling.
+            Agent a = ReadOnlyAgent("ro", new string[] { "files__edit" });
+            string[] parent = new string[] { "files__edit" };
+            Assert.False(AgentAvailability.IsAvailable(a, parent, TierOf));
+        }
+    }
+}

--- a/GxPT.Tests/AgentAvailabilityTests.cs
+++ b/GxPT.Tests/AgentAvailabilityTests.cs
@@ -29,7 +29,7 @@ namespace GxPT.Tests
 
         private static Agent ReadOnlyAgent(string slug, string[] tools)
         {
-            return new Agent(slug, slug, "d", tools, AgentMaxTier.ReadOnly, AgentAutonomy.AutoReadOnly,
+            return new Agent(slug, slug, "d", tools, AgentMaxTier.ReadOnly,
                 null, 0, null, AgentSource.Bundled);
         }
 

--- a/GxPT.Tests/AgentCatalogTests.cs
+++ b/GxPT.Tests/AgentCatalogTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentCatalogTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _bundled;
+        private readonly string _user;
+        private readonly string _project;
+
+        public AgentCatalogTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_agents_" + Guid.NewGuid().ToString("N"));
+            _bundled = Path.Combine(_root, "bundled");
+            _user = Path.Combine(_root, "user");
+            _project = Path.Combine(_root, "project");
+            Directory.CreateDirectory(_bundled);
+            Directory.CreateDirectory(_user);
+            Directory.CreateDirectory(_project);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        // Writes <root>/<fileName> with the given frontmatter. fileName carries its own extension so the
+        // ".md only" filter can be exercised. A null description omits the line.
+        private static void WriteFile(string root, string fileName, string body, params string[] fmLines)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("---\n");
+            for (int i = 0; i < fmLines.Length; i++)
+                if (fmLines[i] != null) sb.Append(fmLines[i]).Append('\n');
+            sb.Append("---\n\n").Append(body == null ? "" : body).Append('\n');
+            File.WriteAllText(Path.Combine(root, fileName), sb.ToString(), new UTF8Encoding(false));
+        }
+
+        [Fact]
+        public void Build_DiscoversBundledAgent()
+        {
+            WriteFile(_bundled, "code-explorer.md", "You explore code.",
+                "name: Code Explorer", "description: Search the codebase.");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Assert.Single(cat.Agents);
+            Agent a;
+            Assert.True(cat.TryGet("code-explorer", out a));
+            Assert.Equal("Code Explorer", a.Name);
+            Assert.Equal("Search the codebase.", a.Description);
+            Assert.Equal(AgentSource.Bundled, a.Source);
+            Assert.EndsWith("code-explorer.md", a.FilePath);
+        }
+
+        [Fact]
+        public void Build_NormalizesFileNameToSlug_NameFallsBackToSlug()
+        {
+            WriteFile(_bundled, "Code Explorer.md", "body", "description: d");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Agent a;
+            Assert.True(cat.TryGet("code-explorer", out a));
+            Assert.Equal("code-explorer", a.Name);   // no frontmatter name -> slug
+        }
+
+        [Fact]
+        public void Build_CarriesFrontmatterContract()
+        {
+            WriteFile(_bundled, "verify.md", "You verify.",
+                "description: Run the build and tests.",
+                "tools: [files__read, command__run]",
+                "max_tier: write",
+                "autonomy: auto-readonly",
+                "model: anthropic/claude-sonnet-4-6");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Agent a;
+            Assert.True(cat.TryGet("verify", out a));
+            Assert.Equal(new string[] { "files__read", "command__run" }, a.Tools);
+            Assert.Equal(AgentMaxTier.Write, a.MaxTier);
+            Assert.Equal(AgentAutonomy.AutoReadOnly, a.Autonomy);
+            Assert.Equal("anthropic/claude-sonnet-4-6", a.Model);
+        }
+
+        [Fact]
+        public void Build_ProjectShadowsUserShadowsBundled()
+        {
+            WriteFile(_bundled, "dup.md", "b", "description: bundled one");
+            WriteFile(_user, "dup.md", "b", "description: user one");
+            WriteFile(_project, "dup.md", "b", "description: project one");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _user, _project);
+
+            Agent a;
+            Assert.True(cat.TryGet("dup", out a));
+            Assert.Equal("project one", a.Description);
+            Assert.Equal(AgentSource.Project, a.Source);
+            Assert.Single(cat.Agents);
+        }
+
+        [Fact]
+        public void Build_UserShadowsBundled_WhenNoProject()
+        {
+            WriteFile(_bundled, "dup.md", "b", "description: bundled one");
+            WriteFile(_user, "dup.md", "b", "description: user one");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _user, null);
+
+            Agent a;
+            Assert.True(cat.TryGet("dup", out a));
+            Assert.Equal("user one", a.Description);
+            Assert.Equal(AgentSource.User, a.Source);
+        }
+
+        [Fact]
+        public void Build_SkipsFileWithoutDescription()
+        {
+            WriteFile(_bundled, "no-desc.md", "body", "name: No Description");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Assert.Empty(cat.Agents);
+        }
+
+        [Fact]
+        public void Build_IgnoresNonMarkdownFiles()
+        {
+            WriteFile(_bundled, "real.md", "b", "description: real");
+            File.WriteAllText(Path.Combine(_bundled, "notes.txt"), "not an agent", new UTF8Encoding(false));
+            File.WriteAllText(Path.Combine(_bundled, "README"), "nope", new UTF8Encoding(false));
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Assert.Single(cat.Agents);
+            Agent a;
+            Assert.True(cat.TryGet("real", out a));
+        }
+
+        [Fact]
+        public void Build_MissingOrNullRootsAreSkipped()
+        {
+            WriteFile(_bundled, "only.md", "b", "description: only");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, null,
+                Path.Combine(_root, "does-not-exist"));
+
+            Assert.Single(cat.Agents);
+        }
+
+        [Fact]
+        public void TryGet_IsCaseInsensitive()
+        {
+            WriteFile(_bundled, "code-explorer.md", "b", "description: d");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Agent a;
+            Assert.True(cat.TryGet("CODE-Explorer", out a));
+        }
+
+        [Fact]
+        public void Agents_AreSlugSorted()
+        {
+            WriteFile(_bundled, "zebra.md", "b", "description: z");
+            WriteFile(_bundled, "alpha.md", "b", "description: a");
+            WriteFile(_bundled, "mike.md", "b", "description: m");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Assert.Equal(3, cat.Agents.Count);
+            Assert.Equal("alpha", cat.Agents[0].Slug);
+            Assert.Equal("mike", cat.Agents[1].Slug);
+            Assert.Equal("zebra", cat.Agents[2].Slug);
+        }
+
+        [Fact]
+        public void BuildManifest_OneSlugDescriptionLinePerAgent_SlugOrdered()
+        {
+            WriteFile(_bundled, "zebra.md", "b", "description: Z agent.");
+            WriteFile(_bundled, "alpha.md", "b", "description: A agent.");
+
+            AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
+
+            Assert.Equal("- alpha - A agent.\n- zebra - Z agent.", cat.BuildManifest());
+        }
+    }
+}

--- a/GxPT.Tests/AgentCatalogTests.cs
+++ b/GxPT.Tests/AgentCatalogTests.cs
@@ -79,7 +79,6 @@ namespace GxPT.Tests
                 "description: Run the build and tests.",
                 "tools: [files__read, command__run]",
                 "max_tier: write",
-                "autonomy: auto-readonly",
                 "model: anthropic/claude-sonnet-4-6");
 
             AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
@@ -88,7 +87,6 @@ namespace GxPT.Tests
             Assert.True(cat.TryGet("verify", out a));
             Assert.Equal(new string[] { "files__read", "command__run" }, a.Tools);
             Assert.Equal(AgentMaxTier.Write, a.MaxTier);
-            Assert.Equal(AgentAutonomy.AutoReadOnly, a.Autonomy);
             Assert.Equal("anthropic/claude-sonnet-4-6", a.Model);
         }
 

--- a/GxPT.Tests/AgentCommandsTests.cs
+++ b/GxPT.Tests/AgentCommandsTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using System.Text;
+using GxPT;
+using GxPT.Tests.Commands;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentCommandsTests : IDisposable
+    {
+        private readonly string _work;
+
+        public AgentCommandsTests()
+        {
+            _work = Path.Combine(Path.GetTempPath(), "gxpt_agentcmd_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_work);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_work, true); } catch { }
+        }
+
+        private void WriteProjectAgent(string slug, string desc)
+        {
+            string dir = Path.Combine(Path.Combine(_work, ".gxpt"), "agents");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, slug + ".md"),
+                "---\nname: " + slug + "\ndescription: " + desc + "\n---\nbody\n", new UTF8Encoding(false));
+        }
+
+        // ---- /toggle-agents (conversation scope; global scope writes settings.json so is not exercised here) ----
+
+        [Fact]
+        public void ToggleAgents_Here_On_SetsConversationOverrideTrue()
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            SlashCommandResult r = new ToggleAgentsCommand().Invoke("here on", ctx);
+
+            Assert.Null(r.Error);
+            Assert.True(ctx.AgentStore.ConvAgentsEnabled.HasValue && ctx.AgentStore.ConvAgentsEnabled.Value);
+        }
+
+        [Fact]
+        public void ToggleAgents_Here_Off_SetsConversationOverrideFalse()
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            new ToggleAgentsCommand().Invoke("here off", ctx);
+            Assert.True(ctx.AgentStore.ConvAgentsEnabled.HasValue && !ctx.AgentStore.ConvAgentsEnabled.Value);
+        }
+
+        [Fact]
+        public void ToggleAgents_Here_Inherit_ClearsConversationOverride()
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            ctx.AgentStore.ConvAgentsEnabled = true;
+            new ToggleAgentsCommand().Invoke("here inherit", ctx);
+            Assert.False(ctx.AgentStore.ConvAgentsEnabled.HasValue);
+        }
+
+        [Fact]
+        public void ToggleAgents_Global_Inherit_IsRejected()
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            SlashCommandResult r = new ToggleAgentsCommand().Invoke("global inherit", ctx);
+            Assert.NotNull(r.Error);
+        }
+
+        [Theory]
+        [InlineData("")]            // no args
+        [InlineData("here")]        // missing verb
+        [InlineData("here on off")] // too many
+        [InlineData("sideways on")] // bad scope
+        [InlineData("here maybe")]  // bad verb
+        public void ToggleAgents_BadUsage_Fails(string args)
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            SlashCommandResult r = new ToggleAgentsCommand().Invoke(args, ctx);
+            Assert.NotNull(r.Error);
+        }
+
+        // ---- /dispatch-agent ----
+
+        [Fact]
+        public void DispatchAgent_KnownAgent_SendsInstruction()
+        {
+            WriteProjectAgent("explorer", "Explore the code.");
+            var ctx = new FakeSlashCommandContext(_work);
+
+            SlashCommandResult r = new DispatchAgentCommand().Invoke("explorer find the parser", ctx);
+
+            Assert.Null(r.Error);
+            Assert.True(r.SendToModel);
+            Assert.Equal("Dispatch the explorer agent with this task: find the parser", r.TextToSend);
+        }
+
+        [Fact]
+        public void DispatchAgent_UnknownAgent_Fails()
+        {
+            var ctx = new FakeSlashCommandContext(_work);
+            SlashCommandResult r = new DispatchAgentCommand().Invoke("ghost do something", ctx);
+            Assert.NotNull(r.Error);
+            Assert.Contains("Unknown agent", r.Error);
+        }
+
+        [Theory]
+        [InlineData("")]            // empty
+        [InlineData("explorer")]    // slug but no task
+        public void DispatchAgent_BadUsage_Fails(string args)
+        {
+            WriteProjectAgent("explorer", "Explore.");
+            var ctx = new FakeSlashCommandContext(_work);
+            SlashCommandResult r = new DispatchAgentCommand().Invoke(args, ctx);
+            Assert.NotNull(r.Error);
+        }
+    }
+}

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -201,12 +201,13 @@ namespace GxPT.Tests
         private sealed class FakeActivityUi : IAgentActivityUi
         {
             private readonly object _gate = new object();
-            public int FanOutStarts, FanOutEnds, Starts, Finishes, LastFanOutCount;
+            public int FanOutStarts, FanOutEnds, Starts, Finishes, Cancellations, LastFanOutCount;
 
             public void OnFanOutStart(System.Collections.Generic.IList<string> slugs)
             { lock (_gate) { FanOutStarts++; LastFanOutCount = slugs.Count; } }
             public void OnAgentStart(int index, string slug, string task) { lock (_gate) { Starts++; } }
-            public void OnAgentFinished(int index, string slug) { lock (_gate) { Finishes++; } }
+            public void OnAgentFinished(int index, string slug, bool cancelled)
+            { lock (_gate) { Finishes++; if (cancelled) Cancellations++; } }
             public void OnFanOutEnd() { lock (_gate) { FanOutEnds++; } }
         }
 
@@ -241,6 +242,23 @@ namespace GxPT.Tests
 
             Assert.Equal(0, ui.FanOutStarts);   // nothing runnable -> no fan-out announced
             Assert.Equal(0, ui.FanOutEnds);
+        }
+
+        [Fact]
+        public void ActivityUi_ReportsCancelledFinish_WhenGroupCancelled()
+        {
+            Agent a = WriteAgent("w", "writes", "b");
+            var group = new RequestCancellation();
+            group.Cancel();   // user stopped: the child bails and its finish is reported as cancelled
+            var ui = new FakeActivityUi();
+            AgentDispatcher d = Dispatcher(new ScriptedStreamer(), a);
+            d.GroupCancellation = group;
+            d.ActivityUi = ui;
+
+            d.Dispatch("{\"agents\":[{\"name\":\"w\",\"task\":\"t\"}]}");
+
+            Assert.Equal(1, ui.Finishes);
+            Assert.Equal(1, ui.Cancellations);
         }
 
         // ---- user-stop wrap-up directive ----

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -305,6 +305,36 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void TranscriptPersistence_SaveLoadDelete_RoundTrips()
+        {
+            string conv = "conv-" + System.Guid.NewGuid().ToString("N");
+            string rec = "rec1";
+            var msgs = new System.Collections.Generic.List<ChatMessage>
+            {
+                new ChatMessage("system", "persona"),
+                new ChatMessage("user", "do it"),
+                new ChatMessage("assistant", "ok"),
+                new ChatMessage("tool", "result"),
+            };
+            AgentTranscript[] arr = new AgentTranscript[] { new AgentTranscript("ra", "do it", msgs), null };
+            try
+            {
+                AgentTranscriptPersistence.Save(conv, rec, arr);
+                var map = AgentTranscriptPersistence.LoadAll(conv);
+                Assert.True(map.ContainsKey(rec));
+                AgentTranscript[] back = map[rec];
+                Assert.Equal(2, back.Length);
+                Assert.NotNull(back[0]);
+                Assert.Equal("ra", back[0].Slug);
+                Assert.Equal("do it", back[0].Task);
+                Assert.Equal(1, back[0].ToolCallCount);     // one tool-role message
+                Assert.Null(back[1]);                       // null slot preserved
+            }
+            finally { AgentTranscriptPersistence.DeleteConversation(conv); }
+            Assert.False(AgentTranscriptPersistence.LoadAll(conv).ContainsKey(rec));
+        }
+
+        [Fact]
         public void Dispatch_UnknownSlot_HasNullTranscript()
         {
             Agent a = WriteReadOnlyAgent("ra", "A");

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -242,5 +242,35 @@ namespace GxPT.Tests
             Assert.Equal(0, ui.FanOutStarts);   // nothing runnable -> no fan-out announced
             Assert.Equal(0, ui.FanOutEnds);
         }
+
+        // ---- user-stop wrap-up directive ----
+
+        [Fact]
+        public void Dispatch_WhenGroupCancelled_AppendsWrapUpDirective()
+        {
+            Agent a = WriteAgent("w", "writes", "b");
+            var group = new RequestCancellation();
+            group.Cancel();   // simulate the user having clicked "Stop agents" (children bail immediately)
+            AgentDispatcher d = Dispatcher(new ScriptedStreamer(), a);
+            d.GroupCancellation = group;
+
+            string result = d.Dispatch("{\"agents\":[{\"name\":\"w\",\"task\":\"t\"}]}");
+
+            Assert.Contains("stopped the sub-agents", result);
+            Assert.Contains("how they would like to proceed", result);
+        }
+
+        [Fact]
+        public void Dispatch_NotCancelled_NoWrapUpDirective()
+        {
+            Agent a = WriteAgent("w", "writes", "b");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("all done"));
+            AgentDispatcher d = Dispatcher(streamer, a);   // GroupCancellation null
+
+            string result = d.Dispatch("{\"agents\":[{\"name\":\"w\",\"task\":\"t\"}]}");
+
+            Assert.DoesNotContain("stopped the sub-agents", result);
+        }
     }
 }

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -128,5 +128,72 @@ namespace GxPT.Tests
             Assert.False(Dispatcher(new ScriptedStreamer()).HasAgents);
             Assert.True(Dispatcher(new ScriptedStreamer(), WriteAgent("x", "d", "b")).HasAgents);
         }
+
+        // ---- parallel fan-out (phase 7) ----
+
+        // A read-only agent (max_tier: readonly) - eligible for the parallel path.
+        private Agent WriteReadOnlyAgent(string slug, string desc)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file,
+                "---\nname: " + slug + "\ndescription: " + desc + "\nmax_tier: readonly\n---\nbody\n",
+                new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        // A streamer whose answer is derived from the request (the task in the last user message), so a
+        // parallel batch's results are deterministic regardless of which child runs first.
+        private sealed class TaskEchoStreamer : IChatStreamer
+        {
+            public void StreamChat(string model, System.Collections.Generic.IList<ChatMessage> messages,
+                System.Collections.Generic.IList<Newtonsoft.Json.Linq.JObject> tools, ClientProperties props,
+                Action<ChatCompletionChunk> onChunk, Action<string> onError, RequestCancellation cancel)
+            {
+                string task = "";
+                for (int i = messages.Count - 1; i >= 0; i--)
+                    if (messages[i].Role == "user") { task = messages[i].Content; break; }
+                if (onChunk != null)
+                    foreach (ChatCompletionChunk ch in Chunks.Text("answer for: " + task)) onChunk(ch);
+            }
+        }
+
+        [Fact]
+        public void ParallelDispatch_ReadOnlyBatch_AllResultsCorrect_InOrder()
+        {
+            Agent a = WriteReadOnlyAgent("ra", "Read A.");
+            Agent b = WriteReadOnlyAgent("rb", "Read B.");
+            Agent c = WriteReadOnlyAgent("rc", "Read C.");
+            var d = new AgentDispatcher(new System.Collections.Generic.List<Agent> { a, b, c },
+                new TaskEchoStreamer(), null, null, "m", null, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+
+            string result = d.Dispatch(
+                "{\"agents\":[{\"name\":\"ra\",\"task\":\"task-A\"}," +
+                "{\"name\":\"rb\",\"task\":\"task-B\"},{\"name\":\"rc\",\"task\":\"task-C\"}]}");
+
+            int ia = result.IndexOf("## Agent: ra");
+            int ib = result.IndexOf("## Agent: rb");
+            int ic = result.IndexOf("## Agent: rc");
+            Assert.True(ia >= 0 && ia < ib && ib < ic);     // order preserved
+            Assert.Contains("answer for: task-A", result);
+            Assert.Contains("answer for: task-B", result);
+            Assert.Contains("answer for: task-C", result);
+        }
+
+        [Fact]
+        public void RunsInParallel_OnlyWhenMultipleAndAllReadOnly()
+        {
+            Agent r1 = WriteReadOnlyAgent("r1", "ro");
+            Agent r2 = WriteReadOnlyAgent("r2", "ro");
+            Agent w = WriteAgent("w", "writes", "b"); // default max_tier = write
+
+            Agent[] all = new Agent[] { r1, r2, w };
+            Assert.True(AgentDispatcher.RunsInParallel(all, new System.Collections.Generic.List<int> { 0, 1 }));      // both read-only
+            Assert.False(AgentDispatcher.RunsInParallel(all, new System.Collections.Generic.List<int> { 0, 1, 2 }));  // one writer -> serial
+            Assert.False(AgentDispatcher.RunsInParallel(all, new System.Collections.Generic.List<int> { 0 }));       // single -> serial
+        }
     }
 }

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -260,6 +260,32 @@ namespace GxPT.Tests
             Assert.True(sawUserTask);
         }
 
+        [Theory]
+        [InlineData("abc123", 0)]
+        [InlineData("deadbeefcafe", 7)]
+        public void TranscriptLinks_RoundTrip(string key, int slot)
+        {
+            string url = AgentTranscriptLinks.Build(key, slot);
+            Assert.True(AgentTranscriptLinks.IsTranscriptLink(url));
+            string k; int s;
+            Assert.True(AgentTranscriptLinks.TryParse(url, out k, out s));
+            Assert.Equal(key, k);
+            Assert.Equal(slot, s);
+        }
+
+        [Theory]
+        [InlineData("https://example.com")]
+        [InlineData("gxpt-agent:")]
+        [InlineData("gxpt-agent:keyonly")]
+        [InlineData("gxpt-agent:key:notanumber")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TranscriptLinks_RejectsNonLinks(string url)
+        {
+            string k; int s;
+            Assert.False(AgentTranscriptLinks.TryParse(url, out k, out s));
+        }
+
         [Fact]
         public void TranscriptStore_RoundTripsByKeyAndIndex()
         {

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -202,12 +202,15 @@ namespace GxPT.Tests
         {
             private readonly object _gate = new object();
             public int FanOutStarts, FanOutEnds, Starts, Finishes, Cancellations, LastFanOutCount;
+            public int Activities, LastFanOutTaskCount;
 
-            public void OnFanOutStart(System.Collections.Generic.IList<string> slugs)
-            { lock (_gate) { FanOutStarts++; LastFanOutCount = slugs.Count; } }
+            public void OnFanOutStart(System.Collections.Generic.IList<string> slugs,
+                                      System.Collections.Generic.IList<string> tasks)
+            { lock (_gate) { FanOutStarts++; LastFanOutCount = slugs.Count; LastFanOutTaskCount = (tasks != null ? tasks.Count : 0); } }
             public void OnAgentStart(int index, string slug, string task) { lock (_gate) { Starts++; } }
             public void OnAgentFinished(int index, string slug, bool cancelled)
             { lock (_gate) { Finishes++; if (cancelled) Cancellations++; } }
+            public void OnAgentActivity(int index, string lastTool, int toolCount) { lock (_gate) { Activities++; } }
             public void OnFanOutEnd() { lock (_gate) { FanOutEnds++; } }
         }
 
@@ -227,8 +230,71 @@ namespace GxPT.Tests
             Assert.Equal(1, ui.FanOutStarts);
             Assert.Equal(1, ui.FanOutEnds);
             Assert.Equal(2, ui.LastFanOutCount);
+            Assert.Equal(2, ui.LastFanOutTaskCount);   // tier 2: tasks travel with the slugs
             Assert.Equal(2, ui.Starts);
             Assert.Equal(2, ui.Finishes);
+        }
+
+        [Fact]
+        public void Dispatch_CapturesPerSlotChildTranscripts()
+        {
+            Agent a = WriteReadOnlyAgent("ra", "A");
+            Agent b = WriteReadOnlyAgent("rb", "B");
+            var d = new AgentDispatcher(new System.Collections.Generic.List<Agent> { a, b },
+                new TaskEchoStreamer(), null, null, "m", null, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+
+            d.Dispatch("{\"agents\":[{\"name\":\"ra\",\"task\":\"t1\"},{\"name\":\"rb\",\"task\":\"t2\"}]}");
+
+            AgentTranscript[] ts = d.LastTranscripts;
+            Assert.NotNull(ts);
+            Assert.Equal(2, ts.Length);
+            Assert.NotNull(ts[0]);
+            Assert.Equal("ra", ts[0].Slug);
+            Assert.Equal("t1", ts[0].Task);
+            // The child's message list carries at least the user task and the assistant answer.
+            Assert.NotNull(ts[0].Messages);
+            bool sawUserTask = false;
+            foreach (ChatMessage m in ts[0].Messages)
+                if (m != null && m.Role == "user" && m.Content == "t1") sawUserTask = true;
+            Assert.True(sawUserTask);
+        }
+
+        [Fact]
+        public void TranscriptStore_RoundTripsByKeyAndIndex()
+        {
+            ChatMessage msg = new ChatMessage("assistant", "hi");
+            AgentTranscript[] arr = new AgentTranscript[]
+            {
+                new AgentTranscript("ra", "t0", new System.Collections.Generic.List<ChatMessage> { msg }),
+                null
+            };
+            string key = "store-test-" + System.Guid.NewGuid().ToString("N");
+            AgentTranscriptStore.Put(key, arr);
+
+            Assert.Same(arr[0], AgentTranscriptStore.Get(key, 0));
+            Assert.Null(AgentTranscriptStore.Get(key, 1));        // null slot
+            Assert.Null(AgentTranscriptStore.Get(key, 5));        // out of range
+            Assert.Null(AgentTranscriptStore.Get("no-such-key", 0));
+        }
+
+        [Fact]
+        public void Dispatch_UnknownSlot_HasNullTranscript()
+        {
+            Agent a = WriteReadOnlyAgent("ra", "A");
+            var d = new AgentDispatcher(new System.Collections.Generic.List<Agent> { a },
+                new TaskEchoStreamer(), null, null, "m", null, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+
+            // slot 0 = unknown agent (no child), slot 1 = real agent
+            d.Dispatch("{\"agents\":[{\"name\":\"ghost\",\"task\":\"t0\"},{\"name\":\"ra\",\"task\":\"t1\"}]}");
+
+            AgentTranscript[] ts = d.LastTranscripts;
+            Assert.NotNull(ts);
+            Assert.Equal(2, ts.Length);
+            Assert.Null(ts[0]);             // unknown slot ran no child
+            Assert.NotNull(ts[1]);
+            Assert.Equal("ra", ts[1].Slug);
         }
 
         [Fact]

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using GxPT;
+using GxPT.Tests.Mcp;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentDispatcherTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public AgentDispatcherTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gxpt_dispatch_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        // Writes an agent file under _dir and returns the loaded Agent (so FilePath/body are real).
+        private Agent WriteAgent(string slug, string desc, string body)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file, "---\nname: " + slug + "\ndescription: " + desc + "\n---\n" + body + "\n",
+                              new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        // A dispatcher with a null registry (child runs a pure text turn) and an allow-all approval (null
+        // => the child orchestrator defaults to allow-all).
+        private static AgentDispatcher Dispatcher(ScriptedStreamer streamer, params Agent[] agents)
+        {
+            return new AgentDispatcher(new List<Agent>(agents), streamer, null, null,
+                "parent-model", null, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+        }
+
+        [Fact]
+        public void SingleDispatch_RunsChild_ReturnsFinalAnswer()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore code.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("Found it in foo.cs:42"));
+
+            string result = Dispatcher(streamer, a)
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"find X\"}]}");
+
+            Assert.Contains("## Agent: explorer", result);
+            Assert.Contains("Found it in foo.cs:42", result);
+        }
+
+        [Fact]
+        public void UnknownAgent_ReturnsNote_KnownStillRuns()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));   // served to the one known agent
+
+            string result = Dispatcher(streamer, a)
+                .Dispatch("{\"agents\":[{\"name\":\"ghost\",\"task\":\"t\"},{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.Contains("Unknown agent: ghost", result);
+            Assert.Contains("done", result);
+        }
+
+        [Fact]
+        public void BatchDispatch_ConcatenatesLabeledSections()
+        {
+            Agent a = WriteAgent("a1", "One.", "b1");
+            Agent b = WriteAgent("a2", "Two.", "b2");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("answer-1"));
+            streamer.Turns.Add(Chunks.Text("answer-2"));
+
+            string result = Dispatcher(streamer, a, b)
+                .Dispatch("{\"agents\":[{\"name\":\"a1\",\"task\":\"t\"},{\"name\":\"a2\",\"task\":\"t\"}]}");
+
+            Assert.Contains("## Agent: a1", result);
+            Assert.Contains("answer-1", result);
+            Assert.Contains("## Agent: a2", result);
+            Assert.Contains("answer-2", result);
+        }
+
+        [Fact]
+        public void EmptyOrMalformed_ReturnsNote()
+        {
+            AgentDispatcher d = Dispatcher(new ScriptedStreamer());
+            Assert.Equal("No agents specified to dispatch.", d.Dispatch("{\"agents\":[]}"));
+            Assert.Equal("No agents specified to dispatch.", d.Dispatch("not json"));
+            Assert.Equal("No agents specified to dispatch.", d.Dispatch(null));
+        }
+
+        [Fact]
+        public void MissingTask_ReturnsNote()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "body");
+            string result = Dispatcher(new ScriptedStreamer(), a)
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\"}]}");
+            Assert.Contains("No task was provided", result);
+        }
+
+        [Fact]
+        public void DispatchAgentDef_ShapeAndPredicates()
+        {
+            AgentDispatcher d = Dispatcher(new ScriptedStreamer());
+            JObject def = d.DispatchAgentDef();
+
+            Assert.Equal("function", (string)def["type"]);
+            Assert.Equal("dispatch_agent", (string)def["function"]["name"]);
+            Assert.NotNull(def["function"]["parameters"]["properties"]["agents"]);
+            Assert.True(d.IsDispatchAgent("dispatch_agent"));
+            Assert.False(d.IsDispatchAgent("files__read"));
+        }
+
+        [Fact]
+        public void HasAgents_ReflectsCatalog()
+        {
+            Assert.False(Dispatcher(new ScriptedStreamer()).HasAgents);
+            Assert.True(Dispatcher(new ScriptedStreamer(), WriteAgent("x", "d", "b")).HasAgents);
+        }
+    }
+}

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -195,5 +195,52 @@ namespace GxPT.Tests
             Assert.False(AgentDispatcher.RunsInParallel(all, new System.Collections.Generic.List<int> { 0, 1, 2 }));  // one writer -> serial
             Assert.False(AgentDispatcher.RunsInParallel(all, new System.Collections.Generic.List<int> { 0 }));       // single -> serial
         }
+
+        // ---- observability hooks (phase 7b engine) ----
+
+        private sealed class FakeActivityUi : IAgentActivityUi
+        {
+            private readonly object _gate = new object();
+            public int FanOutStarts, FanOutEnds, Starts, Finishes, LastFanOutCount;
+
+            public void OnFanOutStart(System.Collections.Generic.IList<string> slugs)
+            { lock (_gate) { FanOutStarts++; LastFanOutCount = slugs.Count; } }
+            public void OnAgentStart(int index, string slug, string task) { lock (_gate) { Starts++; } }
+            public void OnAgentFinished(int index, string slug) { lock (_gate) { Finishes++; } }
+            public void OnFanOutEnd() { lock (_gate) { FanOutEnds++; } }
+        }
+
+        [Fact]
+        public void ActivityUi_ReportsFanOutAndPerAgentLifecycle()
+        {
+            Agent a = WriteReadOnlyAgent("ra", "A");
+            Agent b = WriteReadOnlyAgent("rb", "B");
+            var ui = new FakeActivityUi();
+            var d = new AgentDispatcher(new System.Collections.Generic.List<Agent> { a, b },
+                new TaskEchoStreamer(), null, null, "m", null, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+            d.ActivityUi = ui;
+
+            d.Dispatch("{\"agents\":[{\"name\":\"ra\",\"task\":\"t1\"},{\"name\":\"rb\",\"task\":\"t2\"}]}");
+
+            Assert.Equal(1, ui.FanOutStarts);
+            Assert.Equal(1, ui.FanOutEnds);
+            Assert.Equal(2, ui.LastFanOutCount);
+            Assert.Equal(2, ui.Starts);
+            Assert.Equal(2, ui.Finishes);
+        }
+
+        [Fact]
+        public void ActivityUi_NoFanOutWhenNothingRunnable()
+        {
+            var ui = new FakeActivityUi();
+            AgentDispatcher d = Dispatcher(new ScriptedStreamer());   // no agents in catalog
+            d.ActivityUi = ui;
+
+            d.Dispatch("{\"agents\":[{\"name\":\"ghost\",\"task\":\"t\"}]}");
+
+            Assert.Equal(0, ui.FanOutStarts);   // nothing runnable -> no fan-out announced
+            Assert.Equal(0, ui.FanOutEnds);
+        }
     }
 }

--- a/GxPT.Tests/AgentEnablementTests.cs
+++ b/GxPT.Tests/AgentEnablementTests.cs
@@ -1,0 +1,25 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentEnablementTests
+    {
+        [Theory]
+        [InlineData(null, false, false)]   // no override, global off  -> off (the default)
+        [InlineData(null, true, true)]     // no override, global on   -> on
+        [InlineData(true, false, true)]    // override on  beats global off
+        [InlineData(false, true, false)]   // override off beats global on
+        public void FeatureEnabled_OverrideBeatsGlobal(bool? convOverride, bool global, bool expected)
+        {
+            Assert.Equal(expected, AgentEnablement.FeatureEnabled(convOverride, global));
+        }
+
+        [Fact]
+        public void GlobalDefault_IsOff()
+        {
+            Assert.False(AgentEnablement.GlobalDefault);
+            Assert.False(AgentEnablement.FeatureEnabled(null, AgentEnablement.GlobalDefault));
+        }
+    }
+}

--- a/GxPT.Tests/AgentEnablementTests.cs
+++ b/GxPT.Tests/AgentEnablementTests.cs
@@ -16,10 +16,13 @@ namespace GxPT.Tests
         }
 
         [Fact]
-        public void GlobalDefault_IsOff()
+        public void GlobalDefault_IsOn()
         {
-            Assert.False(AgentEnablement.GlobalDefault);
-            Assert.False(AgentEnablement.FeatureEnabled(null, AgentEnablement.GlobalDefault));
+            // On by default (a first-party agent suite ships with the app).
+            Assert.True(AgentEnablement.GlobalDefault);
+            Assert.True(AgentEnablement.FeatureEnabled(null, AgentEnablement.GlobalDefault));
+            // An explicit per-conversation override still wins.
+            Assert.False(AgentEnablement.FeatureEnabled(false, AgentEnablement.GlobalDefault));
         }
     }
 }

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -130,6 +130,24 @@ namespace GxPT.Tests
             Assert.Equal("body line", fm.Body);
         }
 
+        [Theory]
+        [InlineData("max_turns: 50", 50)]
+        [InlineData("max_turns: 0", 0)]        // 0 stays unset
+        [InlineData("max_turns: -5", 0)]       // negative ignored -> unset
+        [InlineData("max_turns: abc", 0)]      // non-numeric ignored -> unset
+        public void Parse_MaxTurns(string line, int expected)
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\n" + line + "\n---\nb\n");
+            Assert.Equal(expected, fm.MaxTurns);
+        }
+
+        [Fact]
+        public void Parse_MaxTurns_DefaultsToZeroWhenAbsent()
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\n---\nb\n");
+            Assert.Equal(0, fm.MaxTurns);
+        }
+
         [Fact]
         public void Parse_NoFrontmatter_WholeTextIsBody()
         {

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -73,27 +73,29 @@ namespace GxPT.Tests
             Assert.Null(absent.Tools);
         }
 
+        // Expected is the enum's name (a string), not the enum itself: a public xUnit test method can't
+        // take an `internal` enum parameter (CS0051). The body compares against fm.MaxTier.ToString().
         [Theory]
-        [InlineData("readonly", AgentMaxTier.ReadOnly)]
-        [InlineData("read-only", AgentMaxTier.ReadOnly)]
-        [InlineData("WRITE", AgentMaxTier.Write)]
-        [InlineData("destructive", AgentMaxTier.Destructive)]
-        [InlineData("nonsense", AgentMaxTier.Write)]   // invalid => default Write
-        public void Parse_MaxTier(string value, AgentMaxTier expected)
+        [InlineData("readonly", "ReadOnly")]
+        [InlineData("read-only", "ReadOnly")]
+        [InlineData("WRITE", "Write")]
+        [InlineData("destructive", "Destructive")]
+        [InlineData("nonsense", "Write")]   // invalid => default Write
+        public void Parse_MaxTier(string value, string expected)
         {
             AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nmax_tier: " + value + "\n---\nb\n");
-            Assert.Equal(expected, fm.MaxTier);
+            Assert.Equal(expected, fm.MaxTier.ToString());
         }
 
         [Theory]
-        [InlineData("gated", AgentAutonomy.Gated)]
-        [InlineData("auto-readonly", AgentAutonomy.AutoReadOnly)]
-        [InlineData("Auto_ReadOnly", AgentAutonomy.AutoReadOnly)]
-        [InlineData("bogus", AgentAutonomy.Gated)]     // invalid => default Gated
-        public void Parse_Autonomy(string value, AgentAutonomy expected)
+        [InlineData("gated", "Gated")]
+        [InlineData("auto-readonly", "AutoReadOnly")]
+        [InlineData("Auto_ReadOnly", "AutoReadOnly")]
+        [InlineData("bogus", "Gated")]     // invalid => default Gated
+        public void Parse_Autonomy(string value, string expected)
         {
             AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nautonomy: " + value + "\n---\nb\n");
-            Assert.Equal(expected, fm.Autonomy);
+            Assert.Equal(expected, fm.Autonomy.ToString());
         }
 
         [Fact]

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -14,7 +14,6 @@ namespace GxPT.Tests
                 "description: Use to search the codebase. Read-only.\n" +
                 "tools: [files__read, files__list, files__search]\n" +
                 "max_tier: readonly\n" +
-                "autonomy: auto-readonly\n" +
                 "model: anthropic/claude-sonnet-4-6\n" +
                 "---\n" +
                 "\n" +
@@ -27,7 +26,6 @@ namespace GxPT.Tests
             Assert.Equal("Use to search the codebase. Read-only.", fm.Description);
             Assert.Equal(new string[] { "files__read", "files__list", "files__search" }, fm.Tools);
             Assert.Equal(AgentMaxTier.ReadOnly, fm.MaxTier);
-            Assert.Equal(AgentAutonomy.AutoReadOnly, fm.Autonomy);
             Assert.Equal("anthropic/claude-sonnet-4-6", fm.Model);
             Assert.Equal("You are a code-exploration specialist.", fm.Body);
         }
@@ -46,7 +44,6 @@ namespace GxPT.Tests
 
             Assert.Null(fm.Tools);                          // absent => null (resolved to ReadOnly default later)
             Assert.Equal(AgentMaxTier.Write, fm.MaxTier);   // default ceiling
-            Assert.Equal(AgentAutonomy.Gated, fm.Autonomy); // default dial
             Assert.Null(fm.Model);
         }
 
@@ -85,17 +82,6 @@ namespace GxPT.Tests
         {
             AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nmax_tier: " + value + "\n---\nb\n");
             Assert.Equal(expected, fm.MaxTier.ToString());
-        }
-
-        [Theory]
-        [InlineData("gated", "Gated")]
-        [InlineData("auto-readonly", "AutoReadOnly")]
-        [InlineData("Auto_ReadOnly", "AutoReadOnly")]
-        [InlineData("bogus", "Gated")]     // invalid => default Gated
-        public void Parse_Autonomy(string value, string expected)
-        {
-            AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nautonomy: " + value + "\n---\nb\n");
-            Assert.Equal(expected, fm.Autonomy.ToString());
         }
 
         [Fact]

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -1,0 +1,141 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentFrontmatterTests
+    {
+        [Fact]
+        public void Parse_ReadsAllKeysAndBody()
+        {
+            string text =
+                "---\n" +
+                "name: Code Explorer\n" +
+                "description: Use to search the codebase. Read-only.\n" +
+                "tools: [files__read, files__list, files__search]\n" +
+                "max_tier: readonly\n" +
+                "autonomy: auto-readonly\n" +
+                "model: anthropic/claude-sonnet-4-6\n" +
+                "---\n" +
+                "\n" +
+                "You are a code-exploration specialist.\n";
+
+            AgentFrontmatter fm = AgentFrontmatter.Parse(text);
+
+            Assert.True(fm.HasFrontmatter);
+            Assert.Equal("Code Explorer", fm.Name);
+            Assert.Equal("Use to search the codebase. Read-only.", fm.Description);
+            Assert.Equal(new string[] { "files__read", "files__list", "files__search" }, fm.Tools);
+            Assert.Equal(AgentMaxTier.ReadOnly, fm.MaxTier);
+            Assert.Equal(AgentAutonomy.AutoReadOnly, fm.Autonomy);
+            Assert.Equal("anthropic/claude-sonnet-4-6", fm.Model);
+            Assert.Equal("You are a code-exploration specialist.", fm.Body);
+        }
+
+        [Fact]
+        public void Parse_DefaultsWhenKeysOmitted()
+        {
+            string text =
+                "---\n" +
+                "name: Plain\n" +
+                "description: Minimal agent.\n" +
+                "---\n" +
+                "body\n";
+
+            AgentFrontmatter fm = AgentFrontmatter.Parse(text);
+
+            Assert.Null(fm.Tools);                          // absent => null (resolved to ReadOnly default later)
+            Assert.Equal(AgentMaxTier.Write, fm.MaxTier);   // default ceiling
+            Assert.Equal(AgentAutonomy.Gated, fm.Autonomy); // default dial
+            Assert.Null(fm.Model);
+        }
+
+        [Fact]
+        public void ParseToolList_Variants()
+        {
+            Assert.Equal(new string[] { "a", "b" }, AgentFrontmatter.ParseToolList("[a, b]"));
+            Assert.Equal(new string[] { "*" }, AgentFrontmatter.ParseToolList("[*]"));
+            Assert.Equal(new string[] { "files__read" }, AgentFrontmatter.ParseToolList("files__read")); // bare single
+            Assert.Equal(new string[] { "a", "b" }, AgentFrontmatter.ParseToolList("[\"a\", 'b']"));      // quotes stripped
+            Assert.Empty(AgentFrontmatter.ParseToolList("[]"));     // explicit empty => zero-length, not null
+            Assert.Null(AgentFrontmatter.ParseToolList(""));        // blank => null (not specified)
+            Assert.Null(AgentFrontmatter.ParseToolList(null));
+        }
+
+        [Fact]
+        public void Parse_EmptyToolsListIsDistinctFromAbsent()
+        {
+            AgentFrontmatter present = AgentFrontmatter.Parse("---\ndescription: d\ntools: []\n---\nb\n");
+            Assert.NotNull(present.Tools);
+            Assert.Empty(present.Tools);
+
+            AgentFrontmatter absent = AgentFrontmatter.Parse("---\ndescription: d\n---\nb\n");
+            Assert.Null(absent.Tools);
+        }
+
+        [Theory]
+        [InlineData("readonly", AgentMaxTier.ReadOnly)]
+        [InlineData("read-only", AgentMaxTier.ReadOnly)]
+        [InlineData("WRITE", AgentMaxTier.Write)]
+        [InlineData("destructive", AgentMaxTier.Destructive)]
+        [InlineData("nonsense", AgentMaxTier.Write)]   // invalid => default Write
+        public void Parse_MaxTier(string value, AgentMaxTier expected)
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nmax_tier: " + value + "\n---\nb\n");
+            Assert.Equal(expected, fm.MaxTier);
+        }
+
+        [Theory]
+        [InlineData("gated", AgentAutonomy.Gated)]
+        [InlineData("auto-readonly", AgentAutonomy.AutoReadOnly)]
+        [InlineData("Auto_ReadOnly", AgentAutonomy.AutoReadOnly)]
+        [InlineData("bogus", AgentAutonomy.Gated)]     // invalid => default Gated
+        public void Parse_Autonomy(string value, AgentAutonomy expected)
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse("---\ndescription: d\nautonomy: " + value + "\n---\nb\n");
+            Assert.Equal(expected, fm.Autonomy);
+        }
+
+        [Fact]
+        public void Parse_UnknownKeysIgnored_FirstWins()
+        {
+            string text =
+                "---\n" +
+                "description: First.\n" +
+                "description: Second.\n" +   // duplicate ignored (first wins)
+                "max_tier: readonly\n" +
+                "max_tier: destructive\n" +  // duplicate ignored (first wins)
+                "color: blue\n" +            // unknown key ignored
+                "---\n" +
+                "body\n";
+
+            AgentFrontmatter fm = AgentFrontmatter.Parse(text);
+
+            Assert.Equal("First.", fm.Description);
+            Assert.Equal(AgentMaxTier.ReadOnly, fm.MaxTier);
+        }
+
+        [Fact]
+        public void Parse_IsCrlfAgnosticAndStripsBom()
+        {
+            string text = "\uFEFF---\r\ndescription: D\r\ntools: [a]\r\n---\r\nbody line\r\n";
+
+            AgentFrontmatter fm = AgentFrontmatter.Parse(text);
+
+            Assert.True(fm.HasFrontmatter);
+            Assert.Equal("D", fm.Description);
+            Assert.Equal(new string[] { "a" }, fm.Tools);
+            Assert.Equal("body line", fm.Body);
+        }
+
+        [Fact]
+        public void Parse_NoFrontmatter_WholeTextIsBody()
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse("just a body, no frontmatter");
+
+            Assert.False(fm.HasFrontmatter);
+            Assert.Null(fm.Description);
+            Assert.Equal("just a body, no frontmatter", fm.Body);
+        }
+    }
+}

--- a/GxPT.Tests/AgentInjectionTests.cs
+++ b/GxPT.Tests/AgentInjectionTests.cs
@@ -8,7 +8,7 @@ namespace GxPT.Tests
     {
         private static Agent A(string slug, string desc)
         {
-            return new Agent(slug, slug, desc, null, AgentMaxTier.Write, AgentAutonomy.Gated, null,
+            return new Agent(slug, slug, desc, null, AgentMaxTier.Write, null,
                              0, slug + ".md", AgentSource.Bundled);
         }
 

--- a/GxPT.Tests/AgentInjectionTests.cs
+++ b/GxPT.Tests/AgentInjectionTests.cs
@@ -9,7 +9,7 @@ namespace GxPT.Tests
         private static Agent A(string slug, string desc)
         {
             return new Agent(slug, slug, desc, null, AgentMaxTier.Write, AgentAutonomy.Gated, null,
-                             slug + ".md", AgentSource.Bundled);
+                             0, slug + ".md", AgentSource.Bundled);
         }
 
         [Fact]

--- a/GxPT.Tests/AgentInjectionTests.cs
+++ b/GxPT.Tests/AgentInjectionTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentInjectionTests
+    {
+        private static Agent A(string slug, string desc)
+        {
+            return new Agent(slug, slug, desc, null, AgentMaxTier.Write, AgentAutonomy.Gated, null,
+                             slug + ".md", AgentSource.Bundled);
+        }
+
+        [Fact]
+        public void BuildManifestMessage_NullOrEmpty_ReturnsNull()
+        {
+            Assert.Null(AgentInjection.BuildManifestMessage(null));
+            Assert.Null(AgentInjection.BuildManifestMessage(new List<Agent>()));
+        }
+
+        [Fact]
+        public void BuildManifestMessage_HasFramingAndManifestLines()
+        {
+            List<Agent> agents = new List<Agent>();
+            agents.Add(A("code-explorer", "Search the codebase."));
+            agents.Add(A("verify", "Run tests."));
+
+            string msg = AgentInjection.BuildManifestMessage(agents);
+
+            Assert.Contains("# Agents", msg);
+            Assert.Contains("dispatch_agent", msg);
+            Assert.Contains("- code-explorer - Search the codebase.", msg);
+            Assert.Contains("- verify - Run tests.", msg);
+        }
+    }
+}

--- a/GxPT.Tests/AgentRootsTests.cs
+++ b/GxPT.Tests/AgentRootsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Text;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Root/catalog resolution for agents - the AgentRoots analogue of SkillRootsTests.
+    public sealed class AgentRootsTests : IDisposable
+    {
+        private readonly string _root;
+
+        public AgentRootsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "gxpt_agentroots_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch { }
+        }
+
+        [Fact]
+        public void BundledRoot_AppendsAgentsDir()
+        {
+            Assert.Equal(Path.Combine("base", "agents"), AgentRoots.BundledRoot("base"));
+            Assert.Null(AgentRoots.BundledRoot(null));
+        }
+
+        [Fact]
+        public void ProjectRoot_IsUnderDotGxpt_OrNull()
+        {
+            string expected = Path.Combine(Path.Combine("work", ".gxpt"), "agents");
+            Assert.Equal(expected, AgentRoots.ProjectRoot("work"));
+            Assert.Null(AgentRoots.ProjectRoot(null));
+        }
+
+        [Fact]
+        public void BuildCatalog_DiscoversProjectAgentUnderDotGxpt()
+        {
+            string agentsDir = Path.Combine(Path.Combine(_root, ".gxpt"), "agents");
+            Directory.CreateDirectory(agentsDir);
+            File.WriteAllText(Path.Combine(agentsDir, "proj-agent.md"),
+                "---\ndescription: A project agent.\n---\nbody\n", new UTF8Encoding(false));
+
+            AgentCatalog cat = AgentRoots.BuildCatalog("no-such-exe-dir", _root);
+
+            Agent a;
+            Assert.True(cat.TryGet("proj-agent", out a));
+            Assert.Equal(AgentSource.Project, a.Source);
+        }
+    }
+}

--- a/GxPT.Tests/AgentToolResolverTests.cs
+++ b/GxPT.Tests/AgentToolResolverTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class AgentToolResolverTests
+    {
+        // A fixed tier table for the tests (private helper; internal ToolTier is fine in a private member).
+        private static ToolTier TierOf(string name)
+        {
+            switch (name)
+            {
+                case "files__read":
+                case "files__list":
+                case "git__status":
+                    return ToolTier.ReadOnly;
+                case "files__write":
+                case "files__edit":
+                case "git__commit":
+                    return ToolTier.Write;
+                case "files__delete":
+                case "git__push":
+                    return ToolTier.Destructive;
+                default:
+                    return ToolTier.Write;
+            }
+        }
+
+        private static readonly string[] Parent = new string[] {
+            "files__read", "files__list", "files__write", "files__edit", "files__delete",
+            "git__status", "git__commit", "git__push"
+        };
+
+        private static List<string> Resolve(string[] tools, AgentMaxTier tier)
+        {
+            return AgentToolResolver.Resolve(tools, tier, Parent, TierOf);
+        }
+
+        [Fact]
+        public void NullTools_InheritsReadOnlyOnly_RegardlessOfCeiling()
+        {
+            // Omitted allowlist => only ReadOnly tools, even with a Write ceiling (fail-safe default A5).
+            List<string> eff = Resolve(null, AgentMaxTier.Write);
+            Assert.Equal(new string[] { "files__read", "files__list", "git__status" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void StarTools_WithWriteCeiling_IncludesReadOnlyAndWrite_NotDestructive()
+        {
+            List<string> eff = Resolve(new string[] { "*" }, AgentMaxTier.Write);
+            Assert.Equal(new string[] {
+                "files__read", "files__list", "files__write", "files__edit",
+                "git__status", "git__commit"
+            }, eff.ToArray());
+            Assert.DoesNotContain("files__delete", eff);
+            Assert.DoesNotContain("git__push", eff);
+        }
+
+        [Fact]
+        public void StarTools_WithDestructiveCeiling_IncludesEverything_OrderPreserved()
+        {
+            List<string> eff = Resolve(new string[] { "*" }, AgentMaxTier.Destructive);
+            Assert.Equal(Parent, eff.ToArray());
+        }
+
+        [Fact]
+        public void StarTools_WithReadOnlyCeiling_CapsToReadOnly()
+        {
+            List<string> eff = Resolve(new string[] { "*" }, AgentMaxTier.ReadOnly);
+            Assert.Equal(new string[] { "files__read", "files__list", "git__status" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void PrefixGlob_MatchesServerFamily_TierCapped()
+        {
+            List<string> eff = Resolve(new string[] { "files__*" }, AgentMaxTier.Write);
+            Assert.Equal(new string[] { "files__read", "files__list", "files__write", "files__edit" }, eff.ToArray());
+            Assert.DoesNotContain("files__delete", eff);   // Destructive, over the Write ceiling
+            Assert.DoesNotContain("git__status", eff);     // different family
+        }
+
+        [Fact]
+        public void SuffixGlob_Matches()
+        {
+            List<string> eff = Resolve(new string[] { "*__read" }, AgentMaxTier.Write);
+            Assert.Equal(new string[] { "files__read" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void ExactAndMultiplePatterns()
+        {
+            List<string> eff = Resolve(new string[] { "files__read", "git__commit" }, AgentMaxTier.Write);
+            Assert.Equal(new string[] { "files__read", "git__commit" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void AllowlistedToolNotAvailableToParent_IsExcluded_NoEscalation()
+        {
+            // The agent lists a tool the parent can't call here -> it is simply absent (never granted).
+            List<string> eff = Resolve(new string[] { "files__read", "web__search" }, AgentMaxTier.Write);
+            Assert.Equal(new string[] { "files__read" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void DispatchAgent_NeverIncluded_EvenWithStar()
+        {
+            string[] parent = new string[] { "files__read", "dispatch_agent" };
+            List<string> eff = AgentToolResolver.Resolve(new string[] { "*" }, AgentMaxTier.Destructive, parent,
+                delegate(string n) { return ToolTier.ReadOnly; });
+            Assert.Equal(new string[] { "files__read" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void Hidden_IsParentMinusEffective()
+        {
+            List<string> hidden = AgentToolResolver.Hidden(new string[] { "files__*" }, AgentMaxTier.Write, Parent, TierOf);
+            Assert.Equal(new string[] { "files__delete", "git__status", "git__commit", "git__push" }, hidden.ToArray());
+        }
+
+        [Fact]
+        public void Resolve_DedupesParent_PreservesFirstOrder()
+        {
+            string[] parent = new string[] { "files__read", "files__read", "files__list" };
+            List<string> eff = AgentToolResolver.Resolve(new string[] { "*" }, AgentMaxTier.ReadOnly, parent, TierOf);
+            Assert.Equal(new string[] { "files__read", "files__list" }, eff.ToArray());
+        }
+
+        [Fact]
+        public void NullTierOf_TreatsEveryToolAsWrite()
+        {
+            string[] parent = new string[] { "x__a", "x__b" };
+            Assert.Empty(AgentToolResolver.Resolve(new string[] { "*" }, AgentMaxTier.ReadOnly, parent, null));
+            Assert.Equal(parent,
+                AgentToolResolver.Resolve(new string[] { "*" }, AgentMaxTier.Write, parent, null).ToArray());
+        }
+
+        // ---- WildcardMatch unit cases (all-public signature; no internal types) ----
+
+        [Theory]
+        [InlineData("*", "anything", true)]
+        [InlineData("files__read", "files__read", true)]
+        [InlineData("files__read", "files__write", false)]
+        [InlineData("FILES__READ", "files__read", true)]      // case-insensitive
+        [InlineData("files__*", "files__read", true)]
+        [InlineData("files__*", "git__status", false)]
+        [InlineData("*__read", "files__read", true)]
+        [InlineData("*__read", "files__readme", false)]       // suffix must be at the end
+        [InlineData("a*c", "abc", true)]
+        [InlineData("a*c", "ac", true)]                       // '*' matches empty
+        [InlineData("a*c", "axyc", true)]
+        [InlineData("a*c", "abd", false)]
+        [InlineData("", "x", false)]                          // empty pattern matches nothing
+        public void WildcardMatch_Cases(string pattern, string name, bool expected)
+        {
+            Assert.Equal(expected, AgentToolResolver.WildcardMatch(pattern, name));
+        }
+    }
+}

--- a/GxPT.Tests/Commands/FakeSlashCommandContext.cs
+++ b/GxPT.Tests/Commands/FakeSlashCommandContext.cs
@@ -33,10 +33,12 @@ namespace GxPT.Tests.Commands
         public readonly FakeModelControl ModelStore = new FakeModelControl();
         public readonly FakeServerControl ServerStore = new FakeServerControl();
         public readonly FakeSkillEnablementStore SkillStore = new FakeSkillEnablementStore();
+        public readonly FakeAgentEnablementStore AgentStore = new FakeAgentEnablementStore();
 
         public IModelControl Models { get { return ModelStore; } }
         public IServerControl Servers { get { return ServerStore; } }
         public ISkillEnablementStore Skills { get { return SkillStore; } }
+        public IAgentEnablementStore Agents { get { return AgentStore; } }
 
         // ---- top-level state / recorded actions ----
         public List<string> Infos = new List<string>();
@@ -100,5 +102,13 @@ namespace GxPT.Tests.Commands
         { if (value.HasValue) ConvOverrides[slug] = value.Value; else ConvOverrides.Remove(slug); }
         public void ResetConversationSkills() { ConvFeatureOff = null; ConvOverrides.Clear(); }
         public void RefreshSkillsServer() { RefreshSkillsServerCount++; }
+    }
+
+    // Backs /toggle-agents: the per-conversation agents-enabled override (null = inherit global).
+    internal sealed class FakeAgentEnablementStore : IAgentEnablementStore
+    {
+        public bool? ConvAgentsEnabled;
+        public bool? GetConversationAgentsEnabled() { return ConvAgentsEnabled; }
+        public void SetConversationAgentsEnabled(bool? value) { ConvAgentsEnabled = value; }
     }
 }

--- a/GxPT.Tests/ConversationStoreTests.cs
+++ b/GxPT.Tests/ConversationStoreTests.cs
@@ -37,6 +37,28 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void RoundTrip_PreservesAgentsEnabled()
+        {
+            var convo = new Conversation(null);
+            convo.Id = "abc";
+            convo.AgentsEnabled = true;
+
+            var loaded = ConversationStore.LoadFromJson(null, ConversationStore.ToJson(convo));
+            Assert.Equal(true, loaded.AgentsEnabled);
+
+            convo.AgentsEnabled = false;
+            loaded = ConversationStore.LoadFromJson(null, ConversationStore.ToJson(convo));
+            Assert.Equal(false, loaded.AgentsEnabled);
+        }
+
+        [Fact]
+        public void LoadFromJson_MissingAgentsEnabled_InheritsGlobal()
+        {
+            var convo = ConversationStore.LoadFromJson(null, "{\"Id\":\"x\",\"Name\":\"N\",\"Messages\":[]}");
+            Assert.Null(convo.AgentsEnabled);   // absent -> inherit the global default
+        }
+
+        [Fact]
         public void LoadFromJson_NullOrEmpty_ReturnsNull()
         {
             Assert.Null(ConversationStore.LoadFromJson(null, null));

--- a/GxPT.Tests/ConversationUsageTests.cs
+++ b/GxPT.Tests/ConversationUsageTests.cs
@@ -1,0 +1,34 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    public sealed class ConversationUsageTests
+    {
+        [Fact]
+        public void RecordUsage_SubAgent_AddsToTotals_ButNotContextGauge()
+        {
+            var convo = new Conversation(null);
+
+            var parent = new ResponseUsage(); parent.PromptTokens = 1000; parent.Cost = 0.01m;
+            convo.RecordUsage(parent);              // parent's own request - moves the gauge
+            Assert.Equal(1000, convo.LastPromptTokens);
+
+            var child = new ResponseUsage(); child.PromptTokens = 9000; child.Cost = 0.05m;
+            convo.RecordUsage(child, false);        // sub-agent usage - totals only, no gauge move
+
+            Assert.Equal(1000, convo.LastPromptTokens);     // gauge unchanged (still the parent's size)
+            Assert.Equal(10000L, convo.TotalPromptTokens);  // totals include the child
+            Assert.Equal(0.06m, convo.TotalCost);           // cost includes the child
+        }
+
+        [Fact]
+        public void RecordUsage_Default_MovesContextGauge()
+        {
+            var convo = new Conversation(null);
+            var u = new ResponseUsage(); u.PromptTokens = 4242;
+            convo.RecordUsage(u);
+            Assert.Equal(4242, convo.LastPromptTokens);
+        }
+    }
+}

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentFrontmatter.cs" Link="Linked\Agents\AgentFrontmatter.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentCatalog.cs" Link="Linked\Agents\AgentCatalog.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentRoots.cs" Link="Linked\Agents\AgentRoots.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentToolResolver.cs" Link="Linked\Agents\AgentToolResolver.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="..\GxPT\Services\Agents\AgentCatalog.cs" Link="Linked\Agents\AgentCatalog.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentRoots.cs" Link="Linked\Agents\AgentRoots.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentToolResolver.cs" Link="Linked\Agents\AgentToolResolver.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -77,6 +77,8 @@
     <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentTranscript.cs" Link="Linked\Agents\AgentTranscript.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentTranscriptStore.cs" Link="Linked\Agents\AgentTranscriptStore.cs" />
     <Compile Include="..\GxPT\Services\Agents\IAgentActivityUi.cs" Link="Linked\Agents\IAgentActivityUi.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentToolResolver.cs" Link="Linked\Agents\AgentToolResolver.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentCatalog.cs" Link="Linked\Agents\AgentCatalog.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentRoots.cs" Link="Linked\Agents\AgentRoots.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentToolResolver.cs" Link="Linked\Agents\AgentToolResolver.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentAvailability.cs" Link="Linked\Agents\AgentAvailability.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -84,6 +84,8 @@
     <Compile Include="..\GxPT\Services\Commands\IModelControl.cs" Link="Linked\Commands\IModelControl.cs" />
     <Compile Include="..\GxPT\Services\Commands\IServerControl.cs" Link="Linked\Commands\IServerControl.cs" />
     <Compile Include="..\GxPT\Services\Commands\ISkillEnablementStore.cs" Link="Linked\Commands\ISkillEnablementStore.cs" />
+    <Compile Include="..\GxPT\Services\Commands\IAgentEnablementStore.cs" Link="Linked\Commands\IAgentEnablementStore.cs" />
+    <Compile Include="..\GxPT\Services\Commands\AgentCommands.cs" Link="Linked\Commands\AgentCommands.cs" />
     <Compile Include="..\GxPT\Services\Commands\ISlashCommand.cs" Link="Linked\Commands\ISlashCommand.cs" />
     <Compile Include="..\GxPT\Services\Commands\WorkspacePath.cs" Link="Linked\Commands\WorkspacePath.cs" />
     <Compile Include="..\GxPT\Services\Commands\IArgumentCompleter.cs" Link="Linked\Commands\IArgumentCompleter.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscript.cs" Link="Linked\Agents\AgentTranscript.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscriptStore.cs" Link="Linked\Agents\AgentTranscriptStore.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentTranscriptPersistence.cs" Link="Linked\Agents\AgentTranscriptPersistence.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscriptLinks.cs" Link="Linked\Agents\AgentTranscriptLinks.cs" />
     <Compile Include="..\GxPT\Services\Agents\IAgentActivityUi.cs" Link="Linked\Agents\IAgentActivityUi.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -77,6 +77,8 @@
     <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
+    <Compile Include="..\GxPT\Services\Agents\IAgentLiveSink.cs" Link="Linked\Agents\IAgentLiveSink.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentLiveStream.cs" Link="Linked\Agents\AgentLiveStream.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscript.cs" Link="Linked\Agents\AgentTranscript.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscriptStore.cs" Link="Linked\Agents\AgentTranscriptStore.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscriptPersistence.cs" Link="Linked\Agents\AgentTranscriptPersistence.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -69,6 +69,10 @@
     <Compile Include="..\GxPT\Services\Skills\SkillEnablement.cs" Link="Linked\Skills\SkillEnablement.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillResolve.cs" Link="Linked\Skills\SkillResolve.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillToolGate.cs" Link="Linked\Skills\SkillToolGate.cs" />
+    <Compile Include="..\GxPT\Services\Agents\Agent.cs" Link="Linked\Agents\Agent.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentFrontmatter.cs" Link="Linked\Agents\AgentFrontmatter.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentCatalog.cs" Link="Linked\Agents\AgentCatalog.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentRoots.cs" Link="Linked\Agents\AgentRoots.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentInjection.cs" Link="Linked\Agents\AgentInjection.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentEnablement.cs" Link="Linked\Agents\AgentEnablement.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
+    <Compile Include="..\GxPT\Services\Agents\IAgentActivityUi.cs" Link="Linked\Agents\IAgentActivityUi.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashArgs.cs" Link="Linked\Commands\SlashArgs.cs" />

--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\GxPT\Services\Agents\AgentDispatcher.cs" Link="Linked\Agents\AgentDispatcher.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscript.cs" Link="Linked\Agents\AgentTranscript.cs" />
     <Compile Include="..\GxPT\Services\Agents\AgentTranscriptStore.cs" Link="Linked\Agents\AgentTranscriptStore.cs" />
+    <Compile Include="..\GxPT\Services\Agents\AgentTranscriptLinks.cs" Link="Linked\Agents\AgentTranscriptLinks.cs" />
     <Compile Include="..\GxPT\Services\Agents\IAgentActivityUi.cs" Link="Linked\Agents\IAgentActivityUi.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandKind.cs" Link="Linked\Commands\SlashCommandKind.cs" />
     <Compile Include="..\GxPT\Services\Commands\SlashCommandResult.cs" Link="Linked\Commands\SlashCommandResult.cs" />

--- a/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
+++ b/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // The user-stop wrap-up: when a dispatch_agent fan-out was cancelled by the user (its GroupCancellation
+    // is tripped), the orchestrator forces the next model call to tool_choice "none" so the model produces
+    // a text summary + "how should I proceed?" rather than charging into more tool calls.
+    public sealed class OrchestratorAgentStopTests
+    {
+        [Fact]
+        public void UserStoppedDispatch_ForcesTextOnlyNextCall()
+        {
+            // Parent stream: iteration 0 calls dispatch_agent; iteration 1 is the (forced) text wrap-up.
+            ScriptedStreamer parent = new ScriptedStreamer();
+            parent.Turns.Add(Chunks.OneToolCall("call_1", "dispatch_agent",
+                "{\"agents\":[{\"name\":\"x\",\"task\":\"t\"}]}"));
+            parent.Turns.Add(Chunks.Text("Here is a summary so far; how would you like to proceed?"));
+
+            // A dispatcher whose group is already cancelled: the child bails immediately, the dispatch
+            // returns partial + the stop directive, and the orchestrator should force the wrap-up.
+            RequestCancellation group = new RequestCancellation();
+            group.Cancel();
+            Agent agent = new Agent("x", "x", "d", null, AgentMaxTier.ReadOnly, AgentAutonomy.Gated, null, 0,
+                "nonexistent.md", AgentSource.Bundled);
+            AgentDispatcher dispatcher = new AgentDispatcher(new List<Agent> { agent }, new ScriptedStreamer(),
+                null, null, "m", null, null, delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+            dispatcher.GroupCancellation = group;
+
+            McpChatOrchestrator orch = new McpChatOrchestrator(parent, null, null, "m", null);
+            orch.AgentDispatcher = dispatcher;
+
+            List<ChatMessage> history = new List<ChatMessage>();
+            history.Add(new ChatMessage("user", "go"));
+            orch.RunTurn(history, new RecordingUi());
+
+            Assert.True(parent.Calls >= 2);
+            Assert.Null(parent.SeenProps[0].ToolChoice);            // the dispatch call: normal auto
+            Assert.Equal("none", parent.SeenProps[1].ToolChoice);   // the wrap-up call: forced text-only
+
+            string last = null;
+            for (int i = history.Count - 1; i >= 0; i--)
+                if (history[i].Role == "assistant" && !string.IsNullOrEmpty(history[i].Content))
+                { last = history[i].Content; break; }
+            Assert.Contains("how would you like to proceed", last);
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
+++ b/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
@@ -22,7 +22,7 @@ namespace GxPT.Tests.Mcp
             // returns partial + the stop directive, and the orchestrator should force the wrap-up.
             RequestCancellation group = new RequestCancellation();
             group.Cancel();
-            Agent agent = new Agent("x", "x", "d", null, AgentMaxTier.ReadOnly, AgentAutonomy.Gated, null, 0,
+            Agent agent = new Agent("x", "x", "d", null, AgentMaxTier.ReadOnly, null, 0,
                 "nonexistent.md", AgentSource.Bundled);
             AgentDispatcher dispatcher = new AgentDispatcher(new List<Agent> { agent }, new ScriptedStreamer(),
                 null, null, "m", null, null, delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -118,8 +118,8 @@ namespace GxPT.Tests.Mcp
         public bool Completed;
 
         public void AppendTextDelta(string text) { Text.Append(text); }
-        public void OnToolCall(string functionName, string argumentsJson) { ToolCalls.Add(functionName); }
-        public void OnToolResult(string functionName, string resultText, bool isError)
+        public void OnToolCall(string functionName, string argumentsJson, string callId) { ToolCalls.Add(functionName); }
+        public void OnToolResult(string functionName, string resultText, bool isError, string callId)
         {
             ToolResults.Add(resultText);
             ToolErrors.Add(isError);

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -41,6 +41,27 @@ namespace GxPT.Tests.Mcp
             return new ToolApprovalPolicy(new ToolClassifier(), prompt, store, annotations);
         }
 
+        // ---- TierOf (used by the sub-agent tool resolver) ----
+
+        [Fact]
+        public void TierOf_FirstParty_MatchesTable()
+        {
+            var pol = Policy(new ScriptedPrompt(), new InMemoryApprovalStore());
+            Assert.Equal(ToolTier.ReadOnly, pol.TierOf("files__read"));
+            Assert.Equal(ToolTier.Write, pol.TierOf("files__write"));
+            Assert.Equal(ToolTier.Destructive, pol.TierOf("files__delete"));
+        }
+
+        [Fact]
+        public void TierOf_ThirdParty_UsesAnnotations_FailsClosed()
+        {
+            var ann = new FakeAnnotations().Set("acme__peek", JObject.Parse("{\"readOnlyHint\":true}"));
+            var pol = Policy(new ScriptedPrompt(), new InMemoryApprovalStore(), ann);
+            Assert.Equal(ToolTier.ReadOnly, pol.TierOf("acme__peek"));
+            // Unknown third-party with no annotation must not classify as ReadOnly (fails closed).
+            Assert.NotEqual(ToolTier.ReadOnly, pol.TierOf("acme__unknown"));
+        }
+
         // ---- classification (spec §2) ----
 
         [Fact]

--- a/GxPT.Tests/OrchestratorEphemeralTailTests.cs
+++ b/GxPT.Tests/OrchestratorEphemeralTailTests.cs
@@ -1,0 +1,48 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Covers the <agents> section added to the orchestrator's ephemeral context tail (phase 3): it sits
+    // after <skills> and before <available_tools>, and is omitted when empty.
+    public sealed class OrchestratorEphemeralTailTests
+    {
+        [Fact]
+        public void AgentsSection_OrderedAfterSkills_BeforeTools()
+        {
+            string tail = McpChatOrchestrator.BuildEphemeralContextText("mem", "sk", "ag", "tools");
+
+            int mem = tail.IndexOf("<memory>");
+            int sk = tail.IndexOf("<skills>");
+            int ag = tail.IndexOf("<agents>");
+            int tl = tail.IndexOf("<available_tools>");
+
+            Assert.True(mem >= 0 && sk >= 0 && ag >= 0 && tl >= 0);
+            Assert.True(mem < sk && sk < ag && ag < tl);
+            Assert.Contains("<agents>\nag\n</agents>", tail);
+        }
+
+        [Fact]
+        public void AgentsSection_OmittedWhenEmpty()
+        {
+            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, null, "tools");
+
+            Assert.DoesNotContain("<agents>", tail);
+            Assert.Contains("<available_tools>", tail);
+        }
+
+        [Fact]
+        public void OnlyAgents_StillProducesTail()
+        {
+            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, "ag", null);
+
+            Assert.Contains("<agents>\nag\n</agents>", tail);
+        }
+
+        [Fact]
+        public void AllEmpty_ReturnsNull()
+        {
+            Assert.Null(McpChatOrchestrator.BuildEphemeralContextText(null, null, null, null));
+        }
+    }
+}

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -72,8 +72,14 @@ namespace GxPT
 
         private void RecalcHeight()
         {
+            // Flexible: header line + one row per agent. The ceiling is sized to the dispatcher's batch
+            // maximum (1 + MaxAgentsPerCall rows) at the current font, so the realistic worst case always
+            // fits without clipping; it stays only as a defensive bound (the dispatcher caps the batch, so
+            // the panel never actually exceeds it).
+            int rowH = LineH() + 2;
             int lines = (_slugs != null) ? 1 + _slugs.Length : 1;
-            this.Height = Math.Min(Pad * 2 + lines * (LineH() + 2), 240);
+            int ceiling = Pad * 2 + (1 + AgentDispatcher.MaxAgentsPerCall) * rowH;
+            this.Height = Math.Min(Pad * 2 + lines * rowH, ceiling);
         }
 
         private Font BoldFont()

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -22,7 +22,15 @@ namespace GxPT
 
         private string[] _slugs;
         private int[] _state;
+        private string[] _tasks;        // tier 2: per-row task, shown as a hover tooltip
+        private string[] _lastTool;     // tier 2: most recent tool the child called (null until first call)
+        private int[] _toolCount;       // tier 2: how many tool calls the child has made
         private Font _boldFont;
+
+        // Per-row task tooltip (tier 2): the panel is owner-drawn with no child controls, so we drive a
+        // single ToolTip manually, retargeting it as the hovered row changes.
+        private ToolTip _tip;
+        private int _hoverRow = -1;
 
         // The "Stop" button: an owner-drawn region in the header that cancels the fan-out (trips the
         // dispatcher's GroupCancellation via _onStop). _stopRect is recomputed each paint and hit-tested
@@ -48,15 +56,24 @@ namespace GxPT
 
         // Start showing a fan-out of the given agents (in dispatch order), all queued. onStop (may be null)
         // is invoked when the user clicks the panel's Stop button.
-        public void BeginFanOut(IList<string> slugs, Action onStop)
+        public void BeginFanOut(IList<string> slugs, IList<string> tasks, Action onStop)
         {
             int n = slugs != null ? slugs.Count : 0;
             _slugs = new string[n];
             _state = new int[n];
-            for (int i = 0; i < n; i++) { _slugs[i] = slugs[i]; _state[i] = StateQueued; }
+            _tasks = new string[n];
+            _lastTool = new string[n];
+            _toolCount = new int[n];
+            for (int i = 0; i < n; i++)
+            {
+                _slugs[i] = slugs[i];
+                _state[i] = StateQueued;
+                _tasks[i] = (tasks != null && i < tasks.Count) ? tasks[i] : null;
+            }
             _onStop = onStop;
             _stopping = false;
             _stopHover = false;
+            _hoverRow = -1;
             // Match the theme background up front so there's no white flash before the first paint.
             try { this.BackColor = ThemeService.GetColors(IsDark()).AssistantBubbleBack; }
             catch { }
@@ -69,14 +86,28 @@ namespace GxPT
         public void SetDone(int index) { SetState(index, StateDone); }
         public void SetCancelled(int index) { SetState(index, StateCancelled); }
 
+        // Update a row's live activity line (tier 2): the latest tool the child called and the running count.
+        public void SetActivity(int index, string lastTool, int toolCount)
+        {
+            if (_lastTool == null || index < 0 || index >= _lastTool.Length) return;
+            _lastTool[index] = lastTool;
+            _toolCount[index] = toolCount;
+            Invalidate();
+        }
+
         public void EndFanOut()
         {
             this.Visible = false;
             _slugs = null;
             _state = null;
+            _tasks = null;
+            _lastTool = null;
+            _toolCount = null;
             _onStop = null;
             _stopping = false;
             _stopHover = false;
+            _hoverRow = -1;
+            if (_tip != null) _tip.SetToolTip(this, string.Empty);
             this.Cursor = Cursors.Default;
         }
 
@@ -182,9 +213,39 @@ namespace GxPT
                 else if (_state[i] == StateRunning) { tag = "[running]"; tagColor = cRunning; }
                 else if (_state[i] == StateCancelled) { tag = "[cancelled]"; tagColor = cCancelled; }
                 else { tag = "[queued]"; tagColor = cQueued; }
-                TextRenderer.DrawText(g, tag, this.Font, new Point(rowX + slugW + 8, y), tagColor, TextFormatFlags.NoPadding);
+                int tagX = rowX + slugW + 8;
+                TextRenderer.DrawText(g, tag, this.Font, new Point(tagX, y), tagColor, TextFormatFlags.NoPadding);
+
+                // Live activity line (tier 2): tool count, plus the latest tool while the child runs.
+                string activity = BuildActivity(i);
+                if (activity.Length > 0)
+                {
+                    int tagW = TextRenderer.MeasureText(g, tag, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+                    TextRenderer.DrawText(g, activity, this.Font, new Point(tagX + tagW + 8, y), cQueued, TextFormatFlags.NoPadding);
+                }
                 y += lineH;
             }
+        }
+
+        // The muted per-row activity text: "N tools" once the child has called any tool, with the latest
+        // tool's short name appended while it is still running (e.g. "3 tools - read"). Empty otherwise.
+        private string BuildActivity(int i)
+        {
+            if (_toolCount == null || i < 0 || i >= _toolCount.Length) return string.Empty;
+            int n = _toolCount[i];
+            if (n <= 0) return string.Empty;
+            string s = n + (n == 1 ? " tool" : " tools");
+            if (_state[i] == StateRunning && _lastTool != null && !string.IsNullOrEmpty(_lastTool[i]))
+                s += " - " + ShortTool(_lastTool[i]);
+            return s;
+        }
+
+        // The unqualified tool name (drop the "server__" prefix) so the activity line stays short.
+        private static string ShortTool(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return string.Empty;
+            int idx = name.LastIndexOf("__", StringComparison.Ordinal);
+            return idx >= 0 && idx + 2 < name.Length ? name.Substring(idx + 2) : name;
         }
 
         private bool OverStop(Point p)
@@ -202,6 +263,14 @@ namespace GxPT
                 this.Cursor = over ? Cursors.Hand : Cursors.Default;
                 Invalidate(_stopRect);
             }
+            // Retarget the task tooltip as the hovered row changes (no row, or over Stop -> clear).
+            int row = over ? -1 : RowAt(e.Location);
+            if (row != _hoverRow)
+            {
+                _hoverRow = row;
+                string task = (row >= 0 && _tasks != null && row < _tasks.Length) ? _tasks[row] : null;
+                EnsureTip().SetToolTip(this, string.IsNullOrEmpty(task) ? string.Empty : task);
+            }
         }
 
         protected override void OnMouseLeave(EventArgs e)
@@ -213,6 +282,36 @@ namespace GxPT
                 this.Cursor = Cursors.Default;
                 Invalidate(_stopRect);
             }
+            if (_hoverRow != -1)
+            {
+                _hoverRow = -1;
+                if (_tip != null) _tip.SetToolTip(this, string.Empty);
+            }
+        }
+
+        // The row index under a client point (the header is the first line; rows follow), or -1 if the
+        // point is on the header or below the last row. Mirrors the OnPaint row layout.
+        private int RowAt(Point p)
+        {
+            if (_slugs == null || _slugs.Length == 0) return -1;
+            int lineH = LineH() + 2;
+            int first = Pad + lineH;            // y of the first agent row (header occupies one line)
+            if (p.Y < first) return -1;
+            int row = (p.Y - first) / lineH;
+            return (row >= 0 && row < _slugs.Length) ? row : -1;
+        }
+
+        private ToolTip EnsureTip()
+        {
+            if (_tip == null)
+            {
+                _tip = new ToolTip();
+                _tip.ShowAlways = true;
+                _tip.AutoPopDelay = 30000;     // keep long tasks visible
+                _tip.InitialDelay = 400;
+                _tip.ReshowDelay = 100;
+            }
+            return _tip;
         }
 
         protected override void OnMouseDown(MouseEventArgs e)
@@ -242,6 +341,7 @@ namespace GxPT
         protected override void Dispose(bool disposing)
         {
             if (disposing && _boldFont != null) { _boldFont.Dispose(); _boldFont = null; }
+            if (disposing && _tip != null) { _tip.Dispose(); _tip = null; }
             base.Dispose(disposing);
         }
     }

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -148,7 +148,7 @@ namespace GxPT
             // Stop button, right-aligned in the header row.
             if (_onStop != null)
             {
-                string btnText = _stopping ? "Stopping..." : "Stop";
+                string btnText = _stopping ? "Stopping..." : "Stop agents";
                 int btnW = TextRenderer.MeasureText(g, btnText, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width + 16;
                 int btnX = this.ClientRectangle.Width - Pad - btnW - 1;
                 if (btnX < Pad) btnX = Pad;

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -16,6 +16,7 @@ namespace GxPT
         private const int StateQueued = 0;
         private const int StateRunning = 1;
         private const int StateDone = 2;
+        private const int StateCancelled = 3;
         private const int Pad = 8;
         private const int RowIndent = 14;
 
@@ -66,6 +67,7 @@ namespace GxPT
 
         public void SetRunning(int index) { SetState(index, StateRunning); }
         public void SetDone(int index) { SetState(index, StateDone); }
+        public void SetCancelled(int index) { SetState(index, StateCancelled); }
 
         public void EndFanOut()
         {
@@ -135,14 +137,18 @@ namespace GxPT
             Color cDone = dark ? Color.FromArgb(126, 204, 126) : Color.FromArgb(34, 139, 34);
             Color cRunning = tc.Link;
             Color cQueued = dark ? Color.FromArgb(150, 150, 150) : Color.FromArgb(120, 120, 120);
+            Color cCancelled = dark ? Color.FromArgb(240, 120, 120) : Color.FromArgb(192, 0, 0);
 
-            int done = 0, running = 0;
+            int done = 0, running = 0, cancelled = 0;
             for (int i = 0; i < _state.Length; i++)
             {
                 if (_state[i] == StateDone) done++;
                 else if (_state[i] == StateRunning) running++;
+                else if (_state[i] == StateCancelled) cancelled++;
             }
-            string header = "Sub-agents: " + running + " running, " + done + " of " + _slugs.Length + " done";
+            string header = "Sub-agents: " + running + " running, " + done + " done";
+            if (cancelled > 0) header += ", " + cancelled + " cancelled";
+            header += " (" + _slugs.Length + " total)";
             TextRenderer.DrawText(g, header, BoldFont(), new Point(Pad, y), tc.UiForeground, TextFormatFlags.NoPadding);
 
             // Stop button, right-aligned in the header row.
@@ -174,6 +180,7 @@ namespace GxPT
                 string tag; Color tagColor;
                 if (_state[i] == StateDone) { tag = "[done]"; tagColor = cDone; }
                 else if (_state[i] == StateRunning) { tag = "[running]"; tagColor = cRunning; }
+                else if (_state[i] == StateCancelled) { tag = "[cancelled]"; tagColor = cCancelled; }
                 else { tag = "[queued]"; tagColor = cQueued; }
                 TextRenderer.DrawText(g, tag, this.Font, new Point(rowX + slugW + 8, y), tagColor, TextFormatFlags.NoPadding);
                 y += lineH;

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -32,6 +32,13 @@ namespace GxPT
         private ToolTip _tip;
         private int _hoverRow = -1;
 
+        // Per-row "View transcript" link (tier 3 "watch live"): _onViewTranscript(row) opens the streaming
+        // viewer; _viewRects[i] is the row's link hit-rect (recomputed each paint); _hoverView is the
+        // row whose link is hovered (-1 = none).
+        private Action<int> _onViewTranscript;
+        private Rectangle[] _viewRects;
+        private int _hoverView = -1;
+
         // The "Stop" button: an owner-drawn region in the header that cancels the fan-out (trips the
         // dispatcher's GroupCancellation via _onStop). _stopRect is recomputed each paint and hit-tested
         // by the mouse handlers; _stopping latches after a click so the label reads "Stopping..." and
@@ -56,7 +63,7 @@ namespace GxPT
 
         // Start showing a fan-out of the given agents (in dispatch order), all queued. onStop (may be null)
         // is invoked when the user clicks the panel's Stop button.
-        public void BeginFanOut(IList<string> slugs, IList<string> tasks, Action onStop)
+        public void BeginFanOut(IList<string> slugs, IList<string> tasks, Action onStop, Action<int> onViewTranscript)
         {
             int n = slugs != null ? slugs.Count : 0;
             _slugs = new string[n];
@@ -64,6 +71,7 @@ namespace GxPT
             _tasks = new string[n];
             _lastTool = new string[n];
             _toolCount = new int[n];
+            _viewRects = new Rectangle[n];
             for (int i = 0; i < n; i++)
             {
                 _slugs[i] = slugs[i];
@@ -71,9 +79,11 @@ namespace GxPT
                 _tasks[i] = (tasks != null && i < tasks.Count) ? tasks[i] : null;
             }
             _onStop = onStop;
+            _onViewTranscript = onViewTranscript;
             _stopping = false;
             _stopHover = false;
             _hoverRow = -1;
+            _hoverView = -1;
             // Match the theme background up front so there's no white flash before the first paint.
             try { this.BackColor = ThemeService.GetColors(IsDark()).AssistantBubbleBack; }
             catch { }
@@ -103,10 +113,13 @@ namespace GxPT
             _tasks = null;
             _lastTool = null;
             _toolCount = null;
+            _viewRects = null;
             _onStop = null;
+            _onViewTranscript = null;
             _stopping = false;
             _stopHover = false;
             _hoverRow = -1;
+            _hoverView = -1;
             if (_tip != null) _tip.SetToolTip(this, string.Empty);
             this.Cursor = Cursors.Default;
         }
@@ -223,6 +236,22 @@ namespace GxPT
                     int tagW = TextRenderer.MeasureText(g, tag, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
                     TextRenderer.DrawText(g, activity, this.Font, new Point(tagX + tagW + 8, y), cQueued, TextFormatFlags.NoPadding);
                 }
+
+                // Per-row "View transcript" link (tier 3 "watch live"), right-aligned. Shown once the child
+                // has started (a queued row has no stream yet). Underlined-ish via the theme link color;
+                // its rect is hit-tested by the mouse handlers.
+                if (_onViewTranscript != null && _state[i] != StateQueued)
+                {
+                    string vt = "View transcript";
+                    int vtW = TextRenderer.MeasureText(g, vt, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+                    int vtX = this.ClientRectangle.Width - Pad - vtW - 1;
+                    if (vtX < tagX) vtX = tagX;
+                    Rectangle vr = new Rectangle(vtX, y, vtW, LineH());
+                    if (_viewRects != null && i < _viewRects.Length) _viewRects[i] = vr;
+                    Color vc = (_hoverView == i) ? tc.UiForeground : tc.Link;
+                    TextRenderer.DrawText(g, vt, this.Font, new Point(vtX, y), vc, TextFormatFlags.NoPadding);
+                }
+                else if (_viewRects != null && i < _viewRects.Length) _viewRects[i] = Rectangle.Empty;
                 y += lineH;
             }
         }
@@ -256,21 +285,32 @@ namespace GxPT
         protected override void OnMouseMove(MouseEventArgs e)
         {
             base.OnMouseMove(e);
-            bool over = OverStop(e.Location);
-            if (over != _stopHover)
-            {
-                _stopHover = over;
-                this.Cursor = over ? Cursors.Hand : Cursors.Default;
-                Invalidate(_stopRect);
-            }
-            // Retarget the task tooltip as the hovered row changes (no row, or over Stop -> clear).
-            int row = over ? -1 : RowAt(e.Location);
+            bool overStop = OverStop(e.Location);
+            if (overStop != _stopHover) { _stopHover = overStop; Invalidate(_stopRect); }
+
+            int vrow = overStop ? -1 : ViewRowAt(e.Location);
+            if (vrow != _hoverView) { _hoverView = vrow; Invalidate(); }
+
+            this.Cursor = (overStop || vrow >= 0) ? Cursors.Hand : Cursors.Default;
+
+            // Retarget the task tooltip as the hovered row changes (over Stop -> clear; over a row, incl.
+            // its View link, shows that row's task).
+            int row = overStop ? -1 : RowAt(e.Location);
             if (row != _hoverRow)
             {
                 _hoverRow = row;
                 string task = (row >= 0 && _tasks != null && row < _tasks.Length) ? _tasks[row] : null;
                 EnsureTip().SetToolTip(this, string.IsNullOrEmpty(task) ? string.Empty : task);
             }
+        }
+
+        // The row whose "View transcript" link contains the point, or -1.
+        private int ViewRowAt(Point p)
+        {
+            if (_onViewTranscript == null || _viewRects == null) return -1;
+            for (int i = 0; i < _viewRects.Length; i++)
+                if (_viewRects[i].Width > 0 && _viewRects[i].Contains(p)) return i;
+            return -1;
         }
 
         protected override void OnMouseLeave(EventArgs e)
@@ -282,6 +322,7 @@ namespace GxPT
                 this.Cursor = Cursors.Default;
                 Invalidate(_stopRect);
             }
+            if (_hoverView != -1) { _hoverView = -1; Invalidate(); }
             if (_hoverRow != -1)
             {
                 _hoverRow = -1;
@@ -317,7 +358,8 @@ namespace GxPT
         protected override void OnMouseDown(MouseEventArgs e)
         {
             base.OnMouseDown(e);
-            if (e.Button == MouseButtons.Left && OverStop(e.Location))
+            if (e.Button != MouseButtons.Left) return;
+            if (OverStop(e.Location))
             {
                 Action onStop = _onStop;
                 _stopping = true;          // latch: label -> "Stopping...", further clicks ignored
@@ -325,7 +367,10 @@ namespace GxPT
                 this.Cursor = Cursors.Default;
                 Invalidate();
                 if (onStop != null) onStop();
+                return;
             }
+            int vrow = ViewRowAt(e.Location);
+            if (vrow >= 0 && _onViewTranscript != null) _onViewTranscript(vrow);
         }
 
         private static bool IsDark()

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // A native panel docked at the bottom of the chat area that shows the sub-agents running during a
+    // dispatch_agent fan-out (design sec.14). Transient: shown on BeginFanOut, updated per child, hidden
+    // on EndFanOut. Display-only - a child's activity is shown to the user here, never fed to the model
+    // (A7). All public methods must be called on the UI thread; the dispatcher's IAgentActivityUi callbacks
+    // are marshaled there by the host (AgentActivityUiBridge). Kept deliberately simple (one multi-line
+    // label) - the live tool-by-tool detail is a later enhancement.
+    internal sealed class AgentActivityPanel : Panel
+    {
+        private const int StateQueued = 0;
+        private const int StateRunning = 1;
+        private const int StateDone = 2;
+
+        private readonly Label _label;
+        private string[] _slugs;
+        private int[] _state;
+
+        public AgentActivityPanel()
+        {
+            this.Dock = DockStyle.Bottom;
+            this.Visible = false;
+            this.AutoSize = false;
+            this.Height = 24;
+            this.Padding = new Padding(8, 4, 8, 4);
+
+            _label = new Label();
+            _label.Dock = DockStyle.Fill;
+            _label.AutoSize = false;
+            _label.TextAlign = ContentAlignment.TopLeft;
+            this.Controls.Add(_label);
+        }
+
+        // Start showing a fan-out of the given agents (in dispatch order), all queued.
+        public void BeginFanOut(System.Collections.Generic.IList<string> slugs)
+        {
+            int n = slugs != null ? slugs.Count : 0;
+            _slugs = new string[n];
+            _state = new int[n];
+            for (int i = 0; i < n; i++) { _slugs[i] = slugs[i]; _state[i] = StateQueued; }
+            Render();
+            this.Visible = n > 0;
+        }
+
+        public void SetRunning(int index) { SetState(index, StateRunning); }
+        public void SetDone(int index) { SetState(index, StateDone); }
+
+        public void EndFanOut()
+        {
+            this.Visible = false;
+            _slugs = null;
+            _state = null;
+        }
+
+        private void SetState(int index, int state)
+        {
+            if (_state == null || index < 0 || index >= _state.Length) return;
+            _state[index] = state;
+            Render();
+        }
+
+        private void Render()
+        {
+            if (_slugs == null || _slugs.Length == 0) { _label.Text = string.Empty; return; }
+
+            int done = 0, running = 0;
+            for (int i = 0; i < _state.Length; i++)
+            {
+                if (_state[i] == StateDone) done++;
+                else if (_state[i] == StateRunning) running++;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Sub-agents: ").Append(running).Append(" running, ")
+              .Append(done).Append(" of ").Append(_slugs.Length).Append(" done");
+            for (int i = 0; i < _slugs.Length; i++)
+            {
+                string tag = _state[i] == StateDone ? "[done]"
+                    : (_state[i] == StateRunning ? "[running]" : "[queued]");
+                sb.Append("\r\n   ").Append(_slugs[i]).Append("  ").Append(tag);
+            }
+            _label.Text = sb.ToString();
+
+            // Header line + one line per agent, bounded so a big fan-out doesn't take the whole pane.
+            int lines = 1 + _slugs.Length;
+            this.Height = Math.Min(10 + lines * 16, 160);
+        }
+    }
+}

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -1,51 +1,54 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 
 namespace GxPT
 {
     // A native panel docked at the bottom of the chat area that shows the sub-agents running during a
-    // dispatch_agent fan-out (design sec.14). Transient: shown on BeginFanOut, updated per child, hidden
-    // on EndFanOut. Display-only - a child's activity is shown to the user here, never fed to the model
-    // (A7). All public methods must be called on the UI thread; the dispatcher's IAgentActivityUi callbacks
-    // are marshaled there by the host (AgentActivityUiBridge). Kept deliberately simple (one multi-line
-    // label) - the live tool-by-tool detail is a later enhancement.
+    // dispatch_agent fan-out (design sec.14). Transient: shown on BeginFanOut, updated per child, hidden on
+    // EndFanOut. Owner-drawn so it matches the active dark/light theme (ThemeService) and colors each
+    // agent's status. Display-only - a child's activity is shown to the user here, never fed to the model
+    // (A7). All public methods must be called on the UI thread (the dispatcher's callbacks are marshaled
+    // there by AgentActivityUiBridge).
     internal sealed class AgentActivityPanel : Panel
     {
         private const int StateQueued = 0;
         private const int StateRunning = 1;
         private const int StateDone = 2;
+        private const int Pad = 8;
+        private const int RowIndent = 14;
 
-        private readonly Label _label;
         private string[] _slugs;
         private int[] _state;
+        private Font _boldFont;
 
         public AgentActivityPanel()
         {
             this.Dock = DockStyle.Bottom;
             this.Visible = false;
             this.AutoSize = false;
-            this.BorderStyle = BorderStyle.FixedSingle;   // defined edge, like ToolApprovalPanel
             this.Height = 24;
-            this.Padding = new Padding(8);
-
-            _label = new Label();
-            _label.Dock = DockStyle.Fill;
-            _label.AutoSize = false;
-            _label.TextAlign = ContentAlignment.TopLeft;
-            this.Controls.Add(_label);
+            // Owner-draw, flicker-free: we fill + border + text ourselves so the panel tracks the theme.
+            this.SetStyle(ControlStyles.AllPaintingInWmPaint
+                | ControlStyles.OptimizedDoubleBuffer
+                | ControlStyles.ResizeRedraw
+                | ControlStyles.UserPaint, true);
         }
 
         // Start showing a fan-out of the given agents (in dispatch order), all queued.
-        public void BeginFanOut(System.Collections.Generic.IList<string> slugs)
+        public void BeginFanOut(IList<string> slugs)
         {
             int n = slugs != null ? slugs.Count : 0;
             _slugs = new string[n];
             _state = new int[n];
             for (int i = 0; i < n; i++) { _slugs[i] = slugs[i]; _state[i] = StateQueued; }
-            Render();
+            // Match the theme background up front so there's no white flash before the first paint.
+            try { this.BackColor = ThemeService.GetColors(IsDark()).AssistantBubbleBack; }
+            catch { }
+            RecalcHeight();
             this.Visible = n > 0;
+            Invalidate();
         }
 
         public void SetRunning(int index) { SetState(index, StateRunning); }
@@ -62,12 +65,49 @@ namespace GxPT
         {
             if (_state == null || index < 0 || index >= _state.Length) return;
             _state[index] = state;
-            Render();
+            Invalidate();
         }
 
-        private void Render()
+        private int LineH() { return this.Font.Height > 0 ? this.Font.Height : 16; }
+
+        private void RecalcHeight()
         {
-            if (_slugs == null || _slugs.Length == 0) { _label.Text = string.Empty; return; }
+            int lines = (_slugs != null) ? 1 + _slugs.Length : 1;
+            this.Height = Math.Min(Pad * 2 + lines * (LineH() + 2), 240);
+        }
+
+        private Font BoldFont()
+        {
+            if (_boldFont == null)
+                _boldFont = new Font(this.Font, FontStyle.Bold);
+            return _boldFont;
+        }
+
+        protected override void OnFontChanged(EventArgs e)
+        {
+            base.OnFontChanged(e);
+            if (_boldFont != null) { _boldFont.Dispose(); _boldFont = null; }
+            RecalcHeight();
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            bool dark = IsDark();
+            ThemeColors tc = ThemeService.GetColors(dark);
+            Graphics g = e.Graphics;
+
+            using (SolidBrush bg = new SolidBrush(tc.AssistantBubbleBack))
+                g.FillRectangle(bg, this.ClientRectangle);
+            Rectangle border = this.ClientRectangle;
+            border.Width -= 1; border.Height -= 1;
+            using (Pen pen = new Pen(tc.AssistantBubbleBorder))
+                g.DrawRectangle(pen, border);
+
+            if (_slugs == null || _slugs.Length == 0) return;
+
+            int lineH = LineH() + 2;
+            int y = Pad;
 
             int done = 0, running = 0;
             for (int i = 0; i < _state.Length; i++)
@@ -75,24 +115,43 @@ namespace GxPT
                 if (_state[i] == StateDone) done++;
                 else if (_state[i] == StateRunning) running++;
             }
+            string header = "Sub-agents: " + running + " running, " + done + " of " + _slugs.Length + " done";
+            TextRenderer.DrawText(g, header, BoldFont(), new Point(Pad, y), tc.UiForeground, TextFormatFlags.NoPadding);
+            y += lineH;
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append("Sub-agents: ").Append(running).Append(" running, ")
-              .Append(done).Append(" of ").Append(_slugs.Length).Append(" done");
+            Color cDone = dark ? Color.FromArgb(126, 204, 126) : Color.FromArgb(34, 139, 34);
+            Color cRunning = tc.Link;
+            Color cQueued = dark ? Color.FromArgb(150, 150, 150) : Color.FromArgb(120, 120, 120);
+
             for (int i = 0; i < _slugs.Length; i++)
             {
-                string tag = _state[i] == StateDone ? "[done]"
-                    : (_state[i] == StateRunning ? "[running]" : "[queued]");
-                sb.Append("\r\n   ").Append(_slugs[i]).Append("  ").Append(tag);
-            }
-            _label.Text = sb.ToString();
+                int rowX = Pad + RowIndent;
+                TextRenderer.DrawText(g, _slugs[i], this.Font, new Point(rowX, y), tc.UiForeground, TextFormatFlags.NoPadding);
+                int slugW = TextRenderer.MeasureText(g, _slugs[i], this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
 
-            // Size to the header line + one line per agent, measured from the label's real font height so
-            // nothing clips, plus the border (2px) and a line of headroom; bounded so a big fan-out can't
-            // swallow the whole pane.
-            int lineH = _label.Font != null && _label.Font.Height > 0 ? _label.Font.Height : 16;
-            int lines = 1 + _slugs.Length;
-            this.Height = Math.Min(2 + this.Padding.Vertical + (lines + 1) * lineH, 240);
+                string tag; Color tagColor;
+                if (_state[i] == StateDone) { tag = "[done]"; tagColor = cDone; }
+                else if (_state[i] == StateRunning) { tag = "[running]"; tagColor = cRunning; }
+                else { tag = "[queued]"; tagColor = cQueued; }
+                TextRenderer.DrawText(g, tag, this.Font, new Point(rowX + slugW + 8, y), tagColor, TextFormatFlags.NoPadding);
+                y += lineH;
+            }
+        }
+
+        private static bool IsDark()
+        {
+            try
+            {
+                string th = AppSettings.GetString("theme");
+                return !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _boldFont != null) { _boldFont.Dispose(); _boldFont = null; }
+            base.Dispose(disposing);
         }
     }
 }

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -26,8 +26,9 @@ namespace GxPT
             this.Dock = DockStyle.Bottom;
             this.Visible = false;
             this.AutoSize = false;
+            this.BorderStyle = BorderStyle.FixedSingle;   // defined edge, like ToolApprovalPanel
             this.Height = 24;
-            this.Padding = new Padding(8, 4, 8, 4);
+            this.Padding = new Padding(8);
 
             _label = new Label();
             _label.Dock = DockStyle.Fill;
@@ -86,9 +87,12 @@ namespace GxPT
             }
             _label.Text = sb.ToString();
 
-            // Header line + one line per agent, bounded so a big fan-out doesn't take the whole pane.
+            // Size to the header line + one line per agent, measured from the label's real font height so
+            // nothing clips, plus the border (2px) and a line of headroom; bounded so a big fan-out can't
+            // swallow the whole pane.
+            int lineH = _label.Font != null && _label.Font.Height > 0 ? _label.Font.Height : 16;
             int lines = 1 + _slugs.Length;
-            this.Height = Math.Min(10 + lines * 16, 160);
+            this.Height = Math.Min(2 + this.Padding.Vertical + (lines + 1) * lineH, 240);
         }
     }
 }

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -23,6 +23,15 @@ namespace GxPT
         private int[] _state;
         private Font _boldFont;
 
+        // The "Stop" button: an owner-drawn region in the header that cancels the fan-out (trips the
+        // dispatcher's GroupCancellation via _onStop). _stopRect is recomputed each paint and hit-tested
+        // by the mouse handlers; _stopping latches after a click so the label reads "Stopping..." and
+        // further clicks are ignored until the fan-out ends.
+        private Action _onStop;
+        private Rectangle _stopRect;
+        private bool _stopHover;
+        private bool _stopping;
+
         public AgentActivityPanel()
         {
             this.Dock = DockStyle.Bottom;
@@ -36,13 +45,17 @@ namespace GxPT
                 | ControlStyles.UserPaint, true);
         }
 
-        // Start showing a fan-out of the given agents (in dispatch order), all queued.
-        public void BeginFanOut(IList<string> slugs)
+        // Start showing a fan-out of the given agents (in dispatch order), all queued. onStop (may be null)
+        // is invoked when the user clicks the panel's Stop button.
+        public void BeginFanOut(IList<string> slugs, Action onStop)
         {
             int n = slugs != null ? slugs.Count : 0;
             _slugs = new string[n];
             _state = new int[n];
             for (int i = 0; i < n; i++) { _slugs[i] = slugs[i]; _state[i] = StateQueued; }
+            _onStop = onStop;
+            _stopping = false;
+            _stopHover = false;
             // Match the theme background up front so there's no white flash before the first paint.
             try { this.BackColor = ThemeService.GetColors(IsDark()).AssistantBubbleBack; }
             catch { }
@@ -59,6 +72,10 @@ namespace GxPT
             this.Visible = false;
             _slugs = null;
             _state = null;
+            _onStop = null;
+            _stopping = false;
+            _stopHover = false;
+            this.Cursor = Cursors.Default;
         }
 
         private void SetState(int index, int state)
@@ -110,10 +127,14 @@ namespace GxPT
             using (Pen pen = new Pen(tc.AssistantBubbleBorder))
                 g.DrawRectangle(pen, border);
 
-            if (_slugs == null || _slugs.Length == 0) return;
+            if (_slugs == null || _slugs.Length == 0) { _stopRect = Rectangle.Empty; return; }
 
             int lineH = LineH() + 2;
             int y = Pad;
+
+            Color cDone = dark ? Color.FromArgb(126, 204, 126) : Color.FromArgb(34, 139, 34);
+            Color cRunning = tc.Link;
+            Color cQueued = dark ? Color.FromArgb(150, 150, 150) : Color.FromArgb(120, 120, 120);
 
             int done = 0, running = 0;
             for (int i = 0; i < _state.Length; i++)
@@ -123,11 +144,26 @@ namespace GxPT
             }
             string header = "Sub-agents: " + running + " running, " + done + " of " + _slugs.Length + " done";
             TextRenderer.DrawText(g, header, BoldFont(), new Point(Pad, y), tc.UiForeground, TextFormatFlags.NoPadding);
-            y += lineH;
 
-            Color cDone = dark ? Color.FromArgb(126, 204, 126) : Color.FromArgb(34, 139, 34);
-            Color cRunning = tc.Link;
-            Color cQueued = dark ? Color.FromArgb(150, 150, 150) : Color.FromArgb(120, 120, 120);
+            // Stop button, right-aligned in the header row.
+            if (_onStop != null)
+            {
+                string btnText = _stopping ? "Stopping..." : "Stop";
+                int btnW = TextRenderer.MeasureText(g, btnText, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width + 16;
+                int btnX = this.ClientRectangle.Width - Pad - btnW - 1;
+                if (btnX < Pad) btnX = Pad;
+                _stopRect = new Rectangle(btnX, y, btnW, lineH);
+
+                Color face = (_stopHover && !_stopping) ? tc.CopyHover : tc.CodeBack;
+                using (SolidBrush bb = new SolidBrush(face)) g.FillRectangle(bb, _stopRect);
+                Rectangle br = _stopRect; br.Width -= 1; br.Height -= 1;
+                using (Pen bp = new Pen(tc.AssistantBubbleBorder)) g.DrawRectangle(bp, br);
+                TextRenderer.DrawText(g, btnText, this.Font, _stopRect, _stopping ? cQueued : tc.UiForeground,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding);
+            }
+            else _stopRect = Rectangle.Empty;
+
+            y += lineH;
 
             for (int i = 0; i < _slugs.Length; i++)
             {
@@ -141,6 +177,48 @@ namespace GxPT
                 else { tag = "[queued]"; tagColor = cQueued; }
                 TextRenderer.DrawText(g, tag, this.Font, new Point(rowX + slugW + 8, y), tagColor, TextFormatFlags.NoPadding);
                 y += lineH;
+            }
+        }
+
+        private bool OverStop(Point p)
+        {
+            return _onStop != null && !_stopping && _stopRect.Width > 0 && _stopRect.Contains(p);
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+            bool over = OverStop(e.Location);
+            if (over != _stopHover)
+            {
+                _stopHover = over;
+                this.Cursor = over ? Cursors.Hand : Cursors.Default;
+                Invalidate(_stopRect);
+            }
+        }
+
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            base.OnMouseLeave(e);
+            if (_stopHover)
+            {
+                _stopHover = false;
+                this.Cursor = Cursors.Default;
+                Invalidate(_stopRect);
+            }
+        }
+
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            base.OnMouseDown(e);
+            if (e.Button == MouseButtons.Left && OverStop(e.Location))
+            {
+                Action onStop = _onStop;
+                _stopping = true;          // latch: label -> "Stopping...", further clicks ignored
+                _stopHover = false;
+                this.Cursor = Cursors.Default;
+                Invalidate();
+                if (onStop != null) onStop();
             }
         }
 

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -211,6 +211,9 @@ namespace GxPT
         public event Action<int, string> UserMessageEditRequested;
         // Raised when the user clicks the Retry button on a trailing error notice
         public event Action RetryRequested;
+        // Raised when the user clicks an agent "View transcript" link (the custom gxpt-agent: scheme); the
+        // host opens the read-only child transcript viewer instead of launching a browser.
+        public event Action<string> AgentTranscriptLinkClicked;
         // Hover/drag state for code block UI
         private MessageItem _hoverCopyItem;
         private int _hoverCopyCodeIndex = -1;
@@ -2833,6 +2836,14 @@ namespace GxPT
                     string link = HitTestLink(e.Location);
                     if (!string.IsNullOrEmpty(link))
                     {
+                        // Agent "View transcript" links are handled in-app (open the read-only viewer),
+                        // never launched as a URL.
+                        if (AgentTranscriptLinks.IsTranscriptLink(link))
+                        {
+                            Action<string> h = AgentTranscriptLinkClicked;
+                            if (h != null) h(link);
+                            return;
+                        }
                         try
                         {
                             string supermiumPath = @"C:\\Program Files\\Supermium\\chrome.exe";

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1830,16 +1830,16 @@ namespace GxPT
                     y += headerH;
 
                     // Expanded body. A Markdown record (e.g. dispatch_agent) reuses the normal block
-                    // renderer so **bold**/*italic* show as formatting; everything else is the
+                    // renderer so bold/tables/etc. render as formatting; everything else is the
                     // chromeless highlighted code body below.
                     if (hasBody && !collapsed && data.BodyIsMarkdown)
                     {
                         y += EditDiffBodyGap;
                         List<Block> bodyBlocks = MarkdownParser.ParseMarkdown(data.Body);
                         int bodyH = MeasureMarkdownBlocks(bodyBlocks, maxWidth).Height;
-                        // owner == null: the body's inline text is display-only (no copy/hit tracking),
-                        // matching the highlighted-code path which is also not part of message copy.
-                        DrawBlocks(g, new Rectangle(x0, y, maxWidth, bodyH), bodyBlocks, null);
+                        // Pass the owner so tables (TableScroll state) and copy work; the body's blocks
+                        // carry no EditDiff sentinels, so there's no re-entrancy.
+                        DrawBlocks(g, new Rectangle(x0, y, maxWidth, bodyH), bodyBlocks, owner);
                         y += bodyH + EditDiffBodyPad;
                     }
                     // Expanded: chromeless highlighted body, clipped to width (with horizontal scroll

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -302,6 +302,9 @@ namespace GxPT
             public string HeaderText;
             public string Body;
             public string Language;
+            // When true the body is rendered with the normal Markdown renderer (DrawBlocks) instead of
+            // the syntax-highlighted code path - used for prose-style records like dispatch_agent.
+            public bool BodyIsMarkdown;
             public int Added = -1;
             public int Removed = -1;
         }
@@ -328,6 +331,8 @@ namespace GxPT
                     HeaderText = headerText ?? string.Empty,
                     Body = body ?? string.Empty,
                     Language = language ?? "text",
+                    BodyIsMarkdown = !string.IsNullOrEmpty(language)
+                        && language.Equals("markdown", StringComparison.OrdinalIgnoreCase),
                     Added = added,
                     Removed = removed
                 };
@@ -1221,7 +1226,13 @@ namespace GxPT
                                     + (countsText.Length > 0 ? TextRenderer.MeasureText(countsText, _baseFont).Width : 0);
                         int w = headerW;
                         int h = headerH;
-                        if (hasBody && !collapsed)
+                        if (hasBody && !collapsed && data.BodyIsMarkdown)
+                        {
+                            Size body = MeasureMarkdownBlocks(MarkdownParser.ParseMarkdown(data.Body), maxWidth);
+                            h += EditDiffBodyGap + body.Height + EditDiffBodyPad;
+                            w = Math.Max(w, body.Width);
+                        }
+                        else if (hasBody && !collapsed)
                         {
                             using (Graphics g = CreateGraphics())
                             {
@@ -1283,6 +1294,30 @@ namespace GxPT
                     }
             }
             return Size.Empty;
+        }
+
+        // Measures a list of Markdown blocks the same way a message body is measured (MeasureBlock plus
+        // the per-block-type trailing spacing in the height loop), so the value matches what DrawBlocks
+        // consumes. Used for tool records whose body is rendered as Markdown rather than highlighted code.
+        private Size MeasureMarkdownBlocks(List<Block> blocks, int maxWidth)
+        {
+            int h = 0;
+            int w = 0;
+            var numberedCounters = new Dictionary<int, int>();
+            for (int i = 0; i < blocks.Count; i++)
+            {
+                Block blk = blocks[i];
+                if (blk.Type != BlockType.NumberedList && blk.Type != BlockType.BulletList)
+                    numberedCounters.Clear();
+                Size sz = MeasureBlock(blk, maxWidth, numberedCounters);
+                h += sz.Height;
+                if (blk.Type == BlockType.Heading) h += 4;
+                else if (blk.Type == BlockType.Paragraph) h += 2;
+                else if (blk.Type == BlockType.CodeBlock) h += 4;
+                else if (blk.Type == BlockType.Error) h += 2;
+                w = Math.Max(w, sz.Width);
+            }
+            return new Size(Math.Min(maxWidth, w), h);
         }
 
         // Build the inline runs for an error notice. The message is treated as literal text (no
@@ -1794,9 +1829,22 @@ namespace GxPT
                     }
                     y += headerH;
 
+                    // Expanded body. A Markdown record (e.g. dispatch_agent) reuses the normal block
+                    // renderer so **bold**/*italic* show as formatting; everything else is the
+                    // chromeless highlighted code body below.
+                    if (hasBody && !collapsed && data.BodyIsMarkdown)
+                    {
+                        y += EditDiffBodyGap;
+                        List<Block> bodyBlocks = MarkdownParser.ParseMarkdown(data.Body);
+                        int bodyH = MeasureMarkdownBlocks(bodyBlocks, maxWidth).Height;
+                        // owner == null: the body's inline text is display-only (no copy/hit tracking),
+                        // matching the highlighted-code path which is also not part of message copy.
+                        DrawBlocks(g, new Rectangle(x0, y, maxWidth, bodyH), bodyBlocks, null);
+                        y += bodyH + EditDiffBodyPad;
+                    }
                     // Expanded: chromeless highlighted body, clipped to width (with horizontal scroll
                     // for over-wide content).
-                    if (hasBody && !collapsed)
+                    else if (hasBody && !collapsed)
                     {
                         y += EditDiffBodyGap;
                         SyntaxHighlightingRenderer.EnqueueHighlight(data.Language, _isDarkTheme, data.Body, _monoFont);

--- a/GxPT/Controls/StopGenerationItem.cs
+++ b/GxPT/Controls/StopGenerationItem.cs
@@ -19,15 +19,22 @@ namespace GxPT
         private bool _hover;
         private bool _pressed;
         private bool _awaiting;
+        private bool _agentsRunning;
 
         private const int PadX = 8;        // horizontal label padding, matching RetryBtnPadX
         public const int ItemHeight = 15;  // tspGenProgress's height
 
         private const string StopText = "Stop";
         private const string AwaitingText = "Awaiting user...";
+        private const string AgentsText = "Sub-agents running...";
 
         private const string StopTip = "Stop generating";
         private const string AwaitingTip = "Waiting for tool approval";
+        private const string AgentsTip = "Sub-agents are running - use Stop in the panel above to cancel them";
+
+        // Either passive state drops the button chrome and shows a status label instead (the turn isn't
+        // stopping from here: it's paused at a prompt, or its work is happening in sub-agents).
+        private bool Passive { get { return _awaiting || _agentsRunning; } }
 
         public StopGenerationItem()
         {
@@ -43,18 +50,28 @@ namespace GxPT
         public bool Awaiting
         {
             get { return _awaiting; }
-            set
-            {
-                if (_awaiting == value) return;
-                _awaiting = value;
-                _hover = false;
-                _pressed = false;
-                this.Text = value ? AwaitingText : StopText;
-                this.ToolTipText = value ? AwaitingTip : StopTip;
-                try { this.Width = PreferredWidth(); }
-                catch { }
-                Invalidate();
-            }
+            set { if (_awaiting != value) { _awaiting = value; OnPassiveChanged(); } }
+        }
+
+        // While a dispatch_agent fan-out runs, the turn is busy but the work is in the sub-agents (cancel
+        // them with the panel's Stop button); this item shows a passive "Sub-agents running..." label, the
+        // host keeps the marquee running, and clicks here are ignored.
+        public bool AgentsRunning
+        {
+            get { return _agentsRunning; }
+            set { if (_agentsRunning != value) { _agentsRunning = value; OnPassiveChanged(); } }
+        }
+
+        private void OnPassiveChanged()
+        {
+            _hover = false;
+            _pressed = false;
+            if (_awaiting) { this.Text = AwaitingText; this.ToolTipText = AwaitingTip; }
+            else if (_agentsRunning) { this.Text = AgentsText; this.ToolTipText = AgentsTip; }
+            else { this.Text = StopText; this.ToolTipText = StopTip; }
+            try { this.Width = PreferredWidth(); }
+            catch { }
+            Invalidate();
         }
 
         protected override Size DefaultSize
@@ -77,9 +94,9 @@ namespace GxPT
             catch { }
         }
 
-        protected override void OnMouseEnter(EventArgs e) { if (!_awaiting) { _hover = true; Invalidate(); } base.OnMouseEnter(e); }
+        protected override void OnMouseEnter(EventArgs e) { if (!Passive) { _hover = true; Invalidate(); } base.OnMouseEnter(e); }
         protected override void OnMouseLeave(EventArgs e) { _hover = false; _pressed = false; Invalidate(); base.OnMouseLeave(e); }
-        protected override void OnMouseDown(MouseEventArgs e) { if (!_awaiting && e.Button == MouseButtons.Left) { _pressed = true; Invalidate(); } base.OnMouseDown(e); }
+        protected override void OnMouseDown(MouseEventArgs e) { if (!Passive && e.Button == MouseButtons.Left) { _pressed = true; Invalidate(); } base.OnMouseDown(e); }
         protected override void OnMouseUp(MouseEventArgs e) { _pressed = false; Invalidate(); base.OnMouseUp(e); }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -89,10 +106,10 @@ namespace GxPT
 
             Rectangle bounds = new Rectangle(0, 0, this.Width, this.Height);
 
-            // Awaiting state: a flat status label, no border/fill, so it reads as passive text rather
-            // than a clickable Stop button. Uses ControlText (like the strip's other labels) rather
-            // than the lighter GrayText, which next to them reads as thinner/smaller.
-            if (_awaiting)
+            // Passive state (awaiting a prompt, or sub-agents running): a flat status label, no
+            // border/fill, so it reads as passive text rather than a clickable Stop button. Uses
+            // ControlText (like the strip's other labels) rather than the lighter GrayText.
+            if (Passive)
             {
                 TextRenderer.DrawText(g, this.Text, this.Font, bounds, SystemColors.ControlText,
                     TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter |

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -107,6 +107,7 @@ namespace GxPT
                 Zdr = convo.Zdr,
                 ZdrFirstMessageIndex = convo.ZdrFirstMessageIndex,
                 SkillsFeatureOff = convo.SkillsFeatureOff,
+                AgentsEnabled = convo.AgentsEnabled,
                 // Omit an empty map so untouched conversations stay clean (NullValueHandling.Ignore).
                 SkillOverrides = (convo.SkillOverrides != null && convo.SkillOverrides.Count > 0)
                     ? convo.SkillOverrides : null,
@@ -193,6 +194,7 @@ namespace GxPT
                 // Absent in older files -> not latched (-1), never index 0.
                 ZdrFirstMessageIndex = dto.ZdrFirstMessageIndex.HasValue ? dto.ZdrFirstMessageIndex.Value : -1,
                 SkillsFeatureOff = dto.SkillsFeatureOff,
+                AgentsEnabled = dto.AgentsEnabled,
                 SkillOverrides = dto.SkillOverrides != null
                     ? new Dictionary<string, bool>(dto.SkillOverrides, StringComparer.OrdinalIgnoreCase)
                     : new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase),
@@ -377,6 +379,8 @@ namespace GxPT
             // from JSON when null/empty via NullValueHandling.Ignore.
             public bool? SkillsFeatureOff { get; set; }
             public Dictionary<string, bool> SkillOverrides { get; set; }
+            // Per-conversation sub-agents feature override (null/absent in older files -> inherit global).
+            public bool? AgentsEnabled { get; set; }
             // Revealed MCP tool names (prompt caching; null/absent in older files -> none revealed).
             public List<string> RevealedTools { get; set; }
             // Sticky cache-routing provider: the endpoint that last demonstrated a cache hit

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -335,6 +335,8 @@ namespace GxPT
                     File.Delete(path);
             }
             catch { }
+            // Sub-agent transcripts persist alongside the conversation; remove them with it.
+            try { AgentTranscriptPersistence.DeleteConversation(id); } catch { }
         }
 
         public static int DeleteAll()
@@ -355,12 +357,16 @@ namespace GxPT
                 }
             }
             catch { }
+            try { AgentTranscriptPersistence.DeleteAll(); } catch { }
             return count;
         }
 
         public static void DeletePath(string path)
         {
             try { if (!string.IsNullOrEmpty(path) && File.Exists(path)) File.Delete(path); }
+            catch { }
+            // The conversation file is "<id>.json"; remove that conversation's sub-agent transcripts too.
+            try { AgentTranscriptPersistence.DeleteConversation(Path.GetFileNameWithoutExtension(path)); }
             catch { }
         }
 

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // Bridges the AgentDispatcher's IAgentActivityUi callbacks (raised on child worker threads) to a tab's
+    // AgentActivityPanel on the UI thread (design sec.14). Bound to one tab's context for the duration of a
+    // turn; updates that tab's own panel (which is only visible when the tab is active), so no active-tab
+    // gating is needed. Created per send in MainForm and handed to the dispatcher.
+    internal sealed class AgentActivityUiBridge : IAgentActivityUi
+    {
+        private readonly MainForm _form;
+        private readonly TabManager.ChatTabContext _ctx;
+
+        public AgentActivityUiBridge(MainForm form, TabManager.ChatTabContext ctx)
+        {
+            _form = form;
+            _ctx = ctx;
+        }
+
+        public void OnFanOutStart(IList<string> slugs)
+        {
+            // Copy the list: it is the dispatcher's and may change; the UI thread reads it later.
+            List<string> copy = slugs != null ? new List<string>(slugs) : new List<string>();
+            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.BeginFanOut(copy); });
+        }
+
+        public void OnAgentStart(int index, string slug, string task)
+        {
+            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetRunning(index); });
+        }
+
+        public void OnAgentFinished(int index, string slug)
+        {
+            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetDone(index); });
+        }
+
+        public void OnFanOutEnd()
+        {
+            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.EndFanOut(); });
+        }
+
+        private AgentActivityPanel Panel()
+        {
+            return _ctx != null ? _ctx.AgentActivityPanel : null;
+        }
+
+        private void Marshal(MethodInvoker action)
+        {
+            try
+            {
+                if (_form == null || _form.IsDisposed || !_form.IsHandleCreated) return;
+                _form.BeginInvoke(action);
+            }
+            catch
+            {
+                // Form closing / handle gone between the checks and the invoke - safe to drop.
+            }
+        }
+    }
+}

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -12,12 +12,15 @@ namespace GxPT
         private readonly MainForm _form;
         private readonly TabManager.ChatTabContext _ctx;
         private readonly RequestCancellation _group;   // tripped by the panel's Stop button (may be null)
+        private readonly AgentDispatcher _dispatcher;  // source of per-row live streams (tier 3 watch-live)
 
-        public AgentActivityUiBridge(MainForm form, TabManager.ChatTabContext ctx, RequestCancellation group)
+        public AgentActivityUiBridge(MainForm form, TabManager.ChatTabContext ctx, RequestCancellation group,
+                                     AgentDispatcher dispatcher)
         {
             _form = form;
             _ctx = ctx;
             _group = group;
+            _dispatcher = dispatcher;
         }
 
         public void OnFanOutStart(IList<string> slugs, IList<string> tasks)
@@ -26,10 +29,19 @@ namespace GxPT
             List<string> slugCopy = slugs != null ? new List<string>(slugs) : new List<string>();
             List<string> taskCopy = tasks != null ? new List<string>(tasks) : new List<string>();
             RequestCancellation group = _group;
+            AgentDispatcher dispatcher = _dispatcher;
             Marshal(delegate
             {
                 AgentActivityPanel p = Panel();
-                if (p != null) p.BeginFanOut(slugCopy, taskCopy, delegate { if (group != null) group.Cancel(); });
+                if (p != null)
+                    p.BeginFanOut(slugCopy, taskCopy,
+                        delegate { if (group != null) group.Cancel(); },
+                        delegate(int row)
+                        {
+                            // On the UI thread (panel click): open the streaming viewer for this row's child.
+                            if (_form != null && dispatcher != null)
+                                _form.OpenAgentLiveTranscript(dispatcher.GetLiveStream(row));
+                        });
                 if (_form != null) _form.NotifyAgentFanOutChanged(_ctx, true);
             });
         }

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -29,6 +29,7 @@ namespace GxPT
             {
                 AgentActivityPanel p = Panel();
                 if (p != null) p.BeginFanOut(copy, delegate { if (group != null) group.Cancel(); });
+                if (_form != null) _form.NotifyAgentFanOutChanged(_ctx, true);
             });
         }
 
@@ -44,7 +45,12 @@ namespace GxPT
 
         public void OnFanOutEnd()
         {
-            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.EndFanOut(); });
+            Marshal(delegate
+            {
+                AgentActivityPanel p = Panel();
+                if (p != null) p.EndFanOut();
+                if (_form != null) _form.NotifyAgentFanOutChanged(_ctx, false);
+            });
         }
 
         private AgentActivityPanel Panel()

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -20,15 +20,16 @@ namespace GxPT
             _group = group;
         }
 
-        public void OnFanOutStart(IList<string> slugs)
+        public void OnFanOutStart(IList<string> slugs, IList<string> tasks)
         {
-            // Copy the list: it is the dispatcher's and may change; the UI thread reads it later.
-            List<string> copy = slugs != null ? new List<string>(slugs) : new List<string>();
+            // Copy the lists: they are the dispatcher's and may change; the UI thread reads them later.
+            List<string> slugCopy = slugs != null ? new List<string>(slugs) : new List<string>();
+            List<string> taskCopy = tasks != null ? new List<string>(tasks) : new List<string>();
             RequestCancellation group = _group;
             Marshal(delegate
             {
                 AgentActivityPanel p = Panel();
-                if (p != null) p.BeginFanOut(copy, delegate { if (group != null) group.Cancel(); });
+                if (p != null) p.BeginFanOut(slugCopy, taskCopy, delegate { if (group != null) group.Cancel(); });
                 if (_form != null) _form.NotifyAgentFanOutChanged(_ctx, true);
             });
         }
@@ -36,6 +37,13 @@ namespace GxPT
         public void OnAgentStart(int index, string slug, string task)
         {
             Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetRunning(index); });
+        }
+
+        public void OnAgentActivity(int index, string lastTool, int toolCount)
+        {
+            string tool = lastTool;
+            int count = toolCount;
+            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetActivity(index, tool, count); });
         }
 
         public void OnAgentFinished(int index, string slug, bool cancelled)

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -38,9 +38,13 @@ namespace GxPT
             Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetRunning(index); });
         }
 
-        public void OnAgentFinished(int index, string slug)
+        public void OnAgentFinished(int index, string slug, bool cancelled)
         {
-            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.SetDone(index); });
+            Marshal(delegate
+            {
+                AgentActivityPanel p = Panel();
+                if (p != null) { if (cancelled) p.SetCancelled(index); else p.SetDone(index); }
+            });
         }
 
         public void OnFanOutEnd()

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -11,18 +11,25 @@ namespace GxPT
     {
         private readonly MainForm _form;
         private readonly TabManager.ChatTabContext _ctx;
+        private readonly RequestCancellation _group;   // tripped by the panel's Stop button (may be null)
 
-        public AgentActivityUiBridge(MainForm form, TabManager.ChatTabContext ctx)
+        public AgentActivityUiBridge(MainForm form, TabManager.ChatTabContext ctx, RequestCancellation group)
         {
             _form = form;
             _ctx = ctx;
+            _group = group;
         }
 
         public void OnFanOutStart(IList<string> slugs)
         {
             // Copy the list: it is the dispatcher's and may change; the UI thread reads it later.
             List<string> copy = slugs != null ? new List<string>(slugs) : new List<string>();
-            Marshal(delegate { AgentActivityPanel p = Panel(); if (p != null) p.BeginFanOut(copy); });
+            RequestCancellation group = _group;
+            Marshal(delegate
+            {
+                AgentActivityPanel p = Panel();
+                if (p != null) p.BeginFanOut(copy, delegate { if (group != null) group.Cancel(); });
+            });
         }
 
         public void OnAgentStart(int index, string slug, string task)

--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -1,25 +1,39 @@
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 
 namespace GxPT
 {
-    // A transient, read-only popup that renders one child agent's full transcript (design sec.14, tier 3).
-    // Opened from a dispatch_agent record's "View transcript" link. Pure UI: it shows the child's own
-    // message list to the user; nothing here feeds back into any model (the context firewall, A3/A7, holds).
-    // Reuses ChatTranscriptControl for themed Markdown/code rendering; the control auto-themes from settings
-    // in its constructor, so the popup matches the active light/dark theme at open time. Code-only (no
-    // designer) - it hosts a single docked transcript control.
-    internal sealed class AgentTranscriptViewerForm : Form
+    // A popup that renders one child agent's transcript (design sec.14, tier 3). Two modes:
+    //  - static: a finished AgentTranscript (from a dispatch record's "View transcript" link), shown read-only.
+    //  - live: an AgentLiveStream for a running child (the activity panel's per-row "View transcript"); the
+    //    viewer attaches, replays what already happened, then streams the rest - the same rendering the main
+    //    chat uses (text deltas into an assistant bubble, tool calls/results as their own rows).
+    // Pure UI: the child's activity is shown to the user, never fed back to any model (the context firewall,
+    // A3/A7, holds). Reuses ChatTranscriptControl, which auto-themes from settings in its constructor. Code-
+    // only (no designer); hosts a single docked transcript control.
+    internal sealed class AgentTranscriptViewerForm : Form, IAgentLiveSink
     {
         private readonly ChatTranscriptControl _transcript;
-        private readonly AgentTranscript _data;
+        private readonly AgentTranscript _data;     // static mode (null in live mode)
+        private readonly AgentLiveStream _stream;   // live mode (null in static mode)
+        private bool _liveAssistantOpen;            // is the last live message an open assistant bubble?
 
         public AgentTranscriptViewerForm(AgentTranscript transcript)
         {
             _data = transcript;
-            this.Text = BuildTitle(transcript);
+            Init(BuildTitle(transcript != null ? transcript.Slug : null));
+        }
+
+        public AgentTranscriptViewerForm(AgentLiveStream stream)
+        {
+            _stream = stream;
+            Init(BuildTitle(stream != null ? stream.Slug : null) + " (live)");
+        }
+
+        private void Init(string title)
+        {
+            this.Text = title;
             this.StartPosition = FormStartPosition.CenterParent;
             this.FormBorderStyle = FormBorderStyle.Sizable;
             this.MinimizeBox = false;
@@ -36,21 +50,72 @@ namespace GxPT
             ApplyFontSetting();
         }
 
-        // Populate once the handle exists - the transcript control skips layout until it has a window, so
-        // adding messages in the constructor would render nothing.
+        // Populate once the handle exists - the transcript control skips layout until it has a window.
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            _transcript.BeginBatchUpdates();
-            try { Populate(_data); }
-            finally { _transcript.EndBatchUpdates(false); }
-            _transcript.ScrollToTop();
+            if (_stream != null)
+            {
+                // Show the task first (the streamed events are the model's output only, not the seed
+                // persona/task), then attach: replay what already happened, then stream the rest.
+                if (!string.IsNullOrEmpty(_stream.Task))
+                    _transcript.AddMessage(MessageRole.User, _stream.Task);
+                _stream.Attach(this);
+            }
+            else
+            {
+                _transcript.BeginBatchUpdates();
+                try { Populate(_data); }
+                finally { _transcript.EndBatchUpdates(false); }
+                _transcript.ScrollToTop();
+            }
         }
 
-        private static string BuildTitle(AgentTranscript t)
+        protected override void OnFormClosed(FormClosedEventArgs e)
         {
-            string slug = (t != null && !string.IsNullOrEmpty(t.Slug)) ? t.Slug : "agent";
-            return "Agent transcript - " + slug;
+            if (_stream != null) _stream.Detach(this);
+            base.OnFormClosed(e);
+        }
+
+        // ---------- IAgentLiveSink (called from a worker thread or, during replay, this one) ----------
+        public void OnText(string delta)
+        {
+            if (string.IsNullOrEmpty(delta)) return;
+            Ui(delegate
+            {
+                if (_liveAssistantOpen) _transcript.AppendToLastMessage(delta);
+                else { _transcript.AddMessage(MessageRole.Assistant, delta); _liveAssistantOpen = true; }
+            });
+        }
+
+        public void OnToolCall(string functionName, string callId)
+        {
+            string fn = !string.IsNullOrEmpty(functionName) ? functionName : "(tool)";
+            Ui(delegate { _liveAssistantOpen = false; _transcript.AddMessage(MessageRole.Tool, "Called `" + fn + "`"); });
+        }
+
+        public void OnToolResult(string functionName, string resultText, bool isError)
+        {
+            string res = resultText ?? string.Empty;
+            Ui(delegate { _liveAssistantOpen = false; _transcript.AddMessage(MessageRole.Tool, res); });
+        }
+
+        public void OnComplete()
+        {
+            Ui(delegate { _liveAssistantOpen = false; });
+        }
+
+        // Marshal an action onto the UI thread (sink callbacks may arrive on the child's worker thread; even
+        // the replay is deferred so nothing renders under the stream's lock).
+        private void Ui(MethodInvoker a)
+        {
+            try { if (this.IsHandleCreated && !this.IsDisposed) this.BeginInvoke(a); }
+            catch { }
+        }
+
+        private static string BuildTitle(string slug)
+        {
+            return "Agent transcript - " + (!string.IsNullOrEmpty(slug) ? slug : "agent");
         }
 
         private void ApplyFontSetting()
@@ -65,9 +130,8 @@ namespace GxPT
             catch { }
         }
 
-        // Renders the child's message list. The leading system message is the agent's persona; the first
-        // user message is the task; assistant/tool turns follow. Assistant tool calls are shown as a compact
-        // Tool-role note (name + JSON args) so the run reads in order.
+        // Renders a finished message list. Leading system message is the persona; the first user message is
+        // the task; assistant/tool turns follow. Assistant tool calls are shown as a compact Tool-role note.
         private void Populate(AgentTranscript t)
         {
             if (t == null || t.Messages == null) { _transcript.AddMessage(MessageRole.System, "(transcript unavailable)"); return; }

--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -14,7 +14,7 @@ namespace GxPT
     // only (no designer); hosts a single docked transcript control.
     internal sealed class AgentTranscriptViewerForm : Form, IAgentLiveSink
     {
-        private readonly ChatTranscriptControl _transcript;
+        private ChatTranscriptControl _transcript;   // set in Init() (a ctor helper), so not readonly
         private readonly AgentTranscript _data;     // static mode (null in live mode)
         private readonly AgentLiveStream _stream;   // live mode (null in static mode)
         private bool _liveAssistantOpen;            // is the last live message an open assistant bubble?

--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -57,8 +57,11 @@ namespace GxPT
             base.OnLoad(e);
             if (_stream != null)
             {
-                // Show the task first (the streamed events are the model's output only, not the seed
-                // persona/task), then attach: replay what already happened, then stream the rest.
+                // Seed the persona + task first (the streamed events are the model's output only, not the
+                // seed system/user messages), then attach: replay what already happened, then stream the
+                // rest. Matches the static viewer, which shows the agent's system prompt unlike the main chat.
+                if (!string.IsNullOrEmpty(_stream.Persona))
+                    _transcript.AddMessage(MessageRole.System, _stream.Persona);
                 if (!string.IsNullOrEmpty(_stream.Task))
                     _transcript.AddMessage(MessageRole.User, _stream.Task);
                 _stream.Attach(this);

--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // A transient, read-only popup that renders one child agent's full transcript (design sec.14, tier 3).
+    // Opened from a dispatch_agent record's "View transcript" link. Pure UI: it shows the child's own
+    // message list to the user; nothing here feeds back into any model (the context firewall, A3/A7, holds).
+    // Reuses ChatTranscriptControl for themed Markdown/code rendering; the control auto-themes from settings
+    // in its constructor, so the popup matches the active light/dark theme at open time. Code-only (no
+    // designer) - it hosts a single docked transcript control.
+    internal sealed class AgentTranscriptViewerForm : Form
+    {
+        private readonly ChatTranscriptControl _transcript;
+        private readonly AgentTranscript _data;
+
+        public AgentTranscriptViewerForm(AgentTranscript transcript)
+        {
+            _data = transcript;
+            this.Text = BuildTitle(transcript);
+            this.StartPosition = FormStartPosition.CenterParent;
+            this.FormBorderStyle = FormBorderStyle.Sizable;
+            this.MinimizeBox = false;
+            this.MaximizeBox = true;
+            this.ShowInTaskbar = false;
+            this.ClientSize = new Size(720, 560);
+            this.MinimumSize = new Size(360, 240);
+            this.KeyPreview = true;
+
+            _transcript = new ChatTranscriptControl();
+            _transcript.Dock = DockStyle.Fill;
+            this.Controls.Add(_transcript);
+
+            ApplyFontSetting();
+        }
+
+        // Populate once the handle exists - the transcript control skips layout until it has a window, so
+        // adding messages in the constructor would render nothing.
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            _transcript.BeginBatchUpdates();
+            try { Populate(_data); }
+            finally { _transcript.EndBatchUpdates(false); }
+            _transcript.ScrollToTop();
+        }
+
+        private static string BuildTitle(AgentTranscript t)
+        {
+            string slug = (t != null && !string.IsNullOrEmpty(t.Slug)) ? t.Slug : "agent";
+            return "Agent transcript - " + slug;
+        }
+
+        private void ApplyFontSetting()
+        {
+            try
+            {
+                double fs = AppSettings.GetDouble("font_size", 0);
+                if (fs <= 0 || _transcript == null) return;
+                float size = (float)Math.Max(6, Math.Min(48, fs));
+                _transcript.Font = new Font(_transcript.Font.FontFamily, size, _transcript.Font.Style);
+            }
+            catch { }
+        }
+
+        // Renders the child's message list. The leading system message is the agent's persona; the first
+        // user message is the task; assistant/tool turns follow. Assistant tool calls are shown as a compact
+        // Tool-role note (name + JSON args) so the run reads in order.
+        private void Populate(AgentTranscript t)
+        {
+            if (t == null || t.Messages == null) { _transcript.AddMessage(MessageRole.System, "(transcript unavailable)"); return; }
+
+            for (int i = 0; i < t.Messages.Count; i++)
+            {
+                ChatMessage m = t.Messages[i];
+                if (m == null) continue;
+                string role = m.Role ?? string.Empty;
+                string content = m.Content ?? string.Empty;
+
+                if (role == "user")
+                {
+                    _transcript.AddMessage(MessageRole.User, content);
+                }
+                else if (role == "system")
+                {
+                    if (content.Length > 0) _transcript.AddMessage(MessageRole.System, content);
+                }
+                else if (role == "tool")
+                {
+                    _transcript.AddMessage(MessageRole.Tool, content);
+                }
+                else if (role == "assistant")
+                {
+                    if (content.Length > 0)
+                        _transcript.AddMessage(MessageRole.Assistant, content);
+                    if (m.ToolCalls != null)
+                    {
+                        for (int c = 0; c < m.ToolCalls.Count; c++)
+                            _transcript.AddMessage(MessageRole.Tool, FormatToolCall(m.ToolCalls[c]));
+                    }
+                }
+                else if (content.Length > 0)
+                {
+                    _transcript.AddMessage(MessageRole.Tool, content);
+                }
+            }
+        }
+
+        private static string FormatToolCall(ToolCall call)
+        {
+            if (call == null) return "(tool call)";
+            string name = !string.IsNullOrEmpty(call.Name) ? call.Name : "(tool)";
+            string args = call.ArgumentsJson != null ? call.ArgumentsJson.Trim() : string.Empty;
+            string head = "Called `" + name + "`";
+            if (args.Length == 0 || args == "{}") return head;
+            return head + "\n```json\n" + args + "\n```";
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            base.OnKeyDown(e);
+            if (e.KeyCode == Keys.Escape) { this.Close(); e.Handled = true; }
+        }
+    }
+}

--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -17,7 +17,8 @@ namespace GxPT
         private ChatTranscriptControl _transcript;   // set in Init() (a ctor helper), so not readonly
         private readonly AgentTranscript _data;     // static mode (null in live mode)
         private readonly AgentLiveStream _stream;   // live mode (null in static mode)
-        private bool _liveAssistantOpen;            // is the last live message an open assistant bubble?
+        private bool _liveAssistantOpen;            // is the last message an open assistant bubble?
+        private bool _toolBlockOpen;                // is the last message an open chrome-less tool block?
 
         public AgentTranscriptViewerForm(AgentTranscript transcript)
         {
@@ -83,26 +84,33 @@ namespace GxPT
             if (string.IsNullOrEmpty(delta)) return;
             Ui(delegate
             {
+                _toolBlockOpen = false;
                 if (_liveAssistantOpen) _transcript.AppendToLastMessage(delta);
                 else { _transcript.AddMessage(MessageRole.Assistant, delta); _liveAssistantOpen = true; }
             });
         }
 
-        public void OnToolCall(string functionName, string callId)
+        public void OnToolCall(string functionName, string argumentsJson, string callId)
         {
-            string fn = !string.IsNullOrEmpty(functionName) ? functionName : "(tool)";
-            Ui(delegate { _liveAssistantOpen = false; _transcript.AddMessage(MessageRole.Tool, "Called `" + fn + "`"); });
+            string fn = functionName, args = argumentsJson, key = callId;
+            Ui(delegate { AddToolMarker(MainForm.EditDiffMarkerOrCall(_transcript, fn, args, key)); });
         }
 
-        public void OnToolResult(string functionName, string resultText, bool isError)
-        {
-            string res = resultText ?? string.Empty;
-            Ui(delegate { _liveAssistantOpen = false; _transcript.AddMessage(MessageRole.Tool, res); });
-        }
+        // Tool results are hidden, to match the main chat (which never shows raw tool output).
+        public void OnToolResult(string functionName, string resultText, bool isError) { }
 
         public void OnComplete()
         {
-            Ui(delegate { _liveAssistantOpen = false; });
+            Ui(delegate { _liveAssistantOpen = false; _toolBlockOpen = false; });
+        }
+
+        // Append a tool marker (a collapsible-record sentinel or a "using <tool>" line) the way the main
+        // chat does: consecutive tool calls accumulate into one chrome-less block; assistant text breaks it.
+        private void AddToolMarker(string marker)
+        {
+            _liveAssistantOpen = false;
+            if (_toolBlockOpen) _transcript.AppendToLastMessage("\r\n" + marker);
+            else { _transcript.AddMessage(MessageRole.Tool, marker); _toolBlockOpen = true; }
         }
 
         // Marshal an action onto the UI thread (sink callbacks may arrive on the child's worker thread; even
@@ -130,8 +138,9 @@ namespace GxPT
             catch { }
         }
 
-        // Renders a finished message list. Leading system message is the persona; the first user message is
-        // the task; assistant/tool turns follow. Assistant tool calls are shown as a compact Tool-role note.
+        // Renders a finished message list the same way the main chat does: the persona/task as bubbles,
+        // assistant text as bubbles, and each tool call as the same collapsible record (via the shared
+        // EditDiffMarkerOrCall). Raw tool results (role "tool") are skipped - the main chat never shows them.
         private void Populate(AgentTranscript t)
         {
             if (t == null || t.Messages == null) { _transcript.AddMessage(MessageRole.System, "(transcript unavailable)"); return; }
@@ -143,43 +152,37 @@ namespace GxPT
                 string role = m.Role ?? string.Empty;
                 string content = m.Content ?? string.Empty;
 
+                if (role == "tool") continue;   // results hidden, like the main chat
+
                 if (role == "user")
                 {
                     _transcript.AddMessage(MessageRole.User, content);
+                    _liveAssistantOpen = false; _toolBlockOpen = false;
                 }
                 else if (role == "system")
                 {
-                    if (content.Length > 0) _transcript.AddMessage(MessageRole.System, content);
-                }
-                else if (role == "tool")
-                {
-                    _transcript.AddMessage(MessageRole.Tool, content);
+                    if (content.Length > 0)
+                    {
+                        _transcript.AddMessage(MessageRole.System, content);
+                        _liveAssistantOpen = false; _toolBlockOpen = false;
+                    }
                 }
                 else if (role == "assistant")
                 {
                     if (content.Length > 0)
-                        _transcript.AddMessage(MessageRole.Assistant, content);
-                    if (m.ToolCalls != null)
                     {
-                        for (int c = 0; c < m.ToolCalls.Count; c++)
-                            _transcript.AddMessage(MessageRole.Tool, FormatToolCall(m.ToolCalls[c]));
+                        _transcript.AddMessage(MessageRole.Assistant, content);
+                        _liveAssistantOpen = false; _toolBlockOpen = false;
                     }
-                }
-                else if (content.Length > 0)
-                {
-                    _transcript.AddMessage(MessageRole.Tool, content);
+                    if (m.ToolCalls != null)
+                        for (int c = 0; c < m.ToolCalls.Count; c++)
+                        {
+                            ToolCall call = m.ToolCalls[c];
+                            if (call == null) continue;
+                            AddToolMarker(MainForm.EditDiffMarkerOrCall(_transcript, call.Name, call.ArgumentsJson, call.Id));
+                        }
                 }
             }
-        }
-
-        private static string FormatToolCall(ToolCall call)
-        {
-            if (call == null) return "(tool call)";
-            string name = !string.IsNullOrEmpty(call.Name) ? call.Name : "(tool)";
-            string args = call.ArgumentsJson != null ? call.ArgumentsJson.Trim() : string.Empty;
-            string head = "Called `" + name + "`";
-            if (args.Length == 0 || args == "{}") return head;
-            return head + "\n```json\n" + args + "\n```";
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -84,6 +84,8 @@
             this.tslToolsValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSkills = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSkillsValue = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslAgents = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tslAgentsValue = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslSpring = new System.Windows.Forms.ToolStripStatusLabel();
             this.tslContext = new System.Windows.Forms.ToolStripStatusLabel();
             this.tspContextMeter = new GxPT.ContextMeterItem();
@@ -559,6 +561,8 @@
             this.tslToolsValue,
             this.tslSkills,
             this.tslSkillsValue,
+            this.tslAgents,
+            this.tslAgentsValue,
             this.tslSpring,
             this.tslContext,
             this.tspContextMeter,
@@ -629,6 +633,22 @@
             this.tslSkillsValue.Name = "tslSkillsValue";
             this.tslSkillsValue.Size = new System.Drawing.Size(0, 17);
             this.tslSkillsValue.ToolTipText = "Skills enabled for this conversation";
+            //
+            // tslAgents
+            //
+            this.tslAgents.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
+            this.tslAgents.Margin = new System.Windows.Forms.Padding(5, 3, 0, 2);
+            this.tslAgents.Name = "tslAgents";
+            this.tslAgents.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.tslAgents.Size = new System.Drawing.Size(0, 17);
+            this.tslAgents.ToolTipText = "Sub-agents available to this conversation";
+            //
+            // tslAgentsValue
+            //
+            this.tslAgentsValue.Margin = new System.Windows.Forms.Padding(-2, 3, 0, 2);
+            this.tslAgentsValue.Name = "tslAgentsValue";
+            this.tslAgentsValue.Size = new System.Drawing.Size(0, 17);
+            this.tslAgentsValue.ToolTipText = "Sub-agents available to this conversation";
             //
             // tslSpring
             //
@@ -775,6 +795,8 @@
         private System.Windows.Forms.ToolStripStatusLabel tslToolsValue;
         private System.Windows.Forms.ToolStripStatusLabel tslSkills;
         private System.Windows.Forms.ToolStripStatusLabel tslSkillsValue;
+        private System.Windows.Forms.ToolStripStatusLabel tslAgents;
+        private System.Windows.Forms.ToolStripStatusLabel tslAgentsValue;
         private System.Windows.Forms.ToolStripStatusLabel tslSpring;
         private System.Windows.Forms.ToolStripStatusLabel tslContext;
         private ContextMeterItem tspContextMeter;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4184,13 +4184,15 @@ namespace GxPT
                         string task = Str(ag, "task");
                         if (slug.Length == 0 && task.Length == 0) continue;
                         count++;
-                        if (lines.Length > 0) lines.Append('\n');
-                        lines.Append("- ").Append(slug.Length > 0 ? slug : "(agent)");
-                        if (task.Length > 0) lines.Append(": ").Append(task);
+                        // Blank line between entries so each agent is its own Markdown paragraph
+                        // (one per line); slug in bold, task in italics.
+                        if (lines.Length > 0) lines.Append("\n\n");
+                        lines.Append("**").Append(slug.Length > 0 ? slug : "(agent)").Append(":**");
+                        if (task.Length > 0) lines.Append(" *").Append(task).Append('*');
                     }
                     if (count == 0) return false;
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");
-                    body = lines.ToString(); language = "text"; return true;
+                    body = lines.ToString(); language = "markdown"; return true;
                 }
                 case "web__search":
                 {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -797,6 +797,7 @@ namespace GxPT
                 // Bottom approval panel. Add the docked siblings, then send the transcript to front.
                 ctx.Page.Controls.Add(strip);
                 AttachApprovalPanel(ctx);
+                AttachAgentActivityPanel(ctx);
                 if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
                 // Honor a persisted dismissal (only meaningful when no folder is set; setting one
@@ -823,6 +824,20 @@ namespace GxPT
                 // While this tab's prompt awaits the user, pause the status-bar marquee and swap the
                 // Stop button for an "awaiting user..." label (only when this is the active tab).
                 panel.PromptVisibleChanged += delegate { SyncGenerationIndicatorFromActiveTab(); };
+                ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
+            }
+            catch { }
+        }
+
+        // The per-tab sub-agents activity panel (design sec.14), docked at the bottom like the approval
+        // panel. Shown only while a dispatch_agent fan-out runs; updated via AgentActivityUiBridge.
+        internal void AttachAgentActivityPanel(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Page == null) return;
+            try
+            {
+                AgentActivityPanel panel = new AgentActivityPanel();
+                ctx.AgentActivityPanel = panel;
                 ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
@@ -3046,6 +3061,10 @@ namespace GxPT
                                 RecordUsageAndReconcile(revealConvo, u,
                                     OpenRouterClient.ModelSupportsPromptCaching(model), false);
                             };
+                            // Observability: marshal the fan-out / per-child lifecycle to this tab's
+                            // activity panel (design sec.14). The turn's Stop still cancels children
+                            // (dispatcher.Cancellation = ctx.Cancellation), so no separate group handle yet.
+                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx);
                             orch.AgentDispatcher = dispatcher;
                         }
                     }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4170,6 +4170,28 @@ namespace GxPT
                     string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
                     header = "Ran a command"; body = cmd; language = "batch"; return true;
                 }
+                case "dispatch_agent":
+                {
+                    Newtonsoft.Json.Linq.JToken arr = args != null ? args["agents"] : null;
+                    if (arr == null || arr.Type != Newtonsoft.Json.Linq.JTokenType.Array) return false;
+                    int count = 0;
+                    System.Text.StringBuilder lines = new System.Text.StringBuilder();
+                    foreach (Newtonsoft.Json.Linq.JToken t in (Newtonsoft.Json.Linq.JArray)arr)
+                    {
+                        if (t == null || t.Type != Newtonsoft.Json.Linq.JTokenType.Object) continue;
+                        Newtonsoft.Json.Linq.JObject ag = (Newtonsoft.Json.Linq.JObject)t;
+                        string slug = Str(ag, "name");
+                        string task = Str(ag, "task");
+                        if (slug.Length == 0 && task.Length == 0) continue;
+                        count++;
+                        if (lines.Length > 0) lines.Append('\n');
+                        lines.Append("- ").Append(slug.Length > 0 ? slug : "(agent)");
+                        if (task.Length > 0) lines.Append(": ").Append(task);
+                    }
+                    if (count == 0) return false;
+                    header = "Dispatched " + count + (count == 1 ? " agent" : " agents");
+                    body = lines.ToString(); language = "text"; return true;
+                }
                 case "web__search":
                 {
                     string query = Str(args, "query"); if (query.Trim().Length == 0) return false;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1656,6 +1656,7 @@ namespace GxPT
             var all = new List<ISlashCommand>();
             all.AddRange(ClientCommands.BuiltIns());
             all.AddRange(SkillCommandShared.BuiltIns());
+            all.AddRange(AgentCommands.BuiltIns());
             all.AddRange(SlashCommandConfig.LoadMerged(userJson, LoggerSink.Instance));
 
             _slashRegistry = new SlashCommandRegistry(all);
@@ -1795,6 +1796,20 @@ namespace GxPT
             var c = _tabManager != null ? _tabManager.GetActiveContext() : null;
             if (c == null || c.Conversation == null) return;
             c.Conversation.SkillsFeatureOff = value;
+            SaveConversationContext(c);
+        }
+
+        internal bool? SlashGetConversationAgentsEnabled()
+        {
+            var c = _tabManager != null ? _tabManager.GetActiveContext() : null;
+            return (c != null && c.Conversation != null) ? c.Conversation.AgentsEnabled : null;
+        }
+
+        internal void SlashSetConversationAgentsEnabled(bool? value)
+        {
+            var c = _tabManager != null ? _tabManager.GetActiveContext() : null;
+            if (c == null || c.Conversation == null) return;
+            c.Conversation.AgentsEnabled = value;
             SaveConversationContext(c);
         }
 
@@ -3001,9 +3016,9 @@ namespace GxPT
                     // Sub-agents: when the agents feature is enabled (settings.json `agents_enabled`),
                     // discover all agents under <exe>/agents + <workdir>/.gxpt/agents + %AppData%/GxPT/agents
                     // and expose the manifest + dispatch_agent. Rebuilt per send, so on-disk edits take
-                    // effect on the next turn. No per-agent enablement (design A15); the per-conversation
-                    // override is a later phase, so this uses the global setting only.
-                    if (AgentEnablement.GlobalEnabled())
+                    // effect on the next turn. No per-agent enablement (design A15); the conversation
+                    // override (/toggle-agents here) wins over the global settings.json default.
+                    if (AgentEnablement.FeatureEnabled(convo != null ? convo.AgentsEnabled : null))
                     {
                         AgentCatalog agentCatalog =
                             AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4175,23 +4175,23 @@ namespace GxPT
                     Newtonsoft.Json.Linq.JToken arr = args != null ? args["agents"] : null;
                     if (arr == null || arr.Type != Newtonsoft.Json.Linq.JTokenType.Array) return false;
                     int count = 0;
-                    // Headerless 2-column Markdown table: bold slug on the left, raw task on the right.
-                    // (GitHub tables require a header + separator row, so the first row is left empty.)
-                    System.Text.StringBuilder rows = new System.Text.StringBuilder();
+                    System.Text.StringBuilder md = new System.Text.StringBuilder();
                     foreach (Newtonsoft.Json.Linq.JToken t in (Newtonsoft.Json.Linq.JArray)arr)
                     {
                         if (t == null || t.Type != Newtonsoft.Json.Linq.JTokenType.Object) continue;
                         Newtonsoft.Json.Linq.JObject ag = (Newtonsoft.Json.Linq.JObject)t;
-                        string slug = TableCell(Str(ag, "name"));
-                        string task = TableCell(Str(ag, "task"));
+                        string slug = Str(ag, "name").Trim();
+                        string task = Str(ag, "task").Trim();
                         if (slug.Length == 0 && task.Length == 0) continue;
                         count++;
-                        rows.Append("| **").Append(slug.Length > 0 ? slug : "(agent)").Append("** | ")
-                            .Append(task).Append(" |\n");
+                        // Blank line between agents so each is its own paragraph: bold slug, then the
+                        // task with its own newlines preserved (the parser keeps single newlines within
+                        // a paragraph as hard breaks).
+                        if (md.Length > 0) md.Append("\n\n");
+                        md.Append("**").Append(slug.Length > 0 ? slug : "(agent)").Append(":**");
+                        if (task.Length > 0) md.Append(' ').Append(task);
                     }
                     if (count == 0) return false;
-                    System.Text.StringBuilder md = new System.Text.StringBuilder();
-                    md.Append("|  |  |\n| --- | --- |\n").Append(rows);
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");
                     body = md.ToString(); language = "markdown"; return true;
                 }
@@ -4467,14 +4467,6 @@ namespace GxPT
         {
             try { var t = args[name]; return t == null ? string.Empty : ((string)t ?? string.Empty); }
             catch { return string.Empty; }
-        }
-        // Flattens a string into a single Markdown table cell: newlines become spaces and pipes are
-        // swapped for '/' (the simple table parser splits on every '|' and has no escape support).
-        private static string TableCell(string s)
-        {
-            if (string.IsNullOrEmpty(s)) return string.Empty;
-            s = s.Replace("\r", " ").Replace("\n", " ").Replace("|", "/");
-            return s.Trim();
         }
         private static bool Bool(Newtonsoft.Json.Linq.JObject args, string name)
         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4175,24 +4175,25 @@ namespace GxPT
                     Newtonsoft.Json.Linq.JToken arr = args != null ? args["agents"] : null;
                     if (arr == null || arr.Type != Newtonsoft.Json.Linq.JTokenType.Array) return false;
                     int count = 0;
-                    System.Text.StringBuilder lines = new System.Text.StringBuilder();
+                    // Headerless 2-column Markdown table: bold slug on the left, raw task on the right.
+                    // (GitHub tables require a header + separator row, so the first row is left empty.)
+                    System.Text.StringBuilder rows = new System.Text.StringBuilder();
                     foreach (Newtonsoft.Json.Linq.JToken t in (Newtonsoft.Json.Linq.JArray)arr)
                     {
                         if (t == null || t.Type != Newtonsoft.Json.Linq.JTokenType.Object) continue;
                         Newtonsoft.Json.Linq.JObject ag = (Newtonsoft.Json.Linq.JObject)t;
-                        string slug = Str(ag, "name");
-                        string task = Str(ag, "task");
+                        string slug = TableCell(Str(ag, "name"));
+                        string task = TableCell(Str(ag, "task"));
                         if (slug.Length == 0 && task.Length == 0) continue;
                         count++;
-                        // Blank line between entries so each agent is its own Markdown paragraph
-                        // (one per line); slug in bold, task in italics.
-                        if (lines.Length > 0) lines.Append("\n\n");
-                        lines.Append("**").Append(slug.Length > 0 ? slug : "(agent)").Append(":**");
-                        if (task.Length > 0) lines.Append(" *").Append(task).Append('*');
+                        rows.Append("| **").Append(slug.Length > 0 ? slug : "(agent)").Append("** | ")
+                            .Append(task).Append(" |\n");
                     }
                     if (count == 0) return false;
+                    System.Text.StringBuilder md = new System.Text.StringBuilder();
+                    md.Append("|  |  |\n| --- | --- |\n").Append(rows);
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");
-                    body = lines.ToString(); language = "markdown"; return true;
+                    body = md.ToString(); language = "markdown"; return true;
                 }
                 case "web__search":
                 {
@@ -4466,6 +4467,14 @@ namespace GxPT
         {
             try { var t = args[name]; return t == null ? string.Empty : ((string)t ?? string.Empty); }
             catch { return string.Empty; }
+        }
+        // Flattens a string into a single Markdown table cell: newlines become spaces and pipes are
+        // swapped for '/' (the simple table parser splits on every '|' and has no escape support).
+        private static string TableCell(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            s = s.Replace("\r", " ").Replace("\n", " ").Replace("|", "/");
+            return s.Trim();
         }
         private static bool Bool(Newtonsoft.Json.Linq.JObject args, string name)
         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -983,8 +983,81 @@ namespace GxPT
                 if (this.tslSkills != null) this.tslSkills.Text = "Skills:";
                 if (this.tslSkillsValue != null)
                     this.tslSkillsValue.Text = enabledSkills.Count.ToString(inv);
+
+                // Agents (after Skills): how many sub-agents are usable on the next turn. "Usable" means the
+                // agent's required tools are actually available here (runtime per-agent enablement), matching
+                // the send path's filter. The tooltip lists the enabled ones and, for any disabled, what to
+                // turn on (e.g. web-research needs the web tools).
+                int agentCount = 0;
+                string agentTip = "Sub-agents available to this conversation";
+                bool agentsOn = AgentEnablement.FeatureEnabled(convo != null ? convo.AgentsEnabled : null);
+                if (!agentsOn)
+                {
+                    agentTip = "Sub-agents are off. Turn them on in Settings (Tools) or with /toggle-agents.";
+                }
+                else
+                {
+                    AgentCatalog acat = AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, workdir);
+                    if (acat.Agents.Count == 0)
+                    {
+                        agentTip = "No agents found. Add <slug>.md files under the app's agents folder, "
+                            + "%AppData%/GxPT/agents, or <workspace>/.gxpt/agents.";
+                    }
+                    else
+                    {
+                        IList<string> aNames = (_mcpRegistry != null)
+                            ? _mcpRegistry.NamesForWorkdir(workdir) : (IList<string>)new List<string>();
+                        Func<string, ToolTier> agentTierOf = AgentTierOf();
+                        List<string> enabledNames = new List<string>();
+                        List<string> disabledLines = new List<string>();
+                        for (int i = 0; i < acat.Agents.Count; i++)
+                        {
+                            Agent a = acat.Agents[i];
+                            if (AgentAvailability.IsAvailable(a, aNames, agentTierOf))
+                            {
+                                enabledNames.Add(a.Slug);
+                                agentCount++;
+                            }
+                            else
+                            {
+                                List<string> need = AgentAvailability.MissingTools(a, aNames);
+                                disabledLines.Add("  " + a.Slug + (need.Count > 0
+                                    ? " - needs " + string.Join(", ", need.ToArray()) : " - (no available tools)"));
+                            }
+                        }
+                        System.Text.StringBuilder tip = new System.Text.StringBuilder();
+                        tip.Append("Enabled (").Append(enabledNames.Count.ToString(inv)).Append("): ");
+                        tip.Append(enabledNames.Count > 0 ? string.Join(", ", enabledNames.ToArray()) : "none");
+                        if (disabledLines.Count > 0)
+                        {
+                            tip.Append("\r\n\r\nDisabled - required tools not available:");
+                            for (int i = 0; i < disabledLines.Count; i++) tip.Append("\r\n").Append(disabledLines[i]);
+                        }
+                        agentTip = tip.ToString();
+                    }
+                }
+                if (this.tslAgents != null) { this.tslAgents.Text = "Agents:"; this.tslAgents.ToolTipText = agentTip; }
+                if (this.tslAgentsValue != null)
+                {
+                    this.tslAgentsValue.Text = agentCount.ToString(inv);
+                    this.tslAgentsValue.ToolTipText = agentTip;
+                }
             }
             catch { }
+        }
+
+        // A tool->tier classifier for status-bar agent availability (workdir-independent classification,
+        // built fresh and cheap). Mirrors the send path's tierOf (the approval policy's classification);
+        // first-party agent tools are classified by the hardcoded table, so annotations are best-effort.
+        private Func<string, ToolTier> AgentTierOf()
+        {
+            try
+            {
+                ToolApprovalPolicy p = new ToolApprovalPolicy(new ToolClassifier(), null, null,
+                    _mcpRegistry as IToolAnnotationSource);
+                return p.TierOf;
+            }
+            catch { return null; }
         }
 
         // The tool registry changed (a server connected, refreshed its tools, or went away) on a
@@ -3104,36 +3177,47 @@ namespace GxPT
                             AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
                         if (agentCatalog.Agents.Count > 0)
                         {
-                            List<Agent> agentsForTurn = new List<Agent>(agentCatalog.Agents);
-                            orch.AgentsManifestSystemMessageProvider =
-                                delegate { return AgentInjection.BuildManifestMessage(agentsForTurn); };
                             // tierOf reuses the approval policy's classification so an agent's max_tier
                             // ceiling matches the gate; the AllowAll fallback (no policy) leaves it null
                             // and the resolver treats every tool as Write.
                             Func<string, ToolTier> tierOf = null;
                             ToolApprovalPolicy tap = approval as ToolApprovalPolicy;
                             if (tap != null) tierOf = tap.TierOf;
-                            AgentDispatcher dispatcher = new AgentDispatcher(
-                                agentsForTurn, _client, _mcpRegistry, approval, model, ctx.WorkingDir,
-                                LoggerSink.Instance, tierOf,
-                                McpChatOrchestrator.DefaultMaxIterations, McpChatOrchestrator.DefaultCallTimeoutMs);
-                            dispatcher.Cancellation = ctx.Cancellation;
-                            // Child usage adds to cost/token totals but must NOT move the parent's context
-                            // gauge (the child has its own isolated context) - so it routes through the
-                            // updateContextGauge=false overload, not orch.UsageReported.
-                            dispatcher.UsageReported = delegate(ResponseUsage u)
+                            // Runtime per-agent enablement: only offer agents whose required tools are
+                            // actually available in this workspace (e.g. web-research needs the web tools),
+                            // so the model never dispatches an agent that would resolve to nothing.
+                            IList<string> parentNames = _mcpRegistry != null
+                                ? _mcpRegistry.NamesForWorkdir(ctx.WorkingDir) : (IList<string>)new List<string>();
+                            List<Agent> agentsForTurn = new List<Agent>();
+                            for (int ai = 0; ai < agentCatalog.Agents.Count; ai++)
+                                if (AgentAvailability.IsAvailable(agentCatalog.Agents[ai], parentNames, tierOf))
+                                    agentsForTurn.Add(agentCatalog.Agents[ai]);
+                            if (agentsForTurn.Count > 0)
                             {
-                                RecordUsageAndReconcile(revealConvo, u,
-                                    OpenRouterClient.ModelSupportsPromptCaching(model), false);
-                            };
-                            // Observability + group cancel (design sec.14): a dedicated handle the panel's
-                            // Stop button trips, so it cancels the agents (children watch GroupCancellation)
-                            // without ending the turn - the parent loop resumes with the partial results.
-                            RequestCancellation agentGroup = new RequestCancellation();
-                            dispatcher.GroupCancellation = agentGroup;
-                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup, dispatcher);
-                            orch.AgentDispatcher = dispatcher;
-                            dispatcherForTurn = dispatcher;
+                                orch.AgentsManifestSystemMessageProvider =
+                                    delegate { return AgentInjection.BuildManifestMessage(agentsForTurn); };
+                                AgentDispatcher dispatcher = new AgentDispatcher(
+                                    agentsForTurn, _client, _mcpRegistry, approval, model, ctx.WorkingDir,
+                                    LoggerSink.Instance, tierOf,
+                                    McpChatOrchestrator.DefaultMaxIterations, McpChatOrchestrator.DefaultCallTimeoutMs);
+                                dispatcher.Cancellation = ctx.Cancellation;
+                                // Child usage adds to cost/token totals but must NOT move the parent's context
+                                // gauge (the child has its own isolated context) - so it routes through the
+                                // updateContextGauge=false overload, not orch.UsageReported.
+                                dispatcher.UsageReported = delegate(ResponseUsage u)
+                                {
+                                    RecordUsageAndReconcile(revealConvo, u,
+                                        OpenRouterClient.ModelSupportsPromptCaching(model), false);
+                                };
+                                // Observability + group cancel (design sec.14): a dedicated handle the panel's
+                                // Stop button trips, so it cancels the agents (children watch GroupCancellation)
+                                // without ending the turn - the parent loop resumes with the partial results.
+                                RequestCancellation agentGroup = new RequestCancellation();
+                                dispatcher.GroupCancellation = agentGroup;
+                                dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup, dispatcher);
+                                orch.AgentDispatcher = dispatcher;
+                                dispatcherForTurn = dispatcher;
+                            }
                         }
                     }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -888,6 +888,14 @@ namespace GxPT
             catch { }
         }
 
+        // Called by AgentActivityUiBridge (on the UI thread) when a fan-out starts/ends on a tab, so the
+        // status bar's passive "Sub-agents running..." indicator tracks it.
+        internal void NotifyAgentFanOutChanged(TabManager.ChatTabContext ctx, bool active)
+        {
+            if (ctx != null) ctx.AgentsFanOutActive = active;
+            SyncGenerationIndicatorFromActiveTab();
+        }
+
         private void SyncGenerationIndicatorFromActiveTab()
         {
             try
@@ -897,12 +905,15 @@ namespace GxPT
                 // The turn is paused at an approval/continuation gate when the active tab's prompt is
                 // up: pause the marquee and show "awaiting user..." in place of the Stop button.
                 bool awaiting = busy && act.ApprovalPanel != null && act.ApprovalPanel.IsPromptVisible;
-                SetGenerationIndicatorVisible(busy, awaiting);
+                // A dispatch_agent fan-out is running: keep the marquee going but show a passive
+                // "Sub-agents running..." label (cancel them from the panel). Approval takes priority.
+                bool agentsRunning = busy && act.AgentsFanOutActive && !awaiting;
+                SetGenerationIndicatorVisible(busy, awaiting, agentsRunning);
             }
             catch { }
         }
 
-        private void SetGenerationIndicatorVisible(bool busy, bool awaiting)
+        private void SetGenerationIndicatorVisible(bool busy, bool awaiting, bool agentsRunning)
         {
             try
             {
@@ -920,6 +931,7 @@ namespace GxPT
                 if (this.tsiStopGen != null)
                 {
                     this.tsiStopGen.Awaiting = awaiting;
+                    this.tsiStopGen.AgentsRunning = agentsRunning;
                     this.tsiStopGen.Visible = busy;
                 }
                 // The slot's idle face: the active conversation's tool/skill counts. Refresh before
@@ -996,9 +1008,10 @@ namespace GxPT
         // cancel the active tab's request.
         private void tsiStopGen_Click(object sender, EventArgs e)
         {
-            // While the item shows "awaiting user...", there's nothing to stop (the turn is paused at
-            // an approval gate); ignore clicks so it behaves as a passive label.
-            if (this.tsiStopGen != null && this.tsiStopGen.Awaiting) return;
+            // While the item shows a passive label ("awaiting user..." at an approval gate, or
+            // "sub-agents running..." during a fan-out - cancel those from the panel), there's nothing to
+            // stop from here; ignore clicks.
+            if (this.tsiStopGen != null && (this.tsiStopGen.Awaiting || this.tsiStopGen.AgentsRunning)) return;
             try { CancelActiveRequest(_tabManager != null ? _tabManager.GetActiveContext() : null); }
             catch { }
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2666,6 +2666,11 @@ namespace GxPT
         // the turn restarts over the unchanged history — this holds for both the plain stream (the
         // user message is committed before the request) and the tool loop (the orchestrator's partial
         // progress stays in history, same as when the user keeps typing after a failure).
+        private static string ConvId(TabManager.ChatTabContext ctx)
+        {
+            return (ctx != null && ctx.Conversation != null) ? ctx.Conversation.Id : null;
+        }
+
         // Open the read-only child-transcript viewer for a dispatch_agent "View transcript" link (tier 3).
         // The link encodes the dispatch record's key + agent slot; resolve it against the session cache. A
         // miss (cache evicted, or a record reloaded from history after restart) shows a short notice rather
@@ -3160,17 +3165,22 @@ namespace GxPT
                     };
                     // argsJson is threaded through for files__edit etc., which render a collapsible
                     // record instead of the generic "using" marker; register the record (it has its own
-                    // lock) before taking sbLock. Live keys are per-call GUIDs (ephemeral — the reloaded
-                    // view re-derives under the persisted call id).
-                    Action<string, string, string, bool> onToolResult = delegate(string name, string argsJson, string resultText, bool isError)
+                    // lock) before taking sbLock. The record key is the model's call id, so the live and
+                    // reloaded views share one identity (and persisted agent transcripts resolve on reload).
+                    Action<string, string, string, bool, string> onToolResult = delegate(string name, string argsJson, string resultText, bool isError, string callId)
                     {
-                        string recKey = Guid.NewGuid().ToString("N");
+                        string recKey = !string.IsNullOrEmpty(callId) ? callId : Guid.NewGuid().ToString("N");
                         // A dispatch_agent record gets per-agent "View transcript" links keyed by recKey;
-                        // cache this fan-out's child transcripts under the same key so the links resolve
-                        // (tier 3). Tool calls are serial, so LastTranscripts is this call's batch.
+                        // cache + persist this fan-out's child transcripts under the same key so the links
+                        // resolve now and after reload. Tool calls are serial, so LastTranscripts is this
+                        // call's batch.
                         if (dispatcherForTurn != null && AgentDispatcher.DispatchAgentName == name
                             && dispatcherForTurn.LastTranscripts != null)
+                        {
                             AgentTranscriptStore.Put(recKey, dispatcherForTurn.LastTranscripts);
+                            try { AgentTranscriptPersistence.Save(ConvId(ctx), recKey, dispatcherForTurn.LastTranscripts); }
+                            catch { }
+                        }
                         string marker = McpMarkers.IsDenied(resultText)
                             ? McpMarkers.Denied(name)
                             : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, recKey);
@@ -4221,19 +4231,22 @@ namespace GxPT
                         string task = Str(ag, "task").Trim();
                         if (slug.Length == 0 && task.Length == 0) continue;
                         count++;
-                        // Blank line between agents so each is its own paragraph: bold slug, then the
-                        // task with its own newlines preserved (the parser keeps single newlines within
-                        // a paragraph as hard breaks).
+                        // Blank line between agents so each is its own paragraph. Bold slug, then the
+                        // child's tool-call count (from its transcript) on its own line, then the
+                        // "View transcript" link. The count/link only show when a transcript exists
+                        // (live: just cached; reloaded: re-seeded from disk) - so an unknown agent that
+                        // ran no child has neither.
                         if (md.Length > 0) md.Append("\n\n");
                         md.Append("**").Append(slug.Length > 0 ? slug : "(agent)").Append(":**");
-                        // Newline after the slug so the task starts on its own line (single newline =
-                        // hard break within the paragraph).
-                        if (task.Length > 0) md.Append('\n').Append(task);
-                        // Tier 3: a per-agent "View transcript" link the transcript control intercepts
-                        // (AgentTranscriptLinkScheme) to open the read-only child transcript popup. Keyed
-                        // by the record key + slot so it resolves against AgentTranscriptStore.
-                        if (!string.IsNullOrEmpty(key))
+                        AgentTranscript tr = !string.IsNullOrEmpty(key) ? AgentTranscriptStore.Get(key, slot) : null;
+                        if (tr != null)
+                        {
+                            int tc = tr.ToolCallCount;
+                            md.Append('\n').Append(tc).Append(tc == 1 ? " tool call" : " tool calls");
+                            // Tier 3: a per-agent "View transcript" link the transcript control intercepts
+                            // (AgentTranscriptLinks scheme) to open the read-only child transcript popup.
                             md.Append("\n[View transcript](").Append(AgentTranscriptLinks.Build(key, slot)).Append(')');
+                        }
                     }
                     if (count == 0) return false;
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");
@@ -4742,6 +4755,18 @@ namespace GxPT
                 ctx.Transcript.ClearMessages();
                 if (_themeManager != null) _themeManager.ApplyFontSetting(ctx.Transcript);
                 try { ctx.Transcript.RefreshTheme(); }
+                catch { }
+
+                // Re-seed this conversation's persisted sub-agent transcripts into the in-memory store (keyed
+                // by the dispatch record id = tool call id), so the rebuilt records show the tool-call count
+                // and their "View transcript" links resolve after a restart.
+                try
+                {
+                    System.Collections.Generic.Dictionary<string, AgentTranscript[]> persisted =
+                        AgentTranscriptPersistence.LoadAll(convo.Id);
+                    foreach (System.Collections.Generic.KeyValuePair<string, AgentTranscript[]> kv in persisted)
+                        AgentTranscriptStore.Put(kv.Key, kv.Value);
+                }
                 catch { }
 
                 // Snapshot messages to process. System and tool-result messages are not shown. A

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4189,7 +4189,9 @@ namespace GxPT
                         // a paragraph as hard breaks).
                         if (md.Length > 0) md.Append("\n\n");
                         md.Append("**").Append(slug.Length > 0 ? slug : "(agent)").Append(":**");
-                        if (task.Length > 0) md.Append(' ').Append(task);
+                        // Newline after the slug so the task starts on its own line (single newline =
+                        // hard break within the paragraph).
+                        if (task.Length > 0) md.Append('\n').Append(task);
                     }
                     if (count == 0) return false;
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3038,7 +3038,14 @@ namespace GxPT
                                 LoggerSink.Instance, tierOf,
                                 McpChatOrchestrator.DefaultMaxIterations, McpChatOrchestrator.DefaultCallTimeoutMs);
                             dispatcher.Cancellation = ctx.Cancellation;
-                            dispatcher.UsageReported = orch.UsageReported;
+                            // Child usage adds to cost/token totals but must NOT move the parent's context
+                            // gauge (the child has its own isolated context) - so it routes through the
+                            // updateContextGauge=false overload, not orch.UsageReported.
+                            dispatcher.UsageReported = delegate(ResponseUsage u)
+                            {
+                                RecordUsageAndReconcile(revealConvo, u,
+                                    OpenRouterClient.ModelSupportsPromptCaching(model), false);
+                            };
                             orch.AgentDispatcher = dispatcher;
                         }
                     }
@@ -5312,8 +5319,15 @@ namespace GxPT
         // dashboard shows cache activity on every request.
         private void RecordUsageAndReconcile(Conversation convo, ResponseUsage u, bool cachingModel)
         {
+            RecordUsageAndReconcile(convo, u, cachingModel, true);
+        }
+
+        // updateContextGauge=false (sub-agent usage): accumulate cost/token totals and reconcile cost, but
+        // do not move the parent conversation's context gauge - the child runs in its own isolated context.
+        private void RecordUsageAndReconcile(Conversation convo, ResponseUsage u, bool cachingModel, bool updateContextGauge)
+        {
             if (convo == null || u == null) return;
-            convo.RecordUsage(u);
+            convo.RecordUsage(u, updateContextGauge);
             NotifyUsageUpdated(convo);
 
             if (string.IsNullOrEmpty(u.Id) || _client == null) return;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3167,7 +3167,7 @@ namespace GxPT
                     // record instead of the generic "using" marker; register the record (it has its own
                     // lock) before taking sbLock. The record key is the model's call id, so the live and
                     // reloaded views share one identity (and persisted agent transcripts resolve on reload).
-                    Action<string, string, string, bool, string> onToolResult = delegate(string name, string argsJson, string resultText, bool isError, string callId)
+                    ToolResultCallback onToolResult = delegate(string name, string argsJson, string resultText, bool isError, string callId)
                     {
                         string recKey = !string.IsNullOrEmpty(callId) ? callId : Guid.NewGuid().ToString("N");
                         // A dispatch_agent record gets per-agent "View transcript" links keyed by recKey;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2666,6 +2666,30 @@ namespace GxPT
         // the turn restarts over the unchanged history — this holds for both the plain stream (the
         // user message is committed before the request) and the tool loop (the orchestrator's partial
         // progress stays in history, same as when the user keeps typing after a failure).
+        // Open the read-only child-transcript viewer for a dispatch_agent "View transcript" link (tier 3).
+        // The link encodes the dispatch record's key + agent slot; resolve it against the session cache. A
+        // miss (cache evicted, or a record reloaded from history after restart) shows a short notice rather
+        // than nothing, so the click is never silently dead.
+        internal void OpenAgentTranscript(string url)
+        {
+            string key; int slot;
+            if (!AgentTranscriptLinks.TryParse(url, out key, out slot)) return;
+            AgentTranscript t = AgentTranscriptStore.Get(key, slot);
+            if (t == null)
+            {
+                MessageBox.Show(this,
+                    "This agent's transcript is no longer available (it is kept only for the current session).",
+                    "Agent transcript", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            try
+            {
+                using (AgentTranscriptViewerForm viewer = new AgentTranscriptViewerForm(t))
+                    viewer.ShowDialog(this);
+            }
+            catch { }
+        }
+
         internal void RetryLastTurn(TabManager.ChatTabContext ctx)
         {
             if (ctx == null || ctx.Conversation == null || ctx.Transcript == null) return;
@@ -3046,6 +3070,9 @@ namespace GxPT
                     // and expose the manifest + dispatch_agent. Rebuilt per send, so on-disk edits take
                     // effect on the next turn. No per-agent enablement (design A15); the conversation
                     // override (/toggle-agents here) wins over the global settings.json default.
+                    // Hoisted so onToolResult (below) can snapshot the most recent fan-out's child
+                    // transcripts under the dispatch record's key for the tier-3 viewer.
+                    AgentDispatcher dispatcherForTurn = null;
                     if (AgentEnablement.FeatureEnabled(convo != null ? convo.AgentsEnabled : null))
                     {
                         AgentCatalog agentCatalog =
@@ -3081,6 +3108,7 @@ namespace GxPT
                             dispatcher.GroupCancellation = agentGroup;
                             dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup);
                             orch.AgentDispatcher = dispatcher;
+                            dispatcherForTurn = dispatcher;
                         }
                     }
 
@@ -3136,9 +3164,16 @@ namespace GxPT
                     // view re-derives under the persisted call id).
                     Action<string, string, string, bool> onToolResult = delegate(string name, string argsJson, string resultText, bool isError)
                     {
+                        string recKey = Guid.NewGuid().ToString("N");
+                        // A dispatch_agent record gets per-agent "View transcript" links keyed by recKey;
+                        // cache this fan-out's child transcripts under the same key so the links resolve
+                        // (tier 3). Tool calls are serial, so LastTranscripts is this call's batch.
+                        if (dispatcherForTurn != null && AgentDispatcher.DispatchAgentName == name
+                            && dispatcherForTurn.LastTranscripts != null)
+                            AgentTranscriptStore.Put(recKey, dispatcherForTurn.LastTranscripts);
                         string marker = McpMarkers.IsDenied(resultText)
                             ? McpMarkers.Denied(name)
-                            : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, Guid.NewGuid().ToString("N"));
+                            : EditDiffMarkerOrCall(ctx.Transcript, name, argsJson, recKey);
                         lock (sbLock)
                         {
                             if (pendingToolSeg != null)
@@ -4079,7 +4114,7 @@ namespace GxPT
                 {
                     var args = Newtonsoft.Json.Linq.JObject.Parse(string.IsNullOrEmpty(argsJson) ? "{}" : argsJson);
                     string header, body, language; int added, removed;
-                    if (TryBuildToolRecord(name, args, out header, out body, out language, out added, out removed))
+                    if (TryBuildToolRecord(name, args, key, out header, out body, out language, out added, out removed))
                     {
                         transcript.RegisterToolRecord(key, header, body, language, added, removed);
                         return McpMarkers.EditDiff(key);
@@ -4112,7 +4147,7 @@ namespace GxPT
         // Maps a tool call to a transcript record. An empty body yields a one-line label (no expansion);
         // a non-empty body is a collapsible record highlighted in 'language'. Returns false for tools
         // that should keep the generic marker.
-        private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, out string header, out string body, out string language, out int added, out int removed)
+        private static bool TryBuildToolRecord(string name, Newtonsoft.Json.Linq.JObject args, string key, out string header, out string body, out string language, out int added, out int removed)
         {
             header = null; body = string.Empty; language = "text"; added = -1; removed = -1;
 
@@ -4175,10 +4210,12 @@ namespace GxPT
                     Newtonsoft.Json.Linq.JToken arr = args != null ? args["agents"] : null;
                     if (arr == null || arr.Type != Newtonsoft.Json.Linq.JTokenType.Array) return false;
                     int count = 0;
+                    int slot = -1;   // entry slot, aligned with AgentDispatcher.LastTranscripts (counts every object element)
                     System.Text.StringBuilder md = new System.Text.StringBuilder();
                     foreach (Newtonsoft.Json.Linq.JToken t in (Newtonsoft.Json.Linq.JArray)arr)
                     {
                         if (t == null || t.Type != Newtonsoft.Json.Linq.JTokenType.Object) continue;
+                        slot++;
                         Newtonsoft.Json.Linq.JObject ag = (Newtonsoft.Json.Linq.JObject)t;
                         string slug = Str(ag, "name").Trim();
                         string task = Str(ag, "task").Trim();
@@ -4192,6 +4229,11 @@ namespace GxPT
                         // Newline after the slug so the task starts on its own line (single newline =
                         // hard break within the paragraph).
                         if (task.Length > 0) md.Append('\n').Append(task);
+                        // Tier 3: a per-agent "View transcript" link the transcript control intercepts
+                        // (AgentTranscriptLinkScheme) to open the read-only child transcript popup. Keyed
+                        // by the record key + slot so it resolves against AgentTranscriptStore.
+                        if (!string.IsNullOrEmpty(key))
+                            md.Append("\n[View transcript](").Append(AgentTranscriptLinks.Build(key, slot)).Append(')');
                     }
                     if (count == 0) return false;
                     header = "Dispatched " + count + (count == 1 ? " agent" : " agents");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2671,6 +2671,26 @@ namespace GxPT
             return (ctx != null && ctx.Conversation != null) ? ctx.Conversation.Id : null;
         }
 
+        // Open the live, streaming viewer for a running child agent (the panel's per-row "View transcript",
+        // tier 3 "watch live"). Modeless, so the user can keep watching while the fan-out continues (and
+        // still hit "Stop agents"). A null stream means the child already finished and its stream was
+        // dropped - fall back to a short notice.
+        internal void OpenAgentLiveTranscript(AgentLiveStream stream)
+        {
+            if (stream == null)
+            {
+                MessageBox.Show(this, "That agent has finished. Open its transcript from the dispatch record below.",
+                    "Agent transcript", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            try
+            {
+                AgentTranscriptViewerForm viewer = new AgentTranscriptViewerForm(stream);
+                viewer.Show(this);
+            }
+            catch { }
+        }
+
         // Open the read-only child-transcript viewer for a dispatch_agent "View transcript" link (tier 3).
         // The link encodes the dispatch record's key + agent slot; resolve it against the session cache. A
         // miss (cache evicted, or a record reloaded from history after restart) shows a short notice rather
@@ -3111,7 +3131,7 @@ namespace GxPT
                             // without ending the turn - the parent loop resumes with the partial results.
                             RequestCancellation agentGroup = new RequestCancellation();
                             dispatcher.GroupCancellation = agentGroup;
-                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup);
+                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup, dispatcher);
                             orch.AgentDispatcher = dispatcher;
                             dispatcherForTurn = dispatcher;
                         }
@@ -4242,7 +4262,8 @@ namespace GxPT
                         if (tr != null)
                         {
                             int tc = tr.ToolCallCount;
-                            md.Append('\n').Append(tc).Append(tc == 1 ? " tool call" : " tool calls");
+                            // Count on the same line as the slug; the link drops to the next line.
+                            md.Append(' ').Append(tc).Append(tc == 1 ? " tool call" : " tool calls");
                             // Tier 3: a per-agent "View transcript" link the transcript control intercepts
                             // (AgentTranscriptLinks scheme) to open the read-only child transcript popup.
                             md.Append("\n[View transcript](").Append(AgentTranscriptLinks.Build(key, slot)).Append(')');

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4135,8 +4135,9 @@ namespace GxPT
 
         // Activity marker for a tool call. If the tool maps to a collapsible/labelled record, register
         // it with the transcript under a stable key and return its sentinel; otherwise (or on any
-        // failure) return the generic "using <tool>" marker.
-        private static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
+        // failure) return the generic "using <tool>" marker. internal so the agent transcript viewer can
+        // render a child's tool calls identically to the main chat.
+        internal static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
         {
             if (transcript != null && !string.IsNullOrEmpty(key))
             {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1008,26 +1008,31 @@ namespace GxPT
                         IList<string> aNames = (_mcpRegistry != null)
                             ? _mcpRegistry.NamesForWorkdir(workdir) : (IList<string>)new List<string>();
                         Func<string, ToolTier> agentTierOf = AgentTierOf();
-                        List<string> enabledNames = new List<string>();
+                        List<string> enabledLines = new List<string>();
                         List<string> disabledLines = new List<string>();
                         for (int i = 0; i < acat.Agents.Count; i++)
                         {
                             Agent a = acat.Agents[i];
+                            // Tools the agent wants that aren't available here. For an enabled agent this is a
+                            // partial gap ("degraded"); for a disabled one it's all of them.
+                            List<string> need = AgentAvailability.MissingTools(a, aNames);
+                            string missing = need.Count > 0 ? " (missing " + string.Join(", ", need.ToArray()) + ")" : "";
                             if (AgentAvailability.IsAvailable(a, aNames, agentTierOf))
                             {
-                                enabledNames.Add(a.Slug);
                                 agentCount++;
+                                enabledLines.Add("  " + a.Slug + missing);
                             }
                             else
                             {
-                                List<string> need = AgentAvailability.MissingTools(a, aNames);
-                                disabledLines.Add("  " + a.Slug + (need.Count > 0
-                                    ? " - needs " + string.Join(", ", need.ToArray()) : " - (no available tools)"));
+                                disabledLines.Add("  " + a.Slug + (need.Count > 0 ? missing : " (no available tools)"));
                             }
                         }
                         System.Text.StringBuilder tip = new System.Text.StringBuilder();
-                        tip.Append("Enabled (").Append(enabledNames.Count.ToString(inv)).Append("): ");
-                        tip.Append(enabledNames.Count > 0 ? string.Join(", ", enabledNames.ToArray()) : "none");
+                        tip.Append("Enabled (").Append(agentCount.ToString(inv)).Append("):");
+                        if (enabledLines.Count > 0)
+                            for (int i = 0; i < enabledLines.Count; i++) tip.Append("\r\n").Append(enabledLines[i]);
+                        else
+                            tip.Append(" none");
                         if (disabledLines.Count > 0)
                         {
                             tip.Append("\r\n\r\nDisabled - required tools not available:");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1008,19 +1008,21 @@ namespace GxPT
                         IList<string> aNames = (_mcpRegistry != null)
                             ? _mcpRegistry.NamesForWorkdir(workdir) : (IList<string>)new List<string>();
                         Func<string, ToolTier> agentTierOf = AgentTierOf();
-                        List<string> enabledLines = new List<string>();
+                        // Three buckets: full use (all tools available), degraded (usable but missing some),
+                        // disabled (no tools available). The status-bar count is full + degraded (all usable).
+                        List<string> fullLines = new List<string>();
+                        List<string> degradedLines = new List<string>();
                         List<string> disabledLines = new List<string>();
                         for (int i = 0; i < acat.Agents.Count; i++)
                         {
                             Agent a = acat.Agents[i];
-                            // Tools the agent wants that aren't available here. For an enabled agent this is a
-                            // partial gap ("degraded"); for a disabled one it's all of them.
                             List<string> need = AgentAvailability.MissingTools(a, aNames);
                             string missing = need.Count > 0 ? " (missing " + string.Join(", ", need.ToArray()) + ")" : "";
                             if (AgentAvailability.IsAvailable(a, aNames, agentTierOf))
                             {
                                 agentCount++;
-                                enabledLines.Add("  " + a.Slug + missing);
+                                if (need.Count > 0) degradedLines.Add("  " + a.Slug + missing);
+                                else fullLines.Add("  " + a.Slug);
                             }
                             else
                             {
@@ -1028,16 +1030,9 @@ namespace GxPT
                             }
                         }
                         System.Text.StringBuilder tip = new System.Text.StringBuilder();
-                        tip.Append("Enabled (").Append(agentCount.ToString(inv)).Append("):");
-                        if (enabledLines.Count > 0)
-                            for (int i = 0; i < enabledLines.Count; i++) tip.Append("\r\n").Append(enabledLines[i]);
-                        else
-                            tip.Append(" none");
-                        if (disabledLines.Count > 0)
-                        {
-                            tip.Append("\r\n\r\nDisabled - required tools not available:");
-                            for (int i = 0; i < disabledLines.Count; i++) tip.Append("\r\n").Append(disabledLines[i]);
-                        }
+                        AppendAgentSection(tip, "Full use", fullLines);
+                        AppendAgentSection(tip, "Degraded", degradedLines);
+                        AppendAgentSection(tip, "Disabled", disabledLines);
                         agentTip = tip.ToString();
                     }
                 }
@@ -1063,6 +1058,16 @@ namespace GxPT
                 return p.TierOf;
             }
             catch { return null; }
+        }
+
+        // Appends a "<header> (N):" section + its indented lines to the agents tooltip; skips empty sections,
+        // and separates non-first sections with a blank line.
+        private static void AppendAgentSection(System.Text.StringBuilder sb, string header, List<string> lines)
+        {
+            if (sb == null || lines == null || lines.Count == 0) return;
+            if (sb.Length > 0) sb.Append("\r\n\r\n");
+            sb.Append(header).Append(" (").Append(lines.Count).Append("):");
+            for (int i = 0; i < lines.Count; i++) sb.Append("\r\n").Append(lines[i]);
         }
 
         // The tool registry changed (a server connected, refreshed its tools, or went away) on a

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -942,6 +942,8 @@ namespace GxPT
                 if (this.tslToolsValue != null) this.tslToolsValue.Visible = !busy;
                 if (this.tslSkills != null) this.tslSkills.Visible = !busy;
                 if (this.tslSkillsValue != null) this.tslSkillsValue.Visible = !busy;
+                if (this.tslAgents != null) this.tslAgents.Visible = !busy;
+                if (this.tslAgentsValue != null) this.tslAgentsValue.Visible = !busy;
             }
             catch { }
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2998,6 +2998,36 @@ namespace GxPT
                     ICollection<string> hiddenTools = SkillToolGate.HiddenTools(enabledSkills);
                     if (hiddenTools.Count > 0) orch.HiddenToolNames = hiddenTools;
 
+                    // Sub-agents: when the agents feature is enabled (settings.json `agents_enabled`),
+                    // discover all agents under <exe>/agents + <workdir>/.gxpt/agents + %AppData%/GxPT/agents
+                    // and expose the manifest + dispatch_agent. Rebuilt per send, so on-disk edits take
+                    // effect on the next turn. No per-agent enablement (design A15); the per-conversation
+                    // override is a later phase, so this uses the global setting only.
+                    if (AgentEnablement.GlobalEnabled())
+                    {
+                        AgentCatalog agentCatalog =
+                            AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
+                        if (agentCatalog.Agents.Count > 0)
+                        {
+                            List<Agent> agentsForTurn = new List<Agent>(agentCatalog.Agents);
+                            orch.AgentsManifestSystemMessageProvider =
+                                delegate { return AgentInjection.BuildManifestMessage(agentsForTurn); };
+                            // tierOf reuses the approval policy's classification so an agent's max_tier
+                            // ceiling matches the gate; the AllowAll fallback (no policy) leaves it null
+                            // and the resolver treats every tool as Write.
+                            Func<string, ToolTier> tierOf = null;
+                            ToolApprovalPolicy tap = approval as ToolApprovalPolicy;
+                            if (tap != null) tierOf = tap.TierOf;
+                            AgentDispatcher dispatcher = new AgentDispatcher(
+                                agentsForTurn, _client, _mcpRegistry, approval, model, ctx.WorkingDir,
+                                LoggerSink.Instance, tierOf,
+                                McpChatOrchestrator.DefaultMaxIterations, McpChatOrchestrator.DefaultCallTimeoutMs);
+                            dispatcher.Cancellation = ctx.Cancellation;
+                            dispatcher.UsageReported = orch.UsageReported;
+                            orch.AgentDispatcher = dispatcher;
+                        }
+                    }
+
                     // Assistant text appends to the current assistant bubble; a tool call closes it so
                     // the next run of text starts a fresh bubble below the tool record. Inter-turn
                     // whitespace (a stray newline some models emit before the next tool call) must NOT

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3061,10 +3061,12 @@ namespace GxPT
                                 RecordUsageAndReconcile(revealConvo, u,
                                     OpenRouterClient.ModelSupportsPromptCaching(model), false);
                             };
-                            // Observability: marshal the fan-out / per-child lifecycle to this tab's
-                            // activity panel (design sec.14). The turn's Stop still cancels children
-                            // (dispatcher.Cancellation = ctx.Cancellation), so no separate group handle yet.
-                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx);
+                            // Observability + group cancel (design sec.14): a dedicated handle the panel's
+                            // Stop button trips, so it cancels the agents (children watch GroupCancellation)
+                            // without ending the turn - the parent loop resumes with the partial results.
+                            RequestCancellation agentGroup = new RequestCancellation();
+                            dispatcher.GroupCancellation = agentGroup;
+                            dispatcher.ActivityUi = new AgentActivityUiBridge(this, ctx, agentGroup);
                             orch.AgentDispatcher = dispatcher;
                         }
                     }

--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -93,6 +93,8 @@
             this.chkMcpMsBuild = new System.Windows.Forms.CheckBox();
             this.chkMcpCommandScratch = new System.Windows.Forms.CheckBox();
             this.grpMcpCustom = new System.Windows.Forms.GroupBox();
+            this.grpAgents = new System.Windows.Forms.GroupBox();
+            this.chkAgents = new System.Windows.Forms.CheckBox();
             this.tblMcpCustom = new System.Windows.Forms.TableLayoutPanel();
             this.rtbMcpJson = new System.Windows.Forms.RichTextBox();
             this.flowLayoutPanel1.SuspendLayout();
@@ -122,6 +124,7 @@
             this.grpMcpWeb.SuspendLayout();
             this.tblMcpWeb.SuspendLayout();
             this.grpMcpWorkspace.SuspendLayout();
+            this.grpAgents.SuspendLayout();
             this.tblMcpWorkspace.SuspendLayout();
             this.tblMcpKeyless.SuspendLayout();
             this.grpMcpCustom.SuspendLayout();
@@ -754,13 +757,15 @@
             this.tblMcp.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblMcp.Controls.Add(this.grpMcpWeb, 0, 0);
             this.tblMcp.Controls.Add(this.grpMcpWorkspace, 0, 1);
-            this.tblMcp.Controls.Add(this.grpMcpCustom, 0, 2);
+            this.tblMcp.Controls.Add(this.grpAgents, 0, 2);
+            this.tblMcp.Controls.Add(this.grpMcpCustom, 0, 3);
             this.tblMcp.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tblMcp.Location = new System.Drawing.Point(3, 3);
             this.tblMcp.Name = "tblMcp";
-            this.tblMcp.RowCount = 3;
+            this.tblMcp.RowCount = 4;
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 84F));
+            this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 54F));
             this.tblMcp.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblMcp.Size = new System.Drawing.Size(590, 357);
             this.tblMcp.TabIndex = 0;
@@ -953,9 +958,32 @@
             this.grpMcpCustom.Name = "grpMcpCustom";
             this.grpMcpCustom.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
             this.grpMcpCustom.Size = new System.Drawing.Size(584, 187);
-            this.grpMcpCustom.TabIndex = 2;
+            this.grpMcpCustom.TabIndex = 3;
             this.grpMcpCustom.TabStop = false;
             this.grpMcpCustom.Text = "Custom servers (mcp.json)";
+            //
+            // grpAgents
+            //
+            this.grpAgents.Controls.Add(this.chkAgents);
+            this.grpAgents.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpAgents.Location = new System.Drawing.Point(3, 173);
+            this.grpAgents.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.grpAgents.Name = "grpAgents";
+            this.grpAgents.Padding = new System.Windows.Forms.Padding(6, 0, 6, 6);
+            this.grpAgents.Size = new System.Drawing.Size(584, 48);
+            this.grpAgents.TabIndex = 2;
+            this.grpAgents.TabStop = false;
+            this.grpAgents.Text = "Sub-agents";
+            //
+            // chkAgents
+            //
+            this.chkAgents.AutoSize = true;
+            this.chkAgents.Location = new System.Drawing.Point(9, 20);
+            this.chkAgents.Name = "chkAgents";
+            this.chkAgents.Size = new System.Drawing.Size(320, 17);
+            this.chkAgents.TabIndex = 0;
+            this.chkAgents.Text = "Enable sub-agents (delegate sub-tasks to specialist agents)";
+            this.chkAgents.UseVisualStyleBackColor = true;
             //
             // tblMcpCustom
             //
@@ -1032,6 +1060,8 @@
             this.tblMcpWeb.ResumeLayout(false);
             this.tblMcpWeb.PerformLayout();
             this.grpMcpWorkspace.ResumeLayout(false);
+            this.grpAgents.ResumeLayout(false);
+            this.grpAgents.PerformLayout();
             this.tblMcpWorkspace.ResumeLayout(false);
             this.tblMcpWorkspace.PerformLayout();
             this.tblMcpKeyless.ResumeLayout(false);
@@ -1100,6 +1130,8 @@
         private System.Windows.Forms.TableLayoutPanel tblMcpWorkspace;
         private System.Windows.Forms.TableLayoutPanel tblMcpKeyless;
         private System.Windows.Forms.GroupBox grpMcpCustom;
+        private System.Windows.Forms.GroupBox grpAgents;
+        private System.Windows.Forms.CheckBox chkAgents;
         private System.Windows.Forms.TableLayoutPanel tblMcpCustom;
         private System.Windows.Forms.CheckBox chkMcpWeb;
         private System.Windows.Forms.TextBox txtWebSearchKey;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -21,6 +21,12 @@ namespace GxPT
         // In-memory working copy (unsaved until Save/CTRL+S)
         private SettingsData _working = new SettingsData();
 
+        // Free-form settings.json keys that SettingsData does not model (e.g. "agents_enabled", written by
+        // AppSettings via the /toggle-agents command). Captured on load and on JSON edits, then merged back
+        // into the JSON view and the saved file so the typed editor never silently drops them. Without this,
+        // saving Settings would wipe such keys (which is exactly how globally-enabled agents would turn off).
+        private Dictionary<string, object> _extraKeys = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
         // Guard to prevent event loops during programmatic sync
         private bool _isSyncing = false;
 
@@ -188,6 +194,8 @@ namespace GxPT
                 {
                     _working = BuildDefaultSettings();
                 }
+                // Remember any keys SettingsData doesn't model so they aren't dropped on save.
+                _extraKeys = ComputeExtraKeys(raw);
 
                 _isSyncing = true;
                 try
@@ -326,7 +334,7 @@ namespace GxPT
                 if (!TryValidateMcpJson(out mcpJsonText)) return false;
                 CaptureMcpControlsToWorking(_working);
 
-                var json = Serialize(_working);
+                var json = MergeExtraKeys(Serialize(_working));
                 File.WriteAllText(_settingsFile, json, Encoding.UTF8);
                 WriteMcpJson(mcpJsonText);
 
@@ -486,9 +494,55 @@ namespace GxPT
             return ser.Serialize(settings);
         }
 
+        // The settings.json keys SettingsData models (its property names are the JSON keys 1:1).
+        private static HashSet<string> KnownSettingKeys()
+        {
+            HashSet<string> known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Reflection.PropertyInfo p in typeof(SettingsData).GetProperties())
+                known.Add(p.Name);
+            return known;
+        }
+
+        // The free-form keys in a raw settings.json that SettingsData does not model (so they'd otherwise be
+        // lost on a typed round-trip). Returns an empty map on any parse error.
+        private static Dictionary<string, object> ComputeExtraKeys(string rawJson)
+        {
+            Dictionary<string, object> extra = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var ser = new JavaScriptSerializer();
+                Dictionary<string, object> dict = ser.Deserialize<Dictionary<string, object>>(rawJson ?? string.Empty);
+                if (dict != null)
+                {
+                    HashSet<string> known = KnownSettingKeys();
+                    foreach (KeyValuePair<string, object> kv in dict)
+                        if (!known.Contains(kv.Key)) extra[kv.Key] = kv.Value;
+                }
+            }
+            catch { }
+            return extra;
+        }
+
+        // Overlay the captured free-form keys onto a typed-settings JSON string so they survive the round-trip
+        // (typed keys win; extras fill in). Used for both the JSON view and the saved file.
+        private string MergeExtraKeys(string typedJson)
+        {
+            if (_extraKeys == null || _extraKeys.Count == 0) return typedJson;
+            try
+            {
+                var ser = new JavaScriptSerializer();
+                Dictionary<string, object> dict = ser.Deserialize<Dictionary<string, object>>(typedJson ?? string.Empty)
+                    ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                foreach (KeyValuePair<string, object> kv in _extraKeys)
+                    if (!dict.ContainsKey(kv.Key)) dict[kv.Key] = kv.Value;
+                return ser.Serialize(dict);
+            }
+            catch { return typedJson; }
+        }
+
         private void UpdateJsonEditorFromSettings(SettingsData settings)
         {
-            var json = Serialize(settings);
+            var json = MergeExtraKeys(Serialize(settings));
             this.rtbJson.Text = PrettyPrintJson(json);
             // Do not trigger highlight here; only on TextChanged
         }
@@ -500,6 +554,8 @@ namespace GxPT
                 var ser = new JavaScriptSerializer();
                 settings = ser.Deserialize<SettingsData>(this.rtbJson.Text ?? string.Empty) ?? new SettingsData();
                 PostProcess(settings);
+                // Re-capture free-form keys from the edited JSON so edits to them (e.g. agents_enabled) persist.
+                _extraKeys = ComputeExtraKeys(this.rtbJson.Text);
                 error = string.Empty;
                 return true;
             }

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1467,6 +1467,9 @@ namespace GxPT
             this.chkMcpGithub.Checked = s.mcp_github_enabled;
             this.txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
             this.txtGithubPat.Text = s.mcp_github_pat != null ? s.mcp_github_pat : string.Empty;
+            // Sub-agents: a free-form settings.json key (written by /toggle-agents), so read it via GetBool
+            // with the feature default - just like git/msbuild - so an absent key shows as on, not off.
+            this.chkAgents.Checked = AppSettings.GetBool(AgentEnablement.GlobalSettingKey, AgentEnablement.GlobalDefault);
             UpdateMcpEnableStates();
         }
 
@@ -1484,6 +1487,10 @@ namespace GxPT
             target.mcp_github_enabled = this.chkMcpGithub.Checked;
             target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
             target.mcp_github_pat = this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : string.Empty;
+            // Sub-agents lives in settings.json as a free-form key, so persist it through the merge map
+            // (SettingsData doesn't model it). Captured here so Save writes the checkbox state.
+            if (_extraKeys == null) _extraKeys = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            _extraKeys[AgentEnablement.GlobalSettingKey] = this.chkAgents.Checked;
         }
 
         // A web-search / GitHub toggle is only enableable when its key/PAT looks plausibly valid;

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Services\Agents\AgentDispatcher.cs" />
     <Compile Include="Services\Agents\AgentTranscript.cs" />
     <Compile Include="Services\Agents\AgentTranscriptStore.cs" />
+    <Compile Include="Services\Agents\AgentTranscriptPersistence.cs" />
     <Compile Include="Services\Agents\AgentTranscriptLinks.cs" />
     <Compile Include="Services\Agents\IAgentActivityUi.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -422,6 +422,13 @@
       <BundledSkillFiles Include="..\skills\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(BundledSkillFiles)" DestinationFiles="@(BundledSkillFiles->'$(OutDir)skills\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <!-- Ship the bundled (first-party) agents next to GxPT.exe in an 'agents' folder. The host's
+         AgentRoots.BundledRoot resolves <exe>/agents, so a shipped agent (explore, plan, ...) is
+         discoverable at runtime. Flat <slug>.md files (design A4). Mirrors the skills copy above. -->
+    <ItemGroup>
+      <BundledAgentFiles Include="..\agents\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BundledAgentFiles)" DestinationFiles="@(BundledAgentFiles->'$(OutDir)agents\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" ContinueOnError="true" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Services\Agents\AgentCatalog.cs" />
     <Compile Include="Services\Agents\AgentRoots.cs" />
     <Compile Include="Services\Agents\AgentToolResolver.cs" />
+    <Compile Include="Services\Agents\AgentAvailability.cs" />
     <Compile Include="Services\Agents\AgentInjection.cs" />
     <Compile Include="Services\Agents\AgentEnablement.cs" />
     <Compile Include="Services\Agents\AgentDispatcher.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -179,6 +179,9 @@
     <Compile Include="Controls\ToolApprovalPanel.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\AgentActivityPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\StopGenerationItem.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -205,6 +208,7 @@
     <Compile Include="Forms\MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Forms\AgentActivityUiBridge.cs" />
     <Compile Include="Forms\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -129,6 +129,8 @@
     <Compile Include="Services\Commands\IModelControl.cs" />
     <Compile Include="Services\Commands\IServerControl.cs" />
     <Compile Include="Services\Commands\ISkillEnablementStore.cs" />
+    <Compile Include="Services\Commands\IAgentEnablementStore.cs" />
+    <Compile Include="Services\Commands\AgentCommands.cs" />
     <Compile Include="Services\Commands\ISlashCommand.cs" />
     <Compile Include="Services\Commands\WorkspacePath.cs" />
     <Compile Include="Services\Commands\IArgumentCompleter.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -119,6 +119,8 @@
     <Compile Include="Services\Agents\AgentCatalog.cs" />
     <Compile Include="Services\Agents\AgentRoots.cs" />
     <Compile Include="Services\Agents\AgentToolResolver.cs" />
+    <Compile Include="Services\Agents\AgentInjection.cs" />
+    <Compile Include="Services\Agents\AgentEnablement.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Services\Agents\AgentToolResolver.cs" />
     <Compile Include="Services\Agents\AgentInjection.cs" />
     <Compile Include="Services\Agents\AgentEnablement.cs" />
+    <Compile Include="Services\Agents\AgentDispatcher.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -122,6 +122,8 @@
     <Compile Include="Services\Agents\AgentInjection.cs" />
     <Compile Include="Services\Agents\AgentEnablement.cs" />
     <Compile Include="Services\Agents\AgentDispatcher.cs" />
+    <Compile Include="Services\Agents\AgentTranscript.cs" />
+    <Compile Include="Services\Agents\AgentTranscriptStore.cs" />
     <Compile Include="Services\Agents\IAgentActivityUi.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -122,6 +122,8 @@
     <Compile Include="Services\Agents\AgentInjection.cs" />
     <Compile Include="Services\Agents\AgentEnablement.cs" />
     <Compile Include="Services\Agents\AgentDispatcher.cs" />
+    <Compile Include="Services\Agents\IAgentLiveSink.cs" />
+    <Compile Include="Services\Agents\AgentLiveStream.cs" />
     <Compile Include="Services\Agents\AgentTranscript.cs" />
     <Compile Include="Services\Agents\AgentTranscriptStore.cs" />
     <Compile Include="Services\Agents\AgentTranscriptPersistence.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Services\Agents\AgentDispatcher.cs" />
     <Compile Include="Services\Agents\AgentTranscript.cs" />
     <Compile Include="Services\Agents\AgentTranscriptStore.cs" />
+    <Compile Include="Services\Agents\AgentTranscriptLinks.cs" />
     <Compile Include="Services\Agents\IAgentActivityUi.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
@@ -211,6 +212,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Forms\AgentActivityUiBridge.cs" />
+    <Compile Include="Forms\AgentTranscriptViewerForm.cs" />
     <Compile Include="Forms\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -114,6 +114,10 @@
     <Compile Include="Services\Skills\SkillEnablement.cs" />
     <Compile Include="Services\Skills\SkillResolve.cs" />
     <Compile Include="Services\Skills\SkillToolGate.cs" />
+    <Compile Include="Services\Agents\Agent.cs" />
+    <Compile Include="Services\Agents\AgentFrontmatter.cs" />
+    <Compile Include="Services\Agents\AgentCatalog.cs" />
+    <Compile Include="Services\Agents\AgentRoots.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Services\Agents\AgentFrontmatter.cs" />
     <Compile Include="Services\Agents\AgentCatalog.cs" />
     <Compile Include="Services\Agents\AgentRoots.cs" />
+    <Compile Include="Services\Agents\AgentToolResolver.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Services\Agents\AgentInjection.cs" />
     <Compile Include="Services\Agents\AgentEnablement.cs" />
     <Compile Include="Services\Agents\AgentDispatcher.cs" />
+    <Compile Include="Services\Agents\IAgentActivityUi.cs" />
     <Compile Include="Services\Commands\SlashCommandKind.cs" />
     <Compile Include="Services\Commands\SlashCommandResult.cs" />
     <Compile Include="Services\Commands\SlashArgs.cs" />

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -216,7 +216,9 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Forms\AgentActivityUiBridge.cs" />
-    <Compile Include="Forms\AgentTranscriptViewerForm.cs" />
+    <Compile Include="Forms\AgentTranscriptViewerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Forms\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -66,6 +66,9 @@ namespace GxPT
             // The per-tab tool-approval panel docked at the bottom of this tab's transcript (set by
             // MainForm). A pending approval shows only on the conversation that requested it.
             public ToolApprovalPanel ApprovalPanel;
+            // The per-tab sub-agents activity panel docked at the bottom (set by MainForm). Shown only
+            // while a dispatch_agent fan-out runs on this tab's conversation.
+            public AgentActivityPanel AgentActivityPanel;
             // The in-flight request's cancellation handle (null when idle). The status bar's Stop
             // button calls Cancel() on it to kill the model request.
             public RequestCancellation Cancellation;

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -766,6 +766,12 @@ namespace GxPT
                 try { _mainForm.RetryLastTurn(ctx); }
                 catch { }
             };
+            // A dispatch_agent record's "View transcript" link opens the read-only child viewer (tier 3).
+            ctx.Transcript.AgentTranscriptLinkClicked += delegate(string url)
+            {
+                try { _mainForm.OpenAgentTranscript(url); }
+                catch { }
+            };
         }
 
         // Wire a tab's transcript edit-request to populate the input box and enter edit mode.

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -698,6 +698,10 @@ namespace GxPT
                 {
                     try { if (kv.Value.Transcript != null) kv.Value.Transcript.RefreshTheme(); }
                     catch { }
+                    // The agent activity panel is owner-drawn and reads the theme in OnPaint, so a theme
+                    // toggle while it is visible needs an explicit repaint (it ignores BackColor/ForeColor).
+                    try { if (kv.Value.AgentActivityPanel != null) kv.Value.AgentActivityPanel.Invalidate(); }
+                    catch { }
                 }
             }
             catch { }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -69,6 +69,9 @@ namespace GxPT
             // The per-tab sub-agents activity panel docked at the bottom (set by MainForm). Shown only
             // while a dispatch_agent fan-out runs on this tab's conversation.
             public AgentActivityPanel AgentActivityPanel;
+            // True while a dispatch_agent fan-out is running on this tab - drives the status bar's passive
+            // "Sub-agents running..." indicator (set by AgentActivityUiBridge).
+            public bool AgentsFanOutActive;
             // The in-flight request's cancellation handle (null when idle). The status bar's Stop
             // button calls Cancel() on it to kill the model request.
             public RequestCancellation Cancellation;

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -99,6 +99,16 @@ namespace GxPT
         // counted as zero, so totals stay "sum of what was billed and reported".
         internal void RecordUsage(ResponseUsage u)
         {
+            RecordUsage(u, true);
+        }
+
+        // updateContextGauge=false records a request's cost/token TOTALS without moving the "newest
+        // request's context size" gauge (Last* fields). Used for sub-agent (dispatch_agent) usage: a child
+        // runs in an isolated context, so the user is still billed for it (totals), but its prompt size
+        // must not be shown as this conversation's context fill - that gauge tracks the parent's own
+        // requests only.
+        internal void RecordUsage(ResponseUsage u, bool updateContextGauge)
+        {
             if (u == null) return;
             lock (_usageGate)
             {
@@ -108,9 +118,12 @@ namespace GxPT
                 TotalCachedTokens += u.CachedTokens;
                 TotalCompletionTokens += u.CompletionTokens;
                 TotalReasoningTokens += u.ReasoningTokens;
-                LastPromptTokens = u.PromptTokens;
-                LastCachedTokens = u.CachedTokens;
-                LastCacheWriteTokens = u.CacheWriteTokens;
+                if (updateContextGauge)
+                {
+                    LastPromptTokens = u.PromptTokens;
+                    LastCachedTokens = u.CachedTokens;
+                    LastCacheWriteTokens = u.CacheWriteTokens;
+                }
             }
             LastUpdated = DateTime.Now;
         }

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -56,6 +56,10 @@ namespace GxPT
         // = force off); a slug absent inherits the global default. Set by the /toggle-skills and /toggle-skill commands.
         public bool? SkillsFeatureOff { get; set; }
         public Dictionary<string, bool> SkillOverrides { get; set; }
+        // Per-conversation sub-agents feature override (design A15/sec.7): null = inherit the global
+        // default (settings.json agents_enabled), true = on, false = off. No per-agent state. Set by the
+        // /toggle-agents command.
+        public bool? AgentsEnabled { get; set; }
         // Server-qualified MCP tool names this conversation has revealed, in recency order (reveal
         // and call both move a name to the end). Owned by the conversation - not the registry - so
         // concurrent tabs don't share reveal state (which would churn each other's tools array and

--- a/GxPT/Services/Agents/Agent.cs
+++ b/GxPT/Services/Agents/Agent.cs
@@ -23,15 +23,6 @@ namespace GxPT
         Destructive
     }
 
-    // How much an agent may do unattended within the approval gate (design sec.8 layer 3). Default Gated -
-    // behaves like the main agent (every tier prompts per the normal rules). AutoReadOnly lets the
-    // agent's ReadOnly-tier calls auto-allow for the duration of a dispatch, once granted.
-    internal enum AgentAutonomy
-    {
-        Gated,
-        AutoReadOnly
-    }
-
     // One discovered sub-agent: a flat <slug>.md file whose frontmatter declares the agent's contract
     // and whose body is the agent's system prompt (design A4 - one file per agent, no folder). The
     // catalog holds a slug -> Agent map. The body is read from FilePath on dispatch (a single small
@@ -55,7 +46,6 @@ namespace GxPT
         public string[] Tools { get; private set; }
 
         public AgentMaxTier MaxTier { get; private set; }
-        public AgentAutonomy Autonomy { get; private set; }
 
         // Optional model id override; null/empty => the parent turn's model.
         public string Model { get; private set; }
@@ -71,7 +61,7 @@ namespace GxPT
         public AgentSource Source { get; private set; }
 
         public Agent(string slug, string name, string description, string[] tools,
-                     AgentMaxTier maxTier, AgentAutonomy autonomy, string model, int maxTurns,
+                     AgentMaxTier maxTier, string model, int maxTurns,
                      string filePath, AgentSource source)
         {
             Slug = slug;
@@ -79,7 +69,6 @@ namespace GxPT
             Description = description;
             Tools = tools;
             MaxTier = maxTier;
-            Autonomy = autonomy;
             Model = model;
             MaxTurns = maxTurns;
             FilePath = filePath;

--- a/GxPT/Services/Agents/Agent.cs
+++ b/GxPT/Services/Agents/Agent.cs
@@ -60,13 +60,18 @@ namespace GxPT
         // Optional model id override; null/empty => the parent turn's model.
         public string Model { get; private set; }
 
+        // Per-agent iteration budget (design A17), fed to the child orchestrator's maxIterations. 0 => unset
+        // (use the host default). Lets an explore agent cap low and a coder run long; a tight budget is also
+        // a safety bound on an unattended run.
+        public int MaxTurns { get; private set; }
+
         // Absolute path to the agent's <slug>.md. The body (= system prompt) is read from here at dispatch.
         public string FilePath { get; private set; }
 
         public AgentSource Source { get; private set; }
 
         public Agent(string slug, string name, string description, string[] tools,
-                     AgentMaxTier maxTier, AgentAutonomy autonomy, string model,
+                     AgentMaxTier maxTier, AgentAutonomy autonomy, string model, int maxTurns,
                      string filePath, AgentSource source)
         {
             Slug = slug;
@@ -76,6 +81,7 @@ namespace GxPT
             MaxTier = maxTier;
             Autonomy = autonomy;
             Model = model;
+            MaxTurns = maxTurns;
             FilePath = filePath;
             Source = source;
         }

--- a/GxPT/Services/Agents/Agent.cs
+++ b/GxPT/Services/Agents/Agent.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace GxPT
+{
+    // Where a discovered agent came from, in increasing specificity. A more specific source shadows a
+    // less specific one of the same slug: project (this workspace) shadows user (this machine) shadows
+    // bundled (shipped) - design A11/A4, mirroring SkillSource.
+    internal enum AgentSource
+    {
+        Bundled,
+        User,
+        Project
+    }
+
+    // The tier ceiling an agent's tools may reach (design A5/sec.3). Caps the allowlist regardless of what
+    // `tools` names. Parsed here; mapped onto the host ToolClassifier tiers in a later phase
+    // (AgentToolResolver). Default Write - an agent can edit, but the approval gate still confirms;
+    // `destructive` must be opted into explicitly.
+    internal enum AgentMaxTier
+    {
+        ReadOnly,
+        Write,
+        Destructive
+    }
+
+    // How much an agent may do unattended within the approval gate (design sec.8 layer 3). Default Gated -
+    // behaves like the main agent (every tier prompts per the normal rules). AutoReadOnly lets the
+    // agent's ReadOnly-tier calls auto-allow for the duration of a dispatch, once granted.
+    internal enum AgentAutonomy
+    {
+        Gated,
+        AutoReadOnly
+    }
+
+    // One discovered sub-agent: a flat <slug>.md file whose frontmatter declares the agent's contract
+    // and whose body is the agent's system prompt (design A4 - one file per agent, no folder). The
+    // catalog holds a slug -> Agent map. The body is read from FilePath on dispatch (a single small
+    // file, read fresh so edits take effect), not stored here - mirroring how skills read SKILL.md on
+    // open. XP / .NET 3.5 friendly.
+    internal sealed class Agent
+    {
+        // Kebab-case handle: appears in the manifest, taken by dispatch_agent, typed in the slash command.
+        public string Slug { get; private set; }
+
+        // Frontmatter "name" (human label); falls back to the slug when the author omits it.
+        public string Name { get; private set; }
+
+        // Frontmatter "description": the single manifest line the model reads to decide whether/which to
+        // delegate ("use this agent when ...").
+        public string Description { get; private set; }
+
+        // The frontmatter tool allowlist - server-qualified names or glob patterns (files__*, mcp__*, *).
+        // Null when the author omitted `tools:` entirely (resolved to a conservative ReadOnly default
+        // later, design A5). An explicit `tools: []` is a zero-length array, distinct from null.
+        public string[] Tools { get; private set; }
+
+        public AgentMaxTier MaxTier { get; private set; }
+        public AgentAutonomy Autonomy { get; private set; }
+
+        // Optional model id override; null/empty => the parent turn's model.
+        public string Model { get; private set; }
+
+        // Absolute path to the agent's <slug>.md. The body (= system prompt) is read from here at dispatch.
+        public string FilePath { get; private set; }
+
+        public AgentSource Source { get; private set; }
+
+        public Agent(string slug, string name, string description, string[] tools,
+                     AgentMaxTier maxTier, AgentAutonomy autonomy, string model,
+                     string filePath, AgentSource source)
+        {
+            Slug = slug;
+            Name = name;
+            Description = description;
+            Tools = tools;
+            MaxTier = maxTier;
+            Autonomy = autonomy;
+            Model = model;
+            FilePath = filePath;
+            Source = source;
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentAvailability.cs
+++ b/GxPT/Services/Agents/AgentAvailability.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Runtime per-agent enablement: an agent is only usable when at least one of its allowlisted tools is
+    // actually available in the current workspace (and within its max_tier). e.g. web-research is unusable
+    // until the web tools are enabled. The host uses IsAvailable to filter the agents it offers the model,
+    // and MissingTools to tell the user (status-bar tooltip) what to enable for a disabled agent. Pure logic
+    // over AgentToolResolver, so it stays net48-testable.
+    internal static class AgentAvailability
+    {
+        // True when the agent resolves to at least one usable tool given what the parent can call here.
+        public static bool IsAvailable(Agent a, IEnumerable<string> parentAvailable, Func<string, ToolTier> tierOf)
+        {
+            if (a == null) return false;
+            return AgentToolResolver.Resolve(a.Tools, a.MaxTier, parentAvailable, tierOf).Count > 0;
+        }
+
+        // The agent's declared tool patterns that no currently-available tool matches - "what to enable" for a
+        // disabled agent. (a.Tools == null means "inherit read-only", so there's nothing specific to list.)
+        public static List<string> MissingTools(Agent a, IEnumerable<string> parentAvailable)
+        {
+            List<string> missing = new List<string>();
+            if (a == null || a.Tools == null) return missing;
+
+            List<string> avail = new List<string>();
+            if (parentAvailable != null)
+                foreach (string n in parentAvailable)
+                    if (!string.IsNullOrEmpty(n)) avail.Add(n);
+
+            for (int i = 0; i < a.Tools.Length; i++)
+            {
+                string pat = a.Tools[i];
+                if (string.IsNullOrEmpty(pat)) continue;
+                bool any = false;
+                for (int j = 0; j < avail.Count; j++)
+                    if (AgentToolResolver.WildcardMatch(pat, avail[j])) { any = true; break; }
+                if (!any) missing.Add(pat);
+            }
+            return missing;
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentCatalog.cs
+++ b/GxPT/Services/Agents/AgentCatalog.cs
@@ -103,7 +103,7 @@ namespace GxPT
             if (fm == null || string.IsNullOrEmpty(fm.Description)) return null;
 
             string name = (fm.Name != null && fm.Name.Length > 0) ? fm.Name : slug;
-            return new Agent(slug, name, fm.Description, fm.Tools, fm.MaxTier, fm.Autonomy, fm.Model,
+            return new Agent(slug, name, fm.Description, fm.Tools, fm.MaxTier, fm.Model,
                              fm.MaxTurns, file, source);
         }
 

--- a/GxPT/Services/Agents/AgentCatalog.cs
+++ b/GxPT/Services/Agents/AgentCatalog.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GxPT
+{
+    // Discovers sub-agents under one or more roots and exposes them by slug. Unlike skills (a folder per
+    // skill), an agent is a single flat file: <root>/<slug>.md (design A4). Bundled agents are scanned
+    // first, then user, then project; a more specific source shadows a less specific one of the same slug
+    // (project > user > bundled, design A11). Build takes explicit root paths so it stays pure and
+    // net48-testable; resolving the real roots (<exe>/agents, %AppData%/GxPT/agents, <workdir>/.gxpt/agents)
+    // is AgentRoots' job. XP / .NET 3.5 friendly.
+    internal sealed class AgentCatalog
+    {
+        private readonly List<Agent> _agents;                 // sorted by slug (ordinal)
+        private readonly Dictionary<string, Agent> _bySlug;   // case-insensitive
+
+        private AgentCatalog(List<Agent> agents, Dictionary<string, Agent> bySlug)
+        {
+            _agents = agents;
+            _bySlug = bySlug;
+        }
+
+        // All discovered agents, slug-sorted (read-only).
+        public IList<Agent> Agents
+        {
+            get { return _agents.AsReadOnly(); }
+        }
+
+        public bool TryGet(string slug, out Agent agent)
+        {
+            agent = null;
+            if (string.IsNullOrEmpty(slug)) return false;
+            return _bySlug.TryGetValue(slug, out agent);
+        }
+
+        // Convenience: a catalog with no user-global root (bundled + project only).
+        public static AgentCatalog Build(string bundledRoot, string projectRoot)
+        {
+            return Build(bundledRoot, null, projectRoot);
+        }
+
+        // Scans bundled, then user, then project; a more specific source shadows a less specific one of
+        // the same slug (project > user > bundled, design A11). Any root may be null/missing - it is
+        // simply skipped.
+        public static AgentCatalog Build(string bundledRoot, string userRoot, string projectRoot)
+        {
+            Dictionary<string, Agent> bySlug =
+                new Dictionary<string, Agent>(StringComparer.OrdinalIgnoreCase);
+
+            ScanRoot(bundledRoot, AgentSource.Bundled, bySlug);
+            ScanRoot(userRoot, AgentSource.User, bySlug);         // user overrides bundled
+            ScanRoot(projectRoot, AgentSource.Project, bySlug);   // project overrides user + bundled
+
+            List<Agent> list = new List<Agent>(bySlug.Values);
+            list.Sort(delegate(Agent a, Agent b) { return string.CompareOrdinal(a.Slug, b.Slug); });
+            return new AgentCatalog(list, bySlug);
+        }
+
+        private static void ScanRoot(string root, AgentSource source, Dictionary<string, Agent> bySlug)
+        {
+            if (string.IsNullOrEmpty(root) || !Directory.Exists(root)) return;
+
+            string[] files;
+            try { files = Directory.GetFiles(root, "*.md"); }
+            catch { return; }
+            // Sort so two files in the SAME root that normalize to the same slug (e.g. "Code Explorer.md"
+            // and "code-explorer.md") resolve deterministically (last in ordinal order wins), not in
+            // filesystem-enumeration order. Cross-root shadowing is handled by the scan order in Build.
+            Array.Sort(files, StringComparer.Ordinal);
+
+            for (int i = 0; i < files.Length; i++)
+            {
+                Agent agent = TryLoad(files[i], source);
+                if (agent != null) bySlug[agent.Slug] = agent;   // last writer wins -> project shadows bundled
+            }
+        }
+
+        // Loads an agent from a <slug>.md file if its frontmatter declares a non-empty description (the
+        // manifest line every agent needs). Returns null for anything malformed, so a bad file is skipped
+        // rather than breaking discovery. The slug is the file name (minus .md), normalized like a skill
+        // folder name (reusing SkillSlug.Make).
+        internal static Agent TryLoad(string file, AgentSource source)
+        {
+            if (string.IsNullOrEmpty(file)) return null;
+
+            // Guard the Win32 "*.md" wildcard quirk (it can also match longer extensions): require an
+            // exact .md file, so a stray "notes.mdx" is never treated as an agent.
+            string ext = Path.GetExtension(file);
+            if (ext == null || !ext.Equals(".md", StringComparison.OrdinalIgnoreCase)) return null;
+
+            string baseName = Path.GetFileNameWithoutExtension(file);
+            string slug = SkillSlug.Make(baseName);
+            if (string.IsNullOrEmpty(slug)) return null;
+            if (!File.Exists(file)) return null;
+
+            string text;
+            try { text = File.ReadAllText(file, Encoding.UTF8); }
+            catch { return null; }
+
+            AgentFrontmatter fm = AgentFrontmatter.Parse(text);
+            if (fm == null || string.IsNullOrEmpty(fm.Description)) return null;
+
+            string name = (fm.Name != null && fm.Name.Length > 0) ? fm.Name : slug;
+            return new Agent(slug, name, fm.Description, fm.Tools, fm.MaxTier, fm.Autonomy, fm.Model,
+                             file, source);
+        }
+
+        // The manifest body the model sees: one "- <slug> - <description>" line per agent, slug-ordered
+        // (design sec.4 Level-1). The surrounding system-message framing + the feature-enabled gate are a
+        // later phase (AgentInjection); this is the list.
+        public string BuildManifest()
+        {
+            return BuildManifest(_agents);
+        }
+
+        public static string BuildManifest(IEnumerable<Agent> agents)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (Agent a in agents)
+            {
+                if (sb.Length > 0) sb.Append('\n');
+                sb.Append("- ").Append(a.Slug).Append(" - ").Append(a.Description);
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentCatalog.cs
+++ b/GxPT/Services/Agents/AgentCatalog.cs
@@ -104,7 +104,7 @@ namespace GxPT
 
             string name = (fm.Name != null && fm.Name.Length > 0) ? fm.Name : slug;
             return new Agent(slug, name, fm.Description, fm.Tools, fm.MaxTier, fm.Autonomy, fm.Model,
-                             file, source);
+                             fm.MaxTurns, file, source);
         }
 
         // The manifest body the model sees: one "- <slug> - <description>" line per agent, slug-ordered

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -303,8 +303,10 @@ namespace GxPT
             {
                 // The live broadcaster doubles as the child's tool-loop UI: it feeds the panel's count line
                 // and records events for a viewer that attaches mid-run. Registered by row so the panel's
-                // "View transcript" can find it.
-                AgentLiveStream stream = new AgentLiveStream(ui, row, agent.Slug, task);
+                // "View transcript" can find it. The persona (system prompt) is passed so the live viewer can
+                // show it up front, the same way the static viewer does (RunChild reads it again for the
+                // child's actual system message - both are the agent body, read at the same moment).
+                AgentLiveStream stream = new AgentLiveStream(ui, row, agent.Slug, task, ReadBody(agent));
                 lock (_liveLock) { if (_liveStreams != null) _liveStreams[row] = stream; }
                 childUi = stream;
             }

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -406,8 +406,8 @@ namespace GxPT
         {
             public static readonly NullToolLoopUi Instance = new NullToolLoopUi();
             public void AppendTextDelta(string text) { }
-            public void OnToolCall(string functionName, string argumentsJson) { }
-            public void OnToolResult(string functionName, string resultText, bool isError) { }
+            public void OnToolCall(string functionName, string argumentsJson, string callId) { }
+            public void OnToolResult(string functionName, string resultText, bool isError, string callId) { }
             public void OnError(string message) { }
             public void Complete() { }
         }
@@ -423,12 +423,12 @@ namespace GxPT
             private int _count;
             public ChildActivityUi(IAgentActivityUi ui, int row) { _ui = ui; _row = row; }
             public void AppendTextDelta(string text) { }
-            public void OnToolCall(string functionName, string argumentsJson)
+            public void OnToolCall(string functionName, string argumentsJson, string callId)
             {
                 _count++;
                 if (_ui != null) _ui.OnAgentActivity(_row, functionName, _count);
             }
-            public void OnToolResult(string functionName, string resultText, bool isError) { }
+            public void OnToolResult(string functionName, string resultText, bool isError, string callId) { }
             public void OnError(string message) { }
             public void Complete() { }
         }

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -41,6 +41,15 @@ namespace GxPT
         public Action<ResponseUsage> UsageReported { get; set; }
         public RequestCancellation Cancellation { get; set; }
 
+        // Optional observability hooks (design sec.14): the dispatcher reports fan-out / per-child lifecycle
+        // so the host can show the activity panel and relabel the Stop button. Null => headless.
+        public IAgentActivityUi ActivityUi { get; set; }
+
+        // Optional group cancellation: when set, children use THIS handle instead of the parent turn's
+        // (Cancellation), so a "Stop N agents" click can cancel the fan-out without ending the turn. Null
+        // => children fall back to Cancellation (parent Stop cancels them, the phase-4 behavior).
+        public RequestCancellation GroupCancellation { get; set; }
+
         public AgentDispatcher(IList<Agent> agents, IChatStreamer streamer, McpToolRegistry registry,
                                IToolApprovalPolicy approval, string parentModel, string workingDir,
                                ILogSink log, Func<string, ToolTier> tierOf,
@@ -141,18 +150,34 @@ namespace GxPT
                 else { agents[i] = agent; runnable.Add(i); }
             }
 
-            // Read-only batches run concurrently (the win is overlapping LLM streams); a batch with any
-            // write-capable agent runs serially (design A9 - the chosen "reads parallel, writes serial"
-            // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
-            // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
-            if (RunsInParallel(agents, runnable))
-                RunParallel(agents, tasks, runnable, results);
-            else
-                for (int k = 0; k < runnable.Count; k++)
-                {
-                    int i = runnable[k];
-                    results[i] = RunChild(agents[i], tasks[i]);
-                }
+            // Observability: announce the fan-out so the host can show the panel + relabel Stop. Paired
+            // with OnFanOutEnd in finally so the button always reverts, even on an unexpected throw.
+            IAgentActivityUi ui = ActivityUi;
+            if (ui != null && runnable.Count > 0)
+            {
+                List<string> slugs = new List<string>(runnable.Count);
+                for (int k = 0; k < runnable.Count; k++) slugs.Add(agents[runnable[k]].Slug);
+                ui.OnFanOutStart(slugs);
+            }
+            try
+            {
+                // Read-only batches run concurrently (the win is overlapping LLM streams); a batch with any
+                // write-capable agent runs serially (design A9 - the chosen "reads parallel, writes serial"
+                // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
+                // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
+                if (RunsInParallel(agents, runnable))
+                    RunParallel(agents, tasks, runnable, results);
+                else
+                    for (int k = 0; k < runnable.Count; k++)
+                    {
+                        int i = runnable[k];
+                        results[i] = RunChildReported(i, agents[i], tasks[i]);
+                    }
+            }
+            finally
+            {
+                if (ui != null && runnable.Count > 0) ui.OnFanOutEnd();
+            }
 
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < n; i++)
@@ -200,7 +225,7 @@ namespace GxPT
                     dones[g] = done;
                     System.Threading.ThreadPool.QueueUserWorkItem(delegate
                     {
-                        try { results[slot] = RunChild(agent, task); }
+                        try { results[slot] = RunChildReported(slot, agent, task); }
                         catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
                         finally { done.Set(); }
                     });
@@ -209,6 +234,16 @@ namespace GxPT
                 for (int g = 0; g < groupSize; g++) dones[g].Close();
                 pos += groupSize;
             }
+        }
+
+        // Wraps RunChild with the activity-UI start/finished hooks (called from both the serial and the
+        // parallel paths). Safe to call concurrently: a host implementation marshals to the UI thread.
+        private string RunChildReported(int index, Agent agent, string task)
+        {
+            IAgentActivityUi ui = ActivityUi;
+            if (ui != null) ui.OnAgentStart(index, agent.Slug, task);
+            try { return RunChild(agent, task); }
+            finally { if (ui != null) ui.OnAgentFinished(index, agent.Slug); }
         }
 
         // Builds and runs one child orchestrator to completion, returning its final answer.
@@ -220,7 +255,9 @@ namespace GxPT
             McpChatOrchestrator child = new McpChatOrchestrator(_streamer, _registry, _approval, model,
                                                                 _log, maxIter, _callTimeoutMs);
             child.WorkingDir = _workingDir;
-            child.Cancellation = Cancellation;
+            // A "Stop N agents" click trips GroupCancellation (cancels the fan-out, not the turn); when the
+            // host hasn't set one, fall back to the parent turn's handle so a plain Stop still cancels.
+            child.Cancellation = GroupCancellation != null ? GroupCancellation : Cancellation;
             child.UsageReported = UsageReported;
 
             // Restrict the child to the agent's effective tool set by hiding everything else the parent can

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -51,6 +51,23 @@ namespace GxPT
         // by entry slot (aligned with the record body); a slot is null if that agent did not run a child.
         public AgentTranscript[] LastTranscripts { get; private set; }
 
+        // Per-row live broadcasters for the in-flight fan-out (tier 3 "watch live"). Created per child,
+        // dropped when the fan-out ends. Guarded by _liveLock: children register on worker threads while the
+        // UI thread looks one up to open the streaming viewer.
+        private readonly object _liveLock = new object();
+        private Dictionary<int, AgentLiveStream> _liveStreams;
+
+        // The live stream for a panel row, or null if the fan-out ended or that row isn't running.
+        public AgentLiveStream GetLiveStream(int row)
+        {
+            lock (_liveLock)
+            {
+                AgentLiveStream s;
+                if (_liveStreams != null && _liveStreams.TryGetValue(row, out s)) return s;
+                return null;
+            }
+        }
+
         // Optional group cancellation: when set, children use THIS handle instead of the parent turn's
         // (Cancellation), so a "Stop N agents" click can cancel the fan-out without ending the turn. Null
         // => children fall back to Cancellation (parent Stop cancels them, the phase-4 behavior).
@@ -174,6 +191,9 @@ namespace GxPT
                 }
                 ui.OnFanOutStart(slugs, taskList);
             }
+            // Fresh live-stream table for this fan-out (tier 3 "watch live"); the panel looks streams up by
+            // row while the children run, and it is dropped when the fan-out ends.
+            lock (_liveLock) { _liveStreams = new Dictionary<int, AgentLiveStream>(); }
             try
             {
                 // Read-only batches run concurrently (the win is overlapping LLM streams); a batch with any
@@ -192,6 +212,7 @@ namespace GxPT
             finally
             {
                 LastTranscripts = transcripts;
+                lock (_liveLock) { _liveStreams = null; }   // streams are only live during the fan-out
                 if (ui != null && runnable.Count > 0) ui.OnFanOutEnd();
             }
 
@@ -277,7 +298,17 @@ namespace GxPT
         {
             IAgentActivityUi ui = ActivityUi;
             if (ui != null) ui.OnAgentStart(row, agent.Slug, task);
-            IToolLoopUi childUi = ui != null ? (IToolLoopUi)new ChildActivityUi(ui, row) : NullToolLoopUi.Instance;
+            IToolLoopUi childUi;
+            if (ui != null)
+            {
+                // The live broadcaster doubles as the child's tool-loop UI: it feeds the panel's count line
+                // and records events for a viewer that attaches mid-run. Registered by row so the panel's
+                // "View transcript" can find it.
+                AgentLiveStream stream = new AgentLiveStream(ui, row, agent.Slug, task);
+                lock (_liveLock) { if (_liveStreams != null) _liveStreams[row] = stream; }
+                childUi = stream;
+            }
+            else childUi = NullToolLoopUi.Instance;
             try
             {
                 IList<ChatMessage> history;
@@ -407,27 +438,6 @@ namespace GxPT
             public static readonly NullToolLoopUi Instance = new NullToolLoopUi();
             public void AppendTextDelta(string text) { }
             public void OnToolCall(string functionName, string argumentsJson, string callId) { }
-            public void OnToolResult(string functionName, string resultText, bool isError, string callId) { }
-            public void OnError(string message) { }
-            public void Complete() { }
-        }
-
-        // Forwards a child's tool calls to the activity UI as the row's live activity line (tier 2): each
-        // call bumps the count and reports the latest tool name. Text deltas / results are dropped - the
-        // child's content never reaches the parent model (A7); only this lightweight count is shown to the
-        // user. One instance per running child, so _count is single-threaded (no lock needed).
-        private sealed class ChildActivityUi : IToolLoopUi
-        {
-            private readonly IAgentActivityUi _ui;
-            private readonly int _row;
-            private int _count;
-            public ChildActivityUi(IAgentActivityUi ui, int row) { _ui = ui; _row = row; }
-            public void AppendTextDelta(string text) { }
-            public void OnToolCall(string functionName, string argumentsJson, string callId)
-            {
-                _count++;
-                if (_ui != null) _ui.OnAgentActivity(_row, functionName, _count);
-            }
             public void OnToolResult(string functionName, string resultText, bool isError, string callId) { }
             public void OnError(string message) { }
             public void Complete() { }

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -19,8 +19,9 @@ namespace GxPT
     {
         public const string DispatchAgentName = "dispatch_agent";
 
-        // A sane bound on one batch, so a single tool call can't fan out unboundedly.
-        private const int MaxAgentsPerCall = 8;
+        // A sane bound on one batch, so a single tool call can't fan out unboundedly. internal so the
+        // activity panel can size its safety ceiling to the same maximum.
+        internal const int MaxAgentsPerCall = 8;
 
         // Max children running at once in a read-only fan-out (design: bounded concurrency). Tunable.
         private const int MaxParallelAgents = 3;

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -22,6 +22,9 @@ namespace GxPT
         // A sane bound on one batch, so a single tool call can't fan out unboundedly.
         private const int MaxAgentsPerCall = 8;
 
+        // Max children running at once in a read-only fan-out (design: bounded concurrency). Tunable.
+        private const int MaxParallelAgents = 3;
+
         private readonly Dictionary<string, Agent> _bySlug;
         private readonly IChatStreamer _streamer;
         private readonly McpToolRegistry _registry;
@@ -119,32 +122,93 @@ namespace GxPT
             bool truncated = n > MaxAgentsPerCall;
             if (truncated) n = MaxAgentsPerCall;
 
+            // Resolve each entry up front into a per-slot result (unknown slug / missing task are filled
+            // immediately) and a list of slots that will actually run a child, in order.
+            string[] names = new string[n];
+            Agent[] agents = new Agent[n];
+            string[] tasks = new string[n];
+            string[] results = new string[n];
+            List<int> runnable = new List<int>();
+            for (int i = 0; i < n; i++)
+            {
+                names[i] = entries[i][0];
+                tasks[i] = entries[i][1];
+                Agent agent;
+                if (names[i] == null || !_bySlug.TryGetValue(names[i], out agent))
+                    results[i] = "Unknown agent: " + (names[i] != null ? names[i] : "(null)");
+                else if (string.IsNullOrEmpty(tasks[i]))
+                    results[i] = "No task was provided for this agent.";
+                else { agents[i] = agent; runnable.Add(i); }
+            }
+
+            // Read-only batches run concurrently (the win is overlapping LLM streams); a batch with any
+            // write-capable agent runs serially (design A9 - the chosen "reads parallel, writes serial"
+            // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
+            // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
+            if (RunsInParallel(agents, runnable))
+                RunParallel(agents, tasks, runnable, results);
+            else
+                for (int k = 0; k < runnable.Count; k++)
+                {
+                    int i = runnable[k];
+                    results[i] = RunChild(agents[i], tasks[i]);
+                }
+
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < n; i++)
             {
-                string name = entries[i][0];
-                string task = entries[i][1];
-
                 if (sb.Length > 0) sb.Append("\n\n");
-                sb.Append("## Agent: ").Append(name != null ? name : "(null)").Append('\n');
-
-                Agent agent;
-                if (name == null || !_bySlug.TryGetValue(name, out agent))
-                {
-                    sb.Append("Unknown agent: ").Append(name != null ? name : "(null)");
-                    continue;
-                }
-                if (string.IsNullOrEmpty(task))
-                {
-                    sb.Append("No task was provided for this agent.");
-                    continue;
-                }
-                sb.Append(RunChild(agent, task));
+                sb.Append("## Agent: ").Append(names[i] != null ? names[i] : "(null)").Append('\n')
+                  .Append(results[i]);
             }
             if (truncated)
                 sb.Append("\n\n[Note: only the first ").Append(MaxAgentsPerCall)
                   .Append(" agents in this call were dispatched.]");
             return sb.ToString();
+        }
+
+        // A batch runs in parallel iff there is more than one runnable agent and every one of them is
+        // read-only (max_tier ReadOnly) - so none can mutate the workspace (design A9). Any write-capable
+        // agent forces the whole batch serial.
+        internal static bool RunsInParallel(Agent[] agents, List<int> runnable)
+        {
+            if (agents == null || runnable == null || runnable.Count < 2) return false;
+            for (int k = 0; k < runnable.Count; k++)
+            {
+                Agent a = agents[runnable[k]];
+                if (a == null || a.MaxTier != AgentMaxTier.ReadOnly) return false;
+            }
+            return true;
+        }
+
+        // Runs the runnable slots concurrently in waves of at most MaxParallelAgents, each child writing
+        // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
+        // is valid here; no lock is held across the join, so the fan-out cannot deadlock.
+        private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results)
+        {
+            int pos = 0;
+            while (pos < runnable.Count)
+            {
+                int groupSize = Math.Min(MaxParallelAgents, runnable.Count - pos);
+                System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[groupSize];
+                for (int g = 0; g < groupSize; g++)
+                {
+                    int slot = runnable[pos + g];
+                    Agent agent = agents[slot];
+                    string task = tasks[slot];
+                    System.Threading.ManualResetEvent done = new System.Threading.ManualResetEvent(false);
+                    dones[g] = done;
+                    System.Threading.ThreadPool.QueueUserWorkItem(delegate
+                    {
+                        try { results[slot] = RunChild(agent, task); }
+                        catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
+                        finally { done.Set(); }
+                    });
+                }
+                System.Threading.WaitHandle.WaitAll(dones);
+                for (int g = 0; g < groupSize; g++) dones[g].Close();
+                pos += groupSize;
+            }
         }
 
         // Builds and runs one child orchestrator to completion, returning its final answer.

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -46,6 +46,11 @@ namespace GxPT
         // so the host can show the activity panel and relabel the Stop button. Null => headless.
         public IAgentActivityUi ActivityUi { get; set; }
 
+        // The per-slot child transcripts from the most recent Dispatch (tier 3). Set at the end of each
+        // fan-out; the host snapshots it under the dispatch record's key for the read-only viewer. Indexed
+        // by entry slot (aligned with the record body); a slot is null if that agent did not run a child.
+        public AgentTranscript[] LastTranscripts { get; private set; }
+
         // Optional group cancellation: when set, children use THIS handle instead of the parent turn's
         // (Cancellation), so a "Stop N agents" click can cancel the fan-out without ending the turn. Null
         // => children fall back to Cancellation (parent Stop cancels them, the phase-4 behavior).
@@ -138,6 +143,10 @@ namespace GxPT
             Agent[] agents = new Agent[n];
             string[] tasks = new string[n];
             string[] results = new string[n];
+            // Per-slot child transcripts (tier 3): slot i is null until/unless that agent runs a child.
+            // Exposed via LastTranscripts so the host can cache them under the dispatch record's key and
+            // open a read-only viewer. Indexed by slot (entry order), aligned with the record body's rows.
+            AgentTranscript[] transcripts = new AgentTranscript[n];
             List<int> runnable = new List<int>();
             for (int i = 0; i < n; i++)
             {
@@ -157,8 +166,13 @@ namespace GxPT
             if (ui != null && runnable.Count > 0)
             {
                 List<string> slugs = new List<string>(runnable.Count);
-                for (int k = 0; k < runnable.Count; k++) slugs.Add(agents[runnable[k]].Slug);
-                ui.OnFanOutStart(slugs);
+                List<string> taskList = new List<string>(runnable.Count);
+                for (int k = 0; k < runnable.Count; k++)
+                {
+                    slugs.Add(agents[runnable[k]].Slug);
+                    taskList.Add(tasks[runnable[k]]);
+                }
+                ui.OnFanOutStart(slugs, taskList);
             }
             try
             {
@@ -167,16 +181,17 @@ namespace GxPT
                 // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
                 // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
                 if (RunsInParallel(agents, runnable))
-                    RunParallel(agents, tasks, runnable, results);
+                    RunParallel(agents, tasks, runnable, results, transcripts);
                 else
                     for (int k = 0; k < runnable.Count; k++)
                     {
                         int i = runnable[k];
-                        results[i] = RunChildReported(i, agents[i], tasks[i]);
+                        results[i] = RunChildReported(k, i, agents[i], tasks[i], transcripts);
                     }
             }
             finally
             {
+                LastTranscripts = transcripts;
                 if (ui != null && runnable.Count > 0) ui.OnFanOutEnd();
             }
 
@@ -222,7 +237,8 @@ namespace GxPT
         // Runs the runnable slots concurrently in waves of at most MaxParallelAgents, each child writing
         // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
         // is valid here; no lock is held across the join, so the fan-out cannot deadlock.
-        private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results)
+        private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results,
+                                 AgentTranscript[] transcripts)
         {
             int pos = 0;
             while (pos < runnable.Count)
@@ -231,14 +247,15 @@ namespace GxPT
                 System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[groupSize];
                 for (int g = 0; g < groupSize; g++)
                 {
-                    int slot = runnable[pos + g];
+                    int row = pos + g;          // panel row index (position among runnable)
+                    int slot = runnable[row];   // entry slot (position in the full agents/tasks arrays)
                     Agent agent = agents[slot];
                     string task = tasks[slot];
                     System.Threading.ManualResetEvent done = new System.Threading.ManualResetEvent(false);
                     dones[g] = done;
                     System.Threading.ThreadPool.QueueUserWorkItem(delegate
                     {
-                        try { results[slot] = RunChildReported(slot, agent, task); }
+                        try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
                         catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
                         finally { done.Set(); }
                     });
@@ -251,20 +268,34 @@ namespace GxPT
 
         // Wraps RunChild with the activity-UI start/finished hooks (called from both the serial and the
         // parallel paths). Safe to call concurrently: a host implementation marshals to the UI thread.
-        private string RunChildReported(int index, Agent agent, string task)
+        // `row` is the panel-row index (position among runnable, used for all UI callbacks); `slot` is the
+        // entry index (used for the result/transcript arrays). A per-child forwarding UI reports the
+        // child's tool calls as the row's live activity line (tier 2); the run's full message list is
+        // captured into transcripts[slot] for the tier-3 viewer (even on error - the partial history).
+        private string RunChildReported(int row, int slot, Agent agent, string task,
+                                        AgentTranscript[] transcripts)
         {
             IAgentActivityUi ui = ActivityUi;
-            if (ui != null) ui.OnAgentStart(index, agent.Slug, task);
-            try { return RunChild(agent, task); }
+            if (ui != null) ui.OnAgentStart(row, agent.Slug, task);
+            IToolLoopUi childUi = ui != null ? (IToolLoopUi)new ChildActivityUi(ui, row) : NullToolLoopUi.Instance;
+            try
+            {
+                IList<ChatMessage> history;
+                string answer = RunChild(agent, task, childUi, out history);
+                if (transcripts != null) transcripts[slot] = new AgentTranscript(agent.Slug, task, history);
+                return answer;
+            }
             finally
             {
                 bool cancelled = GroupCancellation != null && GroupCancellation.IsCancelled;
-                if (ui != null) ui.OnAgentFinished(index, agent.Slug, cancelled);
+                if (ui != null) ui.OnAgentFinished(row, agent.Slug, cancelled);
             }
         }
 
-        // Builds and runs one child orchestrator to completion, returning its final answer.
-        private string RunChild(Agent agent, string task)
+        // Builds and runs one child orchestrator to completion, returning its final answer. `history` is set
+        // (before the run) to the child's message list so the caller gets the full transcript even if the
+        // turn throws. `childUi` receives the child's tool activity (forwarded to the row's activity line).
+        private string RunChild(Agent agent, string task, IToolLoopUi childUi, out IList<ChatMessage> history)
         {
             string model = !string.IsNullOrEmpty(agent.Model) ? agent.Model : _parentModel;
             int maxIter = agent.MaxTurns > 0 ? agent.MaxTurns : _defaultMaxIterations;
@@ -287,22 +318,23 @@ namespace GxPT
                 if (hidden.Count > 0) child.HiddenToolNames = hidden;
             }
 
-            List<ChatMessage> history = new List<ChatMessage>();
+            List<ChatMessage> msgs = new List<ChatMessage>();
+            history = msgs;                                      // assigned up front so a throw still hands back the partial transcript
             string body = ReadBody(agent);                       // fresh read, so SKILL/AGENT edits apply
             if (!string.IsNullOrEmpty(body))
-                history.Add(new ChatMessage("system", body));    // the agent's persona, after the standing head
-            history.Add(new ChatMessage("user", task));
+                msgs.Add(new ChatMessage("system", body));       // the agent's persona, after the standing head
+            msgs.Add(new ChatMessage("user", task));
 
             try
             {
-                child.RunTurn(history, NullToolLoopUi.Instance);
+                child.RunTurn(msgs, childUi != null ? childUi : NullToolLoopUi.Instance);
             }
             catch (Exception ex)
             {
                 _log.Log("agents", "child '" + agent.Slug + "' threw: " + ex.Message);
                 return "[agent error: " + ex.Message + "]";
             }
-            return ExtractFinalAnswer(history);
+            return ExtractFinalAnswer(msgs);
         }
 
         // The child's final answer is the last assistant message its turn appended to history. Only the
@@ -368,13 +400,34 @@ namespace GxPT
             return (t != null && t.Type == JTokenType.String) ? (string)t : null;
         }
 
-        // A no-op transcript UI: a child's live activity is not surfaced to the parent model (A7); rich
-        // per-child UI is the phase-8 observability work. The answer is read from history, not the UI.
+        // A no-op transcript UI: used when there is no observability host (headless / tests). The answer is
+        // read from history, not the UI.
         private sealed class NullToolLoopUi : IToolLoopUi
         {
             public static readonly NullToolLoopUi Instance = new NullToolLoopUi();
             public void AppendTextDelta(string text) { }
             public void OnToolCall(string functionName, string argumentsJson) { }
+            public void OnToolResult(string functionName, string resultText, bool isError) { }
+            public void OnError(string message) { }
+            public void Complete() { }
+        }
+
+        // Forwards a child's tool calls to the activity UI as the row's live activity line (tier 2): each
+        // call bumps the count and reports the latest tool name. Text deltas / results are dropped - the
+        // child's content never reaches the parent model (A7); only this lightweight count is shown to the
+        // user. One instance per running child, so _count is single-threaded (no lock needed).
+        private sealed class ChildActivityUi : IToolLoopUi
+        {
+            private readonly IAgentActivityUi _ui;
+            private readonly int _row;
+            private int _count;
+            public ChildActivityUi(IAgentActivityUi ui, int row) { _ui = ui; _row = row; }
+            public void AppendTextDelta(string text) { }
+            public void OnToolCall(string functionName, string argumentsJson)
+            {
+                _count++;
+                if (_ui != null) _ui.OnAgentActivity(_row, functionName, _count);
+            }
             public void OnToolResult(string functionName, string resultText, bool isError) { }
             public void OnError(string message) { }
             public void Complete() { }

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -256,7 +256,11 @@ namespace GxPT
             IAgentActivityUi ui = ActivityUi;
             if (ui != null) ui.OnAgentStart(index, agent.Slug, task);
             try { return RunChild(agent, task); }
-            finally { if (ui != null) ui.OnAgentFinished(index, agent.Slug); }
+            finally
+            {
+                bool cancelled = GroupCancellation != null && GroupCancellation.IsCancelled;
+                if (ui != null) ui.OnAgentFinished(index, agent.Slug, cancelled);
+            }
         }
 
         // Builds and runs one child orchestrator to completion, returning its final answer.

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -195,9 +195,12 @@ namespace GxPT
             // above are partial. Steer the model to wrap up rather than silently retry: summarize what was
             // gathered and ask how to proceed (the design's tailored stop directive, sec.14).
             if (GroupCancellation != null && GroupCancellation.IsCancelled)
-                sb.Append("\n\n[The user stopped the sub-agents before they finished, so the results above ")
-                  .Append("may be partial or empty. Summarize what was gathered so far and ask the user how ")
-                  .Append("they would like to proceed - do not silently re-dispatch the agents.]");
+                sb.Append("\n\n[The user deliberately stopped the sub-agents, so the results above may be ")
+                  .Append("partial or empty. Do NOT continue the task yourself, do NOT call any more tools, ")
+                  .Append("and do NOT re-dispatch the agents. In your next message, briefly report what (if ")
+                  .Append("anything) the agents gathered above, then ask the user how they would like to ")
+                  .Append("proceed (for example: retry, narrow the scope, or take a different approach), and ")
+                  .Append("wait for their reply.]");
 
             return sb.ToString();
         }

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -190,6 +190,15 @@ namespace GxPT
             if (truncated)
                 sb.Append("\n\n[Note: only the first ").Append(MaxAgentsPerCall)
                   .Append(" agents in this call were dispatched.]");
+
+            // If the user stopped the fan-out (panel "Stop agents" trips GroupCancellation), the sections
+            // above are partial. Steer the model to wrap up rather than silently retry: summarize what was
+            // gathered and ask how to proceed (the design's tailored stop directive, sec.14).
+            if (GroupCancellation != null && GroupCancellation.IsCancelled)
+                sb.Append("\n\n[The user stopped the sub-agents before they finished, so the results above ")
+                  .Append("may be partial or empty. Summarize what was gathered so far and ask the user how ")
+                  .Append("they would like to proceed - do not silently re-dispatch the agents.]");
+
             return sb.ToString();
         }
 

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mcp35.Core.Diagnostics;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The host-synthesized dispatch_agent meta-tool (phase 4): runs a sub-agent in an isolated child
+    // McpChatOrchestrator and returns only its final answer (design A1-A3). Like open_skill, it is handled
+    // in the orchestrator's ExecuteCall without an MCP round-trip. Phase 4 runs a batch SERIALLY (parallel
+    // fan-out is phase 7). Each child gets a fresh context (the standing agent guidance + workspace block
+    // come from the child orchestrator's own stable head; the agent's body is added as a system message,
+    // then the task), a tool set restricted to allowlist-intersect-parent-intersect-max_tier
+    // (AgentToolResolver, via HiddenToolNames), the parent's shared approval policy, and NO dispatcher - so
+    // a sub-agent cannot itself dispatch (no nesting, A12). XP / .NET 3.5 friendly.
+    internal sealed class AgentDispatcher
+    {
+        public const string DispatchAgentName = "dispatch_agent";
+
+        // A sane bound on one batch, so a single tool call can't fan out unboundedly.
+        private const int MaxAgentsPerCall = 8;
+
+        private readonly Dictionary<string, Agent> _bySlug;
+        private readonly IChatStreamer _streamer;
+        private readonly McpToolRegistry _registry;
+        private readonly IToolApprovalPolicy _approval;
+        private readonly string _parentModel;
+        private readonly string _workingDir;
+        private readonly ILogSink _log;
+        private readonly Func<string, ToolTier> _tierOf;
+        private readonly int _defaultMaxIterations;
+        private readonly int _callTimeoutMs;
+
+        // Optional passthrough to the parent turn (set by the host): child usage aggregates onto the parent
+        // conversation, and the parent's cancellation handle lets a Stop cancel an in-flight child.
+        public Action<ResponseUsage> UsageReported { get; set; }
+        public RequestCancellation Cancellation { get; set; }
+
+        public AgentDispatcher(IList<Agent> agents, IChatStreamer streamer, McpToolRegistry registry,
+                               IToolApprovalPolicy approval, string parentModel, string workingDir,
+                               ILogSink log, Func<string, ToolTier> tierOf,
+                               int defaultMaxIterations, int callTimeoutMs)
+        {
+            if (streamer == null) throw new ArgumentNullException("streamer");
+            _bySlug = new Dictionary<string, Agent>(StringComparer.OrdinalIgnoreCase);
+            if (agents != null)
+            {
+                for (int i = 0; i < agents.Count; i++)
+                {
+                    Agent a = agents[i];
+                    if (a != null && !string.IsNullOrEmpty(a.Slug)) _bySlug[a.Slug] = a;
+                }
+            }
+            _streamer = streamer;
+            _registry = registry;
+            _approval = approval;
+            _parentModel = parentModel;
+            _workingDir = workingDir;
+            _log = log != null ? log : NullLogSink.Instance;
+            _tierOf = tierOf;
+            _defaultMaxIterations = defaultMaxIterations > 0
+                ? defaultMaxIterations : McpChatOrchestrator.DefaultMaxIterations;
+            _callTimeoutMs = callTimeoutMs > 0 ? callTimeoutMs : McpChatOrchestrator.DefaultCallTimeoutMs;
+        }
+
+        public bool HasAgents { get { return _bySlug.Count > 0; } }
+
+        public bool IsDispatchAgent(string functionName) { return functionName == DispatchAgentName; }
+
+        // The OpenAI-style function definition: dispatch_agent({ agents: [{ name, task }] }).
+        public JObject DispatchAgentDef()
+        {
+            JObject nameP = new JObject(); nameP["type"] = "string";
+            JObject taskP = new JObject(); taskP["type"] = "string";
+            JObject entryProps = new JObject();
+            entryProps["name"] = nameP;
+            entryProps["task"] = taskP;
+            JObject entrySchema = new JObject();
+            entrySchema["type"] = "object";
+            entrySchema["properties"] = entryProps;
+            entrySchema["required"] = new JArray("name", "task");
+
+            JObject agentsArr = new JObject();
+            agentsArr["type"] = "array";
+            agentsArr["items"] = entrySchema;
+
+            JObject props = new JObject();
+            props["agents"] = agentsArr;
+            JObject schema = new JObject();
+            schema["type"] = "object";
+            schema["properties"] = props;
+            schema["required"] = new JArray("agents");
+
+            JObject fn = new JObject();
+            fn["name"] = DispatchAgentName;
+            fn["description"] = "Delegate one or more self-contained sub-tasks to specialist agents that "
+                + "work in isolation and report back. Pass each agent's slug (from the agents list) and a "
+                + "complete task description - the agent does not see this conversation, only the task you "
+                + "give it. It returns a written result.";
+            fn["parameters"] = schema;
+
+            JObject def = new JObject();
+            def["type"] = "function";
+            def["function"] = fn;
+            return def;
+        }
+
+        // Runs the requested agents (serially in phase 4) and returns the aggregated result - one labeled
+        // section per agent. Unknown slugs become a short note rather than an error, so a partly-wrong
+        // batch still returns the rest (the open_skill tolerance). Never throws to the caller.
+        public string Dispatch(string argumentsJson)
+        {
+            List<string[]> entries = ParseEntries(argumentsJson);   // each = { name, task }
+            if (entries.Count == 0) return "No agents specified to dispatch.";
+
+            int n = entries.Count;
+            bool truncated = n > MaxAgentsPerCall;
+            if (truncated) n = MaxAgentsPerCall;
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < n; i++)
+            {
+                string name = entries[i][0];
+                string task = entries[i][1];
+
+                if (sb.Length > 0) sb.Append("\n\n");
+                sb.Append("## Agent: ").Append(name != null ? name : "(null)").Append('\n');
+
+                Agent agent;
+                if (name == null || !_bySlug.TryGetValue(name, out agent))
+                {
+                    sb.Append("Unknown agent: ").Append(name != null ? name : "(null)");
+                    continue;
+                }
+                if (string.IsNullOrEmpty(task))
+                {
+                    sb.Append("No task was provided for this agent.");
+                    continue;
+                }
+                sb.Append(RunChild(agent, task));
+            }
+            if (truncated)
+                sb.Append("\n\n[Note: only the first ").Append(MaxAgentsPerCall)
+                  .Append(" agents in this call were dispatched.]");
+            return sb.ToString();
+        }
+
+        // Builds and runs one child orchestrator to completion, returning its final answer.
+        private string RunChild(Agent agent, string task)
+        {
+            string model = !string.IsNullOrEmpty(agent.Model) ? agent.Model : _parentModel;
+            int maxIter = agent.MaxTurns > 0 ? agent.MaxTurns : _defaultMaxIterations;
+
+            McpChatOrchestrator child = new McpChatOrchestrator(_streamer, _registry, _approval, model,
+                                                                _log, maxIter, _callTimeoutMs);
+            child.WorkingDir = _workingDir;
+            child.Cancellation = Cancellation;
+            child.UsageReported = UsageReported;
+
+            // Restrict the child to the agent's effective tool set by hiding everything else the parent can
+            // call (no escalation, A11). Not setting an AgentDispatcher on the child means it has no
+            // dispatch_agent and cannot nest (A12).
+            if (_registry != null)
+            {
+                IList<string> parentNames = _registry.NamesForWorkdir(_workingDir);
+                List<string> hidden = AgentToolResolver.Hidden(agent.Tools, agent.MaxTier, parentNames, _tierOf);
+                if (hidden.Count > 0) child.HiddenToolNames = hidden;
+            }
+
+            List<ChatMessage> history = new List<ChatMessage>();
+            string body = ReadBody(agent);                       // fresh read, so SKILL/AGENT edits apply
+            if (!string.IsNullOrEmpty(body))
+                history.Add(new ChatMessage("system", body));    // the agent's persona, after the standing head
+            history.Add(new ChatMessage("user", task));
+
+            try
+            {
+                child.RunTurn(history, NullToolLoopUi.Instance);
+            }
+            catch (Exception ex)
+            {
+                _log.Log("agents", "child '" + agent.Slug + "' threw: " + ex.Message);
+                return "[agent error: " + ex.Message + "]";
+            }
+            return ExtractFinalAnswer(history);
+        }
+
+        // The child's final answer is the last assistant message its turn appended to history. Only the
+        // final answer crosses back to the parent (context firewall, A3/A7); intermediate tool chatter
+        // stays in the child's own message list.
+        private static string ExtractFinalAnswer(IList<ChatMessage> history)
+        {
+            if (history != null)
+            {
+                for (int i = history.Count - 1; i >= 0; i--)
+                {
+                    ChatMessage m = history[i];
+                    if (m != null && m.Role == "assistant" && !string.IsNullOrEmpty(m.Content))
+                        return m.Content;
+                }
+            }
+            return "(the agent produced no answer)";
+        }
+
+        private static string ReadBody(Agent agent)
+        {
+            if (agent == null || string.IsNullOrEmpty(agent.FilePath)) return string.Empty;
+            try
+            {
+                string text = File.ReadAllText(agent.FilePath, Encoding.UTF8);
+                return AgentFrontmatter.Parse(text).Body;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        // Parses { agents: [ { name, task }, ... ] } into a list of {name, task} pairs. Malformed input
+        // yields an empty list (the tool then reports "no agents"), never an exception.
+        private static List<string[]> ParseEntries(string argumentsJson)
+        {
+            List<string[]> list = new List<string[]>();
+            try
+            {
+                if (string.IsNullOrEmpty(argumentsJson)) return list;
+                JObject o = JObject.Parse(argumentsJson);
+                JToken arr = o["agents"];
+                if (arr != null && arr.Type == JTokenType.Array)
+                {
+                    foreach (JToken t in (JArray)arr)
+                    {
+                        if (t == null || t.Type != JTokenType.Object) continue;
+                        JObject e = (JObject)t;
+                        list.Add(new string[] { AsString(e["name"]), AsString(e["task"]) });
+                    }
+                }
+            }
+            catch
+            {
+                // malformed args -> empty list
+            }
+            return list;
+        }
+
+        private static string AsString(JToken t)
+        {
+            return (t != null && t.Type == JTokenType.String) ? (string)t : null;
+        }
+
+        // A no-op transcript UI: a child's live activity is not surfaced to the parent model (A7); rich
+        // per-child UI is the phase-8 observability work. The answer is read from history, not the UI.
+        private sealed class NullToolLoopUi : IToolLoopUi
+        {
+            public static readonly NullToolLoopUi Instance = new NullToolLoopUi();
+            public void AppendTextDelta(string text) { }
+            public void OnToolCall(string functionName, string argumentsJson) { }
+            public void OnToolResult(string functionName, string resultText, bool isError) { }
+            public void OnError(string message) { }
+            public void Complete() { }
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentEnablement.cs
+++ b/GxPT/Services/Agents/AgentEnablement.cs
@@ -10,7 +10,10 @@ namespace GxPT
         // mechanism as the memory toggle's "mcp_memory_enabled"). Lives in settings.json - not a dedicated
         // agents.json - so a future settings-page checkbox binds to the same value.
         public const string GlobalSettingKey = "agents_enabled";
-        public const bool GlobalDefault = false;   // agents lead OFF (they spawn loops + cost)
+        // On by default now that a first-party agent suite ships with the app (so agents work out of the
+        // box). An absent settings.json key resolves to this; /toggle-agents global off opts out (and writes
+        // the key). A per-conversation override still wins over this.
+        public const bool GlobalDefault = true;
 
         // Effective on/off (pure): the conversation override wins when set; otherwise the global default.
         public static bool FeatureEnabled(bool? conversationOverride, bool globalDefault)

--- a/GxPT/Services/Agents/AgentEnablement.cs
+++ b/GxPT/Services/Agents/AgentEnablement.cs
@@ -1,0 +1,33 @@
+namespace GxPT
+{
+    // The single agents feature toggle (design A15/sec.7): a per-conversation override layered over a
+    // global default stored in settings.json (`agents_enabled`, default false). No per-agent state. The
+    // resolution is pure (FeatureEnabled(bool?, bool)); the AppSettings-backed overloads are host
+    // conveniences for the send path and a future General settings-page checkbox. XP / .NET 3.5 friendly.
+    internal static class AgentEnablement
+    {
+        // The settings.json key the global default lives under (read/written via AppSettings, the same
+        // mechanism as the memory toggle's "mcp_memory_enabled"). Lives in settings.json - not a dedicated
+        // agents.json - so a future settings-page checkbox binds to the same value.
+        public const string GlobalSettingKey = "agents_enabled";
+        public const bool GlobalDefault = false;   // agents lead OFF (they spawn loops + cost)
+
+        // Effective on/off (pure): the conversation override wins when set; otherwise the global default.
+        public static bool FeatureEnabled(bool? conversationOverride, bool globalDefault)
+        {
+            return conversationOverride.HasValue ? conversationOverride.Value : globalDefault;
+        }
+
+        // The global default from settings.json (host-side).
+        public static bool GlobalEnabled()
+        {
+            return AppSettings.GetBool(GlobalSettingKey, GlobalDefault);
+        }
+
+        // Effective on/off using the live global default (host-side send path).
+        public static bool FeatureEnabled(bool? conversationOverride)
+        {
+            return FeatureEnabled(conversationOverride, GlobalEnabled());
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentFrontmatter.cs
+++ b/GxPT/Services/Agents/AgentFrontmatter.cs
@@ -26,6 +26,9 @@ namespace GxPT
         public AgentAutonomy Autonomy { get; private set; }
         public string Model { get; private set; }
 
+        // Per-agent iteration budget (design A17); 0 => unset (host default). Negative/non-numeric ignored.
+        public int MaxTurns { get; private set; }
+
         public string Body { get; private set; }
         public bool HasFrontmatter { get; private set; }
 
@@ -35,6 +38,7 @@ namespace GxPT
             Tools = null;
             MaxTier = AgentMaxTier.Write;     // default ceiling (design A5/sec.3)
             Autonomy = AgentAutonomy.Gated;   // default dial (design sec.8 layer 3)
+            MaxTurns = 0;                     // unset
         }
 
         public static AgentFrontmatter Parse(string text)
@@ -98,6 +102,11 @@ namespace GxPT
                 {
                     AgentAutonomy autonomy;
                     if (!autoSet && TryParseAutonomy(value, out autonomy)) { fm.Autonomy = autonomy; autoSet = true; }
+                }
+                else if (key == "max_turns")
+                {
+                    int n;
+                    if (fm.MaxTurns == 0 && int.TryParse(value.Trim(), out n) && n > 0) fm.MaxTurns = n;
                 }
             }
 

--- a/GxPT/Services/Agents/AgentFrontmatter.cs
+++ b/GxPT/Services/Agents/AgentFrontmatter.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GxPT
+{
+    // Hand-rolled reader for an agent <slug>.md's leading "--- ... ---" frontmatter block (design A5:
+    // net35 has no YAML parser and the repo keeps one JSON lib, so we parse the handful of "key: value"
+    // lines ourselves). It is the SkillFrontmatter reader extended for the agent contract: besides
+    // `name`/`description` it reads `tools` (an inline list), `max_tier` and `autonomy` (enums, with
+    // defaults), and `model`. Unknown keys are ignored (forward-compatible) and each known key is
+    // first-wins. Everything after the closing delimiter is the body (the agent's system prompt).
+    // Lenient: a missing or unterminated block yields no frontmatter and treats the whole text as body;
+    // an unrecognized enum value falls back to the default rather than rejecting the agent.
+    internal sealed class AgentFrontmatter
+    {
+        private const char Bom = '\uFEFF';
+
+        public string Name { get; private set; }
+        public string Description { get; private set; }
+
+        // Null when `tools:` was absent; a (possibly empty) array when present. See Agent.Tools.
+        public string[] Tools { get; private set; }
+
+        public AgentMaxTier MaxTier { get; private set; }
+        public AgentAutonomy Autonomy { get; private set; }
+        public string Model { get; private set; }
+
+        public string Body { get; private set; }
+        public bool HasFrontmatter { get; private set; }
+
+        private AgentFrontmatter()
+        {
+            Body = string.Empty;
+            Tools = null;
+            MaxTier = AgentMaxTier.Write;     // default ceiling (design A5/sec.3)
+            Autonomy = AgentAutonomy.Gated;   // default dial (design sec.8 layer 3)
+        }
+
+        public static AgentFrontmatter Parse(string text)
+        {
+            AgentFrontmatter fm = new AgentFrontmatter();
+            if (string.IsNullOrEmpty(text)) return fm;
+
+            string s = text;
+            if (s.Length > 0 && s[0] == Bom) s = s.Substring(1);   // strip a UTF-8 BOM
+
+            // Normalize line endings so the delimiter scan is CRLF/CR/LF-agnostic.
+            string[] lines = s.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
+
+            int i = 0;
+            while (i < lines.Length && lines[i].Trim().Length == 0) i++;   // skip leading blank lines
+
+            if (i >= lines.Length || lines[i].Trim() != "---")
+            {
+                fm.Body = s.Trim();   // no opening delimiter: the whole text is the body
+                return fm;
+            }
+
+            int start = i + 1;
+            int close = -1;
+            for (int j = start; j < lines.Length; j++)
+            {
+                if (lines[j].Trim() == "---") { close = j; break; }
+            }
+            if (close < 0)
+            {
+                fm.Body = s.Trim();   // unterminated frontmatter: treat the whole thing as body
+                return fm;
+            }
+
+            fm.HasFrontmatter = true;
+            bool toolsSet = false, tierSet = false, autoSet = false;
+            for (int j = start; j < close; j++)
+            {
+                string line = lines[j];
+                if (line.Trim().Length == 0) continue;
+                int colon = line.IndexOf(':');
+                if (colon < 0) continue;
+
+                string key = line.Substring(0, colon).Trim().ToLowerInvariant();
+                string value = line.Substring(colon + 1).Trim();
+
+                // First wins, so a stray duplicate key can't clobber the intended value.
+                if (key == "name") { if (fm.Name == null) fm.Name = value; }
+                else if (key == "description") { if (fm.Description == null) fm.Description = value; }
+                else if (key == "model") { if (fm.Model == null && value.Length > 0) fm.Model = value; }
+                else if (key == "tools")
+                {
+                    if (!toolsSet) { fm.Tools = ParseToolList(value); toolsSet = true; }
+                }
+                else if (key == "max_tier")
+                {
+                    AgentMaxTier tier;
+                    if (!tierSet && TryParseMaxTier(value, out tier)) { fm.MaxTier = tier; tierSet = true; }
+                }
+                else if (key == "autonomy")
+                {
+                    AgentAutonomy autonomy;
+                    if (!autoSet && TryParseAutonomy(value, out autonomy)) { fm.Autonomy = autonomy; autoSet = true; }
+                }
+            }
+
+            StringBuilder body = new StringBuilder();
+            for (int j = close + 1; j < lines.Length; j++)
+            {
+                if (body.Length > 0) body.Append('\n');
+                body.Append(lines[j]);
+            }
+            fm.Body = body.ToString().Trim();
+            return fm;
+        }
+
+        // Parses an inline `tools` value into an array. Null/blank => null (key absent or empty == "not
+        // specified"). A bracketed `[a, b]` or a bare `a, b` both split on commas; `[]` => an empty
+        // array (an explicit "no tools"). Surrounding quotes on a token are stripped. Wildcards (*,
+        // files__*) are kept verbatim - they are expanded against the catalog later (AgentToolResolver).
+        internal static string[] ParseToolList(string value)
+        {
+            if (value == null) return null;
+            string v = value.Trim();
+            if (v.Length == 0) return null;
+
+            if (v[0] == '[')
+            {
+                int end = v.LastIndexOf(']');
+                v = end >= 1 ? v.Substring(1, end - 1) : v.Substring(1);   // tolerate a missing ']'
+            }
+
+            string[] parts = v.Split(',');
+            List<string> list = new List<string>();
+            for (int k = 0; k < parts.Length; k++)
+            {
+                string t = parts[k].Trim();
+                if (t.Length >= 2 && (t[0] == '"' || t[0] == '\'') && t[t.Length - 1] == t[0])
+                    t = t.Substring(1, t.Length - 2).Trim();
+                if (t.Length > 0) list.Add(t);
+            }
+            return list.ToArray();
+        }
+
+        // readonly | write | destructive (a few spelling variants tolerated). Returns false for an
+        // unrecognized value, so the caller keeps the default.
+        internal static bool TryParseMaxTier(string value, out AgentMaxTier tier)
+        {
+            tier = AgentMaxTier.Write;
+            if (value == null) return false;
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "readonly":
+                case "read-only":
+                case "read_only":
+                    tier = AgentMaxTier.ReadOnly; return true;
+                case "write":
+                    tier = AgentMaxTier.Write; return true;
+                case "destructive":
+                    tier = AgentMaxTier.Destructive; return true;
+                default:
+                    return false;
+            }
+        }
+
+        // gated | auto-readonly (a few spelling variants tolerated). Returns false for an unrecognized
+        // value, so the caller keeps the default.
+        internal static bool TryParseAutonomy(string value, out AgentAutonomy autonomy)
+        {
+            autonomy = AgentAutonomy.Gated;
+            if (value == null) return false;
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "gated":
+                    autonomy = AgentAutonomy.Gated; return true;
+                case "auto-readonly":
+                case "auto_readonly":
+                case "autoreadonly":
+                case "auto-read-only":
+                    autonomy = AgentAutonomy.AutoReadOnly; return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentFrontmatter.cs
+++ b/GxPT/Services/Agents/AgentFrontmatter.cs
@@ -7,8 +7,8 @@ namespace GxPT
     // Hand-rolled reader for an agent <slug>.md's leading "--- ... ---" frontmatter block (design A5:
     // net35 has no YAML parser and the repo keeps one JSON lib, so we parse the handful of "key: value"
     // lines ourselves). It is the SkillFrontmatter reader extended for the agent contract: besides
-    // `name`/`description` it reads `tools` (an inline list), `max_tier` and `autonomy` (enums, with
-    // defaults), and `model`. Unknown keys are ignored (forward-compatible) and each known key is
+    // `name`/`description` it reads `tools` (an inline list), `max_tier` (an enum, with a default), and
+    // `model`. Unknown keys are ignored (forward-compatible) and each known key is
     // first-wins. Everything after the closing delimiter is the body (the agent's system prompt).
     // Lenient: a missing or unterminated block yields no frontmatter and treats the whole text as body;
     // an unrecognized enum value falls back to the default rather than rejecting the agent.
@@ -23,7 +23,6 @@ namespace GxPT
         public string[] Tools { get; private set; }
 
         public AgentMaxTier MaxTier { get; private set; }
-        public AgentAutonomy Autonomy { get; private set; }
         public string Model { get; private set; }
 
         // Per-agent iteration budget (design A17); 0 => unset (host default). Negative/non-numeric ignored.
@@ -37,7 +36,6 @@ namespace GxPT
             Body = string.Empty;
             Tools = null;
             MaxTier = AgentMaxTier.Write;     // default ceiling (design A5/sec.3)
-            Autonomy = AgentAutonomy.Gated;   // default dial (design sec.8 layer 3)
             MaxTurns = 0;                     // unset
         }
 
@@ -74,7 +72,7 @@ namespace GxPT
             }
 
             fm.HasFrontmatter = true;
-            bool toolsSet = false, tierSet = false, autoSet = false;
+            bool toolsSet = false, tierSet = false;
             for (int j = start; j < close; j++)
             {
                 string line = lines[j];
@@ -97,11 +95,6 @@ namespace GxPT
                 {
                     AgentMaxTier tier;
                     if (!tierSet && TryParseMaxTier(value, out tier)) { fm.MaxTier = tier; tierSet = true; }
-                }
-                else if (key == "autonomy")
-                {
-                    AgentAutonomy autonomy;
-                    if (!autoSet && TryParseAutonomy(value, out autonomy)) { fm.Autonomy = autonomy; autoSet = true; }
                 }
                 else if (key == "max_turns")
                 {
@@ -164,26 +157,6 @@ namespace GxPT
                     tier = AgentMaxTier.Write; return true;
                 case "destructive":
                     tier = AgentMaxTier.Destructive; return true;
-                default:
-                    return false;
-            }
-        }
-
-        // gated | auto-readonly (a few spelling variants tolerated). Returns false for an unrecognized
-        // value, so the caller keeps the default.
-        internal static bool TryParseAutonomy(string value, out AgentAutonomy autonomy)
-        {
-            autonomy = AgentAutonomy.Gated;
-            if (value == null) return false;
-            switch (value.Trim().ToLowerInvariant())
-            {
-                case "gated":
-                    autonomy = AgentAutonomy.Gated; return true;
-                case "auto-readonly":
-                case "auto_readonly":
-                case "autoreadonly":
-                case "auto-read-only":
-                    autonomy = AgentAutonomy.AutoReadOnly; return true;
                 default:
                     return false;
             }

--- a/GxPT/Services/Agents/AgentInjection.cs
+++ b/GxPT/Services/Agents/AgentInjection.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace GxPT
+{
+    // Host side of the agents feature: frames the always-on agents manifest for injection as an ephemeral
+    // system message (McpChatOrchestrator.AgentsManifestSystemMessageProvider), ordered after the skills
+    // block and before the MCP names manifest (design sec.5). Lists ALL discovered agents - there is no
+    // per-agent enablement (design A15); the whole block is gated by the single feature toggle
+    // (AgentEnablement), so when agents are off the host never sets the provider and the feature leaves no
+    // trace in context. XP / .NET 3.5 friendly.
+    internal static class AgentInjection
+    {
+        // The ephemeral block: framing + the slug/description manifest over all discovered agents. Returns
+        // null when there are none, so a project with no agents injects nothing even when the feature is on.
+        public static string BuildManifestMessage(IList<Agent> agents)
+        {
+            if (agents == null || agents.Count == 0) return null;
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("# Agents\n\n");
+            sb.Append("Agents are specialists you can delegate a self-contained task to. Each runs in ");
+            sb.Append("isolation - it does not see this conversation - does the work with its own tools, ");
+            sb.Append("and returns only its final answer. Delegate by calling dispatch_agent with the ");
+            sb.Append("agent's slug and a complete task description; you may dispatch several at once. ");
+            sb.Append("dispatch_agent is directly callable - you do NOT need to reveal it first. Prefer ");
+            sb.Append("delegating large or parallelizable sub-tasks (exploration, research, verification) ");
+            sb.Append("to keep this conversation focused. Do not mention agents unless they are relevant ");
+            sb.Append("to the request.\n\n");
+            sb.Append("Available agents:\n");
+            sb.Append(AgentCatalog.BuildManifest(agents));
+            return sb.ToString();
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentLiveStream.cs
+++ b/GxPT/Services/Agents/AgentLiveStream.cs
@@ -48,9 +48,9 @@ namespace GxPT
             lock (_lock)
             {
                 _count++;
-                _events.Add(Evt.Call(functionName, callId));
+                _events.Add(Evt.Call(functionName, argumentsJson, callId));
                 if (_activity != null) _activity.OnAgentActivity(_row, functionName, _count);
-                if (_sink != null) _sink.OnToolCall(functionName, callId);
+                if (_sink != null) _sink.OnToolCall(functionName, argumentsJson, callId);
             }
         }
 
@@ -98,11 +98,12 @@ namespace GxPT
             private const int TText = 0, TCall = 1, TResult = 2, TDone = 3;
             private int _t;
             private string _a;      // text delta / function name
-            private string _b;      // call id / result text
+            private string _b;      // args (call) / result text
+            private string _c;      // call id (call)
             private bool _err;
 
             public static Evt Text(string s) { Evt e = new Evt(); e._t = TText; e._a = s; return e; }
-            public static Evt Call(string fn, string id) { Evt e = new Evt(); e._t = TCall; e._a = fn; e._b = id; return e; }
+            public static Evt Call(string fn, string args, string id) { Evt e = new Evt(); e._t = TCall; e._a = fn; e._b = args; e._c = id; return e; }
             public static Evt Result(string fn, string res, bool err) { Evt e = new Evt(); e._t = TResult; e._a = fn; e._b = res; e._err = err; return e; }
             public static Evt Done() { Evt e = new Evt(); e._t = TDone; return e; }
 
@@ -111,7 +112,7 @@ namespace GxPT
                 switch (_t)
                 {
                     case TText: s.OnText(_a); break;
-                    case TCall: s.OnToolCall(_a, _b); break;
+                    case TCall: s.OnToolCall(_a, _b, _c); break;
                     case TResult: s.OnToolResult(_a, _b, _err); break;
                     case TDone: s.OnComplete(); break;
                 }

--- a/GxPT/Services/Agents/AgentLiveStream.cs
+++ b/GxPT/Services/Agents/AgentLiveStream.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // The child agent's tool-loop UI, doubling as a live broadcaster (design sec.14, tier 3 "watch live").
+    // It (a) forwards each tool call to the activity panel as the row's count line - the existing tier-2
+    // behavior - and (b) records every event (text delta / tool call / tool result / complete) so a viewer
+    // attaching mid-run can replay what already happened and then stream the rest. One instance per running
+    // child. Thread-safe: the child raises events on a worker thread while the UI thread attaches/detaches a
+    // viewer; a single lock guards the event log and the (at most one) attached sink. The replay-under-lock
+    // on Attach guarantees no event is missed or duplicated across the snapshot/live boundary.
+    internal sealed class AgentLiveStream : IToolLoopUi
+    {
+        private readonly IAgentActivityUi _activity;   // panel tool-count line (may be null)
+        private readonly int _row;
+        private readonly string _slug;
+        private readonly string _task;
+
+        private readonly object _lock = new object();
+        private readonly List<Evt> _events = new List<Evt>();
+        private IAgentLiveSink _sink;                   // the attached viewer, if any (v1: one at a time)
+        private int _count;
+
+        public AgentLiveStream(IAgentActivityUi activity, int row, string slug, string task)
+        {
+            _activity = activity;
+            _row = row;
+            _slug = slug;
+            _task = task;
+        }
+
+        public string Slug { get { return _slug; } }
+        public string Task { get { return _task; } }
+
+        // ---------- IToolLoopUi (driven by the child orchestrator) ----------
+        public void AppendTextDelta(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            lock (_lock)
+            {
+                _events.Add(Evt.Text(text));
+                if (_sink != null) _sink.OnText(text);
+            }
+        }
+
+        public void OnToolCall(string functionName, string argumentsJson, string callId)
+        {
+            lock (_lock)
+            {
+                _count++;
+                _events.Add(Evt.Call(functionName, callId));
+                if (_activity != null) _activity.OnAgentActivity(_row, functionName, _count);
+                if (_sink != null) _sink.OnToolCall(functionName, callId);
+            }
+        }
+
+        public void OnToolResult(string functionName, string resultText, bool isError, string callId)
+        {
+            lock (_lock)
+            {
+                _events.Add(Evt.Result(functionName, resultText, isError));
+                if (_sink != null) _sink.OnToolResult(functionName, resultText, isError);
+            }
+        }
+
+        public void OnError(string message) { }
+
+        public void Complete()
+        {
+            lock (_lock)
+            {
+                _events.Add(Evt.Done());
+                if (_sink != null) _sink.OnComplete();
+            }
+        }
+
+        // ---------- Viewer attach/detach ----------
+        // Replays the recorded events to the sink, then registers it for live events - all under the lock so
+        // an event arriving concurrently can't slip between the replay and the registration.
+        public void Attach(IAgentLiveSink sink)
+        {
+            if (sink == null) return;
+            lock (_lock)
+            {
+                for (int i = 0; i < _events.Count; i++) _events[i].Dispatch(sink);
+                _sink = sink;
+            }
+        }
+
+        public void Detach(IAgentLiveSink sink)
+        {
+            lock (_lock) { if (_sink == sink) _sink = null; }
+        }
+
+        // A recorded event. Small tagged value so the log can be replayed to a late-attaching sink.
+        private struct Evt
+        {
+            private const int TText = 0, TCall = 1, TResult = 2, TDone = 3;
+            private int _t;
+            private string _a;      // text delta / function name
+            private string _b;      // call id / result text
+            private bool _err;
+
+            public static Evt Text(string s) { Evt e = new Evt(); e._t = TText; e._a = s; return e; }
+            public static Evt Call(string fn, string id) { Evt e = new Evt(); e._t = TCall; e._a = fn; e._b = id; return e; }
+            public static Evt Result(string fn, string res, bool err) { Evt e = new Evt(); e._t = TResult; e._a = fn; e._b = res; e._err = err; return e; }
+            public static Evt Done() { Evt e = new Evt(); e._t = TDone; return e; }
+
+            public void Dispatch(IAgentLiveSink s)
+            {
+                switch (_t)
+                {
+                    case TText: s.OnText(_a); break;
+                    case TCall: s.OnToolCall(_a, _b); break;
+                    case TResult: s.OnToolResult(_a, _b, _err); break;
+                    case TDone: s.OnComplete(); break;
+                }
+            }
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentLiveStream.cs
+++ b/GxPT/Services/Agents/AgentLiveStream.cs
@@ -15,22 +15,25 @@ namespace GxPT
         private readonly int _row;
         private readonly string _slug;
         private readonly string _task;
+        private readonly string _persona;              // the agent's system prompt (shown by the live viewer)
 
         private readonly object _lock = new object();
         private readonly List<Evt> _events = new List<Evt>();
         private IAgentLiveSink _sink;                   // the attached viewer, if any (v1: one at a time)
         private int _count;
 
-        public AgentLiveStream(IAgentActivityUi activity, int row, string slug, string task)
+        public AgentLiveStream(IAgentActivityUi activity, int row, string slug, string task, string persona)
         {
             _activity = activity;
             _row = row;
             _slug = slug;
             _task = task;
+            _persona = persona;
         }
 
         public string Slug { get { return _slug; } }
         public string Task { get { return _task; } }
+        public string Persona { get { return _persona; } }
 
         // ---------- IToolLoopUi (driven by the child orchestrator) ----------
         public void AppendTextDelta(string text)

--- a/GxPT/Services/Agents/AgentRoots.cs
+++ b/GxPT/Services/Agents/AgentRoots.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace GxPT
+{
+    // Resolves the three agent roots - bundled (<exe>/agents), user-global (%AppData%/GxPT/agents), and
+    // project (<workdir>/.gxpt/agents) - and builds the AgentCatalog over them. The agents analogue of
+    // SkillRoots: same three-tier layout, reusing the memory system's .gxpt project home. Kept separate
+    // from discovery (AgentCatalog) so the path resolution stays pure and the catalog takes explicit
+    // roots for net48 tests. XP / .NET 3.5 friendly.
+    internal static class AgentRoots
+    {
+        public const string AgentsDirName = "agents";
+
+        // Bundled agents ship beside GxPT.exe (deployed by the AfterBuild copy like mcp-servers/skills).
+        public static string BundledRoot(string exeDir)
+        {
+            if (string.IsNullOrEmpty(exeDir)) return null;
+            return Path.Combine(exeDir, AgentsDirName);
+        }
+
+        // Project agents live under the conversation's working folder, reusing the memory/skills .gxpt home.
+        public static string ProjectRoot(string workingDir)
+        {
+            if (string.IsNullOrEmpty(workingDir)) return null;
+            return Path.Combine(Path.Combine(workingDir, MemoryInjection.MemoryDirName), AgentsDirName);
+        }
+
+        // User-global agents live under %AppData%/GxPT/agents - one set per Windows user, independent of
+        // workspace. Returns null if %AppData% can't be resolved.
+        public static string UserRoot()
+        {
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (string.IsNullOrEmpty(appData)) return null;
+            return Path.Combine(Path.Combine(appData, "GxPT"), AgentsDirName);
+        }
+
+        public static AgentCatalog BuildCatalog(string exeDir, string workingDir)
+        {
+            return AgentCatalog.Build(BundledRoot(exeDir), UserRoot(), ProjectRoot(workingDir));
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentToolResolver.cs
+++ b/GxPT/Services/Agents/AgentToolResolver.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Resolves the effective tool set a dispatched sub-agent may call: the frontmatter allowlist,
+    // intersected with what the PARENT can actually call in this workspace, and capped at the agent's
+    // max_tier ceiling (design A11/A19 - the no-escalation core). Pure logic: the per-tool tier is
+    // supplied by an injected delegate (the host wires it to ToolClassifier), so this stays
+    // net48-testable with no registry/classifier dependency. XP / .NET 3.5 friendly.
+    internal static class AgentToolResolver
+    {
+        // The no-nesting tool: a child never gets dispatch_agent, even if "*" would match it (design A12).
+        // Kept here so the resolver itself guarantees the exclusion; the dispatcher reuses the same name.
+        public const string DispatchAgentToolName = "dispatch_agent";
+
+        // Returns the subset of parentAvailable the agent may call - in parentAvailable's order, de-duped,
+        // never exceeding the parent's reach or the tier ceiling.
+        //   agentTools      the frontmatter `tools` allowlist (glob patterns); null => inherit the
+        //                   conservative ReadOnly-only default (design A5 fail-safe); a "*" entry => the
+        //                   full parent-available set (still tier-capped).
+        //   maxTier         the agent's ceiling; tools classified above it are dropped.
+        //   parentAvailable server-qualified tool names the parent can call in this workspace.
+        //   tierOf          maps a tool name to its tier (host: ToolClassifier). Null => treat every tool
+        //                   as Write (cautious: never silently grants a tool a ReadOnly-only agent couldn't
+        //                   reach, and never hides a Destructive one).
+        public static List<string> Resolve(string[] agentTools, AgentMaxTier maxTier,
+                                            IEnumerable<string> parentAvailable,
+                                            Func<string, ToolTier> tierOf)
+        {
+            List<string> result = new List<string>();
+            if (parentAvailable == null) return result;
+
+            ToolTier ceiling = ToCeiling(maxTier);
+            Dictionary<string, bool> seen = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string name in parentAvailable)
+            {
+                if (string.IsNullOrEmpty(name) || seen.ContainsKey(name)) continue;
+                seen[name] = true;
+
+                // No nesting: a child can never reach dispatch_agent, regardless of allowlist (design A12).
+                if (string.Equals(name, DispatchAgentToolName, StringComparison.OrdinalIgnoreCase)) continue;
+
+                ToolTier tier = tierOf != null ? tierOf(name) : ToolTier.Write;
+                if ((int)tier > (int)ceiling) continue;   // tier ceiling
+
+                bool allowed = (agentTools == null)
+                    ? (tier == ToolTier.ReadOnly)         // inherit: ReadOnly-only conservative default
+                    : MatchesAny(agentTools, name);       // explicit allowlist (globs)
+
+                if (allowed) result.Add(name);
+            }
+            return result;
+        }
+
+        // The tools the parent can call but this agent cannot - what the dispatcher feeds to the child's
+        // HiddenToolNames so a directly-named out-of-set tool is refused (design A11). Order and de-dup
+        // follow parentAvailable.
+        public static List<string> Hidden(string[] agentTools, AgentMaxTier maxTier,
+                                           IEnumerable<string> parentAvailable,
+                                           Func<string, ToolTier> tierOf)
+        {
+            List<string> hidden = new List<string>();
+            if (parentAvailable == null) return hidden;
+
+            List<string> effective = Resolve(agentTools, maxTier, parentAvailable, tierOf);
+            Dictionary<string, bool> keep = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < effective.Count; i++) keep[effective[i]] = true;
+
+            Dictionary<string, bool> seen = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            foreach (string name in parentAvailable)
+            {
+                if (string.IsNullOrEmpty(name) || seen.ContainsKey(name)) continue;
+                seen[name] = true;
+                if (!keep.ContainsKey(name)) hidden.Add(name);
+            }
+            return hidden;
+        }
+
+        private static ToolTier ToCeiling(AgentMaxTier maxTier)
+        {
+            switch (maxTier)
+            {
+                case AgentMaxTier.ReadOnly: return ToolTier.ReadOnly;
+                case AgentMaxTier.Destructive: return ToolTier.Destructive;
+                default: return ToolTier.Write;
+            }
+        }
+
+        internal static bool MatchesAny(string[] patterns, string name)
+        {
+            if (patterns == null) return false;
+            for (int i = 0; i < patterns.Length; i++)
+                if (WildcardMatch(patterns[i], name)) return true;
+            return false;
+        }
+
+        // Glob match with '*' as the only wildcard (matches any run, including empty), case-insensitive.
+        // "*" => everything; "files__*" => prefix; "*__read" => suffix; "a*b*c" => ordered segments.
+        // A pattern with no '*' is an exact (case-insensitive) match.
+        internal static bool WildcardMatch(string pattern, string name)
+        {
+            if (pattern == null || name == null) return false;
+            string p = pattern.Trim();
+            if (p.Length == 0) return false;
+            if (p == "*") return true;
+            if (p.IndexOf('*') < 0)
+                return string.Equals(p, name, StringComparison.OrdinalIgnoreCase);
+
+            string[] segs = p.Split('*');
+            int pos = 0;
+            for (int i = 0; i < segs.Length; i++)
+            {
+                string seg = segs[i];
+                if (seg.Length == 0) continue;   // adjacent or edge '*'
+
+                if (i == 0)
+                {
+                    if (!name.StartsWith(seg, StringComparison.OrdinalIgnoreCase)) return false;
+                    pos = seg.Length;
+                }
+                else if (i == segs.Length - 1)
+                {
+                    if (!name.EndsWith(seg, StringComparison.OrdinalIgnoreCase)) return false;
+                    if (name.Length - seg.Length < pos) return false;   // must fall after consumed prefix
+                }
+                else
+                {
+                    int idx = name.IndexOf(seg, pos, StringComparison.OrdinalIgnoreCase);
+                    if (idx < 0) return false;
+                    pos = idx + seg.Length;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentTranscript.cs
+++ b/GxPT/Services/Agents/AgentTranscript.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // A read-only snapshot of one child agent's run: its slug, the task it was given, and the full message
+    // list it produced (system persona + user task + assistant/tool turns). Captured by AgentDispatcher and
+    // surfaced to the user via a transient popup viewer (design sec.14, tier 3). This is a UI-only read: the
+    // child's messages are shown to the *user*, never fed back to the parent model (the context firewall,
+    // A3/A7, holds - only the child's final answer crosses back). The message list is the child's own
+    // history, which the dispatcher discards after the run, so this holds the only remaining reference.
+    internal sealed class AgentTranscript
+    {
+        public readonly string Slug;
+        public readonly string Task;
+        public readonly IList<ChatMessage> Messages;
+
+        public AgentTranscript(string slug, string task, IList<ChatMessage> messages)
+        {
+            Slug = slug;
+            Task = task;
+            Messages = messages;
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentTranscript.cs
+++ b/GxPT/Services/Agents/AgentTranscript.cs
@@ -20,5 +20,22 @@ namespace GxPT
             Task = task;
             Messages = messages;
         }
+
+        // How many tools the child ran: each executed tool appends one "tool"-role message to the child's
+        // history, so counting them gives the tool-call count shown on the dispatch record.
+        public int ToolCallCount
+        {
+            get
+            {
+                int n = 0;
+                if (Messages != null)
+                    for (int i = 0; i < Messages.Count; i++)
+                    {
+                        ChatMessage m = Messages[i];
+                        if (m != null && m.Role == "tool") n++;
+                    }
+                return n;
+            }
+        }
     }
 }

--- a/GxPT/Services/Agents/AgentTranscriptLinks.cs
+++ b/GxPT/Services/Agents/AgentTranscriptLinks.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+
+namespace GxPT
+{
+    // The custom link scheme that ties a dispatch_agent record's "View transcript" link to a cached child
+    // transcript (design sec.14, tier 3). The record body embeds Build(key, slot) as a Markdown link URL;
+    // the transcript control recognizes the scheme and, instead of launching a browser, opens the read-only
+    // viewer for AgentTranscriptStore.Get(key, slot). Pure string logic, kept out of the WinForms layer so
+    // it is unit-testable. The key is the dispatch record's id (a GUID hex or provider call id); the slot is
+    // the agent's entry index. Split on the LAST ':' so a key that itself contains ':' still parses.
+    internal static class AgentTranscriptLinks
+    {
+        public const string Scheme = "gxpt-agent:";
+
+        public static string Build(string key, int slot)
+        {
+            return Scheme + (key ?? string.Empty) + ":" + slot.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static bool IsTranscriptLink(string url)
+        {
+            return !string.IsNullOrEmpty(url) && url.StartsWith(Scheme, StringComparison.Ordinal);
+        }
+
+        public static bool TryParse(string url, out string key, out int slot)
+        {
+            key = null;
+            slot = -1;
+            if (!IsTranscriptLink(url)) return false;
+            string rest = url.Substring(Scheme.Length);
+            int colon = rest.LastIndexOf(':');
+            if (colon <= 0 || colon >= rest.Length - 1) return false;
+            int s;
+            if (!int.TryParse(rest.Substring(colon + 1), NumberStyles.Integer, CultureInfo.InvariantCulture, out s))
+                return false;
+            key = rest.Substring(0, colon);
+            slot = s;
+            return true;
+        }
+    }
+}

--- a/GxPT/Services/Agents/AgentTranscriptPersistence.cs
+++ b/GxPT/Services/Agents/AgentTranscriptPersistence.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace GxPT
+{
+    // On-disk persistence for child-agent transcripts (the user's "keep them until the conversation is
+    // deleted"). Each dispatch_agent call's per-slot transcripts are written to a per-conversation folder
+    // under %AppData%/GxPT/AgentTranscripts/<convId>/<recKey>.json, keyed by the dispatch record's id (the
+    // model call id). Loaded back into AgentTranscriptStore when the conversation opens, and the whole
+    // <convId> folder is removed when the conversation is deleted (ConversationStore.Delete*). A lean DTO is
+    // serialized (role/content/tool-call name+args) rather than the live ChatMessage graph. All operations
+    // swallow IO errors - persistence is best-effort and never blocks a turn or a delete.
+    internal static class AgentTranscriptPersistence
+    {
+        private const string DirName = "AgentTranscripts";
+        private const string FileExt = ".json";
+
+        private static string Root()
+        {
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(Path.Combine(appData, "GxPT"), DirName);
+        }
+
+        private static string Sanitize(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return null;
+            foreach (char c in Path.GetInvalidFileNameChars()) s = s.Replace(c, '_');
+            return s;
+        }
+
+        private static string ConvDir(string convId)
+        {
+            string id = Sanitize(convId);
+            return string.IsNullOrEmpty(id) ? null : Path.Combine(Root(), id);
+        }
+
+        // Persist one dispatch call's transcripts (slot-indexed; null slots are kept as null placeholders so
+        // the on-reload slot indices line up with the record body).
+        public static void Save(string convId, string recKey, AgentTranscript[] transcripts)
+        {
+            if (string.IsNullOrEmpty(recKey) || transcripts == null) return;
+            string dir = ConvDir(convId);
+            string file = Sanitize(recKey);
+            if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(file)) return;
+            try
+            {
+                if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                FileDto dto = ToDto(transcripts);
+                File.WriteAllText(Path.Combine(dir, file + FileExt), JsonConvert.SerializeObject(dto));
+            }
+            catch { }
+        }
+
+        // Load every persisted dispatch call for a conversation, keyed by record id, for re-seeding the
+        // in-memory store when the conversation opens.
+        public static Dictionary<string, AgentTranscript[]> LoadAll(string convId)
+        {
+            Dictionary<string, AgentTranscript[]> map = new Dictionary<string, AgentTranscript[]>(StringComparer.Ordinal);
+            string dir = ConvDir(convId);
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return map;
+            string[] files;
+            try { files = Directory.GetFiles(dir, "*" + FileExt); }
+            catch { return map; }
+            for (int i = 0; i < files.Length; i++)
+            {
+                try
+                {
+                    string recKey = Path.GetFileNameWithoutExtension(files[i]);
+                    FileDto dto = JsonConvert.DeserializeObject<FileDto>(File.ReadAllText(files[i]));
+                    AgentTranscript[] arr = FromDto(dto);
+                    if (!string.IsNullOrEmpty(recKey) && arr != null) map[recKey] = arr;
+                }
+                catch { }
+            }
+            return map;
+        }
+
+        public static void DeleteConversation(string convId)
+        {
+            string dir = ConvDir(convId);
+            try { if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir)) Directory.Delete(dir, true); }
+            catch { }
+        }
+
+        public static void DeleteAll()
+        {
+            try { string r = Root(); if (Directory.Exists(r)) Directory.Delete(r, true); }
+            catch { }
+        }
+
+        // ---------- DTO mapping ----------
+        private static FileDto ToDto(AgentTranscript[] transcripts)
+        {
+            FileDto f = new FileDto();
+            f.Agents = new List<TranscriptDto>(transcripts.Length);
+            for (int i = 0; i < transcripts.Length; i++)
+            {
+                AgentTranscript t = transcripts[i];
+                if (t == null) { f.Agents.Add(null); continue; }
+                TranscriptDto td = new TranscriptDto();
+                td.Slug = t.Slug;
+                td.Task = t.Task;
+                td.Messages = new List<MsgDto>();
+                if (t.Messages != null)
+                    for (int m = 0; m < t.Messages.Count; m++)
+                    {
+                        ChatMessage cm = t.Messages[m];
+                        if (cm == null) continue;
+                        MsgDto md = new MsgDto();
+                        md.Role = cm.Role;
+                        md.Content = cm.Content;
+                        md.ToolCallId = cm.ToolCallId;
+                        if (cm.ToolCalls != null && cm.ToolCalls.Count > 0)
+                        {
+                            md.ToolCalls = new List<CallDto>();
+                            for (int k = 0; k < cm.ToolCalls.Count; k++)
+                            {
+                                ToolCall tc = cm.ToolCalls[k];
+                                if (tc == null) continue;
+                                md.ToolCalls.Add(new CallDto { Id = tc.Id, Name = tc.Name, Args = tc.ArgumentsJson });
+                            }
+                        }
+                        td.Messages.Add(md);
+                    }
+                f.Agents.Add(td);
+            }
+            return f;
+        }
+
+        private static AgentTranscript[] FromDto(FileDto f)
+        {
+            if (f == null || f.Agents == null) return null;
+            AgentTranscript[] arr = new AgentTranscript[f.Agents.Count];
+            for (int i = 0; i < f.Agents.Count; i++)
+            {
+                TranscriptDto td = f.Agents[i];
+                if (td == null) { arr[i] = null; continue; }
+                List<ChatMessage> msgs = new List<ChatMessage>();
+                if (td.Messages != null)
+                    for (int m = 0; m < td.Messages.Count; m++)
+                    {
+                        MsgDto md = td.Messages[m];
+                        if (md == null) continue;
+                        ChatMessage cm = new ChatMessage(md.Role, md.Content);
+                        cm.ToolCallId = md.ToolCallId;
+                        if (md.ToolCalls != null && md.ToolCalls.Count > 0)
+                        {
+                            cm.ToolCalls = new List<ToolCall>();
+                            for (int k = 0; k < md.ToolCalls.Count; k++)
+                            {
+                                CallDto cd = md.ToolCalls[k];
+                                if (cd == null) continue;
+                                cm.ToolCalls.Add(new ToolCall(cd.Id, cd.Name, cd.Args));
+                            }
+                        }
+                        msgs.Add(cm);
+                    }
+                arr[i] = new AgentTranscript(td.Slug, td.Task, msgs);
+            }
+            return arr;
+        }
+
+        // Plain serialization DTOs (kept private; the on-disk shape is an implementation detail).
+        private sealed class FileDto { public List<TranscriptDto> Agents; }
+        private sealed class TranscriptDto { public string Slug; public string Task; public List<MsgDto> Messages; }
+        private sealed class MsgDto { public string Role; public string Content; public string ToolCallId; public List<CallDto> ToolCalls; }
+        private sealed class CallDto { public string Id; public string Name; public string Args; }
+    }
+}

--- a/GxPT/Services/Agents/AgentTranscriptStore.cs
+++ b/GxPT/Services/Agents/AgentTranscriptStore.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // A small, session-scoped cache of child-agent transcripts (design sec.14, tier 3). A dispatch_agent
+    // record in the chat is keyed by a per-call id; after the fan-out the host stores that call's per-slot
+    // transcripts here under the same key, so the record's "View transcript" links can later look them up
+    // and open the read-only viewer. In-memory only (not persisted): transcripts survive for the session,
+    // so the link works until the app closes, then the record degrades to "(transcript unavailable)" - the
+    // design's "retained for the session" contract. Bounded by MaxKeys with FIFO eviction so a long session
+    // of fan-outs can't grow unbounded. Thread-safe (the dispatcher runs on worker threads; the UI reads on
+    // the UI thread).
+    internal static class AgentTranscriptStore
+    {
+        // How many dispatch records' transcript sets to retain at once. Oldest evicted first.
+        private const int MaxKeys = 64;
+
+        private static readonly object _lock = new object();
+        private static readonly Dictionary<string, AgentTranscript[]> _map =
+            new Dictionary<string, AgentTranscript[]>(StringComparer.Ordinal);
+        private static readonly Queue<string> _order = new Queue<string>();
+
+        // Stores (or replaces) the per-slot transcripts for one dispatch record key.
+        public static void Put(string key, AgentTranscript[] transcripts)
+        {
+            if (string.IsNullOrEmpty(key) || transcripts == null) return;
+            lock (_lock)
+            {
+                if (!_map.ContainsKey(key)) _order.Enqueue(key);
+                _map[key] = transcripts;
+                // Evict oldest keys past the cap (skip the key just written, if it bubbles up).
+                while (_order.Count > MaxKeys)
+                {
+                    string old = _order.Dequeue();
+                    if (!string.Equals(old, key, StringComparison.Ordinal)) _map.Remove(old);
+                }
+            }
+        }
+
+        // The transcript for slot `index` under `key`, or null if the key is unknown (e.g. evicted, or a
+        // record reloaded from history after restart), the index is out of range, or that slot ran no child.
+        public static AgentTranscript Get(string key, int index)
+        {
+            if (string.IsNullOrEmpty(key) || index < 0) return null;
+            lock (_lock)
+            {
+                AgentTranscript[] arr;
+                if (!_map.TryGetValue(key, out arr) || arr == null || index >= arr.Length) return null;
+                return arr[index];
+            }
+        }
+    }
+}

--- a/GxPT/Services/Agents/IAgentActivityUi.cs
+++ b/GxPT/Services/Agents/IAgentActivityUi.cs
@@ -14,10 +14,11 @@ namespace GxPT
         // and relabels Stop. Always paired with exactly one OnFanOutEnd.
         void OnFanOutStart(IList<string> slugs);
 
-        // One child began / finished (index is its slot in the dispatch order). Under a parallel read-only
-        // fan-out these can interleave across children; the index identifies which row to update.
+        // One child began / finished (index is its slot in the dispatch order). cancelled is true when the
+        // fan-out was stopped by the user before this child completed (its result is partial/empty). Under
+        // a parallel read-only fan-out these can interleave across children; the index identifies the row.
         void OnAgentStart(int index, string slug, string task);
-        void OnAgentFinished(int index, string slug);
+        void OnAgentFinished(int index, string slug, bool cancelled);
 
         // The fan-out is complete; the host hides the panel and reverts the Stop button.
         void OnFanOutEnd();

--- a/GxPT/Services/Agents/IAgentActivityUi.cs
+++ b/GxPT/Services/Agents/IAgentActivityUi.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // The host's view of a dispatch_agent fan-out, for the observability UI (design sec.14). The
+    // AgentDispatcher calls these around the children it runs; the host (MainForm) implements them to
+    // relabel the Stop button to "Stop N agents" and render the in-transcript activity panel. All methods
+    // may be called from worker threads (children run on the ThreadPool), so an implementation must marshal
+    // to the UI thread itself. Optional on the dispatcher - null means no observability (the headless/test
+    // path). A child's live tool activity is shown to the user here, never fed to the parent model (A7).
+    internal interface IAgentActivityUi
+    {
+        // A fan-out is beginning with `slugs.Count` agents (in dispatch order). The host shows the panel
+        // and relabels Stop. Always paired with exactly one OnFanOutEnd.
+        void OnFanOutStart(IList<string> slugs);
+
+        // One child began / finished (index is its slot in the dispatch order). Under a parallel read-only
+        // fan-out these can interleave across children; the index identifies which row to update.
+        void OnAgentStart(int index, string slug, string task);
+        void OnAgentFinished(int index, string slug);
+
+        // The fan-out is complete; the host hides the panel and reverts the Stop button.
+        void OnFanOutEnd();
+    }
+}

--- a/GxPT/Services/Agents/IAgentActivityUi.cs
+++ b/GxPT/Services/Agents/IAgentActivityUi.cs
@@ -10,15 +10,20 @@ namespace GxPT
     // path). A child's live tool activity is shown to the user here, never fed to the parent model (A7).
     internal interface IAgentActivityUi
     {
-        // A fan-out is beginning with `slugs.Count` agents (in dispatch order). The host shows the panel
-        // and relabels Stop. Always paired with exactly one OnFanOutEnd.
-        void OnFanOutStart(IList<string> slugs);
+        // A fan-out is beginning with `slugs.Count` agents (in dispatch order); `tasks[i]` is the task
+        // string handed to `slugs[i]` (parallel lists, same length), shown per-row (tier 2, truncated /
+        // hover-to-expand). The host shows the panel and relabels Stop. Always paired with one OnFanOutEnd.
+        void OnFanOutStart(IList<string> slugs, IList<string> tasks);
 
         // One child began / finished (index is its slot in the dispatch order). cancelled is true when the
         // fan-out was stopped by the user before this child completed (its result is partial/empty). Under
         // a parallel read-only fan-out these can interleave across children; the index identifies the row.
         void OnAgentStart(int index, string slug, string task);
         void OnAgentFinished(int index, string slug, bool cancelled);
+
+        // A running child just issued its `toolCount`-th tool call (`lastTool` is the qualified name). Feeds
+        // the per-row live activity line (tier 2). Shown to the user only, never to the parent model (A7).
+        void OnAgentActivity(int index, string lastTool, int toolCount);
 
         // The fan-out is complete; the host hides the panel and reverts the Stop button.
         void OnFanOutEnd();

--- a/GxPT/Services/Agents/IAgentLiveSink.cs
+++ b/GxPT/Services/Agents/IAgentLiveSink.cs
@@ -8,7 +8,7 @@ namespace GxPT
     internal interface IAgentLiveSink
     {
         void OnText(string delta);
-        void OnToolCall(string functionName, string callId);
+        void OnToolCall(string functionName, string argumentsJson, string callId);
         void OnToolResult(string functionName, string resultText, bool isError);
         void OnComplete();
     }

--- a/GxPT/Services/Agents/IAgentLiveSink.cs
+++ b/GxPT/Services/Agents/IAgentLiveSink.cs
@@ -1,0 +1,15 @@
+namespace GxPT
+{
+    // A live consumer of one child agent's activity - the streaming transcript viewer. An AgentLiveStream
+    // replays its recorded events to a sink on attach, then forwards new ones as the child runs, so the
+    // viewer shows the run from the beginning even when opened mid-flight (design sec.14, tier 3 "watch
+    // live"). Callbacks may arrive on a worker thread (the child runs on the ThreadPool); the implementation
+    // marshals to the UI thread itself. Shown to the user only, never fed to the parent model (A7).
+    internal interface IAgentLiveSink
+    {
+        void OnText(string delta);
+        void OnToolCall(string functionName, string callId);
+        void OnToolResult(string functionName, string resultText, bool isError);
+        void OnComplete();
+    }
+}

--- a/GxPT/Services/Commands/AgentCommands.cs
+++ b/GxPT/Services/Commands/AgentCommands.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Slash commands for the sub-agents feature (design sec.6), in the scope-first hyphen-prefixed style
+    // PRs #156/#157 set for skills. The whole feature is a single on/off toggle (no per-agent management,
+    // A15), so the surface is just two commands:
+    //   /toggle-agents <here|global> <on|off|inherit>   -- enable/disable the feature at that scope
+    //   /dispatch-agent <slug> <task>                    -- explicitly delegate a task to an agent
+    // Reuses the shared scope/verb/completion helpers (SkillCommandShared); the conversation override goes
+    // through ISlashCommandContext.Agents, and global-scope changes go to settings.json via AppSettings.
+    internal static class AgentCommands
+    {
+        public static IList<ISlashCommand> BuiltIns()
+        {
+            List<ISlashCommand> list = new List<ISlashCommand>();
+            list.Add(new ToggleAgentsCommand());
+            list.Add(new DispatchAgentCommand());
+            return list;
+        }
+    }
+
+    // /toggle-agents <here|global> <on|off|inherit>   (scope first; global takes only on|off)
+    internal sealed class ToggleAgentsCommand : ClientCommandBase, IArgumentCompleter
+    {
+        public override string Name { get { return "toggle-agents"; } }
+        public override string Description { get { return "Turn the sub-agents feature on/off"; } }
+        public override string ArgumentHint { get { return "<here|global> <on|off|inherit>"; } }
+
+        public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
+        {
+            string[] tok = SkillCommandShared.Tokens(args);
+            if (tok.Length != 2) // scope + verb, both required
+                return SlashCommandResult.Fail("Usage: /toggle-agents <here|global> <on|off|inherit>");
+
+            bool isGlobal;
+            if (!SkillCommandShared.TryScope(tok[0], out isGlobal))
+                return SlashCommandResult.Fail("Unknown scope '" + tok[0] + "'. Use 'here' or 'global'.");
+
+            bool? onoff;
+            bool isInherit;
+            if (!SkillCommandShared.TryParseVerb(tok[1], out onoff, out isInherit))
+                return SlashCommandResult.Fail("Usage: /toggle-agents <here|global> <on|off|inherit>");
+
+            string info;
+            if (isInherit)
+            {
+                // The global default is the most upstream layer (a plain bool in settings.json), so it has
+                // nothing to inherit from -- only on/off.
+                if (isGlobal)
+                    return SlashCommandResult.Fail("The global agents default is always on or off; use 'on' or 'off'.");
+                ctx.Agents.SetConversationAgentsEnabled(null);
+                info = "Agents: this conversation now follows the global default.";
+            }
+            else
+            {
+                bool on = onoff.Value;
+                if (isGlobal) AppSettings.SetBool(AgentEnablement.GlobalSettingKey, on);
+                else ctx.Agents.SetConversationAgentsEnabled(on ? (bool?)true : (bool?)false);
+                info = "Agents turned " + (on ? "on" : "off") + " "
+                    + (isGlobal ? "globally" : "for this conversation") + ".";
+            }
+
+            ctx.WriteInfo(info);
+            return SlashCommandResult.Handled();
+        }
+
+        public IList<ArgCompletion> CompleteArgument(string argText, ISlashCommandContext ctx)
+        {
+            List<ArgCompletion> result = new List<ArgCompletion>();
+            string a = argText ?? string.Empty;
+            int sp = a.IndexOf(' ');
+            if (sp < 0)
+            {
+                // First token: the scope, which then narrows the verb choices.
+                SkillCommandShared.AddMatching(result, new string[] { "here", "global" }, a, "", true);
+            }
+            else
+            {
+                string scopeTok = a.Substring(0, sp);
+                string rest = a.Substring(sp + 1).TrimStart();
+                bool isGlobal;
+                if (!SkillCommandShared.TryScope(scopeTok, out isGlobal)) return result; // unknown scope
+                SkillCommandShared.AddMatching(result, SkillCommandShared.VerbsForScope(isGlobal, true),
+                    rest, scopeTok + " ", false);
+            }
+            return result;
+        }
+    }
+
+    // /dispatch-agent <slug> <task>   (explicit delegation; sends an instruction so the model issues a real
+    // dispatch_agent tool call - which requires the feature to be enabled so the tool is exposed).
+    internal sealed class DispatchAgentCommand : ClientCommandBase, IArgumentCompleter
+    {
+        public override string Name { get { return "dispatch-agent"; } }
+        public override string Description { get { return "Delegate a task to a sub-agent"; } }
+        public override string ArgumentHint { get { return "<slug> <task>"; } }
+
+        public override SlashCommandResult Invoke(string args, ISlashCommandContext ctx)
+        {
+            string a = (args ?? string.Empty).Trim();
+            if (a.Length == 0) return SlashCommandResult.Fail("Usage: /dispatch-agent <slug> <task>");
+
+            string slugArg, task;
+            int sp = a.IndexOf(' ');
+            if (sp < 0) { slugArg = a; task = string.Empty; }
+            else { slugArg = a.Substring(0, sp); task = a.Substring(sp + 1).Trim(); }
+            if (task.Length == 0) return SlashCommandResult.Fail("Usage: /dispatch-agent <slug> <task>");
+
+            AgentCatalog cat = AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
+            Agent agent;
+            if (!cat.TryGet(slugArg, out agent))
+                return SlashCommandResult.Fail("Unknown agent: " + slugArg);
+
+            // A normal user instruction so the model issues a real dispatch_agent call. Works only while the
+            // feature is enabled (the host exposes dispatch_agent then); otherwise the model has no tool.
+            string msg = "Dispatch the " + agent.Slug + " agent with this task: " + task;
+            return SlashCommandResult.Send(msg);
+        }
+
+        public IList<ArgCompletion> CompleteArgument(string argText, ISlashCommandContext ctx)
+        {
+            List<ArgCompletion> result = new List<ArgCompletion>();
+            string a = argText ?? string.Empty;
+            if (a.IndexOf(' ') >= 0) return result; // only complete the first token (the slug)
+
+            AgentCatalog cat = AgentRoots.BuildCatalog(AppDomain.CurrentDomain.BaseDirectory, ctx.WorkingDir);
+            IList<Agent> agents = cat.Agents;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                string slug = agents[i].Slug;
+                if (a.Length > 0 && !SlashMatch.HyphenPrefix(slug, a)) continue;
+                result.Add(new ArgCompletion(slug + " - " + agents[i].Description, slug + " ", false));
+            }
+            return result;
+        }
+    }
+}

--- a/GxPT/Services/Commands/IAgentEnablementStore.cs
+++ b/GxPT/Services/Commands/IAgentEnablementStore.cs
@@ -1,0 +1,13 @@
+namespace GxPT
+{
+    // Per-conversation sub-agents enablement, the agents analogue of ISkillEnablementStore (issue #119
+    // facet split). The agents feature is a single on/off (design A15) - no per-agent state - so this is
+    // just the conversation override: null = inherit the global default in settings.json
+    // (AgentEnablement.GlobalSettingKey); true = on; false = off. Global-scope changes go straight to
+    // AppSettings, not through here.
+    internal interface IAgentEnablementStore
+    {
+        bool? GetConversationAgentsEnabled();            // null = inherit, true = on, false = off
+        void SetConversationAgentsEnabled(bool? value);  // persists the active conversation
+    }
+}

--- a/GxPT/Services/Commands/ISlashCommandContext.cs
+++ b/GxPT/Services/Commands/ISlashCommandContext.cs
@@ -29,6 +29,9 @@ namespace GxPT
         // Per-conversation skills enablement (used by /toggle-skills and /toggle-skill).
         ISkillEnablementStore Skills { get; }
 
+        // Per-conversation sub-agents enablement (used by /toggle-agents).
+        IAgentEnablementStore Agents { get; }
+
         // ---- conversation / app actions ----
         void NewConversation();
         void ExportConversations();

--- a/GxPT/Services/Commands/MainFormSlashContext.cs
+++ b/GxPT/Services/Commands/MainFormSlashContext.cs
@@ -12,6 +12,7 @@ namespace GxPT
         private readonly IModelControl _models;
         private readonly IServerControl _servers;
         private readonly ISkillEnablementStore _skills;
+        private readonly IAgentEnablementStore _agents;
 
         public MainFormSlashContext(MainForm form)
         {
@@ -19,6 +20,7 @@ namespace GxPT
             _models = new MainFormModelControl(form);
             _servers = new MainFormServerControl(form);
             _skills = new MainFormSkillStore(form);
+            _agents = new MainFormAgentStore(form);
         }
 
         public string WorkingDir { get { return _form.SlashWorkingDir(); } }
@@ -28,6 +30,7 @@ namespace GxPT
         public IModelControl Models { get { return _models; } }
         public IServerControl Servers { get { return _servers; } }
         public ISkillEnablementStore Skills { get { return _skills; } }
+        public IAgentEnablementStore Agents { get { return _agents; } }
 
         public void NewConversation() { _form.SlashNewConversation(); }
         public void ExportConversations() { _form.SlashExportConversations(); }
@@ -67,5 +70,14 @@ namespace GxPT
         public void SetConversationSkillOverride(string slug, bool? value) { _form.SlashSetConversationSkillOverride(slug, value); }
         public void ResetConversationSkills() { _form.SlashResetConversationSkills(); }
         public void RefreshSkillsServer() { _form.SlashRefreshSkillsServer(); }
+    }
+
+    internal sealed class MainFormAgentStore : IAgentEnablementStore
+    {
+        private readonly MainForm _form;
+        public MainFormAgentStore(MainForm form) { _form = form; }
+
+        public bool? GetConversationAgentsEnabled() { return _form.SlashGetConversationAgentsEnabled(); }
+        public void SetConversationAgentsEnabled(bool? value) { _form.SlashSetConversationAgentsEnabled(value); }
     }
 }

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -54,15 +54,15 @@ namespace GxPT
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
-        private readonly Action<string> _onToolCall;                         // (functionName) -> show placeholder
-        private readonly Action<string, string, string, bool> _onToolResult; // (fn, argsJson, resultText, isError) -> replace
+        private readonly Action<string> _onToolCall;                                 // (functionName) -> show placeholder
+        private readonly Action<string, string, string, bool, string> _onToolResult; // (fn, argsJson, resultText, isError, callId) -> replace
         private readonly Action _complete;
         private readonly Action<string> _error;
 
         private string _pendingArgs; // arguments of the in-flight call, awaiting its result
 
         public DelegateToolLoopUi(Action<string> appendText, Action<string> onToolCall,
-                                  Action<string, string, string, bool> onToolResult, Action complete, Action<string> error)
+                                  Action<string, string, string, bool, string> onToolResult, Action complete, Action<string> error)
         {
             _appendText = appendText;
             _onToolCall = onToolCall;
@@ -76,16 +76,16 @@ namespace GxPT
             if (!string.IsNullOrEmpty(text) && _appendText != null) _appendText(text);
         }
 
-        public void OnToolCall(string functionName, string argumentsJson)
+        public void OnToolCall(string functionName, string argumentsJson, string callId)
         {
             // Stash args for the result; show the placeholder now. Calls are serial, so one slot fits.
             _pendingArgs = argumentsJson;
             if (_onToolCall != null) _onToolCall(functionName);
         }
 
-        public void OnToolResult(string functionName, string resultText, bool isError)
+        public void OnToolResult(string functionName, string resultText, bool isError, string callId)
         {
-            if (_onToolResult != null) _onToolResult(functionName, _pendingArgs, resultText, isError);
+            if (_onToolResult != null) _onToolResult(functionName, _pendingArgs, resultText, isError, callId);
             _pendingArgs = null;
         }
 

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -51,18 +51,22 @@ namespace GxPT
     // that placeholder once the outcome is known, so the transcript reflects what actually happened
     // (applied record / denied / errored) rather than the unapproved request. Arguments are stashed at
     // call time since OnToolResult doesn't carry them.
+    // (fn, argsJson, resultText, isError, callId) -> replace the placeholder with the outcome. A named
+    // delegate, not Action<...>: .NET 3.5's Action only goes up to four type arguments.
+    internal delegate void ToolResultCallback(string functionName, string argsJson, string resultText, bool isError, string callId);
+
     internal sealed class DelegateToolLoopUi : IToolLoopUi
     {
         private readonly Action<string> _appendText;
-        private readonly Action<string> _onToolCall;                                 // (functionName) -> show placeholder
-        private readonly Action<string, string, string, bool, string> _onToolResult; // (fn, argsJson, resultText, isError, callId) -> replace
+        private readonly Action<string> _onToolCall;        // (functionName) -> show placeholder
+        private readonly ToolResultCallback _onToolResult;  // (fn, argsJson, resultText, isError, callId) -> replace
         private readonly Action _complete;
         private readonly Action<string> _error;
 
         private string _pendingArgs; // arguments of the in-flight call, awaiting its result
 
         public DelegateToolLoopUi(Action<string> appendText, Action<string> onToolCall,
-                                  Action<string, string, string, bool, string> onToolResult, Action complete, Action<string> error)
+                                  ToolResultCallback onToolResult, Action complete, Action<string> error)
         {
             _appendText = appendText;
             _onToolCall = onToolCall;

--- a/GxPT/Services/Mcp/IChatStreamer.cs
+++ b/GxPT/Services/Mcp/IChatStreamer.cs
@@ -24,8 +24,10 @@ namespace GxPT
     internal interface IToolLoopUi
     {
         void AppendTextDelta(string text);
-        void OnToolCall(string functionName, string argumentsJson);
-        void OnToolResult(string functionName, string resultText, bool isError);
+        // callId is the model-assigned tool-call id (may be null for some providers); the host uses it as
+        // the stable key for a tool record so the live and reloaded views share one identity.
+        void OnToolCall(string functionName, string argumentsJson, string callId);
+        void OnToolResult(string functionName, string resultText, bool isError, string callId);
         void OnError(string message);
         void Complete();
     }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -290,6 +290,10 @@ namespace GxPT
             // The cap is a budget rather than a fixed loop bound so the user can grant another batch
             // when it's reached (ContinuationDecider) instead of dead-ending the turn.
             int budget = _maxIterations;
+            // Set after a dispatch_agent the user stopped: the next model call is forced to tool_choice
+            // "none" so the model must produce a text answer (a summary + "how should I proceed?") instead
+            // of charging ahead with more tool calls. Reset each iteration once consumed.
+            bool forceTextThisCall = false;
             for (int iter = 0; ; iter++)
             {
                 // Stop requested between iterations (e.g. while the previous iteration's tools ran):
@@ -389,7 +393,11 @@ namespace GxPT
 
                 bool errored;
                 string errMessage;
-                ToolCallAssembler asm = StreamOnce(requestMessages, tools, null, ui, out errored, out errMessage);
+                // After a user-stopped fan-out, force a text-only answer (the dispatch result carries the
+                // "summarize and ask" directive); otherwise normal auto tool choice.
+                string toolChoice = forceTextThisCall ? "none" : null;
+                forceTextThisCall = false;
+                ToolCallAssembler asm = StreamOnce(requestMessages, tools, toolChoice, ui, out errored, out errMessage);
                 if (errored)
                 {
                     _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
@@ -404,7 +412,7 @@ namespace GxPT
                 if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
                 {
                     _log.Log("mcp", "[turn " + turnId + "] empty response (no tool calls, no text); retrying once");
-                    asm = StreamOnce(requestMessages, tools, null, ui, out errored, out errMessage);
+                    asm = StreamOnce(requestMessages, tools, toolChoice, ui, out errored, out errMessage);
                     if (errored)
                     {
                         _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
@@ -463,6 +471,14 @@ namespace GxPT
                     ChatMessage toolMsg = new ChatMessage("tool", result);
                     toolMsg.ToolCallId = call.Id;
                     history.Add(toolMsg);
+
+                    // If the user stopped this dispatch_agent fan-out, force the next model call to text
+                    // only so it wraps up (summary + ask) per the directive in the tool result, rather than
+                    // launching into more tool calls.
+                    if (AgentDispatcher != null && AgentDispatcher.IsDispatchAgent(call.Name)
+                        && AgentDispatcher.GroupCancellation != null
+                        && AgentDispatcher.GroupCancellation.IsCancelled)
+                        forceTextThisCall = true;
                 }
                 // Loop: re-call the model with the tool results in context.
             }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -148,6 +148,12 @@ namespace GxPT
         // exposed in the tools array and handled locally without an MCP round-trip, like reveal_tools.
         public SkillTools SkillTools { get; set; }
 
+        // Optional sub-agent dispatch surface (dispatch_agent). When set and it has agents, dispatch_agent
+        // is exposed in the tools array and handled locally (a child McpChatOrchestrator runs the agent and
+        // its final answer is the tool result). The host only sets it when the agents feature is enabled.
+        // A child never gets a dispatcher, so a sub-agent cannot dispatch (no nesting, A12).
+        public AgentDispatcher AgentDispatcher { get; set; }
+
         // Server-qualified MCP tool names to omit from this turn's context (names manifest + exposed
         // defs) and refuse to call. Used to gate the skill-authoring tools on the meta-skill (SkillToolGate).
         // Set per send (the orchestrator is built fresh each turn), so it's not shared/racy.
@@ -326,6 +332,11 @@ namespace GxPT
                     if (tools == null) tools = new List<JObject>();
                     tools.Add(SkillTools.OpenSkillDef());
                     tools.Add(SkillTools.ReadSkillFileDef());
+                }
+                if (AgentDispatcher != null && AgentDispatcher.HasAgents)
+                {
+                    if (tools == null) tools = new List<JObject>();
+                    tools.Add(AgentDispatcher.DispatchAgentDef());
                 }
                 // Hide owned-but-locked tools (e.g. skill-authoring tools when the meta-skill is off):
                 // drop them from the exposed defs and the names manifest so the model can't see or call them.
@@ -721,6 +732,15 @@ namespace GxPT
                 _log.Log("mcp", "[turn " + turnId + "] read_skill_file: "
                     + (skillSlug != null ? skillSlug : "?") + " / " + (relpath != null ? relpath : "?"));
                 return SkillTools.ReadFile(skillSlug, relpath);
+            }
+
+            // dispatch_agent is a host meta-tool too: run the sub-agent(s) in isolated child orchestrators
+            // and return their final answer(s). No MCP round-trip; the child gets no dispatcher, so it
+            // cannot nest (A12). Failures inside a child come back as content, not an exception.
+            if (AgentDispatcher != null && AgentDispatcher.IsDispatchAgent(call.Name))
+            {
+                _log.Log("mcp", "[turn " + turnId + "] dispatch_agent");
+                return AgentDispatcher.Dispatch(call.ArgumentsJson);
             }
 
             // A hidden (gated-off) tool must not be callable even if the model names it directly.

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -462,12 +462,12 @@ namespace GxPT
                 for (int c = 0; c < asm.Calls.Count; c++)
                 {
                     ToolCall call = asm.Calls[c];
-                    if (ui != null) ui.OnToolCall(call.Name, call.ArgumentsJson);
+                    if (ui != null) ui.OnToolCall(call.Name, call.ArgumentsJson, call.Id);
 
                     bool isError;
                     string result = ExecuteCall(call, turnId, out isError);
 
-                    if (ui != null) ui.OnToolResult(call.Name, result, isError);
+                    if (ui != null) ui.OnToolResult(call.Name, result, isError, call.Id);
                     ChatMessage toolMsg = new ChatMessage("tool", result);
                     toolMsg.ToolCallId = call.Id;
                     history.Add(toolMsg);

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -137,6 +137,13 @@ namespace GxPT
         // block, so a skill-less conversation leaves no trace in context.
         public Func<string> SkillsManifestSystemMessageProvider { get; set; }
 
+        // Optional provider of the agents manifest system block (the always-on slug/description list of
+        // dispatchable sub-agents plus its framing), rebuilt each request and injected as an ephemeral
+        // system message ordered after the skills block and before the MCP names manifest (design sec.5).
+        // Gated by the single agents feature toggle (the host only sets it when agents are enabled), so a
+        // conversation with agents off leaves no trace in context. Null/empty => no agents block.
+        public Func<string> AgentsManifestSystemMessageProvider { get; set; }
+
         // Optional skills meta-tool surface (open_skill). When set and it has skills, open_skill is
         // exposed in the tools array and handled locally without an MCP round-trip, like reveal_tools.
         public SkillTools SkillTools { get; set; }
@@ -363,7 +370,9 @@ namespace GxPT
                     ? MemorySystemMessageProvider() : null;
                 string skillsBlock = SkillsManifestSystemMessageProvider != null
                     ? SkillsManifestSystemMessageProvider() : null;
-                string ephemeralTail = BuildEphemeralContextText(memoryBlock, skillsBlock, manifest);
+                string agentsBlock = AgentsManifestSystemMessageProvider != null
+                    ? AgentsManifestSystemMessageProvider() : null;
+                string ephemeralTail = BuildEphemeralContextText(memoryBlock, skillsBlock, agentsBlock, manifest);
                 if (!string.IsNullOrEmpty(ephemeralTail))
                     requestMessages.Add(new ChatMessage("user", ephemeralTail));
 
@@ -633,13 +642,14 @@ namespace GxPT
         // parameter, which would put this back in front of the cached history; as a trailing user
         // message it merges into the same user turn as any preceding tool results ([tool_result...,
         // text] is the order Anthropic requires). Returns null when every block is empty, so a turn
-        // without memory/skills/tools leaves no trace. Never persisted; the UI never renders it.
-        internal static string BuildEphemeralContextText(string memory, string skills, string toolManifest)
+        // without memory/skills/agents/tools leaves no trace. Never persisted; the UI never renders it.
+        internal static string BuildEphemeralContextText(string memory, string skills, string agents, string toolManifest)
         {
             bool hasMemory = !string.IsNullOrEmpty(memory);
             bool hasSkills = !string.IsNullOrEmpty(skills);
+            bool hasAgents = !string.IsNullOrEmpty(agents);
             bool hasManifest = !string.IsNullOrEmpty(toolManifest);
-            if (!hasMemory && !hasSkills && !hasManifest) return null;
+            if (!hasMemory && !hasSkills && !hasAgents && !hasManifest) return null;
 
             StringBuilder sb = new StringBuilder();
             sb.Append("[Ephemeral context appended by the host application for this request. ");
@@ -648,6 +658,8 @@ namespace GxPT
                 sb.Append("\n\n<memory>\n").Append(memory).Append("\n</memory>");
             if (hasSkills)
                 sb.Append("\n\n<skills>\n").Append(skills).Append("\n</skills>");
+            if (hasAgents)
+                sb.Append("\n\n<agents>\n").Append(agents).Append("\n</agents>");
             if (hasManifest)
                 sb.Append("\n\n<available_tools>\n").Append(toolManifest).Append("\n</available_tools>");
             return sb.ToString();

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -78,6 +78,7 @@ namespace GxPT
         // The orchestrator calls this. functionName is the qualified name; args already parsed.
         public ApprovalDecision Check(string functionName, JObject args)
         {
+            string server = ServerOf(functionName);
             ToolPolicy pol = ClassifyTool(functionName);
 
             // Read-only tools never modify anything -> always allowed, no prompt. Driven by the

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -54,19 +54,31 @@ namespace GxPT
             _annotations = annotations;
         }
 
-        // The orchestrator calls this. functionName is the qualified name; args already parsed.
-        public ApprovalDecision Check(string functionName, JObject args)
+        // Classifies a qualified tool name into its ToolPolicy (tier + remember scope). First-party tools
+        // are classified by the authoritative hardcoded table (annotations ignored), so only look them up
+        // for third-party tools. Absent annotations -> null -> classifier fails closed (Write/Tool), so a
+        // forgotten readOnlyHint never silently widens access. Shared by Check and the public TierOf.
+        private ToolPolicy ClassifyTool(string functionName)
         {
             string server = ServerOf(functionName);
             bool firstParty = server != null && _firstPartyServers.ContainsKey(server);
-            // Pull the tool's declared capability hints from the discovered definition. First-party tools
-            // are classified by the authoritative hardcoded table (annotations ignored), so only look them
-            // up for third-party tools. Absent annotations -> null -> classifier fails closed (Write/Tool),
-            // so a forgotten readOnlyHint never silently widens access.
             JObject annotations = (!firstParty && _annotations != null)
                 ? _annotations.AnnotationsFor(functionName)
                 : null;
-            ToolPolicy pol = _classifier.Classify(functionName, annotations, firstParty);
+            return _classifier.Classify(functionName, annotations, firstParty);
+        }
+
+        // The classified tier of a tool, by qualified name - used by AgentToolResolver to enforce a
+        // sub-agent's max_tier ceiling with the same classification the approval gate uses.
+        public ToolTier TierOf(string functionName)
+        {
+            return ClassifyTool(functionName).Tier;
+        }
+
+        // The orchestrator calls this. functionName is the qualified name; args already parsed.
+        public ApprovalDecision Check(string functionName, JObject args)
+        {
+            ToolPolicy pol = ClassifyTool(functionName);
 
             // Read-only tools never modify anything -> always allowed, no prompt. Driven by the
             // classified tier (not a name list), so every ReadOnly tool auto-allows: the read-only

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,0 +1,17 @@
+---
+name: Code Reviewer
+description: Read-only code reviewer. Dispatch it to review a change or diff - it reads the code and reports correctness bugs, risks, and quality issues with file references. Cannot modify files.
+tools: [files__read, files__list, files__search, git__status, git__diff, git__log]
+max_tier: readonly
+max_turns: 25
+---
+You are a code-review specialist.
+
+Given a change (a diff, a set of files, or a described change), review it and report:
+- correctness bugs and edge cases first - the things most likely to break,
+- risks: security, data loss, concurrency, error handling, breaking changes,
+- quality: clarity, naming, duplication, and fit with the project's conventions.
+
+Read the surrounding code, not just the diff, so your review reflects how the change actually behaves. Cite file:line for each finding and order them by severity. Be specific and concrete; skip praise and trivial nitpicks unless they matter. You review only - do not modify files; if a fix is obvious, describe it briefly rather than applying it.
+
+Work by calling tools, not by narrating. A message with no tool call is treated as your final answer, so only stop once you are ready to give your review.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,13 +1,13 @@
 ---
 name: Code Reviewer
-description: Read-only code reviewer. Dispatch it to review a change or diff - it reads the code and reports correctness bugs, risks, and quality issues with file references. Cannot modify files.
-tools: [files__read, files__list, files__search, git__status, git__diff, git__log]
+description: Read-only code reviewer. Dispatch it to review a change, diff, or GitHub pull request - it reads the code and reports correctness bugs, risks, and quality issues with file references. Cannot modify files.
+tools: [files__read, files__list, files__search, git__status, git__diff, git__log, github__*]
 max_tier: readonly
 max_turns: 25
 ---
 You are a code-review specialist.
 
-Given a change (a diff, a set of files, or a described change), review it and report:
+Given a change (a diff, a set of files, a GitHub pull request, or a described change), review it and report:
 - correctness bugs and edge cases first - the things most likely to break,
 - risks: security, data loss, concurrency, error handling, breaking changes,
 - quality: clarity, naming, duplication, and fit with the project's conventions.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -4,6 +4,7 @@ description: Read-only code explorer. Dispatch it to locate and summarize how so
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
 max_tier: readonly
 autonomy: auto-readonly
+model: deepseek/deepseek-v4-flash
 max_turns: 25
 ---
 You are a code-exploration specialist working inside the user's workspace.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -3,7 +3,6 @@ name: Explore
 description: Read-only code explorer. Dispatch it to locate and summarize how something works in the codebase before you change anything - it returns a tight written brief with file paths. Cannot modify files.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
 max_tier: readonly
-autonomy: auto-readonly
 model: deepseek/deepseek-v4-flash
 max_turns: 25
 ---

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,0 +1,18 @@
+---
+name: Explore
+description: Read-only code explorer. Dispatch it to locate and summarize how something works in the codebase before you change anything - it returns a tight written brief with file paths. Cannot modify files.
+tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
+max_tier: readonly
+autonomy: auto-readonly
+max_turns: 25
+---
+You are a code-exploration specialist working inside the user's workspace.
+
+Given a question about the codebase, locate the relevant files, read the parts that matter, and return a tight written summary covering:
+- where the thing lives (file path + line where useful),
+- how it works at a high level,
+- anything surprising or worth flagging.
+
+Cite paths so the user can jump to them. Do NOT modify any files. If you can't find something after a genuine search, say so and name where you looked.
+
+Work by calling tools, not by narrating. Never end a message with a plan to do something ("now let me read X") unless that same message also calls the tool - a message with no tool call is treated as your final answer. When you have gathered enough, write the summary as your final message.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -15,4 +15,4 @@ Given a question about the codebase, locate the relevant files, read the parts t
 
 Cite paths so the user can jump to them. Do NOT modify any files. If you can't find something after a genuine search, say so and name where you looked.
 
-Work by calling tools, not by narrating. Never end a message with a plan to do something ("now let me read X") unless that same message also calls the tool - a message with no tool call is treated as your final answer. When you have gathered enough, write the summary as your final message.
+Work by calling tools, not by narrating. A message with no tool call is treated as your final answer, so only stop once you are ready to give your summary.

--- a/agents/general-purpose.md
+++ b/agents/general-purpose.md
@@ -3,7 +3,6 @@ name: General Purpose
 description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files and inspect git, working in isolation and reporting back. Edits are gated for your approval; it cannot delete files, push, or run shell commands.
 tools: [files__read, files__list, files__search, files__edit, git__status, git__diff, git__log, git__add, git__commit, web__search, web__extract]
 max_tier: write
-autonomy: gated
 max_turns: 40
 ---
 You are a capable generalist working on a self-contained task inside the user's workspace.

--- a/agents/general-purpose.md
+++ b/agents/general-purpose.md
@@ -1,12 +1,12 @@
 ---
 name: General Purpose
-description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files and inspect git, working in isolation and reporting back. Edits are gated for your approval; it cannot delete files, push, or run shell commands.
+description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files, inspect git, and search the web, working in isolation and reporting back. Edits are gated for your approval; it cannot delete files, push, or run shell commands.
 tools: [files__read, files__list, files__search, files__edit, git__status, git__diff, git__log, git__add, git__commit, web__search, web__extract]
 max_tier: write
 max_turns: 40
 ---
 You are a capable generalist working on a self-contained task inside the user's workspace.
 
-Carry the task through end to end: explore what you need, make the necessary edits, and check your work where you can. Match the project's existing conventions and keep changes minimal and focused. You can read and edit files and inspect git, but you cannot delete files, push, or run shell commands - if the task needs those, say so in your report instead of working around it.
+Carry the task through end to end: explore what you need, make the necessary edits, and check your work where you can. Match the project's existing conventions and keep changes minimal and focused. You can read and edit files, inspect git, and search the web, but you cannot delete files, push, or run shell commands - if the task needs those, say so in your report instead of working around it.
 
 When done, report what you changed (with file paths) and anything the user should double-check. Work by calling tools, not by narrating; a message with no tool call is treated as your final answer.

--- a/agents/general-purpose.md
+++ b/agents/general-purpose.md
@@ -1,6 +1,6 @@
 ---
 name: General Purpose
-description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files, inspect git, and search the web, working in isolation and reporting back. Edits are gated for your approval; it cannot delete files, push, or run shell commands.
+description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files, inspect git, and search the web, working in isolation and reporting back. It cannot delete files, push, or run shell commands.
 tools: [files__read, files__list, files__search, files__edit, git__status, git__diff, git__log, git__add, git__commit, web__search, web__extract]
 max_tier: write
 max_turns: 40

--- a/agents/general-purpose.md
+++ b/agents/general-purpose.md
@@ -1,0 +1,13 @@
+---
+name: General Purpose
+description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files and inspect git, working in isolation and reporting back. Edits are gated for your approval; it cannot delete files, push, or run shell commands.
+tools: [files__read, files__list, files__search, files__edit, git__status, git__diff, git__log, git__add, git__commit, web__search, web__extract]
+max_tier: write
+autonomy: gated
+max_turns: 40
+---
+You are a capable generalist working on a self-contained task inside the user's workspace.
+
+Carry the task through end to end: explore what you need, make the necessary edits, and check your work where you can. Match the project's existing conventions and keep changes minimal and focused. You can read and edit files and inspect git, but you cannot delete files, push, or run shell commands - if the task needs those, say so in your report instead of working around it.
+
+When done, report what you changed (with file paths) and anything the user should double-check. Work by calling tools, not by narrating; a message with no tool call is treated as your final answer.

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -1,0 +1,18 @@
+---
+name: Plan
+description: Read-only software architect. Dispatch it to design an implementation plan for a change - it reads the relevant code and returns a step-by-step plan with the files to touch and the trade-offs. Cannot modify files.
+tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
+max_tier: readonly
+autonomy: auto-readonly
+max_turns: 30
+---
+You are a software architect planning a change inside the user's workspace.
+
+Read enough of the codebase to understand the relevant structure, conventions, and constraints, then return an implementation plan covering:
+- the concrete steps, in order,
+- the specific files/functions each step touches (with paths),
+- key design decisions, trade-offs, and any risks or unknowns.
+
+Match the project's existing patterns. Do NOT modify any files - you produce a plan, not the change. If part of the task is unclear or underspecified, call it out rather than guessing.
+
+Work by calling tools, not by narrating. A message with no tool call is treated as your final answer, so only stop once you are ready to present the plan.

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -3,7 +3,6 @@ name: Plan
 description: Read-only software architect. Dispatch it to design an implementation plan for a change - it reads the relevant code and returns a step-by-step plan with the files to touch and the trade-offs. Cannot modify files.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
 max_tier: readonly
-autonomy: auto-readonly
 max_turns: 30
 ---
 You are a software architect planning a change inside the user's workspace.

--- a/agents/verify.md
+++ b/agents/verify.md
@@ -1,0 +1,18 @@
+---
+name: Verify
+description: Adversarial verifier. Dispatch it to check whether a change actually works - it reads the code and runs builds/tests, then reports pass/fail with evidence. Runs build and command-line tools (each gated for your approval).
+tools: [files__read, files__list, files__search, git__status, git__diff, git__log, command__run, msbuild__*]
+max_tier: destructive
+autonomy: gated
+max_turns: 25
+---
+You are an adversarial verification specialist. Your job is to find out whether something actually works - not to assume it does.
+
+Given a claim or a change to verify:
+- read the relevant code and the diff,
+- build the project and/or run the relevant tests via the available build and command tools,
+- look for the failure case, not just the happy path.
+
+Report a clear verdict (works / does not work / inconclusive) backed by concrete evidence - the command you ran and what it produced. If you can't verify something, say exactly what is blocking you. Do not edit files to make tests pass; you verify, you do not fix.
+
+Work by calling tools, not by narrating. A message with no tool call is treated as your final answer.

--- a/agents/verify.md
+++ b/agents/verify.md
@@ -3,7 +3,6 @@ name: Verify
 description: Adversarial verifier. Dispatch it to check whether a change actually works - it reads the code and runs builds/tests, then reports pass/fail with evidence. Runs build and command-line tools (each gated for your approval).
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, command__run, msbuild__*]
 max_tier: destructive
-autonomy: gated
 max_turns: 25
 ---
 You are an adversarial verification specialist. Your job is to find out whether something actually works - not to assume it does.

--- a/agents/verify.md
+++ b/agents/verify.md
@@ -1,6 +1,6 @@
 ---
 name: Verify
-description: Adversarial verifier. Dispatch it to check whether a change actually works - it reads the code and runs builds/tests, then reports pass/fail with evidence. Runs build and command-line tools (each gated for your approval).
+description: Adversarial verifier. Dispatch it to check whether a change actually works - it reads the code, builds the project, and runs tests/commands, then reports pass/fail with evidence.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, command__run, msbuild__*]
 max_tier: destructive
 max_turns: 25

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -15,4 +15,4 @@ Given a topic or question, research it on the internet and return a clear, synth
 
 Search broadly, then read the most promising sources before drawing conclusions. Prefer primary and authoritative sources; note when something is uncertain or when sources conflict. Cite the URLs you used so the user can verify. You research and report only - you cannot change any files.
 
-Work by calling tools, not by narrating. Never end a message describing what you are about to look up unless that same message also calls a tool - a message with no tool call is treated as your final answer. When you have gathered enough, write the summary as your final message.
+Work by calling tools, not by narrating. A message with no tool call is treated as your final answer, so only stop once you are ready to give your summary.

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -3,7 +3,6 @@ name: Web Research
 description: Read-only web researcher. Dispatch it to research a topic on the internet - it searches the web, reads sources, and returns a synthesized summary with citations. Cannot modify files.
 tools: [web__search, web__extract, web__get]
 max_tier: readonly
-autonomy: auto-readonly
 model: deepseek/deepseek-v4-flash
 max_turns: 25
 ---

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -4,6 +4,7 @@ description: Read-only web researcher. Dispatch it to research a topic on the in
 tools: [web__search, web__extract, web__get]
 max_tier: readonly
 autonomy: auto-readonly
+model: deepseek/deepseek-v4-flash
 max_turns: 25
 ---
 You are a web-research specialist.

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -1,0 +1,18 @@
+---
+name: Web Research
+description: Read-only web researcher. Dispatch it to research a topic on the internet - it searches the web, reads sources, and returns a synthesized summary with citations. Cannot modify files.
+tools: [web__search, web__extract, web__get]
+max_tier: readonly
+autonomy: auto-readonly
+max_turns: 25
+---
+You are a web-research specialist.
+
+Given a topic or question, research it on the internet and return a clear, synthesized written summary covering:
+- the key findings, organized by sub-topic,
+- the most relevant sources, cited by URL,
+- any caveats, disagreements between sources, or open questions.
+
+Search broadly, then read the most promising sources before drawing conclusions. Prefer primary and authoritative sources; note when something is uncertain or when sources conflict. Cite the URLs you used so the user can verify. You research and report only - you cannot change any files.
+
+Work by calling tools, not by narrating. Never end a message describing what you are about to look up unless that same message also calls a tool - a message with no tool call is treated as your final answer. When you have gathered enough, write the summary as your final message.

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -8,8 +8,9 @@ OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-l
 detection, wildcard allowlists, and read-concurrent/write-serial fan-out, see §13 and
 A9/A17–A19; added running-agents observability — in-transcript dispatch panel + a
 `Stop N agents` button (stop-all, v1) — see §14 and A20; aligned slash commands to
-PR #156's verb-first hyphen-prefixed style — `/list-agents`, `/toggle-agents`,
-`/toggle-agent`, `/dispatch-agent` — see §6)
+PRs #156/#157's scope-first hyphen-prefixed surface — `/list-agents`,
+`/toggle-agents <here|global> <on|off|inherit>`, `/toggle-agent`, `/reset-agents`,
+`/dispatch-agent` — see §6)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -59,9 +60,10 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
   meta-tool handled in the orchestrator — the skills `open_skill` precedent (S1):
   spawning an in-process loop is not a child process, so it needs no `…McpServer`.
 - **Slash commands, no settings-page UI** — `/list-agents`, `/toggle-agents`,
-  `/toggle-agent <slug> …`, and an explicit `/dispatch-agent <slug> <task>`, on the
-  existing `ISlashCommand` framework, scoped per conversation, in the verb-first
-  hyphen-prefixed style PR #156 set for skills (`/list-skills`, `/toggle-skill`, …).
+  `/toggle-agent <slug> …`, `/reset-agents`, and an explicit `/dispatch-agent <slug>
+  <task>`, on the existing `ISlashCommand` framework, scoped per conversation, in the
+  scope-first hyphen-prefixed style PRs #156/#157 set for skills (`/list-skills`,
+  `/toggle-skill <slug> <here|global> <on|off|inherit>`, `/reset-skills`, …).
 
 ### Non-goals
 - **Nested fan-out.** A sub-agent never gets `dispatch_agent` in its tool set — no
@@ -92,7 +94,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
 | A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
-| A15 | **Enablement reuses the skills tri-state ladder** (`/list-agents`, `/toggle-agents`, `/toggle-agent <slug> [on\|off\|reset] [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). Command naming follows PR #156's verb-first hyphen-prefixed style (§6). |
+| A15 | **Enablement reuses the skills tri-state ladder** (`/list-agents`, `/toggle-agents <here\|global> <on\|off\|inherit>`, `/toggle-agent <slug> …`, `/reset-agents <here\|global>`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). Command surface follows PRs #156/#157 (scope-first, required; `inherit` unsets a layer; the global feature bool has no inherit — see §6/§7). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
@@ -284,32 +286,37 @@ that — it only constructs and joins.
 
 ## 6. Slash commands (on the existing `ISlashCommand` framework)
 
-Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins, in the
-**verb-first, hyphen-prefixed** style PR #156 established for skills (`/list-skills`,
-`/toggle-skills`, `/toggle-skill`, `/use-skill`). `Client` kind (run locally, no LLM
-send) except `/dispatch-agent`, which sends.
+Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins, following the
+**scope-first, hyphen-prefixed** surface PRs #156/#157 established for skills
+(`/list-skills`, `/toggle-skills`, `/toggle-skill`, `/reset-skills`, `/use-skill`).
+Arg hints use the #157 convention — `<…>` required, `[…]` optional. `Client` kind (run
+locally, no LLM send) except `/dispatch-agent`, which sends.
 
 | Command | Kind | Effect |
 |---------|------|--------|
-| `/list-agents` | Client | List agents with effective on/off state + source (bundled/user/project). Listing is its own command (no args), per PR #156. |
-| `/toggle-agents <on\|off\|reset> [here\|global]` | Client | Toggle/reset the **whole feature** at that scope (default `here`). Requires a verb (listing lives in `/list-agents`). |
-| `/toggle-agent <slug> [on\|off\|reset] [here\|global]` | Client | Toggle/reset **one agent**; bare `/toggle-agent <slug>` toggles for this conversation |
-| `/dispatch-agent <slug> <task…>` | Send | **Explicit dispatch**: sends a hidden instruction `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — an explicit user action, the `/use-skill` analogue) |
+| `/list-agents` | Client | List agents with effective on/off state, the rule that decided it, + source (bundled/user/project). No args. |
+| `/toggle-agents <here\|global> <on\|off\|inherit>` | Client | Set the **whole feature** at that scope. **Scope first, both required.** `global` is the most-upstream layer (a plain bool) so it takes only `on\|off` — no `inherit`. |
+| `/toggle-agent <slug> <here\|global> <on\|off\|inherit>` | Client | Set **one agent** at that scope; bare `/toggle-agent <slug>` quick-toggles for this conversation. |
+| `/reset-agents <here\|global>` | Client | Bulk-clear at that scope: `here` drops the conversation's feature on/off **and** all its per-agent overrides; `global` clears only the per-agent global overrides (the on/off master is changed solely by `/toggle-agents global on\|off`). |
+| `/dispatch-agent <slug> <task…>` | Send | **Explicit dispatch**: sends a hidden `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — the `/use-skill` analogue). |
 
-- **Naming follows PR #156**: a verb-first, hyphen-prefixed name per command, with
-  listing split from toggling (`/list-agents` vs. `/toggle-agents`, which now requires
-  a verb) — the same split #156 made for skills. The agent *invocation* verb is
-  `dispatch` (matching the `dispatch_agent` tool and `AgentDispatcher`), where skills
-  use `use`.
-- **Discovery via `SlashMatch.HyphenPrefix`** (PR #156): each hyphen segment is an
-  anchor, so typing `/agent` matches `list-agents`, `toggle-agents`, `toggle-agent`,
-  and `dispatch-agent`; `/dispatch` narrows to `dispatch-agent`. No need to type a full
-  prefix. The registry's `Match()` already does this — agent commands inherit it free.
-- **Slug-first within `/toggle-agent` and `/dispatch-agent`**, mirroring
-  `/toggle-skill` / `/use-skill`. Autocomplete completes slugs (annotated with state)
-  then `on\|off\|reset` then `here\|global`, via `IArgumentCompleter` + the shared
-  `SkillCommandShared.AddMatching` helper (the completion utility #156 factored out) —
-  the exact pattern the skill commands use.
+- **Scope-first and required (PR #157).** Scope (`here`/`global`) is the **first**
+  argument and **mandatory** — not an optional default-`here` suffix. `inherit`
+  (which replaces the old `reset` verb) unsets a *single* layer so it falls through to
+  the one upstream; the **global feature toggle has no `inherit`** (the master bool is
+  always on/off), so bulk-clearing global per-agent settings is `/reset-agents global`.
+- **Naming + discovery (PR #156).** A verb-first, hyphen-prefixed name per command,
+  with listing split from toggling (`/list-agents` vs. `/toggle-agents`). The agent
+  *invocation* verb is `dispatch` (matching the `dispatch_agent` tool and
+  `AgentDispatcher`), where skills use `use`. `SlashMatch.HyphenPrefix` makes `/agent`
+  match `list-agents` / `toggle-agents` / `toggle-agent` / `reset-agents` /
+  `dispatch-agent`, and `/dispatch` narrow to `dispatch-agent` — the registry's
+  `Match()` already does this, so agent commands inherit it free.
+- **Scope-then-verb autocomplete.** The completer offers the **scope first**, then only
+  the verbs that scope accepts (`global` feature → `on|off`; every tri-state layer adds
+  `inherit`), and completes slugs (annotated with state) for `/toggle-agent` /
+  `/dispatch-agent` — via `IArgumentCompleter` + the shared `SkillCommandShared.AddMatching`
+  helper (#156), the exact pattern the skill commands use.
 - Explicit `/dispatch-agent <slug> <task>` routes through the model (not a direct host
   spawn) so the dispatch is a normal, gated `dispatch_agent` tool call with a
   transcript record and approval — no second, ungated entry point into spawning.
@@ -329,8 +336,14 @@ agent is on.
 | 1 | this agent, **here** | `Conversation.AgentOverrides[X]` |
 | 2 | this agent, **global** | `agents.json` `agents[X]` |
 | 3 | all agents, **here** | `Conversation.AgentsFeatureOff` |
-| 4 | all agents, **global** | `agents.json` `feature_off` |
+| 4 | all agents, **global** | `agents.json` `feature_off` (a plain bool — the most-upstream layer, no inherit) |
 | 5 | **default: feature OFF** | — |
+
+The four layers map onto the §6 command surface exactly as skills do (PR #157): rungs
+1–3 are tri-state (`/toggle-… <scope> on|off|inherit`, where `inherit` unsets that one
+layer); rung 4 is a plain on/off bool (`/toggle-agents global on|off` — no `inherit`).
+`/reset-agents here` clears rungs 1 + 3 for the conversation; `/reset-agents global`
+clears the rung-2 per-agent overrides only, leaving the rung-4 master alone.
 
 ### Persistence
 - **Global** — `%AppData%/GxPT/agents.json` (a sibling of `skills.json`), written
@@ -338,6 +351,8 @@ agent is on.
   ```json
   { "feature_off": true, "agents": { "code-explorer": true, "pr-reviewer": true } }
   ```
+  `feature_off` is a plain bool (defaults **true** — agents lead off, A15); `agents`
+  is the tri-state per-agent map (absent slug = inherit).
 - **Conversation** — `AgentsFeatureOff` (`bool?`) + `AgentOverrides` (`slug → bool`)
   on the `Conversation`, round-tripped by `ConversationStore` (absent = inherit).
 
@@ -543,13 +558,15 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 - **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
   a batch with any write-capable agent serializes (A9), asserted by execution order.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
-  `/list-agents` listing; `/toggle-agents` / `/toggle-agent` toggle/reset across
-  here/global (toggle requires a verb); conversation override vs. `agents.json`;
+  `/list-agents` listing; **scope-first** `/toggle-agents` / `/toggle-agent` (scope +
+  verb both required; `inherit` unsets a layer; `global` feature accepts only on/off);
+  `/reset-agents here|global` bulk-clear (here = feature + per-agent overrides; global =
+  per-agent only, master untouched); conversation override vs. `agents.json`;
   default-OFF feature; `/dispatch-agent <slug> <task>` sends the hidden dispatch
-  instruction; unknown slug/scope failures; `SlashMatch.HyphenPrefix` matches `/agent`
-  to all four agent commands (segment-boundary, per PR #156).
+  instruction; unknown scope/verb/slug failures; `SlashMatch.HyphenPrefix` matches
+  `/agent` to all five agent commands (per PR #156).
 - **Enablement resolution** — the 5-rung ladder with feature-default OFF;
-  force-on over a global-off; reset → inherit.
+  force-on over a global-off; `inherit` unsets a layer so it falls through upstream.
 - **`AutonomyApprovalPolicy`** (decorator) — `auto-readonly` + grant ⇒ ReadOnly
   auto-allows; Write/Destructive still delegate to the real gate; no grant ⇒
   everything prompts; the grant is tier-capped and name-scoped.
@@ -580,10 +597,11 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
    strip of `dispatch_agent`.
 5. **Approval integration** — `AutonomyApprovalPolicy` decorator + the one-time
    agent-name grant in the approval store; agent-attributed prompts.
-6. **Agent slash commands** on the `ISlashCommand` framework, verb-first/hyphen-prefixed
-   per PR #156 (`/list-agents`, `/toggle-agents`, `/toggle-agent <slug> …`,
-   `/dispatch-agent <slug> <task>`; `SlashMatch.HyphenPrefix` matching) + per-conversation
-   override fields on `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
+6. **Agent slash commands** on the `ISlashCommand` framework, scope-first/hyphen-prefixed
+   per PRs #156/#157 (`/list-agents`, `/toggle-agents <here|global> <on|off|inherit>`,
+   `/toggle-agent <slug> …`, `/reset-agents <here|global>`, `/dispatch-agent <slug> <task>`;
+   `SlashMatch.HyphenPrefix` matching, `<>`/`[]` arg hints) + per-conversation override
+   fields on `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
 7. **Concurrent fan-out + must-have observability** — batch `dispatch_agent`,
    read-concurrent/write-serial execution on bounded `ThreadPool` work items,
    per-connection mutex, usage aggregation; the **group cancellation** + the

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -1,0 +1,539 @@
+# Sub-Agents System — Design Proposal
+
+**Status:** Design (proposal). No implementation yet.
+**Branch:** `claude/compassionate-goldberg-5c9ccz`
+**Last updated:** 2026-06-16
+
+Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
+with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
+a *specialist* — a system prompt, a bounded tool allowlist, and an autonomy
+setting. The main agent hands a sub-agent a self-contained task; the sub-agent runs
+its **own** `McpChatOrchestrator` loop in a fresh context, does the work through
+tools, and returns **only its final answer** as the dispatching tool's result.
+
+Where a **skill** is *know-how* ("how to do X well here") and an **MCP tool** is an
+*effect* ("read a file"), a **sub-agent** is a *worker* ("go do X and report
+back") — it owns a loop, a context window, and a capability envelope. The three
+compose: a sub-agent's prompt can `open_skill`, a skill body can tell the model to
+`dispatch_agent`, and both ride the same tool catalog and approval gate.
+
+The design rides three principles GxPT already commits to: **progressive
+disclosure to bound token cost** (a names-only manifest, bodies on demand — the
+same idea skills and `reveal_tools` use); **the approval gate is the security
+backstop** (`mcp35-approval-spec.md` §6); and **the orchestrator is built fresh
+per turn, un-shared, and thread-safe to run concurrently** (it already does, across
+tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch).
+
+---
+
+## 1. Scope & goals
+
+- **Three sub-agent sources: bundled + project + user-global.** Identical roots to
+  skills — first-party agents ship beside `GxPT.exe` (`<exe>/agents/`); project
+  agents live under `<workdir>/.gxpt/agents/`; user-global under
+  `%AppData%/GxPT/agents/`. Reuse `SkillRoots`/`SkillFrontmatter` wholesale.
+- **A sub-agent is one markdown file** — `<slug>.md` with frontmatter
+  (`name`/`description`/`tools`/`model`/`autonomy`/`max_tier`) + a body that is the
+  agent's **system prompt**. (Skills use a `<slug>/SKILL.md` folder because they
+  bundle assets; agents rarely do — A4.)
+- **Context isolation is the point.** A dispatched sub-agent runs in a *fresh*
+  history (its system prompt + the parent's task string), never the parent's
+  transcript, and returns only its final text. Keeps the parent's context small and
+  firewalls the two conversations.
+- **Layered security, three independent layers** (§8): a static **tool allowlist**
+  in frontmatter (what it *can* reach), the existing **runtime approval gate** (the
+  backstop — Destructive still always-confirms), and a per-agent **autonomy dial**
+  (how much it prompts within those bounds). The dial can only ever *loosen* inside
+  the ceiling the other two layers set.
+- **Parallel by default where it's safe.** `dispatch_agent` is batch: several agents
+  run on their own worker threads concurrently (the win is overlapping LLM streams),
+  with per-connection serialization on shared MCP servers and a bounded fan-out.
+- **Host-native dispatch, no new server.** `dispatch_agent` is a host-synthesized
+  meta-tool handled in the orchestrator — the skills `open_skill` precedent (S1):
+  spawning an in-process loop is not a child process, so it needs no `…McpServer`.
+- **Slash commands, no settings-page UI** — `/agents`, `/agent <slug> …`, and an
+  explicit `/agent <slug> <task>` dispatch, on the existing `ISlashCommand`
+  framework, scoped per conversation, mirroring `/skills`.
+
+### Non-goals
+- **Nested fan-out.** A sub-agent never gets `dispatch_agent` in its tool set — no
+  agent-spawns-agent (fork-bomb guard, A12). One level deep, always.
+- A marketplace / remote agent install; a per-agent settings-page UI; streaming a
+  sub-agent's *partial* output into the parent's context (only the final answer
+  returns — A7).
+- Cross-turn agent persistence (a dispatched agent is one-shot: it runs to
+  completion within the parent's turn and is gone — A8).
+
+---
+
+## 2. Decision ledger
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| A1 | **Dispatch is a host-synthesized meta-tool** (`dispatch_agent`), handled in `McpChatOrchestrator` like `reveal_tools`/`open_skill` — **not** an MCP server | Spawning a sub-orchestrator is in-process loop reuse, not a child process: there is no exec, timeout, or arg-quoting hazard to isolate (the reasons skills put *only* `run_skill_script` in a server, S1/S11). The dispatcher reuses the host's own `McpChatOrchestrator`, `McpToolRegistry`, and approval policy — all host types — so it cannot live in `Mcp35.*` without breaking the one-way seam anyway. |
+| A2 | **A sub-agent runs its own `McpChatOrchestrator` instance** on a fresh `List<ChatMessage>` seeded with `[system: body] + [user: task]` | The orchestrator is already built fresh per turn, documented un-shared/non-racy, and run on `ThreadPool` worker threads concurrently across tabs. Reusing it gives sub-agents the *entire* loop for free — streaming, reveal/skills, cancellation, usage accounting, the cap wrap-up — with zero new loop code. |
+| A3 | **Context firewall:** the sub-agent never sees the parent transcript; only its **final assistant message** returns as the `dispatch_agent` tool result | This is the whole value — token isolation (a 30-call research dig costs the parent ~one paragraph, not 30 tool results) and a clean trust boundary. Matches every mainstream sub-agent model (Claude Code's `Task`/agents). |
+| A4 | **One file per agent: `agents/<slug>.md`** (flat), not a `<slug>/` folder | Agents are a *prompt + tool list*; they almost never bundle scripts/assets (which is exactly why skills need a folder). A flat file matches the cross-tool `.claude/agents/<name>.md` convention the user already knows, and keeps the catalog a simple glob. An agent that genuinely needs bundled reference files can be paired with a skill it `open_skill`s. (Folder form deferred, A-open.) |
+| A5 | **Frontmatter is the security contract**: `tools` (allowlist), `max_tier` (ceiling), `autonomy` (dial), plus `model` — same `--- … ---` reader as skills (`SkillFrontmatter`), extended for list/enum values | net35 has no YAML parser and the repo keeps one JSON lib (D3); the hand-rolled frontmatter reader already ships for skills (S4). Extending it to parse a `[a, b]` inline list + a few enum keys is a few lines, no new dependency, authoring stays familiar. |
+| A6 | **`description` is the dispatch trigger** — a single "use this agent when…" line, the only thing in the always-on manifest | Identical to skills' `description` (S4): it is what the parent model reads to decide *whether* to delegate and *which* agent. Names-only-plus-one-liner keeps the manifest cheap (§4). |
+| A7 | **Only the final answer crosses back; no streaming into the parent** | Streaming a sub-agent's intermediate tool chatter into the parent re-imports the context cost the firewall exists to remove (A3). The sub-agent's live output still renders in the transcript UI (its own collapsible block, §9) so the user sees it — it just isn't fed to the *parent model*. |
+| A8 | **A dispatch is one-shot within the parent's turn** (no resumable agent sessions) | Keeps state trivial: the sub-orchestrator is a local object on a worker thread, joined before the parent's `dispatch_agent` tool result is formed. Resumable agents would need persisted sub-histories and a handle scheme — deferred until a real need appears. |
+| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`) and runs entries **in parallel** on bounded worker threads | The parent fans out ("explore these three modules") in one tool call; the host joins. Parallelism overlaps the expensive part (LLM streams). A single-entry call is just fan-out of one. |
+| A10 | **Shared MCP server connections are serialized per-connection** under a lock; **revealed-tool state is per-sub-agent** | `McpServerConnection` correlates by request id and the server SDK dispatches serially; concurrent `CallTool` on one connection is unsafe, so a per-connection mutex serializes tool I/O while model streams still overlap. Each sub-agent owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, already the per-tab rule). |
+| A11 | **Effective tools = `allowlist` ∩ `parent-available` ∩ `max_tier`** — a sub-agent can never exceed the parent's own reach | No privilege escalation: delegating cannot grant a capability the parent itself lacks in this workspace (e.g. a folderless turn's sub-agent still can't reach `files__*`). The allowlist *narrows*; it never widens. |
+| A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
+| A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
+| A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
+| A15 | **Enablement reuses the skills tri-state ladder** (`/agents`, `/agent <slug> on\|off\|reset [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). |
+| A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
+
+---
+
+## 3. On-disk layout
+
+### Bundled (first-party, ships beside the exe)
+```
+<GxPT.exe dir>/agents/
+  code-explorer.md
+  test-runner.md
+  pr-reviewer.md
+```
+Deployed by the same `AfterBuild` copy that places `mcp-servers\` and `skills\`
+(and seeded into the setup `.vdproj`), so bundled agents travel with the install.
+
+### Project (scoped to the conversation's working folder)
+```
+<workdir>/.gxpt/agents/
+  <slug>.md
+```
+Reuses the `.gxpt/` home memory and skills established. A project agent **shadows**
+a bundled agent of the same slug (precedence **project > user > bundled**, A11-aligned
+with skills S5).
+
+### User-global
+```
+%AppData%/GxPT/agents/
+  <slug>.md
+```
+
+### `AGENT.md` format
+```markdown
+---
+name: Code Explorer
+description: Use to search and summarize unfamiliar code across the workspace before making changes. Read-only.
+tools: [files__read, files__list, files__search]
+max_tier: readonly
+autonomy: auto-readonly
+model: anthropic/claude-sonnet-4-6
+---
+
+You are a code-exploration specialist working inside the user's workspace.
+
+Given a question about the codebase, locate the relevant files, read the parts that
+matter, and return a tight written summary: where the thing lives (file:line), how
+it works, and anything surprising. Cite paths. Do not modify files. If you can't
+find something after a genuine search, say so and name where you looked.
+```
+
+- **Frontmatter** is a leading `--- … ---` block of `key: value` lines, parsed by
+  the extended `SkillFrontmatter` reader. Keys:
+  - `name` *(required)* — display name.
+  - `description` *(required)* — the **single-line** "use this agent when…" the
+    parent reads in the manifest (A6).
+  - `tools` *(optional)* — inline list `[a, b, c]` of server-qualified function
+    names the agent may use. **Omitted ⇒ inherit a conservative default set**
+    (all ReadOnly-tier tools available in the workspace), *not* everything (A5,
+    fail-safe). `tools: [*]` opts into the full parent-available set (still
+    capped by `max_tier` and the gate).
+  - `max_tier` *(optional)* — `readonly` \| `write` \| `destructive` ceiling,
+    classified via the existing `ToolClassifier`. Caps the allowlist regardless of
+    what `tools` names. Default `write` (an agent can edit but the gate still
+    confirms; `destructive` must be opted into explicitly).
+  - `autonomy` *(optional)* — `gated` (default) \| `auto-readonly` (§8 layer 3).
+  - `model` *(optional)* — model id override; omitted ⇒ the parent turn's model.
+- The **body** is the agent's **system prompt** — it replaces `AgentSystemPrompt`'s
+  *persona*, but the host still prepends the standing agent guidance and the
+  workspace block (§5), so a sub-agent always knows it's tool-using and where it is.
+- Unknown frontmatter keys are ignored (forward-compatible, like skills).
+
+---
+
+## 4. Disclosure levels
+
+| Level | Content | When it enters context | Cost |
+|-------|---------|------------------------|------|
+| 1 | `slug` + `description` (the **agents manifest**) | every request, while the agents feature is enabled for the conversation **and** at least one agent is on | tiny |
+| 2 | `dispatch_agent` meta-tool def | same condition (exposed alongside the manifest) | tiny |
+| 3 | the agent **body** (its system prompt) + its **work** | only inside the *sub-agent's* context when dispatched — **never** in the parent | paid by the sub-agent, isolated |
+| 4 | the agent's **final answer** | returns to the parent as the `dispatch_agent` tool result | one summary |
+
+The parent pays Level 1+2 (a line per agent + one tool def) to *know it can
+delegate*, and Level 4 (a summary) per dispatch. Level 3 — the expensive part —
+lives entirely in the sub-agent's window. That asymmetry is the design.
+
+---
+
+## 5. Host pieces
+
+### Catalog & manifest (host-native, `Services/Agents/`)
+
+```
+Agent                 -- (slug, name, description, ToolSpec, MaxTier, Autonomy, Model, BodyPath)
+AgentFrontmatter      -- extends SkillFrontmatter: inline-list + enum keys
+AgentCatalog          -- scans bundled+user+project agents/*.md, project>user>bundled
+AgentInjection        -- BuildManifestMessage(enabledAgents) -> the Level-1 block
+AgentResolve          -- EnabledAgents(...) over the tri-state ladder (reuses SkillResolve shape)
+AgentToolResolver      -- effective tool defs for an agent = allowlist ∩ parent-available ∩ max_tier
+```
+
+`AgentCatalog` is pure logic (no WinForms) → net48 linked-source tests, exactly like
+`SkillCatalog`. `AgentInjection.BuildManifestMessage` produces the same kind of
+ephemeral block the skills manifest does, slotted into the orchestrator's
+`BuildEphemeralContextText` tail (a new `<agents>` section, after `<skills>`,
+before `<available_tools>`):
+
+```
+McpChatOrchestrator (parent RunTurn loop)
+  ├─ ephemeral tail (Zone C):  <memory> … <skills> … <agents> … <available_tools>
+  └─ exposed tools: reveal_tools, open_skill, read_skill_file, dispatch_agent, …revealed
+```
+
+A new orchestrator field mirrors the skills hooks exactly:
+```csharp
+public Func<string> AgentsManifestSystemMessageProvider { get; set; }   // Level-1 block
+public AgentDispatcher AgentDispatcher { get; set; }                     // exposes + handles dispatch_agent
+```
+`dispatch_agent` is added to the `tools` array (like `OpenSkillDef`) when the
+dispatcher is set and has agents, and handled in `ExecuteCall` *before* MCP
+resolution (like `IsOpenSkill`), so it never hits a server.
+
+### `dispatch_agent` — the meta-tool
+
+```
+dispatch_agent(agents: [ { name: string, task: string }, … ])   // batch (A9)
+```
+Definition shape mirrors `open_skill`/`reveal_tools` so the model treats it the
+same way. Description: *"Delegate one or more self-contained sub-tasks to specialist
+agents that work in isolation and report back. Pass each agent's slug (from the
+agents list) and a complete task description — the agent does not see this
+conversation."*
+
+**On call, the `AgentDispatcher` (host):**
+1. Resolve each `name` → enabled `Agent` (unknown/disabled ⇒ that entry returns a
+   short note, the rest still run — the `open_skill` tolerance, S-style).
+2. For each entry, build a **child** `McpChatOrchestrator`:
+   - history = `[ system: standing-guidance + workspace-block + agent.Body ]`
+     then `[ user: task ]`;
+   - `WorkingDir` = parent's (so scoped servers route to the same folder);
+   - `model` = `agent.Model ?? parentModel`;
+   - **exposed tools restricted** via `AgentToolResolver` (A11) — for a *small*
+     declared allowlist the child skips progressive disclosure and is handed those
+     defs directly (no `reveal_tools` dance); for `tools: [*]` it gets the normal
+     manifest + `reveal_tools`, tier-capped;
+   - `dispatch_agent` **stripped** (A12), `open_skill`/`read_skill_file` allowed;
+   - `HiddenToolNames` = (parent-available − effective) so a directly-named
+     out-of-allowlist tool is refused, the existing gate mechanism (§ `HiddenToolNames`);
+   - approval policy = the parent's, **wrapped** with the agent's autonomy
+     pre-authorization (§8 layer 3) and tagged with the agent name for the prompt;
+   - `Cancellation` = the parent's handle (parent Stop cancels all children, §9);
+   - `UsageReported` → aggregated onto the parent conversation.
+3. Run the children **in parallel** on `ThreadPool` work items, bounded to
+   `MaxParallelAgents` (default 3), joining on a `ManualResetEvent`/countdown.
+4. Each child's **final assistant text** (its `RunTurn` result) becomes one labeled
+   section of the `dispatch_agent` tool result:
+   ```
+   ## Agent: code-explorer
+   <final answer>
+
+   ## Agent: test-runner
+   <final answer>
+   ```
+   A child that errored/hit its cap returns its wrap-up text in the same slot — never
+   throws across the join (failures are content, the loop's existing stance).
+
+### Why reuse the orchestrator wholesale
+
+A child gets, for free: streamed model calls, the names-manifest + `reveal_tools`
+flow, `open_skill`/skills, the `MaxIterations` budget + `ContinuationDecider`
+(children default to **no** continuation prompt — they wrap up at the cap rather
+than block on a user, since the dispatch is meant to be unattended), cancellation,
+usage/cost accounting, and the empty-response retry. The dispatcher writes *none* of
+that — it only constructs and joins.
+
+---
+
+## 6. Slash commands (on the existing `ISlashCommand` framework)
+
+Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins. `Client`
+kind (run locally, no LLM send) except `/agent <slug> <task>`, which dispatches.
+
+| Command | Kind | Effect |
+|---------|------|--------|
+| `/agents` | Client | List agents with effective on/off state + source (bundled/user/project) |
+| `/agents [on\|off\|reset] [here\|global]` | Client | Toggle/reset the **whole feature** at that scope (default `here`) |
+| `/agent <slug> [on\|off\|reset] [here\|global]` | Client | Toggle/reset **one agent**; bare `/agent <slug>` toggles for this conversation |
+| `/agent <slug> <task…>` | Send | **Explicit dispatch**: send a hidden instruction `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — an explicit user action, like `/use`) |
+
+- **Slug-first**, mirroring `/skill` and `/tool`. Autocomplete completes slugs
+  (annotated with state) then `on\|off\|reset` then `here\|global`, via
+  `IArgumentCompleter` — the exact pattern `SkillCommands` uses.
+- Explicit `/agent <slug> <task>` routes through the model (not a direct host
+  spawn) so the dispatch is a normal, gated `dispatch_agent` tool call with a
+  transcript record and approval — no second, ungated entry point into spawning.
+
+---
+
+## 7. Enablement & persistence
+
+Reuses the skills 2×2 (all-agents / one-agent × global / this-conversation),
+resolved by **most-specific-wins**, with **one deliberate difference: the feature
+default is OFF** (A15). An agent is in play only when the feature is on *and* that
+agent is on.
+
+### Resolution ladder (effective state of agent X in conversation C)
+| # | Rule | Source |
+|---|------|--------|
+| 1 | this agent, **here** | `Conversation.AgentOverrides[X]` |
+| 2 | this agent, **global** | `agents.json` `agents[X]` |
+| 3 | all agents, **here** | `Conversation.AgentsFeatureOff` |
+| 4 | all agents, **global** | `agents.json` `feature_off` |
+| 5 | **default: feature OFF** | — |
+
+### Persistence
+- **Global** — `%AppData%/GxPT/agents.json` (a sibling of `skills.json`), written
+  only by `… global` commands:
+  ```json
+  { "feature_off": true, "agents": { "code-explorer": true, "pr-reviewer": true } }
+  ```
+- **Conversation** — `AgentsFeatureOff` (`bool?`) + `AgentOverrides` (`slug → bool`)
+  on the `Conversation`, round-tripped by `ConversationStore` (absent = inherit).
+
+Per-tab by construction; no `settings.json` key, no checkbox — all control is §6.
+The autonomy *grant* (A14) is separate persisted state: a remembered "this agent
+may run autonomously" lives in the approval store keyed by agent name, revocable
+from the same approvals affordance that clears tool allowlists
+(`mcp35-approval-spec.md` §5).
+
+---
+
+## 8. Security & approval — the three layers
+
+The request is "layered security controls **and** leeway to act autonomously." The
+resolution is three independent layers where the security layers set a **ceiling**
+and the autonomy dial only ever moves *within* it — autonomy can never out-vote a
+narrower layer below it.
+
+```
+              ┌─────────────────────────────────────────────┐
+  Layer 1     │ STATIC CAPABILITY  (frontmatter)            │  what it CAN reach
+  (definition)│ tools allowlist ∩ parent-available ∩ max_tier│  — never widens past parent
+              └─────────────────────────────────────────────┘
+                              ▼ bounds
+              ┌─────────────────────────────────────────────┐
+  Layer 2     │ RUNTIME GATE  (ToolApprovalPolicy, shared)  │  whether each call is allowed
+  (per call)  │ Destructive always-confirm; unremembered     │  — the backstop, unchanged
+              │ Write/ReadOnly prompt; narrow remembered rules│
+              └─────────────────────────────────────────────┘
+                              ▼ within which
+              ┌─────────────────────────────────────────────┐
+  Layer 3     │ AUTONOMY DIAL  (autonomy:, approved once)    │  how much it prompts
+  (per agent) │ auto-readonly ⇒ ReadOnly-tier auto-allows     │  — the LEEWAY, bounded by 1&2
+              │ for this run; Write/Destructive still gate     │
+              └─────────────────────────────────────────────┘
+```
+
+### Layer 1 — static capability scoping (definition-time)
+The `tools` allowlist + `max_tier` ceiling are the agent's **maximum reachable
+surface**, resolved by `AgentToolResolver` to `allowlist ∩ parent-available ∩
+max_tier` (A11). Properties:
+- **No escalation** — the effective set is a *subset* of what the parent itself can
+  call in this workspace; delegation never unlocks a new capability.
+- **Fail-safe default** — an omitted `tools` inherits only the ReadOnly tier, not
+  everything (A5). A forgotten allowlist makes an agent *less* capable, never a
+  silent wildcard.
+- Out-of-set tools are placed in the child's `HiddenToolNames`, so even a model that
+  names a tool directly gets `[Unknown tool: …]` — the existing gate-off mechanism.
+
+### Layer 2 — the runtime approval gate (per call, unchanged backstop)
+Every tool call a sub-agent makes flows through the **same** `ToolApprovalPolicy`
+with the **shared** remembered-allowlist and the parent tab's prompt host (A13):
+- **Destructive always-confirms** — a sub-agent cannot silently `files__delete` /
+  `command__run` a new command / `git__push`, even if its allowlist includes them
+  and the user is away (the turn simply blocks at the modal — correct, and the same
+  semantics as the main agent).
+- **Remembered rules stay narrow** — an injected attempt (a malicious tool result
+  steering the sub-agent) to run a *new* command/path won't match an existing
+  argument-scoped rule, so it still prompts. The prompt-injection backstop
+  (`mcp35-approval-spec.md` §6) covers sub-agents identically.
+- **Attribution** — the prompt header shows which agent is asking
+  (`code-explorer · files__read`), so the user always knows *who* wants the effect.
+
+### Layer 3 — the autonomy dial (the leeway, bounded)
+`autonomy` grants a sub-agent room to run unattended **inside** layers 1–2:
+- `gated` *(default)* — behaves exactly like the main agent: every tier prompts per
+  the normal rules. Safe, but a long read-only dig prompts repeatedly.
+- `auto-readonly` — the sub-agent's **ReadOnly-tier** calls auto-allow for the
+  duration of *this dispatch*; **Write and Destructive still hit the gate** (or are
+  absent, if `max_tier: readonly`). This is what lets a fan-out of research/explore
+  agents run while the user is away.
+
+The grant is **approved once, at dispatch**: dispatching an `auto-readonly` agent
+prompts *"`code-explorer` will run autonomously using read-only tools — allow?"*,
+remember-eligible **by agent name** (stored like a tool allowlist entry, A14/§7).
+Crucially:
+- The dial is **capped by `max_tier`** — `autonomy: auto-readonly` on an agent whose
+  ceiling is `readonly` means the whole agent is unattended; on a higher-ceiling
+  agent it still only auto-allows the *ReadOnly* slice.
+- **A dial never auto-approves Write/Destructive** — only an explicit, narrow
+  remembered *rule* (exact command/path) does, exactly as for the main agent. The
+  dial is a tier-scoped convenience over already-remember-eligible ReadOnly calls
+  (which the main agent could itself "always allow"), not a new bypass.
+- Implementation: the dispatcher wraps the shared `IToolApprovalPolicy` in an
+  `AutonomyApprovalPolicy` that, for an `auto-readonly` child, returns `Allow`
+  without a prompt **iff** the call classifies ReadOnly *and* the one-time
+  agent-name grant is present; everything else delegates to the real policy. No
+  change to the gate itself — a decorator at the dispatch seam.
+
+### Why this is both safer *and* more autonomous
+- **Safer than a raw tool allowlist:** the allowlist alone (layer 1) wouldn't stop a
+  manipulated agent from misusing an *allowed* Destructive tool; layer 2 does.
+- **More autonomous than the main agent:** an `auto-readonly` agent, vetted once,
+  runs a long investigation with zero further prompts — leeway the main agent only
+  gets by the user manually "always-allowing" each read tool. The dial packages that
+  as a per-specialist, revocable grant.
+- A loaded agent body is **injected instructions** (the skills stance, §8 there):
+  bundled/project agents are author-trusted; treat the body as untrusted at the
+  parse boundary, and gate a first dispatch of a *user-global/shared* agent so the
+  user sees what persona + capabilities they're about to run.
+
+---
+
+## 9. Parallelism & threading
+
+GxPT already runs each tab's turn on a `ThreadPool` worker thread, with the
+orchestrator built fresh and explicitly documented un-shared. Parallel sub-agents
+extend that, not rework it.
+
+- **Fan-out:** `dispatch_agent` with N entries queues N `ThreadPool` work items
+  (bounded to `MaxParallelAgents`, default 3 — a named constant), each running a
+  child `RunTurn` to completion, joined on a countdown before the tool result forms.
+  The parent worker thread blocks on the join (it has nothing to do until results
+  return) — the same "turn pauses, user present-or-away" model the gate already uses.
+- **The win is overlapping LLM streams**, the turn's real latency. Tool I/O to a
+  **shared** MCP server connection is serialized by a **per-connection mutex** (A10):
+  `McpServerConnection` correlates by id and the server SDK dispatches serially, so
+  concurrent `CallTool` on one connection is unsafe — the lock makes two agents
+  reading files take turns at the file server while their *model* calls still run
+  concurrently. (Per-workdir routing already gives different-folder turns different
+  servers; same-folder children share one, hence the lock.)
+- **Prompt caching is unaffected:** each child owns a *fresh* `RevealedToolNames`
+  and a fresh transcript, so no child churns another's tools array (the per-tab
+  invariant, generalized).
+- **Approval prompts serialize naturally:** modal `Control.Invoke` to the one UI
+  thread queues concurrent asks; each is agent-attributed (§8). A child that needs
+  an unremembered Write blocks just that child until answered.
+- **Cancellation propagates:** the parent's `RequestCancellation` is handed to every
+  child, so the Stop button cancels the whole fan-out; each child finalizes cleanly
+  (keeps partial text, the loop's existing `FinishCancelled`).
+- **UI:** each running child renders as a collapsible transcript block ("▸ Code
+  Explorer — running… 3 tools"), its tool calls/results shown but *not* fed to the
+  parent model (A7). On completion the block collapses to the returned summary.
+- **Cost guardrails:** `MaxParallelAgents` bounds concurrency; each child carries the
+  normal `MaxIterations` budget and wraps up (no continuation prompt) at its cap, so
+  a fan-out can't loop unbounded or stampede the API.
+
+---
+
+## 10. Testing strategy
+
+Same dual-world pattern (net48 linked-source via `dotnet test`):
+
+- **`AgentCatalog` + frontmatter parser** — discovery across the three roots,
+  project>user>bundled shadowing, inline-list `tools` parsing, `max_tier`/`autonomy`
+  enum parsing, malformed/missing frontmatter, manifest assembly for an enabled set.
+- **`AgentToolResolver`** — `allowlist ∩ parent-available ∩ max_tier`; omitted
+  `tools` ⇒ ReadOnly-only; `tools: [*]` ⇒ full set tier-capped; an allowlisted tool
+  the parent lacks in this workdir is excluded (no escalation); `dispatch_agent`
+  always stripped from a child.
+- **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
+  list/toggle/reset across here/global; conversation override vs. `agents.json`;
+  default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
+  unknown slug/scope failures.
+- **Enablement resolution** — the 5-rung ladder with feature-default OFF;
+  force-on over a global-off; reset → inherit.
+- **`AutonomyApprovalPolicy`** (decorator) — `auto-readonly` + grant ⇒ ReadOnly
+  auto-allows; Write/Destructive still delegate to the real gate; no grant ⇒
+  everything prompts; the grant is tier-capped and name-scoped.
+- **Dispatcher / host loop (`GxPT.Tests`)** with a scripted model stream + fake
+  registry: single dispatch → child runs → final answer returns as the tool result;
+  **batch dispatch runs concurrently** and aggregates labeled sections; a child that
+  errors/caps returns wrap-up text without throwing; `dispatch_agent` handled
+  host-side (no MCP round-trip); cancellation propagates to children; an out-of-set
+  tool named directly by a child → `[Unknown tool]`; **no `dispatch_agent` exposed
+  to a child** (no nesting).
+- **Concurrency** — N children sharing one fake connection serialize through the
+  per-connection lock (asserted via call interleaving), while their model streams
+  overlap; `MaxParallelAgents` bounds in-flight children.
+
+---
+
+## 11. Phasing / roadmap
+
+1. **`AgentCatalog` + extended frontmatter parser** + bundled-agent discovery
+   (pure, TDD) — the catalog, `tools`/`max_tier`/`autonomy` parsing, shadowing.
+2. **`AgentToolResolver`** — effective-tool resolution (allowlist ∩ parent ∩ tier),
+   the no-escalation core (pure, TDD).
+3. **Manifest injection** — `AgentInjection.BuildManifestMessage` slotted into the
+   orchestrator's ephemeral tail (`<agents>` section), gated by the enabled set.
+4. **`dispatch_agent` meta-tool + `AgentDispatcher`** — single-dispatch first:
+   build a child orchestrator, run it, return its answer as the tool result
+   (handled in `ExecuteCall` like `open_skill`). Context firewall + `HiddenToolNames`
+   strip of `dispatch_agent`.
+5. **Approval integration** — `AutonomyApprovalPolicy` decorator + the one-time
+   agent-name grant in the approval store; agent-attributed prompts.
+6. **Agent slash commands** on the `ISlashCommand` framework (`/agents`,
+   `/agent <slug> …`, `/agent <slug> <task>`) + per-conversation override fields on
+   `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
+7. **Parallel fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution,
+   per-connection mutex, cancellation propagation, usage aggregation.
+8. **Transcript UI** — collapsible per-child agent blocks (live tool activity shown,
+   not fed to the parent), collapsing to the returned summary.
+9. **Bundled agents + deploy** — ship `code-explorer`, `test-runner`, `pr-reviewer`
+   via an `agents/` source folder copied next to the exe (`AfterBuild` + setup
+   `.vdproj`), like bundled skills.
+10. **(Optional/later)** an agent-authoring surface (an `agent-writer` skill, the
+    skill-writer precedent); folder-form agents with bundled assets; user-global
+    `scope` parity in any authoring flow.
+
+---
+
+## 12. Open / soft decisions
+
+**Soft (lean noted):**
+- **Agent file form** — *lean flat `agents/<slug>.md`* (A4) for parity with the
+  cross-tool convention and catalog simplicity; revisit to `<slug>/AGENT.md` folders
+  only if agents start needing bundled assets (and even then, pairing with a skill
+  may be the better factoring).
+- **Default `max_tier`** — *lean `write`* (an agent can edit, the gate still
+  confirms), with `destructive` opt-in only. Could argue `readonly` default for
+  maximum caution; chosen `write` so the common "fix this" agent works without
+  ceremony while Destructive stays explicit.
+- **`MaxParallelAgents`** — *lean 3* (named constant, tunable), balancing latency
+  win against API/thread pressure on XP-era hardware.
+- **Explicit `/agent <slug> <task>` routing** — *lean route-through-the-model*
+  (a real gated `dispatch_agent` call) rather than a direct host spawn, so there's
+  exactly one spawning path and it's always gated/recorded.
+
+**Deferred:**
+- **Nested delegation** (an agent dispatching agents) — structurally blocked (A12);
+  revisit only with a hard depth cap and cost budget if a real workflow needs it.
+- **Resumable / multi-turn agents** — today a dispatch is one-shot within the
+  parent's turn (A8); a handle scheme + persisted sub-histories is a later feature.
+- **Streaming a child's output into the parent model** — deferred (A7); only the
+  final answer crosses back. The user still *sees* live child activity (§9).
+- **Agent-authoring tools** (a writer like `skill-writer`) — phase 10; until then
+  agents are authored by hand or via the file tools.
+- **Folder-form agents + bundled assets**; **user-global authoring `scope`** parity.
+- **Per-agent model *routing policy*** beyond a static `model:` override (e.g. "use
+  a cheaper model for explore agents") — the static override covers the common case.
+```

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -5,8 +5,7 @@
 **Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
 approval + flag-insensitive command-signature rules, see §7–§8; refined against
 OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
-detection, wildcard allowlists; and fully-concurrent agents with a file-grain
-write-conflict lock, see §9, §13, and A9/A10/A17–A20)
+detection, wildcard allowlists, and read/write-aware fan-out, see §13 and A9/A17–A19)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -82,9 +81,8 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A6 | **`description` is the dispatch trigger** — a single "use this agent when…" line, the only thing in the always-on manifest | Identical to skills' `description` (S4): it is what the parent model reads to decide *whether* to delegate and *which* agent. Names-only-plus-one-liner keeps the manifest cheap (§4). |
 | A7 | **Only the final answer crosses back; no streaming into the parent** | Streaming a sub-agent's intermediate tool chatter into the parent re-imports the context cost the firewall exists to remove (A3). The sub-agent's live output still renders in the transcript UI (its own collapsible block, §9) so the user sees it — it just isn't fed to the *parent model*. |
 | A8 | **A dispatch is one-shot within the parent's turn** (no resumable agent sessions) | Keeps state trivial: the sub-orchestrator is a local object on a worker thread, joined before the parent's `dispatch_agent` tool result is formed. Resumable agents would need persisted sub-histories and a handle scheme — deferred until a real need appears. |
-| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`); **all children run concurrently** (bounded by `MaxParallelAgents`), **write-capable agents included** | The parent fans out in one tool call; the host joins. Agents are independent workers — serializing them because one *can* write throws away the whole point (the user's explicit requirement). Concurrency is real for every tier; the only thing that must not happen is two agents mutating the **same file** at once, and that is prevented at the file grain by the write-conflict model (A20), **not** by blocking write-agents. (This deliberately goes *beyond* OpenMono, whose `AgentTool` dispatches sub-agents serially — see §13.) |
-| A10 | **Each concurrent child gets its own connection to workdir-scoped servers** (files/git/command); **revealed-tool state is per-sub-agent** | `McpServerConnection` is single-flight (id-correlated, serial dispatch), so a *shared* connection would funnel all children's tool I/O through one pipe — fine for the LLM-overlap win, but it needlessly serializes independent work. Giving each child its own scoped-server connection (≤ `MaxParallelAgents`, so ≤ ~3 extra stdio processes) lets different-file work truly overlap; cross-agent safety then rides the host-level lock (A20), not the transport. Each sub-agent also owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, the per-tab rule). |
-| A20 | **Write-conflict model: a host-level lock manager, acquired per tool call, never held across calls** (deadlock-free). Path-scoped writes (`files__write/edit/delete`) lock the **canonical target path**; non-path mutators (`git__*` writes, `command__run`) lock the **workspace root**; ReadOnly tools never lock | This is what makes "concurrent agents, but not on the same file" precise. Two `files__edit` calls to *different* files run in parallel; two to the *same* canonical path serialize (the second waits). Coarse mutators with no single path (git index, arbitrary shell) can't safely interleave at all, so they take the workspace-root key — serializing repo/shell mutations against each other and against file writes in that workspace, while readers and different-workspace agents proceed. Per-call acquisition (release the instant the call returns) means no agent ever holds one lock while waiting on another, so the fan-out cannot deadlock. The lock key reuses the canonical-path normalization the approval store already uses (PR #154 / `PathSandbox`), so locks and remembered approvals agree on file identity. |
+| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`); a batch runs **in parallel** when every named agent is **read-only** (`max_tier: readonly`), else **serially** | The parent fans out in one tool call; the host joins. Parallelism overlaps the expensive part (LLM streams). But two *write*-capable children racing the same workspace can corrupt it logically even with per-connection transport serialization (A10), so a batch with any writer serializes — "reads parallel, writes serial" (OpenMono's intra-turn tool rule) lifted to the **agent** grain. (Per the OpenMono source, `AgentTool` defaults non-concurrency-safe and dispatches **serially**; our parallel read-only fan-out is a deliberate, bounded extension, not a port.) |
+| A10 | **Shared MCP server connections are serialized per-connection** under a lock; **revealed-tool state is per-sub-agent** | `McpServerConnection` correlates by request id and the server SDK dispatches serially; concurrent `CallTool` on one connection is unsafe, so a per-connection mutex serializes tool I/O while model streams still overlap. Each sub-agent owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, already the per-tab rule). |
 | A11 | **Effective tools = `allowlist` ∩ `parent-available` ∩ `max_tier`** — a sub-agent can never exceed the parent's own reach | No privilege escalation: delegating cannot grant a capability the parent itself lacks in this workspace (e.g. a folderless turn's sub-agent still can't reach `files__*`). The allowlist *narrows*; it never widens. |
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
@@ -459,26 +457,23 @@ GxPT already runs each tab's turn on a `ThreadPool` worker thread, with the
 orchestrator built fresh and explicitly documented un-shared. Parallel sub-agents
 extend that, not rework it.
 
-- **Fan-out (A9): every child runs concurrently, write agents included.** A batch
-  queues N `ThreadPool` work items (bounded to `MaxParallelAgents`, default 3 — a
-  named constant), each running a child `RunTurn` to completion, joined on a countdown
-  before the tool result forms. There is **no tier-based serialization** — a coder
-  and a reviewer fan out together; the only constraint is that two agents can't mutate
-  the *same file* at once (A20), which is enforced per call, not by holding back the
-  agent. The parent worker thread blocks on the join — the same "turn pauses, user
-  present-or-away" model the gate already uses.
-- **Two wins, two grains.** Overlapping **LLM streams** is the big latency win and is
-  unconditional (independent, no shared state). Overlapping **tool I/O** comes from
-  giving each child its own connection to the workdir-scoped servers (A10), so
-  different-file reads/writes don't queue behind one pipe.
-- **Write-conflict safety is the host lock manager (A20), not transport.** Each
-  path-scoped write/edit/delete acquires the **canonical-path** lock for the duration
-  of that one call; different files never block each other, the same file serializes,
-  and per-call acquisition (no lock held across calls) makes deadlock impossible.
-  Repo/shell mutators (`git__*` writes, `command__run`) take the **workspace-root**
-  key, since their blast radius isn't a single path and git's own index tolerates no
-  concurrency. Readers never lock. So "agents run concurrently, but never edit the
-  same file simultaneously" holds exactly, with maximum overlap everywhere else.
+- **Fan-out, read/write-aware (A9):** a batch where **every** named agent is
+  read-only (`max_tier: readonly`) queues N `ThreadPool` work items (bounded to
+  `MaxParallelAgents`, default 3 — a named constant), each running a child `RunTurn`
+  to completion, joined on a countdown before the tool result forms. A batch that
+  includes **any write-capable agent runs serially** instead — two writers racing the
+  same workspace can produce a logically inconsistent tree even when individual calls
+  are transport-serialized (A10), so concurrency is restricted to the provably-safe
+  read-only case (OpenMono's "reads parallel, writes serial," at the agent grain).
+  Either way the parent worker thread blocks on the join — the same "turn pauses,
+  user present-or-away" model the gate already uses.
+- **The win is overlapping LLM streams**, the turn's real latency. Tool I/O to a
+  **shared** MCP server connection is *also* serialized by a **per-connection mutex**
+  (A10): `McpServerConnection` correlates by id and the server SDK dispatches
+  serially, so concurrent `CallTool` on one connection is unsafe — the lock makes two
+  read-only agents take turns at the file server while their *model* calls still run
+  concurrently. (The mutex protects *transport*; the A9 read-only rule protects
+  *workspace logical consistency* — two distinct concerns, both needed.)
 - **Prompt caching is unaffected:** each child owns a *fresh* `RevealedToolNames`
   and a fresh transcript, so no child churns another's tools array (the per-tab
   invariant, generalized).
@@ -498,8 +493,7 @@ extend that, not rework it.
   **periodic doom-loop detection** (A18) aborts a child stuck in a repeating *cycle*
   (not just a single repeated call) rather than draining the whole budget. Together these make an
   `auto-readonly`, write-granted fan-out safe to leave running: bounded breadth
-  (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop),
-  bounded concurrency (`MaxParallelAgents`) with same-file races impossible (A20), and
+  (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop), and
   the always-confirm gate on anything destructive.
 
 ---
@@ -521,13 +515,8 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   period 1–4 over the recent `name:normalized-args` signature window (≥3× for period 1,
   ≥2× for longer — A18) aborts with a wrap-up, catching A→B→A→B oscillations and not
   just A→A→A; the abort returns as content, never a throw.
-- **Concurrency + write-conflict model (A9/A20)** — a mixed read/write batch runs all
-  children concurrently (asserted by overlapping execution); two `files__edit` calls to
-  **different** paths proceed in parallel while two to the **same** canonical path
-  serialize (one waits); `git__*`-write / `command__run` calls serialize on the
-  workspace-root key; ReadOnly calls never block; per-call lock release ⇒ no deadlock
-  even with crossed acquisition order; lock keys match the approval store's canonical
-  path identity.
+- **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
+  a batch with any write-capable agent serializes (A9), asserted by execution order.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
   list/toggle/reset across here/global; conversation override vs. `agents.json`;
   default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
@@ -567,10 +556,8 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 6. **Agent slash commands** on the `ISlashCommand` framework (`/agents`,
    `/agent <slug> …`, `/agent <slug> <task>`) + per-conversation override fields on
    `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
-7. **Concurrent fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution of
-   all children (write agents included), per-agent scoped-server connections (A10),
-   the host **write-conflict lock manager** (A20: canonical-path + workspace-root keys,
-   per-call), cancellation propagation, usage aggregation.
+7. **Parallel fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution,
+   per-connection mutex, cancellation propagation, usage aggregation.
 8. **Transcript UI** — collapsible per-child agent blocks (live tool activity shown,
    not fed to the parent), collapsing to the returned summary.
 9. **Bundled agents + deploy** — ship a starter suite via an `agents/` source folder
@@ -599,24 +586,24 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   ceremony while Destructive stays explicit.
 - **`MaxParallelAgents`** — *lean 3* (named constant, tunable), balancing latency
   win against API/thread pressure on XP-era hardware.
-- **Per-agent scoped-server connections (A10)** — *lean yes*: each concurrent child
-  gets its own files/git/command connection (≤ `MaxParallelAgents` extra stdio
-  processes) so different-file tool I/O overlaps. The cheaper alternative — one shared
-  connection, tool calls serialized on it (only LLM overlaps) — stays the fallback if
-  process count proves heavy on XP; the A20 lock is correct either way (it just has
-  less to do when the transport already serializes).
-- **Write-conflict lock granularity (A20)** — *lean canonical-file + workspace-root*.
-  A middle option (directory-boundary locks) was considered but rejected: it would
-  block edits to unrelated files in a busy folder. File-grain maximizes overlap; the
-  workspace-root key is reserved for mutators with no single path (git/shell). Residual
-  *logical* conflict (two agents editing the same file across separate calls based on
-  stale reads) is accepted — locks are per-call, not per-turn transactions — and is
-  rare by construction, since the dispatcher hands children **disjoint** tasks.
 - **Explicit `/agent <slug> <task>` routing** — *lean route-through-the-model*
   (a real gated `dispatch_agent` call) rather than a direct host spawn, so there's
   exactly one spawning path and it's always gated/recorded.
 
 **Deferred:**
+- **Concurrent *write* agents via disjoint sub-workdirs.** Considered and set aside in
+  favor of the simpler **read-concurrent / write-serial** rule (A9). The idea: give
+  each write-child its own sub-workdir (write-root) under the parent — reusing the
+  existing per-workdir `PathSandbox`/`EnsureWorkingDir` routing — so two writers in
+  disjoint subtrees can't touch the same file by construction, no lock manager. It is
+  genuinely attractive (and a smaller blast radius too), but it carries real residual
+  complexity that isn't worth it yet: a filesystem subtree doesn't partition **git**
+  (one `.git` at the repo root) or contain **`command__run`** (a shell escapes its cwd),
+  writers still need to *read* up-tree (asymmetric read-root/write-root scoping), and
+  the host must verify the chosen sub-workdirs are pairwise disjoint at dispatch.
+  Serializing write-agents avoids all of it. Revisit if a real workflow needs several
+  writers at once and the disjoint-subtree contract (incl. the parent doing repo-level
+  git after the join) proves clean enough to adopt.
 - **Nested delegation** (an agent dispatching agents) — structurally blocked (A12);
   revisit only with a hard depth cap and cost budget if a real workflow needs it.
 - **Resumable / multi-turn agents** — today a dispatch is one-shot within the
@@ -681,19 +668,17 @@ really a 2-stage read-parallel/write-serial dispatcher).
   PR #154's workspace-write/command-signature grants extend it cleanly. A
   capability-object refactor is a large change for marginal gain here — noted, not
   adopted.
-- **We run sub-agents concurrently — including write agents — where OpenMono runs
-  them serially.** The source shows OpenMono parallelizes **tools within one turn**
-  (`ToolDispatcher` splits calls on `tool.IsReadOnly && tool.IsConcurrencySafe` →
-  `Task.WhenAll`, writes after) but dispatches **sub-agents serially** (`AgentTool`
-  extends `ToolBase`, which defaults both flags `false`, so a spawn lands in the serial
-  write-group). GxPT can't do the intra-turn tool part — net35 has no `async`/`Task`
-  and the loop is *deliberately serial* (`mcp35-toolloop-spec.md` §6) — but it can and
-  **does** run the *agents* concurrently at every tier (§9, A9), which is the higher-
-  value axis here. We borrow OpenMono's "writes must not collide" instinct but enforce
-  it at the **file grain** (A20: a per-canonical-path lock, with a workspace-root key
-  for git/shell mutators) rather than by serializing whole write-agents — so two coders
-  on different files overlap fully, two on the same file take turns, and nothing
-  deadlocks (per-call locks). This is a deliberate, supported divergence, not a port.
+- **The parallelism axis is opposite, by design.** The source shows OpenMono
+  parallelizes **tools within one turn** (`ToolDispatcher` splits calls on
+  `tool.IsReadOnly && tool.IsConcurrencySafe` → `Task.WhenAll`, writes after) but
+  dispatches **sub-agents serially** (`AgentTool` extends `ToolBase`, which defaults
+  both flags `false`, so a spawn lands in the serial write-group). GxPT can't do the
+  intra-turn part — net35 has no `async`/`Task` and the loop is *deliberately serial*
+  (`mcp35-toolloop-spec.md` §6) — so we take the **agent**-grain version instead:
+  parallel read-only *children* (§9, A9). Same governing principle ("reads parallel,
+  writes serial"), applied one level up — and our read-only fan-out is genuinely
+  *more* concurrent than OpenMono's serial agents, which the read/write gate (A9) +
+  per-connection mutex (A10) keep safe.
 - **Agents are files, not hardcoded records.** OpenMono's agents are C# records in a
   static `BuiltInAgents.All` dictionary — type-safe and simple, but only the authors
   can add one. We keep the **markdown-file** model (the skills/Claude-Code convention,

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -7,7 +7,9 @@ approval + flag-insensitive command-signature rules, see §7–§8; refined agai
 OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
 detection, wildcard allowlists, and read-concurrent/write-serial fan-out, see §13 and
 A9/A17–A19; added running-agents observability — in-transcript dispatch panel + a
-`Stop N agents` button (stop-all, v1) — see §14 and A20)
+`Stop N agents` button (stop-all, v1) — see §14 and A20; aligned slash commands to
+PR #156's verb-first hyphen-prefixed style — `/list-agents`, `/toggle-agents`,
+`/toggle-agent`, `/dispatch-agent` — see §6)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -56,9 +58,10 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 - **Host-native dispatch, no new server.** `dispatch_agent` is a host-synthesized
   meta-tool handled in the orchestrator — the skills `open_skill` precedent (S1):
   spawning an in-process loop is not a child process, so it needs no `…McpServer`.
-- **Slash commands, no settings-page UI** — `/agents`, `/agent <slug> …`, and an
-  explicit `/agent <slug> <task>` dispatch, on the existing `ISlashCommand`
-  framework, scoped per conversation, mirroring `/skills`.
+- **Slash commands, no settings-page UI** — `/list-agents`, `/toggle-agents`,
+  `/toggle-agent <slug> …`, and an explicit `/dispatch-agent <slug> <task>`, on the
+  existing `ISlashCommand` framework, scoped per conversation, in the verb-first
+  hyphen-prefixed style PR #156 set for skills (`/list-skills`, `/toggle-skill`, …).
 
 ### Non-goals
 - **Nested fan-out.** A sub-agent never gets `dispatch_agent` in its tool set — no
@@ -89,7 +92,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
 | A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
-| A15 | **Enablement reuses the skills tri-state ladder** (`/agents`, `/agent <slug> on\|off\|reset [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). |
+| A15 | **Enablement reuses the skills tri-state ladder** (`/list-agents`, `/toggle-agents`, `/toggle-agent <slug> [on\|off\|reset] [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). Command naming follows PR #156's verb-first hyphen-prefixed style (§6). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
@@ -281,20 +284,33 @@ that — it only constructs and joins.
 
 ## 6. Slash commands (on the existing `ISlashCommand` framework)
 
-Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins. `Client`
-kind (run locally, no LLM send) except `/agent <slug> <task>`, which dispatches.
+Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins, in the
+**verb-first, hyphen-prefixed** style PR #156 established for skills (`/list-skills`,
+`/toggle-skills`, `/toggle-skill`, `/use-skill`). `Client` kind (run locally, no LLM
+send) except `/dispatch-agent`, which sends.
 
 | Command | Kind | Effect |
 |---------|------|--------|
-| `/agents` | Client | List agents with effective on/off state + source (bundled/user/project) |
-| `/agents [on\|off\|reset] [here\|global]` | Client | Toggle/reset the **whole feature** at that scope (default `here`) |
-| `/agent <slug> [on\|off\|reset] [here\|global]` | Client | Toggle/reset **one agent**; bare `/agent <slug>` toggles for this conversation |
-| `/agent <slug> <task…>` | Send | **Explicit dispatch**: send a hidden instruction `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — an explicit user action, like `/use`) |
+| `/list-agents` | Client | List agents with effective on/off state + source (bundled/user/project). Listing is its own command (no args), per PR #156. |
+| `/toggle-agents <on\|off\|reset> [here\|global]` | Client | Toggle/reset the **whole feature** at that scope (default `here`). Requires a verb (listing lives in `/list-agents`). |
+| `/toggle-agent <slug> [on\|off\|reset] [here\|global]` | Client | Toggle/reset **one agent**; bare `/toggle-agent <slug>` toggles for this conversation |
+| `/dispatch-agent <slug> <task…>` | Send | **Explicit dispatch**: sends a hidden instruction `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — an explicit user action, the `/use-skill` analogue) |
 
-- **Slug-first**, mirroring `/skill` and `/tool`. Autocomplete completes slugs
-  (annotated with state) then `on\|off\|reset` then `here\|global`, via
-  `IArgumentCompleter` — the exact pattern `SkillCommands` uses.
-- Explicit `/agent <slug> <task>` routes through the model (not a direct host
+- **Naming follows PR #156**: a verb-first, hyphen-prefixed name per command, with
+  listing split from toggling (`/list-agents` vs. `/toggle-agents`, which now requires
+  a verb) — the same split #156 made for skills. The agent *invocation* verb is
+  `dispatch` (matching the `dispatch_agent` tool and `AgentDispatcher`), where skills
+  use `use`.
+- **Discovery via `SlashMatch.HyphenPrefix`** (PR #156): each hyphen segment is an
+  anchor, so typing `/agent` matches `list-agents`, `toggle-agents`, `toggle-agent`,
+  and `dispatch-agent`; `/dispatch` narrows to `dispatch-agent`. No need to type a full
+  prefix. The registry's `Match()` already does this — agent commands inherit it free.
+- **Slug-first within `/toggle-agent` and `/dispatch-agent`**, mirroring
+  `/toggle-skill` / `/use-skill`. Autocomplete completes slugs (annotated with state)
+  then `on\|off\|reset` then `here\|global`, via `IArgumentCompleter` + the shared
+  `SkillCommandShared.AddMatching` helper (the completion utility #156 factored out) —
+  the exact pattern the skill commands use.
+- Explicit `/dispatch-agent <slug> <task>` routes through the model (not a direct host
   spawn) so the dispatch is a normal, gated `dispatch_agent` tool call with a
   transcript record and approval — no second, ungated entry point into spawning.
 
@@ -527,9 +543,11 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 - **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
   a batch with any write-capable agent serializes (A9), asserted by execution order.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
-  list/toggle/reset across here/global; conversation override vs. `agents.json`;
-  default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
-  unknown slug/scope failures.
+  `/list-agents` listing; `/toggle-agents` / `/toggle-agent` toggle/reset across
+  here/global (toggle requires a verb); conversation override vs. `agents.json`;
+  default-OFF feature; `/dispatch-agent <slug> <task>` sends the hidden dispatch
+  instruction; unknown slug/scope failures; `SlashMatch.HyphenPrefix` matches `/agent`
+  to all four agent commands (segment-boundary, per PR #156).
 - **Enablement resolution** — the 5-rung ladder with feature-default OFF;
   force-on over a global-off; reset → inherit.
 - **`AutonomyApprovalPolicy`** (decorator) — `auto-readonly` + grant ⇒ ReadOnly
@@ -562,9 +580,10 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
    strip of `dispatch_agent`.
 5. **Approval integration** — `AutonomyApprovalPolicy` decorator + the one-time
    agent-name grant in the approval store; agent-attributed prompts.
-6. **Agent slash commands** on the `ISlashCommand` framework (`/agents`,
-   `/agent <slug> …`, `/agent <slug> <task>`) + per-conversation override fields on
-   `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
+6. **Agent slash commands** on the `ISlashCommand` framework, verb-first/hyphen-prefixed
+   per PR #156 (`/list-agents`, `/toggle-agents`, `/toggle-agent <slug> …`,
+   `/dispatch-agent <slug> <task>`; `SlashMatch.HyphenPrefix` matching) + per-conversation
+   override fields on `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
 7. **Concurrent fan-out + must-have observability** — batch `dispatch_agent`,
    read-concurrent/write-serial execution on bounded `ThreadPool` work items,
    per-connection mutex, usage aggregation; the **group cancellation** + the
@@ -599,7 +618,7 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   ceremony while Destructive stays explicit.
 - **`MaxParallelAgents`** — *lean 3* (named constant, tunable), balancing latency
   win against API/thread pressure on XP-era hardware.
-- **Explicit `/agent <slug> <task>` routing** — *lean route-through-the-model*
+- **Explicit `/dispatch-agent <slug> <task>` routing** — *lean route-through-the-model*
   (a real gated `dispatch_agent` call) rather than a direct host spawn, so there's
   exactly one spawning path and it's always gated/recorded.
 

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -4,8 +4,8 @@
 **Branch:** `claude/compassionate-goldberg-5c9ccz`
 **Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
 approval + flag-insensitive command-signature rules, see §7–§8; refined against
-OpenMonoAgent.ai prior art — `max_turns`, doom-loop detection, wildcard allowlists,
-see §13 and A17–A19)
+OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
+detection, wildcard allowlists, and read/write-aware fan-out, see §13 and A9/A17–A19)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -81,7 +81,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A6 | **`description` is the dispatch trigger** — a single "use this agent when…" line, the only thing in the always-on manifest | Identical to skills' `description` (S4): it is what the parent model reads to decide *whether* to delegate and *which* agent. Names-only-plus-one-liner keeps the manifest cheap (§4). |
 | A7 | **Only the final answer crosses back; no streaming into the parent** | Streaming a sub-agent's intermediate tool chatter into the parent re-imports the context cost the firewall exists to remove (A3). The sub-agent's live output still renders in the transcript UI (its own collapsible block, §9) so the user sees it — it just isn't fed to the *parent model*. |
 | A8 | **A dispatch is one-shot within the parent's turn** (no resumable agent sessions) | Keeps state trivial: the sub-orchestrator is a local object on a worker thread, joined before the parent's `dispatch_agent` tool result is formed. Resumable agents would need persisted sub-histories and a handle scheme — deferred until a real need appears. |
-| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`) and runs entries **in parallel** on bounded worker threads | The parent fans out ("explore these three modules") in one tool call; the host joins. Parallelism overlaps the expensive part (LLM streams). A single-entry call is just fan-out of one. |
+| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`); a batch runs **in parallel** when every named agent is **read-only** (`max_tier: readonly`), else **serially** | The parent fans out in one tool call; the host joins. Parallelism overlaps the expensive part (LLM streams). But two *write*-capable children racing the same workspace can corrupt it logically even with per-connection transport serialization (A10), so a batch with any writer serializes — "reads parallel, writes serial" (OpenMono's intra-turn tool rule) lifted to the **agent** grain. (Per the OpenMono source, `AgentTool` defaults non-concurrency-safe and dispatches **serially**; our parallel read-only fan-out is a deliberate, bounded extension, not a port.) |
 | A10 | **Shared MCP server connections are serialized per-connection** under a lock; **revealed-tool state is per-sub-agent** | `McpServerConnection` correlates by request id and the server SDK dispatches serially; concurrent `CallTool` on one connection is unsafe, so a per-connection mutex serializes tool I/O while model streams still overlap. Each sub-agent owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, already the per-tab rule). |
 | A11 | **Effective tools = `allowlist` ∩ `parent-available` ∩ `max_tier`** — a sub-agent can never exceed the parent's own reach | No privilege escalation: delegating cannot grant a capability the parent itself lacks in this workspace (e.g. a folderless turn's sub-agent still can't reach `files__*`). The allowlist *narrows*; it never widens. |
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
@@ -89,8 +89,8 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
 | A15 | **Enablement reuses the skills tri-state ladder** (`/agents`, `/agent <slug> on\|off\|reset [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
-| A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (Explore 15, Plan 10, Coder 30, Verify 20); bounding an unattended explore agent lower than a coder is the right grain for cost control, and a tight budget is itself a safety bound on an autonomous (A14) run. |
-| A18 | **Doom-loop detection in the orchestrator**: N (default 3) consecutive *identical* (tool-name + canonical args) calls ⇒ abort the loop with a wrap-up | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget repeating one failed call — wasteful, and worse for an unattended sub-agent (A14) with no user watching. OpenMono aborts on "3 identical tool-call sequences in a row." Cheap to add (a small ring buffer of the last few `(name,args)` hashes in `RunTurn`), benefits the **main** agent too, and ends as content (the loop's existing failure stance), not a throw. |
+| A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
+| A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
 | A19 | **Allowlist `tools` supports glob wildcards** (`files__*`, `mcp__*`, `*__read`, `*`) matched against the qualified catalog | Server-qualified names (`files__read`, `git__status`) make prefix/suffix globs natural and far less brittle than enumerating every tool — "all file tools" is `files__*`, "everything a server exposes" is `mcp__myserver__*`. The OpenMono precedent ("allow-lists support `*`, `mcp__*`"). Still intersected with parent-available and `max_tier` (A11), so a wildcard never widens past the parent or the ceiling. |
 
 ---
@@ -457,18 +457,23 @@ GxPT already runs each tab's turn on a `ThreadPool` worker thread, with the
 orchestrator built fresh and explicitly documented un-shared. Parallel sub-agents
 extend that, not rework it.
 
-- **Fan-out:** `dispatch_agent` with N entries queues N `ThreadPool` work items
-  (bounded to `MaxParallelAgents`, default 3 — a named constant), each running a
-  child `RunTurn` to completion, joined on a countdown before the tool result forms.
-  The parent worker thread blocks on the join (it has nothing to do until results
-  return) — the same "turn pauses, user present-or-away" model the gate already uses.
+- **Fan-out, read/write-aware (A9):** a batch where **every** named agent is
+  read-only (`max_tier: readonly`) queues N `ThreadPool` work items (bounded to
+  `MaxParallelAgents`, default 3 — a named constant), each running a child `RunTurn`
+  to completion, joined on a countdown before the tool result forms. A batch that
+  includes **any write-capable agent runs serially** instead — two writers racing the
+  same workspace can produce a logically inconsistent tree even when individual calls
+  are transport-serialized (A10), so concurrency is restricted to the provably-safe
+  read-only case (OpenMono's "reads parallel, writes serial," at the agent grain).
+  Either way the parent worker thread blocks on the join — the same "turn pauses,
+  user present-or-away" model the gate already uses.
 - **The win is overlapping LLM streams**, the turn's real latency. Tool I/O to a
-  **shared** MCP server connection is serialized by a **per-connection mutex** (A10):
-  `McpServerConnection` correlates by id and the server SDK dispatches serially, so
-  concurrent `CallTool` on one connection is unsafe — the lock makes two agents
-  reading files take turns at the file server while their *model* calls still run
-  concurrently. (Per-workdir routing already gives different-folder turns different
-  servers; same-folder children share one, hence the lock.)
+  **shared** MCP server connection is *also* serialized by a **per-connection mutex**
+  (A10): `McpServerConnection` correlates by id and the server SDK dispatches
+  serially, so concurrent `CallTool` on one connection is unsafe — the lock makes two
+  read-only agents take turns at the file server while their *model* calls still run
+  concurrently. (The mutex protects *transport*; the A9 read-only rule protects
+  *workspace logical consistency* — two distinct concerns, both needed.)
 - **Prompt caching is unaffected:** each child owns a *fresh* `RevealedToolNames`
   and a fresh transcript, so no child churns another's tools array (the per-tab
   invariant, generalized).
@@ -485,8 +490,8 @@ extend that, not rework it.
   `MaxParallelAgents` bounds concurrency; each child carries its **`max_turns`**
   budget (A17) and wraps up at its cap with **no continuation prompt** (the dispatch
   is meant to be unattended — a child can't block the fan-out waiting on a user); and
-  **doom-loop detection** (A18) aborts a child that repeats one call N times rather
-  than draining the whole budget on a stuck step. Together these make an
+  **periodic doom-loop detection** (A18) aborts a child stuck in a repeating *cycle*
+  (not just a single repeated call) rather than draining the whole budget. Together these make an
   `auto-readonly`, write-granted fan-out safe to leave running: bounded breadth
   (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop), and
   the always-confirm gate on anything destructive.
@@ -505,10 +510,13 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   (`files__*`, `mcp__*`, `*__read`) expand against the qualified catalog (A19); an
   allowlisted tool the parent lacks in this workdir is excluded (no escalation);
   `dispatch_agent` always stripped from a child.
-- **`max_turns` + doom-loop** (in the orchestrator, so the main agent is covered too)
-  — a child built with `max_turns` wraps up at that cap (A17); N consecutive identical
-  `(name, canonical-args)` calls abort with a wrap-up rather than draining the budget
-  (A18), and the abort returns as content, never a throw.
+- **`max_turns` + periodic doom-loop** (in the orchestrator, so the main agent is
+  covered too) — a child built with `max_turns` wraps up at that cap (A17); a cycle of
+  period 1–4 over the recent `name:normalized-args` signature window (≥3× for period 1,
+  ≥2× for longer — A18) aborts with a wrap-up, catching A→B→A→B oscillations and not
+  just A→A→A; the abort returns as content, never a throw.
+- **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
+  a batch with any write-capable agent serializes (A9), asserted by execution order.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
   list/toggle/reset across here/global; conversation override vs. `agents.json`;
   default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
@@ -602,7 +610,12 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 [OpenMonoAgent.ai](https://github.com/StartupHakk/OpenMonoAgent.ai) is a .NET sub-agent
 coding system (local llama.cpp inference). It's a useful mirror because it solved the
 same problem in a comparable stack, and most of its choices **independently match**
-ours — which raises confidence — while a few sharpened this design (A17–A19, §9).
+ours — which raises confidence — while a few sharpened this design (A17–A19, §9). The
+findings below come from reading the actual source (`src/OpenMono.Cli/`:
+`Tools/AgentTool.cs`, `Agents/AgentDefinition.cs`, `Tools/ToolDispatcher.cs`,
+`Tools/ToolBase.cs`, `Session/DoomLoopDetector.cs`, `Permissions/Capability.cs`), which
+corrected two things its prose docs overstated (turn budgets; the "12-step pipeline" is
+really a 2-stage read-parallel/write-serial dispatcher).
 
 ### Where it confirms our choices (convergent design)
 | OpenMono | Our design | Note |
@@ -612,17 +625,26 @@ ours — which raises confidence — while a few sharpened this design (A17–A1
 | Returns **final text + artifacts** as a single tool response; parent never sees inner iterations | Only the final assistant message returns (A3/A7) | The context-firewall value is the agreed core. |
 | Sub-agent inherits parent context (`OPENMONO.md`, memory, git status) but its **own message list** | Standing guidance + workspace block + AGENTS.md + memory, in a fresh history (§5) | Same "shared standing context, isolated transcript." |
 | Hard-coded allowlists per agent type; **read-only vs write tiers** | `tools` ∩ `max_tier` (A5/A11), classified by `ToolClassifier` tiers | Same tiered-capability instinct; ours is author-declared per agent rather than five fixed types. |
-| **Spawn is a capability** (`AgentSpawnCap(type, task)`) routed through the permission engine | `dispatch_agent` itself goes through approval; autonomy grant remembered by agent name (A14) | Both gate the *spawn*, not just the spawned calls. |
+| **Spawn is a capability** (`AgentSpawnCap(string AgentType, string TaskSummary)`, source) routed through the permission engine | `dispatch_agent` itself goes through approval; autonomy grant remembered by agent name (A14) | Both gate the *spawn*, not just the spawned calls. |
+| `AgentDefinition` **record**: `Name`, `Description`, `AllowedTools (["*"])`, `MaxTurns`, `SystemPrompt?` (source) | Our `Agent` from frontmatter: `name`, `description`, `tools`, `max_turns`, body-as-prompt — **plus** `max_tier` + `autonomy` | Field-for-field match; our schema is a **superset**, adding the two keys that serve the layered-security goal (§8). |
+| No nesting: `if (tool.Name == "Agent") continue;` (source — sub-agents can't see the Agent tool) | `dispatch_agent` stripped from every child (A12) | Identical fork-bomb guard, confirmed in code. |
 
 ### Where it sharpened our design (adopted)
-- **Distinct turn budgets per specialist** (Explore 15 / Plan 10 / Coder 30 /
-  Verify 20) → adopted as **`max_turns`** (A17), free plumbing over the orchestrator's
-  existing `maxIterations` arg, and a real autonomy safety bound.
-- **Doom-loop detection** ("3 identical tool-call sequences → abort") → adopted as
-  A18; a gap in our prior draft, and exactly the valve an *unattended* agent needs so
-  it can't drain its budget on one stuck call. Benefits the main agent too.
-- **Allowlist wildcards** (`*`, `mcp__*`) → adopted as A19; natural over GxPT's
-  server-qualified names (`files__*`), far less brittle than enumerating tools.
+- **Distinct turn budgets per specialist** → adopted as **`max_turns`** (A17), free
+  plumbing over the orchestrator's existing `maxIterations` arg. Reading the source
+  also corrected the numbers — the real budgets are **100–300** (Explore/Plan 100,
+  Verify 150, general 200, Coder 300), not the 10–30 the docs imply — which flagged
+  that our interactive `DefaultMaxIterations = 25` is too low for an *unattended*
+  write agent (no continuation prompt), so bundled write agents set a generous
+  `max_turns` (A17).
+- **Periodic doom-loop detection** → adopted as A18. The source `DoomLoopDetector` is
+  *cycle*-aware (period 1–4, `reps = period==1?3:2`, JSON-normalized signatures, a
+  12-entry history), not the "3 identical in a row" the prose says — so it catches
+  A→B→A→B oscillations a consecutive-only check misses. We adopt the smarter version.
+  A gap in our prior draft, and exactly the valve an unattended agent needs.
+- **Allowlist wildcards** (`*`, `mcp__*`, confirmed by `IsToolAllowed` in
+  `AgentTool.cs`) → adopted as A19; natural over GxPT's server-qualified names
+  (`files__*`), far less brittle than enumerating tools.
 - **A proven bundled suite** (explore / plan / coder / verify / general) → seeds our
   phase-9 starter agents — pure `AGENT.md` files, no new code.
 
@@ -633,13 +655,23 @@ ours — which raises confidence — while a few sharpened this design (A17–A1
   PR #154's workspace-write/command-signature grants extend it cleanly. A
   capability-object refactor is a large change for marginal gain here — noted, not
   adopted.
-- **Intra-turn read-only tool parallelism** (`Task.WhenAll`; "read-only tasks start
-  while the LLM is still streaming"). We **reject** this for GxPT: net35 has no
-  `async`/`Task`, and the tool loop is *deliberately serial* (`mcp35-toolloop-spec.md`
-  §6). We get the safe slice of the same idea at the **agent** grain — parallel
-  children (§9) with per-connection serialization (A10) — without touching the
-  per-turn loop. The principle "reads overlap, writes serialize" still holds, one
-  level up.
+- **The parallelism axis is opposite, by design.** The source shows OpenMono
+  parallelizes **tools within one turn** (`ToolDispatcher` splits calls on
+  `tool.IsReadOnly && tool.IsConcurrencySafe` → `Task.WhenAll`, writes after) but
+  dispatches **sub-agents serially** (`AgentTool` extends `ToolBase`, which defaults
+  both flags `false`, so a spawn lands in the serial write-group). GxPT can't do the
+  intra-turn part — net35 has no `async`/`Task` and the loop is *deliberately serial*
+  (`mcp35-toolloop-spec.md` §6) — so we take the **agent**-grain version instead:
+  parallel read-only *children* (§9, A9). Same governing principle ("reads parallel,
+  writes serial"), applied one level up — and our read-only fan-out is genuinely
+  *more* concurrent than OpenMono's serial agents, which the read/write gate (A9) +
+  per-connection mutex (A10) keep safe.
+- **Agents are files, not hardcoded records.** OpenMono's agents are C# records in a
+  static `BuiltInAgents.All` dictionary — type-safe and simple, but only the authors
+  can add one. We keep the **markdown-file** model (the skills/Claude-Code convention,
+  A4): bundled *and* user/project-authored, discovered at runtime, enabled per
+  conversation (§7). The cost is a frontmatter parser (already ours, A5); the gain is
+  user-extensibility, which for a skills-parity product is the whole point.
 - **Global "plan mode"** as a session state that forces read-only. Our per-agent
   `max_tier: readonly` covers the same need for a *plan* agent without a new global
   mode; a conversation-level plan toggle is a possible separate feature, not part of

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -6,8 +6,8 @@
 approval + flag-insensitive command-signature rules, see §7–§8; refined against
 OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
 detection, wildcard allowlists, and read-concurrent/write-serial fan-out, see §13 and
-A9/A17–A19; added running-agents observability — status-bar count + in-transcript
-Stop panel + per-agent cancellation — see §14 and A20)
+A9/A17–A19; added running-agents observability — in-transcript dispatch panel + a
+`Stop N agents` button (stop-all, v1) — see §14 and A20)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -94,7 +94,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
 | A19 | **Allowlist `tools` supports glob wildcards** (`files__*`, `mcp__*`, `*__read`, `*`) matched against the qualified catalog | Server-qualified names (`files__read`, `git__status`) make prefix/suffix globs natural and far less brittle than enumerating every tool — "all file tools" is `files__*`, "everything a server exposes" is `mcp__myserver__*`. The OpenMono precedent ("allow-lists support `*`, `mcp__*`"). Still intersected with parent-available and `max_tier` (A11), so a wildcard never widens past the parent or the ceiling. |
-| A20 | **Running agents are surfaced two ways — a status-bar count and an in-transcript dispatch panel — and each child has its own `RequestCancellation`** so the user can stop one agent or all of them | A fan-out the user can't see or stop is unacceptable for an unattended feature. Two surfaces mirror existing patterns: a conditional `tslAgents` status-bar pair ("Agents: 2 running", beside `tslSkills`) for an at-a-glance/jump affordance, and an `AgentActivityPanel` in the transcript (modeled on `ToolApprovalPanel`/`TranscriptContinuationPrompt`) anchored at the `dispatch_agent` call, one row per child. Per-agent stop needs per-child cancellation: each child gets its **own** `RequestCancellation` (registered with the dispatcher), so a row's **Stop** cancels just that child while the parent's master Stop cancels the whole turn (all children). A stopped child finalizes cleanly (keeps partial text, the loop's `FinishCancelled`), the others continue, and the dispatch result notes who was stopped. Full design + disclosure tiers in §14. |
+| A20 | **Running agents are surfaced in-transcript (the dispatch panel) and stopped all-at-once by repurposing the turn's Stop button to `Stop N agents`** (v1: stop-all; N includes queued) | A fan-out the user can't see or stop is unacceptable for an unattended feature. The status bar can't host an `Agents: N` count — mid-turn that region is the marquee + Stop button — and the dispatch is the *latest* thing in the transcript, so it's already on screen (no nav affordance needed). Visibility is the `AgentActivityPanel` (one row per child: glyph + slug + live status), modeled on `ToolApprovalPanel`/`TranscriptContinuationPrompt`. Control is the existing Stop button, relabeled to **`Stop N agents`** while the fan-out runs (N = all not-yet-finished children, running *and* queued, ticking down) and reverted to plain **`Stop`** when the model resumes. The children share a **group `RequestCancellation`** (distinct from the parent turn's), so `Stop N agents` cancels the fan-out — *not* the turn: each child finalizes via `FinishCancelled` (keeps partial), its result is marked `[stopped by user]`, and the parent model resumes with a **tailored wrap-up directive** (sibling of the cap wrap-up, phrased for an interrupted fan-out: summarize partials + ask how to proceed, don't silently restart). A full turn abort is then one more click on the reverted `Stop`. Per-agent stop is deferred (§12). Full design + tiers in §14. |
 
 ---
 
@@ -250,9 +250,9 @@ conversation."*
      out-of-allowlist tool is refused, the existing gate mechanism (§ `HiddenToolNames`);
    - approval policy = the parent's, **wrapped** with the agent's autonomy
      pre-authorization (§8 layer 3) and tagged with the agent name for the prompt;
-   - `Cancellation` = the child's **own** `RequestCancellation`, registered with the
-     dispatcher so a per-agent Stop (§14) cancels just this child; the parent's master
-     Stop trips every child's handle (and the parent turn) at once;
+   - `Cancellation` = the fan-out's shared **group** `RequestCancellation` (distinct
+     from the parent turn's), so the `Stop N agents` button (§14) cancels every
+     running/queued child without ending the turn; the parent then resumes to wrap up;
    - `UsageReported` → aggregated onto the parent conversation.
 3. Run the children **in parallel** on `ThreadPool` work items, bounded to
    `MaxParallelAgents` (default 3), joining on a `ManualResetEvent`/countdown.
@@ -485,13 +485,16 @@ extend that, not rework it.
 - **Approval prompts serialize naturally:** modal `Control.Invoke` to the one UI
   thread queues concurrent asks; each is agent-attributed (§8). A child that needs
   an unremembered Write blocks just that child until answered.
-- **Cancellation propagates:** the parent's `RequestCancellation` is handed to every
-  child, so the Stop button cancels the whole fan-out; each child finalizes cleanly
-  (keeps partial text, the loop's existing `FinishCancelled`).
-- **UI:** running children are surfaced by a status-bar count and an in-transcript
-  panel with per-agent Stop; their tool activity is shown to the *user* but never fed
-  to the parent *model* (A7). Full design — surfaces, stop semantics, and the
-  prompt/transcript disclosure tiers — in **§14**.
+- **Cancellation propagates:** children share a **group** `RequestCancellation`
+  (distinct from the parent turn's) that the `Stop N agents` button trips (§14, A20),
+  so the fan-out cancels without ending the turn; each child finalizes cleanly (keeps
+  partial text, the loop's existing `FinishCancelled`) and the parent resumes to wrap
+  up. The plain `Stop` (parent turn handle) still aborts the whole turn when the model
+  is the thing running.
+- **UI:** running children are shown in the in-transcript dispatch panel and stopped
+  all-at-once via the turn's Stop button, relabeled `Stop N agents` (A20); their tool
+  activity is shown to the *user* but never fed to the parent *model* (A7). Full design
+  — surface, stop semantics, and the prompt/transcript disclosure tiers — in **§14**.
 - **Cost guardrails (three bounds, the unattended-run safety net):**
   `MaxParallelAgents` bounds concurrency; each child carries its **`max_turns`**
   budget (A17) and wraps up at its cap with **no continuation prompt** (the dispatch
@@ -562,10 +565,14 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 6. **Agent slash commands** on the `ISlashCommand` framework (`/agents`,
    `/agent <slug> …`, `/agent <slug> <task>`) + per-conversation override fields on
    `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
-7. **Parallel fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution,
-   per-connection mutex, cancellation propagation, usage aggregation.
-8. **Transcript UI** — collapsible per-child agent blocks (live tool activity shown,
-   not fed to the parent), collapsing to the returned summary.
+7. **Concurrent fan-out + must-have observability** — batch `dispatch_agent`,
+   read-concurrent/write-serial execution on bounded `ThreadPool` work items,
+   per-connection mutex, usage aggregation; the **group cancellation** + the
+   `Stop N agents` button; and the tier-1 **`AgentActivityPanel`** (glyph + slug +
+   status). Observability ships *with* the fan-out — it is not a follow-on (§14 tier 1).
+8. **Transcript UI tiers 2–3** — per-row task/prompt + richer live activity (tier 2),
+   then read-only full child transcript and (optional) per-agent Stop (tier 3). Child
+   tool activity is shown to the user, never fed to the parent (A7).
 9. **Bundled agents + deploy** — ship a starter suite via an `agents/` source folder
    copied next to the exe (`AfterBuild` + setup `.vdproj`), like bundled skills. The
    OpenMono specialist set is a proven shape to seed with: **explore** (read-only
@@ -610,6 +617,10 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   Serializing write-agents avoids all of it. Revisit if a real workflow needs several
   writers at once and the disjoint-subtree contract (incl. the parent doing repo-level
   git after the join) proves clean enough to adopt.
+- **Per-agent Stop** (stop one child, leave the rest running) — v1 is **stop-all**
+  via the `Stop N agents` button (A20/§14), which covers the real need ("halt this
+  fan-out"); per-row Stop buttons + per-child cancellation handles are a later nicety
+  if it's ever wanted.
 - **Nested delegation** (an agent dispatching agents) — structurally blocked (A12);
   revisit only with a hard depth cap and cost budget if a real workflow needs it.
 - **Resumable / multi-turn agents** — today a dispatch is one-shot within the
@@ -710,72 +721,85 @@ really a 2-stage read-parallel/write-serial dispatcher).
 ## 14. Surfacing running agents (UI)
 
 A fan-out the user can neither see nor stop is unacceptable — especially for a
-feature designed to run unattended. Observability is therefore part of the design,
-built on two existing GxPT surfaces and rolled out in disclosure tiers (so the
-must-haves ship with the fan-out and the nice-to-haves follow).
+feature designed to run unattended. Observability is part of the design: a place to
+**see** the running agents and a single control to **stop** them, built on surfaces
+GxPT already has, rolled out in disclosure tiers.
 
-### Two surfaces (both reuse existing patterns)
+### Where it lives (and why *not* the status bar)
 
-**1. Status-bar count — the at-a-glance state.** The bottom `StatusStrip` already
-shows `Tools enabled: N · Skills: N · Context · Cost · Saved` as
-label/value `ToolStripStatusLabel` pairs. Add a conditional **`tslAgents` /
-`tslAgentsValue`** pair — `Agents: 2 running` — beside `Skills`, shown only while a
-dispatch is in flight (hidden at zero, like other conditional indicators). It is the
-global cue ("something is running") and a **jump affordance**: clicking it scrolls
-the transcript to the active dispatch panel. Cheap, always visible, no scrolling.
+During an in-progress turn, the status-bar region that shows `Tools enabled: N ·
+Skills: N` is **already taken over** by the marquee progress bar + Stop button, so a
+standing `Agents: N` label there is a non-starter — that space isn't available
+mid-turn. The design uses two surfaces instead:
 
-**2. In-transcript dispatch panel — the detail + controls.** Because
-`dispatch_agent` is a tool call, it already anchors a spot in the transcript. Render
-an **`AgentActivityPanel`** there (a `Panel`, modeled on `ToolApprovalPanel` /
+**1. See them — the in-transcript dispatch display.** `dispatch_agent` is a tool
+call, and a fan-out is the *most recent* thing in the transcript, so it's already on
+screen — no navigation affordance is needed. Render the dispatch as an
+**`AgentActivityPanel`** (a `Panel`, modeled on `ToolApprovalPanel` /
 `TranscriptContinuationPrompt` — same in-transcript, marshaled-from-worker-thread
-pattern, including its existing **Stop** button), titled `Agents (2 running)`, with
-**one row per child**:
+pattern), one row per child:
 
 ```
-┌ Agents (1 running · 1 done) ───────────────────────────────┐
-│ ● code-explorer    running · 4 tools · files__read …   [Stop]│
-│ ✓ test-runner      done · 31s                       [▸ View] │
+┌ Agents (1 running · 1 queued · 1 done) ─────────────────────┐
+│ ● code-explorer   running · 4 tools · files__read …          │
+│ ⏳ pr-reviewer     queued                                     │
+│ ✓ test-runner     done · 31s                                 │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-Each row carries: a **status glyph** (● running · ⏳ queued — recall write-agents
-serialize, A9 · ✓ done · ✗ failed/capped · ■ stopped), the **agent slug**, a live
-one-line **activity** (last tool / running tool count), and a per-row **Stop**
-button. On completion the row collapses to a result line; the panel persists in
-history (like any tool marker), so reopening the conversation shows
-`dispatched 2 agents` with their outcomes.
+Each row: a **status glyph** (● running · ⏳ queued — write-agents serialize, A9 · ✓
+done · ✗ failed/capped · ■ stopped), the **agent slug**, and a live one-line
+**activity** (last tool / tool count). On completion a row collapses to a result line;
+the panel persists in history (like any tool marker). **No per-row Stop button in v1**
+— stopping is all-or-nothing through surface 2 (per-agent stop is deferred, §12).
 
-### Stop semantics (the must-have control)
-- **Per-agent Stop** (a row's button) trips *that child's* `RequestCancellation`
-  (A20). The child finalizes cleanly via the loop's existing `FinishCancelled` (keeps
-  partial text), siblings keep running, and its `dispatch_agent` result section is
+**2. Stop them — the repurposed turn button.** While a dispatch is in flight the
+marquee keeps running and the **Stop button relabels to `Stop N agents`** (N = every
+not-yet-finished child, **running *and* queued**, so it reads `Stop 3 agents` and
+ticks down — `Stop 1 agent`, singular — as they complete). When the fan-out joins and
+the model resumes streaming, the button reverts to plain **`Stop`** (cancels the
+turn). The label always names exactly what a click stops *right now*; the button never
+moves, it just retargets — so no new status-bar real estate is needed.
+
+### Stop semantics (v1: stop-all)
+- **`Stop N agents` cancels the whole fan-out**, not the turn. The children share a
+  **group cancellation** (distinct from the parent turn's `RequestCancellation`); the
+  button trips it, every running/queued child finalizes via the loop's existing
+  `FinishCancelled` (keeping partial text), and each `dispatch_agent` result section is
   marked `[stopped by user]`.
-- **Master Stop** (the main Send→Stop button during a turn) trips every child's
-  handle and the parent turn at once — the whole fan-out unwinds, the existing
-  turn-level behavior.
-- Stop marshals from the UI thread to the worker via the cancellation handle the loop
-  already polls between steps; a child mid-tool-call finishes that one call then stops
-  (the graceful semantics RunTurn already documents).
+- **Control then returns to the parent model**, which wakes with the (partial,
+  stopped) results and a **tailored wrap-up directive** — a sibling of the existing
+  tool-call-cap wrap-up, but phrased for an interrupted fan-out: *"The user stopped the
+  sub-agents before they finished. Summarize what was gathered so far and ask how they
+  would like to proceed; do not silently restart them."* (Distinct wording so the model
+  never implies the agents completed.) This reuses the cap-wrap-up *mechanism* (inject
+  instruction, let the model answer), tailored in *text*.
+- **A full turn abort is then one more click:** after the model resumes, the reverted
+  `Stop` trips the parent turn's cancellation (existing behavior). Two deliberate,
+  graceful clicks beat one hard kill — and matches the user's point that while agents
+  run the main loop is in standby, so "stop the agents" is the meaningful action.
+- Stop marshals UI→worker via the group handle the children poll between steps; a child
+  mid-tool-call finishes that one call then stops (RunTurn's documented graceful stop).
 
 ### Disclosure tiers (what ships when)
 
 | Tier | Surface | Phase |
 |------|---------|-------|
-| **1 — must-have** | `tslAgents` count + `AgentActivityPanel` rows (glyph + slug) + per-agent **Stop** + master Stop | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
-| **2 — better** | each row shows the child's **task/prompt** (the `dispatch_agent` `task` string, truncated with click/hover to expand) and a live **activity line** (last tool, tool count) | §11 phase 8 |
-| **3 — best, later** | a **View transcript** link per row opening the child's full message list **read-only** (its own dispatched history) | §11 phase 8/later |
+| **1 — must-have** | `AgentActivityPanel` rows (glyph + slug + status) to **see** them + the **`Stop N agents`** button to stop all | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
+| **2 — better** | each row shows the child's **task/prompt** (the `dispatch_agent` `task` string, truncated, click/hover to expand) and a richer live **activity line** | §11 phase 8 |
+| **3 — best, later** | a **View transcript** link per row opening the child's full message list **read-only**; (and, if wanted) **per-agent Stop** | §11 phase 8/later |
 
-The task string (tier 2) is free — it's already in the dispatch args. The full
-transcript (tier 3) is a pure **UI** read of the child's message list and does **not**
-touch the parent's context (A3/A7 hold: the child's transcript is shown to the *user*,
-never fed to the parent *model*), so it costs nothing in tokens and breaks no firewall;
-it only needs the child history retained for the session (or persisted) and a
-read-only viewer (a popup, or a transient read-only tab).
+The task string (tier 2) is free — already in the dispatch args. The full transcript
+(tier 3) is a pure **UI** read of the child's message list and does **not** touch the
+parent's context (A3/A7 hold: shown to the *user*, never fed to the parent *model*), so
+it costs no tokens and breaks no firewall; it needs only the child history retained for
+the session (or persisted) and a read-only viewer (a popup, or a transient read-only
+tab).
 
 ### Threading / marshaling
 Children run on worker threads; the dispatcher reports lifecycle —
 `onAgentStart(id, slug, task)`, `onAgentActivity(id, lastTool, count)`,
 `onAgentComplete(id, outcome)` — through an `IAgentActivityUi` (the `IToolLoopUi`
 sibling), each callback marshaled to the UI thread via the existing `Control.Invoke`
-path. The panel and the `tslAgents` count subscribe; no new threading model, just more
-of the callback plumbing the tool loop already uses.
+path. The panel and the button's `Stop N agents` count subscribe; no new threading
+model, just more of the callback plumbing the tool loop already uses.

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -14,8 +14,8 @@ two commands with no per-agent management — `/toggle-agents <here|global>
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
-a *specialist* — a system prompt, a bounded tool allowlist, and an autonomy
-setting. The main agent hands a sub-agent a self-contained task; the sub-agent runs
+a *specialist* — a system prompt, a bounded tool allowlist, and a tier ceiling.
+The main agent hands a sub-agent a self-contained task; the sub-agent runs
 its **own** `McpChatOrchestrator` loop in a fresh context, does the work through
 tools, and returns **only its final answer** as the dispatching tool's result.
 
@@ -41,18 +41,17 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
   agents live under `<workdir>/.gxpt/agents/`; user-global under
   `%AppData%/GxPT/agents/`. Reuse `SkillRoots`/`SkillFrontmatter` wholesale.
 - **A sub-agent is one markdown file** — `<slug>.md` with frontmatter
-  (`name`/`description`/`tools`/`model`/`autonomy`/`max_tier`) + a body that is the
+  (`name`/`description`/`tools`/`model`/`max_tier`) + a body that is the
   agent's **system prompt**. (Skills use a `<slug>/SKILL.md` folder because they
   bundle assets; agents rarely do — A4.)
 - **Context isolation is the point.** A dispatched sub-agent runs in a *fresh*
   history (its system prompt + the parent's task string), never the parent's
   transcript, and returns only its final text. Keeps the parent's context small and
   firewalls the two conversations.
-- **Layered security, three independent layers** (§8): a static **tool allowlist**
-  in frontmatter (what it *can* reach), the existing **runtime approval gate** (the
-  backstop — Destructive still always-confirms), and a per-agent **autonomy dial**
-  (how much it prompts within those bounds). The dial can only ever *loosen* inside
-  the ceiling the other two layers set.
+- **Layered security** (§8): a static **tool allowlist** + **`max_tier` ceiling**
+  in frontmatter (what it *can* reach) and the existing **runtime approval gate** (the
+  backstop — Destructive still always-confirms, unremembered Write still prompts). (A
+  third "autonomy dial" layer was designed but **dropped** — A14 — as redundant.)
 - **Parallel by default where it's safe.** `dispatch_agent` is batch: several agents
   run on their own worker threads concurrently (the win is overlapping LLM streams),
   with per-connection serialization on shared MCP servers and a bounded fan-out.
@@ -85,7 +84,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A2 | **A sub-agent runs its own `McpChatOrchestrator` instance** on a fresh `List<ChatMessage>` seeded with `[system: body] + [user: task]` | The orchestrator is already built fresh per turn, documented un-shared/non-racy, and run on `ThreadPool` worker threads concurrently across tabs. Reusing it gives sub-agents the *entire* loop for free — streaming, reveal/skills, cancellation, usage accounting, the cap wrap-up — with zero new loop code. |
 | A3 | **Context firewall:** the sub-agent never sees the parent transcript; only its **final assistant message** returns as the `dispatch_agent` tool result | This is the whole value — token isolation (a 30-call research dig costs the parent ~one paragraph, not 30 tool results) and a clean trust boundary. Matches every mainstream sub-agent model (Claude Code's `Task`/agents). |
 | A4 | **One file per agent: `agents/<slug>.md`** (flat), not a `<slug>/` folder | Agents are a *prompt + tool list*; they almost never bundle scripts/assets (which is exactly why skills need a folder). A flat file matches the cross-tool `.claude/agents/<name>.md` convention the user already knows, and keeps the catalog a simple glob. An agent that genuinely needs bundled reference files can be paired with a skill it `open_skill`s. (Folder form deferred, A-open.) |
-| A5 | **Frontmatter is the security contract**: `tools` (allowlist), `max_tier` (ceiling), `autonomy` (dial), plus `model` — same `--- … ---` reader as skills (`SkillFrontmatter`), extended for list/enum values | net35 has no YAML parser and the repo keeps one JSON lib (D3); the hand-rolled frontmatter reader already ships for skills (S4). Extending it to parse a `[a, b]` inline list + a few enum keys is a few lines, no new dependency, authoring stays familiar. |
+| A5 | **Frontmatter is the security contract**: `tools` (allowlist), `max_tier` (ceiling), plus `model` (`autonomy` was specified here originally but later **dropped** — A14) — same `--- … ---` reader as skills (`SkillFrontmatter`), extended for list/enum values | net35 has no YAML parser and the repo keeps one JSON lib (D3); the hand-rolled frontmatter reader already ships for skills (S4). Extending it to parse a `[a, b]` inline list + a few enum keys is a few lines, no new dependency, authoring stays familiar. |
 | A6 | **`description` is the dispatch trigger** — a single "use this agent when…" line, the only thing in the always-on manifest | Identical to skills' `description` (S4): it is what the parent model reads to decide *whether* to delegate and *which* agent. Names-only-plus-one-liner keeps the manifest cheap (§4). |
 | A7 | **Only the final answer crosses back; no streaming into the parent** | Streaming a sub-agent's intermediate tool chatter into the parent re-imports the context cost the firewall exists to remove (A3). The sub-agent's live output still renders in the transcript UI (its own collapsible block, §9) so the user sees it — it just isn't fed to the *parent model*. |
 | A8 | **A dispatch is one-shot within the parent's turn** (no resumable agent sessions) | Keeps state trivial: the sub-orchestrator is a local object on a worker thread, joined before the parent's `dispatch_agent` tool result is formed. Resumable agents would need persisted sub-histories and a handle scheme — deferred until a real need appears. |
@@ -94,7 +93,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A11 | **Effective tools = `allowlist` ∩ `parent-available` ∩ `max_tier`** — a sub-agent can never exceed the parent's own reach | No privilege escalation: delegating cannot grant a capability the parent itself lacks in this workspace (e.g. a folderless turn's sub-agent still can't reach `files__*`). The allowlist *narrows*; it never widens. |
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
-| A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
+| A14 | ~~**Autonomy is a per-agent dial** (`gated` \| `auto-readonly`)~~ **— DROPPED.** Intended to grant read-only leeway, but `max_tier` + the gate already auto-allow read-only and never auto-approve write/destructive, so `gated` and `auto-readonly` were behaviorally identical (and the dial was never wired up). Removed from the frontmatter contract; the gate (A13) + `max_tier` remain the controls. |
 | A15 | **Enablement is a single feature toggle** — a per-conversation override + a global default in **`settings.json`** — default **OFF**; **no per-agent enable/disable** | Simpler than skills' per-skill ladder: a sub-agent fan-out is a coarse capability you grant or not, not something to curate agent-by-agent. The global lives in `settings.json` (via `AppSettings`, like the memory toggle) so a future **General** settings-page checkbox can bind to it; the per-conversation `here` override gives a tab its own on/off (`/toggle-agents <here\|global> <on\|off\|inherit>`, scope-first per PR #157). Default OFF because agents spawn loops + cost. Drops `/list-agents`, `/toggle-agent`, `/reset-agents`, and the `agents.json` per-agent map (§6/§7). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
@@ -139,7 +138,6 @@ description: Use to search and summarize unfamiliar code across the workspace be
 tools: [files__read, files__list, files__search]
 max_tier: readonly
 max_turns: 15
-autonomy: auto-readonly
 model: anthropic/claude-sonnet-4-6
 ---
 
@@ -170,8 +168,11 @@ find something after a genuine search, say so and name where you looked.
     child orchestrator's `maxIterations` ctor arg (A17). Omitted ⇒ the host default
     (`DefaultMaxIterations`). Lets an `explore` agent cap at ~15 while a `coder` runs
     ~30, so an unattended specialist's cost is bounded *to its job*, not the parent's.
-  - `autonomy` *(optional)* — `gated` (default) \| `auto-readonly` (§8 layer 3).
   - `model` *(optional)* — model id override; omitted ⇒ the parent turn's model.
+  - ~~`autonomy`~~ — **dropped.** It was redundant with `max_tier` + the approval
+    gate (read-only auto-allows, write/destructive prompt — for `gated` *and*
+    `auto-readonly` alike), so it never produced a distinct behavior. The key is
+    ignored if present. (Former §8 "layer 3" below is retained for history.)
 - The **body** is the agent's **system prompt** — it replaces `AgentSystemPrompt`'s
   *persona*, but the host still prepends the standing agent guidance and the
   workspace block (§5), so a sub-agent always knows it's tool-using and where it is.
@@ -199,7 +200,7 @@ lives entirely in the sub-agent's window. That asymmetry is the design.
 ### Catalog & manifest (host-native, `Services/Agents/`)
 
 ```
-Agent                 -- (slug, name, description, ToolSpec, MaxTier, Autonomy, Model, BodyPath)
+Agent                 -- (slug, name, description, ToolSpec, MaxTier, Model, BodyPath)
 AgentFrontmatter      -- extends SkillFrontmatter: inline-list + enum keys
 AgentCatalog          -- scans bundled+user+project agents/*.md, project>user>bundled
 AgentInjection        -- BuildManifestMessage(allAgents) -> the Level-1 block (all discovered agents)
@@ -376,12 +377,8 @@ narrower layer below it.
   (per call)  │ Destructive always-confirm; unremembered     │  — the backstop, unchanged
               │ Write/ReadOnly prompt; narrow remembered rules│
               └─────────────────────────────────────────────┘
-                              ▼ within which
-              ┌─────────────────────────────────────────────┐
-  Layer 3     │ AUTONOMY DIAL  (autonomy:, approved once)    │  how much it prompts
-  (per agent) │ auto-readonly ⇒ ReadOnly-tier auto-allows     │  — the LEEWAY, bounded by 1&2
-              │ for this run; Write/Destructive still gate     │
-              └─────────────────────────────────────────────┘
+  (Layer 3, an "autonomy dial", was designed but DROPPED — A14 — as redundant with
+  layers 1-2; the sections below are retained for history.)
 ```
 
 ### Layer 1 — static capability scoping (definition-time)
@@ -421,7 +418,12 @@ sub-agents:
 - **Attribution** — the prompt header shows which agent is asking
   (`code-explorer · files__read`), so the user always knows *who* wants the effect.
 
-### Layer 3 — the autonomy dial (the leeway, bounded)
+### Layer 3 — the autonomy dial (the leeway, bounded) — DROPPED (A14)
+> **Dropped.** This layer never produced a behavior distinct from layers 1-2:
+> `max_tier` + the gate already auto-allow read-only and never auto-approve
+> write/destructive, so `gated` and `auto-readonly` were identical. It was also
+> never wired up. Removed from the frontmatter contract; kept below for history.
+
 `autonomy` grants a sub-agent room to run unattended **inside** layers 1–2:
 - `gated` *(default)* — behaves exactly like the main agent: every tier prompts per
   the normal rules. Safe, but a long read-only dig prompts repeatedly.

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -2,7 +2,8 @@
 
 **Status:** Design (proposal). No implementation yet.
 **Branch:** `claude/compassionate-goldberg-5c9ccz`
-**Last updated:** 2026-06-16
+**Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
+approval + flag-insensitive command-signature rules; see §7–§8)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -309,10 +310,13 @@ agent is on.
   on the `Conversation`, round-tripped by `ConversationStore` (absent = inherit).
 
 Per-tab by construction; no `settings.json` key, no checkbox — all control is §6.
-The autonomy *grant* (A14) is separate persisted state: a remembered "this agent
-may run autonomously" lives in the approval store keyed by agent name, revocable
-from the same approvals affordance that clears tool allowlists
-(`mcp35-approval-spec.md` §5).
+The autonomy *grant* (A14) is separate persisted state in the **shared approval
+store** alongside the existing remember kinds (per-tool, command-signature/path
+rules, and the workdir-keyed workspace-write set from PR #154): a remembered "this
+agent may run autonomously" keyed by agent name, revocable from the same approvals
+affordance that clears tool allowlists and workspace-write grants
+(`mcp35-approval-spec.md` §5). Slotting it beside the workdir-write set means one
+view/clear surface governs every grant a sub-agent can inherit.
 
 ---
 
@@ -356,14 +360,25 @@ max_tier` (A11). Properties:
 
 ### Layer 2 — the runtime approval gate (per call, unchanged backstop)
 Every tool call a sub-agent makes flows through the **same** `ToolApprovalPolicy`
-with the **shared** remembered-allowlist and the parent tab's prompt host (A13):
+with the **shared** `IApprovalStore` and the parent tab's prompt host (A13). The
+policy is **per-turn `WorkingDir`-aware** (PR #154), so the child must be built with
+its `WorkingDir` set to the parent's — which it is (children share the parent's
+folder, §5) — and the `AutonomyApprovalPolicy` decorator (layer 3) forwards
+`WorkingDir` to the inner policy so the workspace fast-path below still fires for
+sub-agents:
 - **Destructive always-confirms** — a sub-agent cannot silently `files__delete` /
   `command__run` a new command / `git__push`, even if its allowlist includes them
   and the user is away (the turn simply blocks at the modal — correct, and the same
-  semantics as the main agent).
-- **Remembered rules stay narrow** — an injected attempt (a malicious tool result
-  steering the sub-agent) to run a *new* command/path won't match an existing
-  argument-scoped rule, so it still prompts. The prompt-injection backstop
+  semantics as the main agent). `files__delete` stays Destructive and is **excluded**
+  from the workspace-write grant (PR #154), so no blanket ever covers a delete.
+- **Remembered grants stay narrow / user-vetted** — sub-agents inherit exactly the
+  three remember kinds the store holds, no more: per-tool (ReadOnly/Write), the
+  argument-scoped **command-signature** and **path** rules, and the session-scoped
+  **workspace-write** set (PR #154, keyed by `server + canonical workdir`). An
+  injected attempt (a malicious tool result steering the sub-agent) to run a tool
+  whose **command signature** or path differs from any remembered grant still
+  prompts — the signature is flag-insensitive but *target*-sensitive (a different
+  file/subcommand re-prompts, PR #154), so the prompt-injection backstop
   (`mcp35-approval-spec.md` §6) covers sub-agents identically.
 - **Attribution** — the prompt header shows which agent is asking
   (`code-explorer · files__read`), so the user always knows *who* wants the effect.
@@ -385,14 +400,31 @@ Crucially:
   ceiling is `readonly` means the whole agent is unattended; on a higher-ceiling
   agent it still only auto-allows the *ReadOnly* slice.
 - **A dial never auto-approves Write/Destructive** — only an explicit, narrow
-  remembered *rule* (exact command/path) does, exactly as for the main agent. The
-  dial is a tier-scoped convenience over already-remember-eligible ReadOnly calls
-  (which the main agent could itself "always allow"), not a new bypass.
+  remembered *rule* (command signature / path) or the user's **workspace-write
+  grant** does, exactly as for the main agent. The dial is a tier-scoped convenience
+  over already-remember-eligible ReadOnly calls (which the main agent could itself
+  "always allow"), not a new bypass.
 - Implementation: the dispatcher wraps the shared `IToolApprovalPolicy` in an
   `AutonomyApprovalPolicy` that, for an `auto-readonly` child, returns `Allow`
   without a prompt **iff** the call classifies ReadOnly *and* the one-time
   agent-name grant is present; everything else delegates to the real policy. No
   change to the gate itself — a decorator at the dispatch seam.
+
+**Write-autonomy is delivered by the user's workspace grant, not a per-agent dial
+(reinforced by PR #154).** PR #154 added *"Allow all edits in this workspace,"* a
+session-scoped, workdir-keyed approval covering every Write-tier `files__` tool in
+the current folder (`files__delete` excluded). Sub-agents inherit it through the
+shared store, so a `gated`, write-capable agent's `files__write`/`files__edit` calls
+pass silently **once the user has made that workspace-level choice** — coarse
+write-autonomy that is *user-controlled at the workspace grain*, not declared by an
+agent's frontmatter. This is deliberately *not* an `auto-write` autonomy level:
+keeping write breadth a user decision (made once, visibly, revocable from the same
+approvals affordance) is safer than letting an authored agent self-grant it, and it
+composes cleanly — the per-agent dial covers the ReadOnly slice, the workspace grant
+covers Writes, and `files__delete` + `command__run` + `git__push` stay on the
+always-confirm backstop for every agent regardless. (If a real need for per-agent
+write-autonomy appears later, it would be a *fourth* remember kind gated like the
+workspace grant — noted, not adopted.)
 
 ### Why this is both safer *and* more autonomous
 - **Safer than a raw tool allowlist:** the allowlist alone (layer 1) wouldn't stop a

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -5,7 +5,8 @@
 **Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
 approval + flag-insensitive command-signature rules, see §7–§8; refined against
 OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
-detection, wildcard allowlists, and read/write-aware fan-out, see §13 and A9/A17–A19)
+detection, wildcard allowlists; and fully-concurrent agents with a file-grain
+write-conflict lock, see §9, §13, and A9/A10/A17–A20)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -81,8 +82,9 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A6 | **`description` is the dispatch trigger** — a single "use this agent when…" line, the only thing in the always-on manifest | Identical to skills' `description` (S4): it is what the parent model reads to decide *whether* to delegate and *which* agent. Names-only-plus-one-liner keeps the manifest cheap (§4). |
 | A7 | **Only the final answer crosses back; no streaming into the parent** | Streaming a sub-agent's intermediate tool chatter into the parent re-imports the context cost the firewall exists to remove (A3). The sub-agent's live output still renders in the transcript UI (its own collapsible block, §9) so the user sees it — it just isn't fed to the *parent model*. |
 | A8 | **A dispatch is one-shot within the parent's turn** (no resumable agent sessions) | Keeps state trivial: the sub-orchestrator is a local object on a worker thread, joined before the parent's `dispatch_agent` tool result is formed. Resumable agents would need persisted sub-histories and a handle scheme — deferred until a real need appears. |
-| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`); a batch runs **in parallel** when every named agent is **read-only** (`max_tier: readonly`), else **serially** | The parent fans out in one tool call; the host joins. Parallelism overlaps the expensive part (LLM streams). But two *write*-capable children racing the same workspace can corrupt it logically even with per-connection transport serialization (A10), so a batch with any writer serializes — "reads parallel, writes serial" (OpenMono's intra-turn tool rule) lifted to the **agent** grain. (Per the OpenMono source, `AgentTool` defaults non-concurrency-safe and dispatches **serially**; our parallel read-only fan-out is a deliberate, bounded extension, not a port.) |
-| A10 | **Shared MCP server connections are serialized per-connection** under a lock; **revealed-tool state is per-sub-agent** | `McpServerConnection` correlates by request id and the server SDK dispatches serially; concurrent `CallTool` on one connection is unsafe, so a per-connection mutex serializes tool I/O while model streams still overlap. Each sub-agent owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, already the per-tab rule). |
+| A9 | **`dispatch_agent` is batch** (`agents: [{name, task}, …]`); **all children run concurrently** (bounded by `MaxParallelAgents`), **write-capable agents included** | The parent fans out in one tool call; the host joins. Agents are independent workers — serializing them because one *can* write throws away the whole point (the user's explicit requirement). Concurrency is real for every tier; the only thing that must not happen is two agents mutating the **same file** at once, and that is prevented at the file grain by the write-conflict model (A20), **not** by blocking write-agents. (This deliberately goes *beyond* OpenMono, whose `AgentTool` dispatches sub-agents serially — see §13.) |
+| A10 | **Each concurrent child gets its own connection to workdir-scoped servers** (files/git/command); **revealed-tool state is per-sub-agent** | `McpServerConnection` is single-flight (id-correlated, serial dispatch), so a *shared* connection would funnel all children's tool I/O through one pipe — fine for the LLM-overlap win, but it needlessly serializes independent work. Giving each child its own scoped-server connection (≤ `MaxParallelAgents`, so ≤ ~3 extra stdio processes) lets different-file work truly overlap; cross-agent safety then rides the host-level lock (A20), not the transport. Each sub-agent also owns its own `RevealedToolNames` list (fresh context), so no agent churns another's tools array (prompt-cache safety, the per-tab rule). |
+| A20 | **Write-conflict model: a host-level lock manager, acquired per tool call, never held across calls** (deadlock-free). Path-scoped writes (`files__write/edit/delete`) lock the **canonical target path**; non-path mutators (`git__*` writes, `command__run`) lock the **workspace root**; ReadOnly tools never lock | This is what makes "concurrent agents, but not on the same file" precise. Two `files__edit` calls to *different* files run in parallel; two to the *same* canonical path serialize (the second waits). Coarse mutators with no single path (git index, arbitrary shell) can't safely interleave at all, so they take the workspace-root key — serializing repo/shell mutations against each other and against file writes in that workspace, while readers and different-workspace agents proceed. Per-call acquisition (release the instant the call returns) means no agent ever holds one lock while waiting on another, so the fan-out cannot deadlock. The lock key reuses the canonical-path normalization the approval store already uses (PR #154 / `PathSandbox`), so locks and remembered approvals agree on file identity. |
 | A11 | **Effective tools = `allowlist` ∩ `parent-available` ∩ `max_tier`** — a sub-agent can never exceed the parent's own reach | No privilege escalation: delegating cannot grant a capability the parent itself lacks in this workspace (e.g. a folderless turn's sub-agent still can't reach `files__*`). The allowlist *narrows*; it never widens. |
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
@@ -457,23 +459,26 @@ GxPT already runs each tab's turn on a `ThreadPool` worker thread, with the
 orchestrator built fresh and explicitly documented un-shared. Parallel sub-agents
 extend that, not rework it.
 
-- **Fan-out, read/write-aware (A9):** a batch where **every** named agent is
-  read-only (`max_tier: readonly`) queues N `ThreadPool` work items (bounded to
-  `MaxParallelAgents`, default 3 — a named constant), each running a child `RunTurn`
-  to completion, joined on a countdown before the tool result forms. A batch that
-  includes **any write-capable agent runs serially** instead — two writers racing the
-  same workspace can produce a logically inconsistent tree even when individual calls
-  are transport-serialized (A10), so concurrency is restricted to the provably-safe
-  read-only case (OpenMono's "reads parallel, writes serial," at the agent grain).
-  Either way the parent worker thread blocks on the join — the same "turn pauses,
-  user present-or-away" model the gate already uses.
-- **The win is overlapping LLM streams**, the turn's real latency. Tool I/O to a
-  **shared** MCP server connection is *also* serialized by a **per-connection mutex**
-  (A10): `McpServerConnection` correlates by id and the server SDK dispatches
-  serially, so concurrent `CallTool` on one connection is unsafe — the lock makes two
-  read-only agents take turns at the file server while their *model* calls still run
-  concurrently. (The mutex protects *transport*; the A9 read-only rule protects
-  *workspace logical consistency* — two distinct concerns, both needed.)
+- **Fan-out (A9): every child runs concurrently, write agents included.** A batch
+  queues N `ThreadPool` work items (bounded to `MaxParallelAgents`, default 3 — a
+  named constant), each running a child `RunTurn` to completion, joined on a countdown
+  before the tool result forms. There is **no tier-based serialization** — a coder
+  and a reviewer fan out together; the only constraint is that two agents can't mutate
+  the *same file* at once (A20), which is enforced per call, not by holding back the
+  agent. The parent worker thread blocks on the join — the same "turn pauses, user
+  present-or-away" model the gate already uses.
+- **Two wins, two grains.** Overlapping **LLM streams** is the big latency win and is
+  unconditional (independent, no shared state). Overlapping **tool I/O** comes from
+  giving each child its own connection to the workdir-scoped servers (A10), so
+  different-file reads/writes don't queue behind one pipe.
+- **Write-conflict safety is the host lock manager (A20), not transport.** Each
+  path-scoped write/edit/delete acquires the **canonical-path** lock for the duration
+  of that one call; different files never block each other, the same file serializes,
+  and per-call acquisition (no lock held across calls) makes deadlock impossible.
+  Repo/shell mutators (`git__*` writes, `command__run`) take the **workspace-root**
+  key, since their blast radius isn't a single path and git's own index tolerates no
+  concurrency. Readers never lock. So "agents run concurrently, but never edit the
+  same file simultaneously" holds exactly, with maximum overlap everywhere else.
 - **Prompt caching is unaffected:** each child owns a *fresh* `RevealedToolNames`
   and a fresh transcript, so no child churns another's tools array (the per-tab
   invariant, generalized).
@@ -493,7 +498,8 @@ extend that, not rework it.
   **periodic doom-loop detection** (A18) aborts a child stuck in a repeating *cycle*
   (not just a single repeated call) rather than draining the whole budget. Together these make an
   `auto-readonly`, write-granted fan-out safe to leave running: bounded breadth
-  (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop), and
+  (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop),
+  bounded concurrency (`MaxParallelAgents`) with same-file races impossible (A20), and
   the always-confirm gate on anything destructive.
 
 ---
@@ -515,8 +521,13 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   period 1–4 over the recent `name:normalized-args` signature window (≥3× for period 1,
   ≥2× for longer — A18) aborts with a wrap-up, catching A→B→A→B oscillations and not
   just A→A→A; the abort returns as content, never a throw.
-- **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
-  a batch with any write-capable agent serializes (A9), asserted by execution order.
+- **Concurrency + write-conflict model (A9/A20)** — a mixed read/write batch runs all
+  children concurrently (asserted by overlapping execution); two `files__edit` calls to
+  **different** paths proceed in parallel while two to the **same** canonical path
+  serialize (one waits); `git__*`-write / `command__run` calls serialize on the
+  workspace-root key; ReadOnly calls never block; per-call lock release ⇒ no deadlock
+  even with crossed acquisition order; lock keys match the approval store's canonical
+  path identity.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
   list/toggle/reset across here/global; conversation override vs. `agents.json`;
   default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
@@ -556,8 +567,10 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 6. **Agent slash commands** on the `ISlashCommand` framework (`/agents`,
    `/agent <slug> …`, `/agent <slug> <task>`) + per-conversation override fields on
    `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
-7. **Parallel fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution,
-   per-connection mutex, cancellation propagation, usage aggregation.
+7. **Concurrent fan-out** — batch `dispatch_agent`, bounded `ThreadPool` execution of
+   all children (write agents included), per-agent scoped-server connections (A10),
+   the host **write-conflict lock manager** (A20: canonical-path + workspace-root keys,
+   per-call), cancellation propagation, usage aggregation.
 8. **Transcript UI** — collapsible per-child agent blocks (live tool activity shown,
    not fed to the parent), collapsing to the returned summary.
 9. **Bundled agents + deploy** — ship a starter suite via an `agents/` source folder
@@ -586,6 +599,19 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   ceremony while Destructive stays explicit.
 - **`MaxParallelAgents`** — *lean 3* (named constant, tunable), balancing latency
   win against API/thread pressure on XP-era hardware.
+- **Per-agent scoped-server connections (A10)** — *lean yes*: each concurrent child
+  gets its own files/git/command connection (≤ `MaxParallelAgents` extra stdio
+  processes) so different-file tool I/O overlaps. The cheaper alternative — one shared
+  connection, tool calls serialized on it (only LLM overlaps) — stays the fallback if
+  process count proves heavy on XP; the A20 lock is correct either way (it just has
+  less to do when the transport already serializes).
+- **Write-conflict lock granularity (A20)** — *lean canonical-file + workspace-root*.
+  A middle option (directory-boundary locks) was considered but rejected: it would
+  block edits to unrelated files in a busy folder. File-grain maximizes overlap; the
+  workspace-root key is reserved for mutators with no single path (git/shell). Residual
+  *logical* conflict (two agents editing the same file across separate calls based on
+  stale reads) is accepted — locks are per-call, not per-turn transactions — and is
+  rare by construction, since the dispatcher hands children **disjoint** tasks.
 - **Explicit `/agent <slug> <task>` routing** — *lean route-through-the-model*
   (a real gated `dispatch_agent` call) rather than a direct host spawn, so there's
   exactly one spawning path and it's always gated/recorded.
@@ -655,17 +681,19 @@ really a 2-stage read-parallel/write-serial dispatcher).
   PR #154's workspace-write/command-signature grants extend it cleanly. A
   capability-object refactor is a large change for marginal gain here — noted, not
   adopted.
-- **The parallelism axis is opposite, by design.** The source shows OpenMono
-  parallelizes **tools within one turn** (`ToolDispatcher` splits calls on
-  `tool.IsReadOnly && tool.IsConcurrencySafe` → `Task.WhenAll`, writes after) but
-  dispatches **sub-agents serially** (`AgentTool` extends `ToolBase`, which defaults
-  both flags `false`, so a spawn lands in the serial write-group). GxPT can't do the
-  intra-turn part — net35 has no `async`/`Task` and the loop is *deliberately serial*
-  (`mcp35-toolloop-spec.md` §6) — so we take the **agent**-grain version instead:
-  parallel read-only *children* (§9, A9). Same governing principle ("reads parallel,
-  writes serial"), applied one level up — and our read-only fan-out is genuinely
-  *more* concurrent than OpenMono's serial agents, which the read/write gate (A9) +
-  per-connection mutex (A10) keep safe.
+- **We run sub-agents concurrently — including write agents — where OpenMono runs
+  them serially.** The source shows OpenMono parallelizes **tools within one turn**
+  (`ToolDispatcher` splits calls on `tool.IsReadOnly && tool.IsConcurrencySafe` →
+  `Task.WhenAll`, writes after) but dispatches **sub-agents serially** (`AgentTool`
+  extends `ToolBase`, which defaults both flags `false`, so a spawn lands in the serial
+  write-group). GxPT can't do the intra-turn tool part — net35 has no `async`/`Task`
+  and the loop is *deliberately serial* (`mcp35-toolloop-spec.md` §6) — but it can and
+  **does** run the *agents* concurrently at every tier (§9, A9), which is the higher-
+  value axis here. We borrow OpenMono's "writes must not collide" instinct but enforce
+  it at the **file grain** (A20: a per-canonical-path lock, with a workspace-root key
+  for git/shell mutators) rather than by serializing whole write-agents — so two coders
+  on different files overlap fully, two on the same file take turns, and nothing
+  deadlocks (per-call locks). This is a deliberate, supported divergence, not a port.
 - **Agents are files, not hardcoded records.** OpenMono's agents are C# records in a
   static `BuiltInAgents.All` dictionary — type-safe and simple, but only the authors
   can add one. We keep the **markdown-file** model (the skills/Claude-Code convention,

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -5,7 +5,9 @@
 **Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
 approval + flag-insensitive command-signature rules, see §7–§8; refined against
 OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-loop
-detection, wildcard allowlists, and read/write-aware fan-out, see §13 and A9/A17–A19)
+detection, wildcard allowlists, and read-concurrent/write-serial fan-out, see §13 and
+A9/A17–A19; added running-agents observability — status-bar count + in-transcript
+Stop panel + per-agent cancellation — see §14 and A20)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -92,6 +94,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
 | A19 | **Allowlist `tools` supports glob wildcards** (`files__*`, `mcp__*`, `*__read`, `*`) matched against the qualified catalog | Server-qualified names (`files__read`, `git__status`) make prefix/suffix globs natural and far less brittle than enumerating every tool — "all file tools" is `files__*`, "everything a server exposes" is `mcp__myserver__*`. The OpenMono precedent ("allow-lists support `*`, `mcp__*`"). Still intersected with parent-available and `max_tier` (A11), so a wildcard never widens past the parent or the ceiling. |
+| A20 | **Running agents are surfaced two ways — a status-bar count and an in-transcript dispatch panel — and each child has its own `RequestCancellation`** so the user can stop one agent or all of them | A fan-out the user can't see or stop is unacceptable for an unattended feature. Two surfaces mirror existing patterns: a conditional `tslAgents` status-bar pair ("Agents: 2 running", beside `tslSkills`) for an at-a-glance/jump affordance, and an `AgentActivityPanel` in the transcript (modeled on `ToolApprovalPanel`/`TranscriptContinuationPrompt`) anchored at the `dispatch_agent` call, one row per child. Per-agent stop needs per-child cancellation: each child gets its **own** `RequestCancellation` (registered with the dispatcher), so a row's **Stop** cancels just that child while the parent's master Stop cancels the whole turn (all children). A stopped child finalizes cleanly (keeps partial text, the loop's `FinishCancelled`), the others continue, and the dispatch result notes who was stopped. Full design + disclosure tiers in §14. |
 
 ---
 
@@ -247,7 +250,9 @@ conversation."*
      out-of-allowlist tool is refused, the existing gate mechanism (§ `HiddenToolNames`);
    - approval policy = the parent's, **wrapped** with the agent's autonomy
      pre-authorization (§8 layer 3) and tagged with the agent name for the prompt;
-   - `Cancellation` = the parent's handle (parent Stop cancels all children, §9);
+   - `Cancellation` = the child's **own** `RequestCancellation`, registered with the
+     dispatcher so a per-agent Stop (§14) cancels just this child; the parent's master
+     Stop trips every child's handle (and the parent turn) at once;
    - `UsageReported` → aggregated onto the parent conversation.
 3. Run the children **in parallel** on `ThreadPool` work items, bounded to
    `MaxParallelAgents` (default 3), joining on a `ManualResetEvent`/countdown.
@@ -483,9 +488,10 @@ extend that, not rework it.
 - **Cancellation propagates:** the parent's `RequestCancellation` is handed to every
   child, so the Stop button cancels the whole fan-out; each child finalizes cleanly
   (keeps partial text, the loop's existing `FinishCancelled`).
-- **UI:** each running child renders as a collapsible transcript block ("▸ Code
-  Explorer — running… 3 tools"), its tool calls/results shown but *not* fed to the
-  parent model (A7). On completion the block collapses to the returned summary.
+- **UI:** running children are surfaced by a status-bar count and an in-transcript
+  panel with per-agent Stop; their tool activity is shown to the *user* but never fed
+  to the parent *model* (A7). Full design — surfaces, stop semantics, and the
+  prompt/transcript disclosure tiers — in **§14**.
 - **Cost guardrails (three bounds, the unattended-run safety net):**
   `MaxParallelAgents` bounds concurrency; each child carries its **`max_turns`**
   budget (A17) and wraps up at its cap with **no continuation prompt** (the dispatch
@@ -698,3 +704,78 @@ really a 2-stage read-parallel/write-serial dispatcher).
 - **Artifact storage for large tool results** (>10 KB off to disk, referenced by
   handle) to keep a child's context lean — orthogonal to sub-agents but a clean
   companion to `FormatResult`'s existing length cap.
+
+---
+
+## 14. Surfacing running agents (UI)
+
+A fan-out the user can neither see nor stop is unacceptable — especially for a
+feature designed to run unattended. Observability is therefore part of the design,
+built on two existing GxPT surfaces and rolled out in disclosure tiers (so the
+must-haves ship with the fan-out and the nice-to-haves follow).
+
+### Two surfaces (both reuse existing patterns)
+
+**1. Status-bar count — the at-a-glance state.** The bottom `StatusStrip` already
+shows `Tools enabled: N · Skills: N · Context · Cost · Saved` as
+label/value `ToolStripStatusLabel` pairs. Add a conditional **`tslAgents` /
+`tslAgentsValue`** pair — `Agents: 2 running` — beside `Skills`, shown only while a
+dispatch is in flight (hidden at zero, like other conditional indicators). It is the
+global cue ("something is running") and a **jump affordance**: clicking it scrolls
+the transcript to the active dispatch panel. Cheap, always visible, no scrolling.
+
+**2. In-transcript dispatch panel — the detail + controls.** Because
+`dispatch_agent` is a tool call, it already anchors a spot in the transcript. Render
+an **`AgentActivityPanel`** there (a `Panel`, modeled on `ToolApprovalPanel` /
+`TranscriptContinuationPrompt` — same in-transcript, marshaled-from-worker-thread
+pattern, including its existing **Stop** button), titled `Agents (2 running)`, with
+**one row per child**:
+
+```
+┌ Agents (1 running · 1 done) ───────────────────────────────┐
+│ ● code-explorer    running · 4 tools · files__read …   [Stop]│
+│ ✓ test-runner      done · 31s                       [▸ View] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Each row carries: a **status glyph** (● running · ⏳ queued — recall write-agents
+serialize, A9 · ✓ done · ✗ failed/capped · ■ stopped), the **agent slug**, a live
+one-line **activity** (last tool / running tool count), and a per-row **Stop**
+button. On completion the row collapses to a result line; the panel persists in
+history (like any tool marker), so reopening the conversation shows
+`dispatched 2 agents` with their outcomes.
+
+### Stop semantics (the must-have control)
+- **Per-agent Stop** (a row's button) trips *that child's* `RequestCancellation`
+  (A20). The child finalizes cleanly via the loop's existing `FinishCancelled` (keeps
+  partial text), siblings keep running, and its `dispatch_agent` result section is
+  marked `[stopped by user]`.
+- **Master Stop** (the main Send→Stop button during a turn) trips every child's
+  handle and the parent turn at once — the whole fan-out unwinds, the existing
+  turn-level behavior.
+- Stop marshals from the UI thread to the worker via the cancellation handle the loop
+  already polls between steps; a child mid-tool-call finishes that one call then stops
+  (the graceful semantics RunTurn already documents).
+
+### Disclosure tiers (what ships when)
+
+| Tier | Surface | Phase |
+|------|---------|-------|
+| **1 — must-have** | `tslAgents` count + `AgentActivityPanel` rows (glyph + slug) + per-agent **Stop** + master Stop | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
+| **2 — better** | each row shows the child's **task/prompt** (the `dispatch_agent` `task` string, truncated with click/hover to expand) and a live **activity line** (last tool, tool count) | §11 phase 8 |
+| **3 — best, later** | a **View transcript** link per row opening the child's full message list **read-only** (its own dispatched history) | §11 phase 8/later |
+
+The task string (tier 2) is free — it's already in the dispatch args. The full
+transcript (tier 3) is a pure **UI** read of the child's message list and does **not**
+touch the parent's context (A3/A7 hold: the child's transcript is shown to the *user*,
+never fed to the parent *model*), so it costs nothing in tokens and breaks no firewall;
+it only needs the child history retained for the session (or persisted) and a
+read-only viewer (a popup, or a transient read-only tab).
+
+### Threading / marshaling
+Children run on worker threads; the dispatcher reports lifecycle —
+`onAgentStart(id, slug, task)`, `onAgentActivity(id, lastTool, count)`,
+`onAgentComplete(id, outcome)` — through an `IAgentActivityUi` (the `IToolLoopUi`
+sibling), each callback marshaled to the UI thread via the existing `Control.Invoke`
+path. The panel and the `tslAgents` count subscribe; no new threading model, just more
+of the callback plumbing the tool loop already uses.

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -8,9 +8,9 @@ OpenMonoAgent.ai prior art read **from source** — `max_turns`, periodic doom-l
 detection, wildcard allowlists, and read-concurrent/write-serial fan-out, see §13 and
 A9/A17–A19; added running-agents observability — in-transcript dispatch panel + a
 `Stop N agents` button (stop-all, v1) — see §14 and A20; aligned slash commands to
-PRs #156/#157's scope-first hyphen-prefixed surface — `/list-agents`,
-`/toggle-agents <here|global> <on|off|inherit>`, `/toggle-agent`, `/reset-agents`,
-`/dispatch-agent` — see §6)
+PRs #156/#157's scope-first hyphen-prefixed style; then simplified the agent surface to
+two commands with no per-agent management — `/toggle-agents <here|global>
+<on|off|inherit>` (global default in settings.json) and `/dispatch-agent` — see §6/§7)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -59,16 +59,17 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 - **Host-native dispatch, no new server.** `dispatch_agent` is a host-synthesized
   meta-tool handled in the orchestrator — the skills `open_skill` precedent (S1):
   spawning an in-process loop is not a child process, so it needs no `…McpServer`.
-- **Slash commands, no settings-page UI** — `/list-agents`, `/toggle-agents`,
-  `/toggle-agent <slug> …`, `/reset-agents`, and an explicit `/dispatch-agent <slug>
-  <task>`, on the existing `ISlashCommand` framework, scoped per conversation, in the
-  scope-first hyphen-prefixed style PRs #156/#157 set for skills (`/list-skills`,
-  `/toggle-skill <slug> <here|global> <on|off|inherit>`, `/reset-skills`, …).
+- **A single feature toggle, two commands.** `/toggle-agents <here|global>
+  <on|off|inherit>` (enable/disable the whole feature; global default in `settings.json`,
+  bindable to a future settings-page checkbox) and `/dispatch-agent <slug> <task>` — on
+  the existing `ISlashCommand` framework, PR #156/#157 style. **No per-agent
+  enable/disable**: when the feature is on, every discovered agent is dispatchable.
 
 ### Non-goals
 - **Nested fan-out.** A sub-agent never gets `dispatch_agent` in its tool set — no
   agent-spawns-agent (fork-bomb guard, A12). One level deep, always.
-- A marketplace / remote agent install; a per-agent settings-page UI; streaming a
+- A marketplace / remote agent install; **any per-agent management** (per-agent
+  enable/disable, listing, or UI — the feature is a single on/off, §6); streaming a
   sub-agent's *partial* output into the parent's context (only the final answer
   returns — A7).
 - Cross-turn agent persistence (a dispatched agent is one-shot: it runs to
@@ -94,7 +95,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A12 | **`dispatch_agent` is never in a sub-agent's tool set** | One level of delegation only — structurally prevents recursive fan-out / fork bombs and unbounded cost. Enforced by the host (the dispatcher strips it from every child's exposed defs), not by author discipline. |
 | A13 | **The approval gate is fully in force for every sub-agent tool call**, with the **shared** remembered-allowlist and per-tab prompt host | The sub-agent isn't a trust upgrade: a Destructive call it makes still always-confirms, an unremembered Write still prompts. Prompts marshal to the parent tab's `ToolApprovalPanel` (the existing `Control.Invoke` path), attributed to the agent. This is the backstop that makes autonomy safe (§8, layer 2). |
 | A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
-| A15 | **Enablement reuses the skills tri-state ladder** (`/list-agents`, `/toggle-agents <here\|global> <on\|off\|inherit>`, `/toggle-agent <slug> …`, `/reset-agents <here\|global>`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). Command surface follows PRs #156/#157 (scope-first, required; `inherit` unsets a layer; the global feature bool has no inherit — see §6/§7). |
+| A15 | **Enablement is a single feature toggle** — a per-conversation override + a global default in **`settings.json`** — default **OFF**; **no per-agent enable/disable** | Simpler than skills' per-skill ladder: a sub-agent fan-out is a coarse capability you grant or not, not something to curate agent-by-agent. The global lives in `settings.json` (via `AppSettings`, like the memory toggle) so a future **General** settings-page checkbox can bind to it; the per-conversation `here` override gives a tab its own on/off (`/toggle-agents <here\|global> <on\|off\|inherit>`, scope-first per PR #157). Default OFF because agents spawn loops + cost. Drops `/list-agents`, `/toggle-agent`, `/reset-agents`, and the `agents.json` per-agent map (§6/§7). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
 | A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (from source: Explore/Plan 100, Verify 150, general 200, Coder 300 — far higher than its docs imply). Two implications: bounding an explore agent below a coder is the right grain, **and** our `DefaultMaxIterations = 25` is tuned for *interactive* turns (the continuation prompt is its release valve) — an **unattended** child has no continuation prompt, so write-capable bundled agents should set a generous `max_turns`, with doom-loop (A18) + cap-wrap-up as the backstops. |
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
@@ -182,7 +183,7 @@ find something after a genuine search, say so and name where you looked.
 
 | Level | Content | When it enters context | Cost |
 |-------|---------|------------------------|------|
-| 1 | `slug` + `description` (the **agents manifest**) | every request, while the agents feature is enabled for the conversation **and** at least one agent is on | tiny |
+| 1 | `slug` + `description` (the **agents manifest**, all discovered agents) | every request, while the agents feature is enabled for the conversation | tiny |
 | 2 | `dispatch_agent` meta-tool def | same condition (exposed alongside the manifest) | tiny |
 | 3 | the agent **body** (its system prompt) + its **work** | only inside the *sub-agent's* context when dispatched — **never** in the parent | paid by the sub-agent, isolated |
 | 4 | the agent's **final answer** | returns to the parent as the `dispatch_agent` tool result | one summary |
@@ -201,8 +202,8 @@ lives entirely in the sub-agent's window. That asymmetry is the design.
 Agent                 -- (slug, name, description, ToolSpec, MaxTier, Autonomy, Model, BodyPath)
 AgentFrontmatter      -- extends SkillFrontmatter: inline-list + enum keys
 AgentCatalog          -- scans bundled+user+project agents/*.md, project>user>bundled
-AgentInjection        -- BuildManifestMessage(enabledAgents) -> the Level-1 block
-AgentResolve          -- EnabledAgents(...) over the tri-state ladder (reuses SkillResolve shape)
+AgentInjection        -- BuildManifestMessage(allAgents) -> the Level-1 block (all discovered agents)
+AgentEnablement       -- FeatureEnabled(conv, settings): conversation override else settings.json default
 AgentToolResolver      -- effective tool defs for an agent = allowlist ∩ parent-available ∩ max_tier
 ```
 
@@ -239,8 +240,9 @@ agents list) and a complete task description — the agent does not see this
 conversation."*
 
 **On call, the `AgentDispatcher` (host):**
-1. Resolve each `name` → enabled `Agent` (unknown/disabled ⇒ that entry returns a
-   short note, the rest still run — the `open_skill` tolerance, S-style).
+1. Resolve each `name` → a discovered `Agent` (unknown ⇒ that entry returns a short
+   note, the rest still run — the `open_skill` tolerance, S-style). No per-agent gate:
+   any discovered agent resolves while the feature is on.
 2. For each entry, build a **child** `McpChatOrchestrator`:
    - history = `[ system: standing-guidance + workspace-block + agent.Body ]`
      then `[ user: task ]`;
@@ -286,37 +288,34 @@ that — it only constructs and joins.
 
 ## 6. Slash commands (on the existing `ISlashCommand` framework)
 
-Register in an `AgentCommands.BuiltIns()` beside the skills/built-ins, following the
-**scope-first, hyphen-prefixed** surface PRs #156/#157 established for skills
-(`/list-skills`, `/toggle-skills`, `/toggle-skill`, `/reset-skills`, `/use-skill`).
-Arg hints use the #157 convention — `<…>` required, `[…]` optional. `Client` kind (run
-locally, no LLM send) except `/dispatch-agent`, which sends.
+**Two commands, no per-agent management.** Register in an `AgentCommands.BuiltIns()`
+beside the skills/built-ins, following PRs #156/#157's hyphen-prefixed, scope-first
+style (arg hints: `<…>` required, `[…]` optional). `/toggle-agents` is `Client` (local,
+no LLM send); `/dispatch-agent` sends.
 
 | Command | Kind | Effect |
 |---------|------|--------|
-| `/list-agents` | Client | List agents with effective on/off state, the rule that decided it, + source (bundled/user/project). No args. |
-| `/toggle-agents <here\|global> <on\|off\|inherit>` | Client | Set the **whole feature** at that scope. **Scope first, both required.** `global` is the most-upstream layer (a plain bool) so it takes only `on\|off` — no `inherit`. |
-| `/toggle-agent <slug> <here\|global> <on\|off\|inherit>` | Client | Set **one agent** at that scope; bare `/toggle-agent <slug>` quick-toggles for this conversation. |
-| `/reset-agents <here\|global>` | Client | Bulk-clear at that scope: `here` drops the conversation's feature on/off **and** all its per-agent overrides; `global` clears only the per-agent global overrides (the on/off master is changed solely by `/toggle-agents global on\|off`). |
+| `/toggle-agents <here\|global> <on\|off\|inherit>` | Client | Enable/disable the **whole agents feature** at that scope. Scope first, both required. `here` sets a per-conversation override (`on\|off\|inherit`); `global` sets the app-wide default in **`settings.json`** and is a plain bool — `on\|off` only, no `inherit`. |
 | `/dispatch-agent <slug> <task…>` | Send | **Explicit dispatch**: sends a hidden `Dispatch the <slug> agent with this task: <task>` so the model issues a real `dispatch_agent` call (works regardless of enablement — the `/use-skill` analogue). |
 
-- **Scope-first and required (PR #157).** Scope (`here`/`global`) is the **first**
-  argument and **mandatory** — not an optional default-`here` suffix. `inherit`
-  (which replaces the old `reset` verb) unsets a *single* layer so it falls through to
-  the one upstream; the **global feature toggle has no `inherit`** (the master bool is
-  always on/off), so bulk-clearing global per-agent settings is `/reset-agents global`.
-- **Naming + discovery (PR #156).** A verb-first, hyphen-prefixed name per command,
-  with listing split from toggling (`/list-agents` vs. `/toggle-agents`). The agent
-  *invocation* verb is `dispatch` (matching the `dispatch_agent` tool and
-  `AgentDispatcher`), where skills use `use`. `SlashMatch.HyphenPrefix` makes `/agent`
-  match `list-agents` / `toggle-agents` / `toggle-agent` / `reset-agents` /
-  `dispatch-agent`, and `/dispatch` narrow to `dispatch-agent` — the registry's
-  `Match()` already does this, so agent commands inherit it free.
-- **Scope-then-verb autocomplete.** The completer offers the **scope first**, then only
-  the verbs that scope accepts (`global` feature → `on|off`; every tri-state layer adds
-  `inherit`), and completes slugs (annotated with state) for `/toggle-agent` /
-  `/dispatch-agent` — via `IArgumentCompleter` + the shared `SkillCommandShared.AddMatching`
-  helper (#156), the exact pattern the skill commands use.
+- **No per-agent enable/disable.** Agents are not individually toggled, listed, or
+  reset — the feature is simply on or off (per conversation or globally), and when on,
+  **every discovered agent is dispatchable**. This is the deliberate simplification over
+  skills (which keep per-skill control): it drops `/list-agents`, `/toggle-agent`, and
+  `/reset-agents` and the entire per-agent override layer.
+- **Global lives in `settings.json` (a future settings-page checkbox).** Unlike skills'
+  dedicated `skills.json`, the agents global default is a `settings.json` bool via
+  `AppSettings` (like the memory toggle), so a future **General** settings-page checkbox
+  binds to the same value. `/toggle-agents global on|off` writes it; `here` writes a
+  per-conversation override; `inherit` (here only) clears that override so the
+  conversation follows the global default. The global bool has no `inherit`.
+- **Discovery via `SlashMatch.HyphenPrefix` (PR #156).** `/agent` matches `toggle-agents`
+  and `dispatch-agent`; `/dispatch` narrows to `dispatch-agent`. The invocation verb is
+  `dispatch` (matching the `dispatch_agent` tool / `AgentDispatcher`), where skills use
+  `use`.
+- **Autocomplete:** scope first, then `on|off|inherit` (`global` → `on|off`), and slugs
+  for `/dispatch-agent` — via `IArgumentCompleter` + the shared
+  `SkillCommandShared.AddMatching` helper (#156).
 - Explicit `/dispatch-agent <slug> <task>` routes through the model (not a direct host
   spawn) so the dispatch is a normal, gated `dispatch_agent` tool call with a
   transcript record and approval — no second, ungated entry point into spawning.
@@ -325,38 +324,30 @@ locally, no LLM send) except `/dispatch-agent`, which sends.
 
 ## 7. Enablement & persistence
 
-Reuses the skills 2×2 (all-agents / one-agent × global / this-conversation),
-resolved by **most-specific-wins**, with **one deliberate difference: the feature
-default is OFF** (A15). An agent is in play only when the feature is on *and* that
-agent is on.
+A **single feature toggle** — on/off — at two layers: a per-conversation override and a
+global default. No per-agent state. Default **OFF** (A15).
 
-### Resolution ladder (effective state of agent X in conversation C)
+### Resolution (effective state in conversation C)
 | # | Rule | Source |
 |---|------|--------|
-| 1 | this agent, **here** | `Conversation.AgentOverrides[X]` |
-| 2 | this agent, **global** | `agents.json` `agents[X]` |
-| 3 | all agents, **here** | `Conversation.AgentsFeatureOff` |
-| 4 | all agents, **global** | `agents.json` `feature_off` (a plain bool — the most-upstream layer, no inherit) |
-| 5 | **default: feature OFF** | — |
+| 1 | this conversation (if set) | `Conversation.AgentsEnabled` (`bool?`; `null` = inherit) |
+| 2 | global default | `settings.json` `agents_enabled` (`bool`, default **false**) |
 
-The four layers map onto the §6 command surface exactly as skills do (PR #157): rungs
-1–3 are tri-state (`/toggle-… <scope> on|off|inherit`, where `inherit` unsets that one
-layer); rung 4 is a plain on/off bool (`/toggle-agents global on|off` — no `inherit`).
-`/reset-agents here` clears rungs 1 + 3 for the conversation; `/reset-agents global`
-clears the rung-2 per-agent overrides only, leaving the rung-4 master alone.
+"Most-specific wins": a conversation override beats the global default; with no
+override, the global value applies. Agents are in play when this resolves to **ON**;
+when on, **every discovered agent** is dispatchable (no per-agent gate). `/dispatch-agent`
+still works regardless (an explicit user action).
 
 ### Persistence
-- **Global** — `%AppData%/GxPT/agents.json` (a sibling of `skills.json`), written
-  only by `… global` commands:
-  ```json
-  { "feature_off": true, "agents": { "code-explorer": true, "pr-reviewer": true } }
-  ```
-  `feature_off` is a plain bool (defaults **true** — agents lead off, A15); `agents`
-  is the tri-state per-agent map (absent slug = inherit).
-- **Conversation** — `AgentsFeatureOff` (`bool?`) + `AgentOverrides` (`slug → bool`)
-  on the `Conversation`, round-tripped by `ConversationStore` (absent = inherit).
+- **Global** — a `settings.json` bool via `AppSettings` (e.g. `agents_enabled`, default
+  **false**), the same mechanism as the memory toggle (`mcp_memory_enabled`). It lives in
+  `settings.json` — **not** a dedicated `agents.json` — precisely so a future **General**
+  settings-page checkbox can bind to it. Written by `/toggle-agents global on|off`.
+- **Conversation** — `AgentsEnabled` (`bool?`, `null` = inherit) on the `Conversation`,
+  round-tripped by `ConversationStore`. Written by `/toggle-agents here on|off|inherit`.
 
-Per-tab by construction; no `settings.json` key, no checkbox — all control is §6.
+There is **no `agents.json`, no per-agent map, and no per-conversation per-agent
+overrides** — the per-skill enablement layer skills carry is intentionally absent (§6).
 The autonomy *grant* (A14) is separate persisted state in the **shared approval
 store** alongside the existing remember kinds (per-tool, command-signature/path
 rules, and the workdir-keyed workspace-write set from PR #154): a remembered "this
@@ -544,7 +535,7 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 
 - **`AgentCatalog` + frontmatter parser** — discovery across the three roots,
   project>user>bundled shadowing, inline-list `tools` parsing, `max_tier`/`autonomy`
-  enum parsing, malformed/missing frontmatter, manifest assembly for an enabled set.
+  enum parsing, malformed/missing frontmatter, manifest assembly over all discovered agents.
 - **`AgentToolResolver`** — `allowlist ∩ parent-available ∩ max_tier`; omitted
   `tools` ⇒ ReadOnly-only; `tools: [*]` ⇒ full set tier-capped; **wildcard patterns**
   (`files__*`, `mcp__*`, `*__read`) expand against the qualified catalog (A19); an
@@ -558,15 +549,13 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 - **Read/write fan-out gating** — an all-read-only batch runs children concurrently;
   a batch with any write-capable agent serializes (A9), asserted by execution order.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
-  `/list-agents` listing; **scope-first** `/toggle-agents` / `/toggle-agent` (scope +
-  verb both required; `inherit` unsets a layer; `global` feature accepts only on/off);
-  `/reset-agents here|global` bulk-clear (here = feature + per-agent overrides; global =
-  per-agent only, master untouched); conversation override vs. `agents.json`;
-  default-OFF feature; `/dispatch-agent <slug> <task>` sends the hidden dispatch
-  instruction; unknown scope/verb/slug failures; `SlashMatch.HyphenPrefix` matches
-  `/agent` to all five agent commands (per PR #156).
-- **Enablement resolution** — the 5-rung ladder with feature-default OFF;
-  force-on over a global-off; `inherit` unsets a layer so it falls through upstream.
+  **scope-first** `/toggle-agents` (scope + verb both required; `here` accepts
+  `on|off|inherit`, `global` only `on|off`); `here` writes the conversation override,
+  `global` writes the `settings.json` bool; `/dispatch-agent <slug> <task>` sends the
+  hidden dispatch instruction; unknown scope/verb/slug failures; `SlashMatch.HyphenPrefix`
+  matches `/agent` to both agent commands (per PR #156).
+- **Enablement resolution** — two layers: conversation override beats the `settings.json`
+  global default; default OFF; `inherit` clears the conversation override; no per-agent state.
 - **`AutonomyApprovalPolicy`** (decorator) — `auto-readonly` + grant ⇒ ReadOnly
   auto-allows; Write/Destructive still delegate to the real gate; no grant ⇒
   everything prompts; the grant is tier-capped and name-scoped.
@@ -589,8 +578,9 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
    (pure, TDD) — the catalog, `tools`/`max_tier`/`autonomy` parsing, shadowing.
 2. **`AgentToolResolver`** — effective-tool resolution (allowlist ∩ parent ∩ tier),
    the no-escalation core (pure, TDD).
-3. **Manifest injection** — `AgentInjection.BuildManifestMessage` slotted into the
-   orchestrator's ephemeral tail (`<agents>` section), gated by the enabled set.
+3. **Manifest injection** — `AgentInjection.BuildManifestMessage` (all discovered
+   agents) slotted into the orchestrator's ephemeral tail (`<agents>` section), gated by
+   the single feature toggle (`AgentEnablement.FeatureEnabled`).
 4. **`dispatch_agent` meta-tool + `AgentDispatcher`** — single-dispatch first:
    build a child orchestrator, run it, return its answer as the tool result
    (handled in `ExecuteCall` like `open_skill`). Context firewall + `HiddenToolNames`
@@ -598,10 +588,10 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 5. **Approval integration** — `AutonomyApprovalPolicy` decorator + the one-time
    agent-name grant in the approval store; agent-attributed prompts.
 6. **Agent slash commands** on the `ISlashCommand` framework, scope-first/hyphen-prefixed
-   per PRs #156/#157 (`/list-agents`, `/toggle-agents <here|global> <on|off|inherit>`,
-   `/toggle-agent <slug> …`, `/reset-agents <here|global>`, `/dispatch-agent <slug> <task>`;
-   `SlashMatch.HyphenPrefix` matching, `<>`/`[]` arg hints) + per-conversation override
-   fields on `Conversation`/`ConversationStore` + global `agents.json` (5-rung ladder).
+   per PRs #156/#157 — just `/toggle-agents <here|global> <on|off|inherit>` and
+   `/dispatch-agent <slug> <task>` (`SlashMatch.HyphenPrefix` matching, `<>`/`[]` arg
+   hints) + the `Conversation.AgentsEnabled` override field on `ConversationStore` + the
+   `settings.json` global bool (two-layer toggle, no per-agent state).
 7. **Concurrent fan-out + must-have observability** — batch `dispatch_agent`,
    read-concurrent/write-serial execution on bounded `ThreadPool` work items,
    per-connection mutex, usage aggregation; the **group cancellation** + the
@@ -641,6 +631,11 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   exactly one spawning path and it's always gated/recorded.
 
 **Deferred:**
+- **Per-agent enable/disable.** Dropped for simplicity (A15): the feature is a single
+  on/off, not a per-agent ladder like skills. If a real need appears (e.g. silencing one
+  noisy bundled agent), a per-agent override layer could be re-added — but it would mean
+  reintroducing an `agents.json`-style map and the `/list-agents` / `/toggle-agent` /
+  `/reset-agents` surface this design deliberately removed.
 - **Concurrent *write* agents via disjoint sub-workdirs.** Considered and set aside in
   favor of the simpler **read-concurrent / write-serial** rule (A9). The idea: give
   each write-child its own sub-workdir (write-root) under the parent — reusing the

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -597,9 +597,17 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
    per-connection mutex, usage aggregation; the **group cancellation** + the
    `Stop N agents` button; and the tier-1 **`AgentActivityPanel`** (glyph + slug +
    status). Observability ships *with* the fan-out — it is not a follow-on (§14 tier 1).
-8. **Transcript UI tiers 2–3** — per-row task/prompt + richer live activity (tier 2),
-   then read-only full child transcript and (optional) per-agent Stop (tier 3). Child
-   tool activity is shown to the user, never fed to the parent (A7).
+8. **Transcript UI tiers 2-3** *(done; per-agent Stop deferred)* — tier 2: each
+   `AgentActivityPanel` row shows its task (hover tooltip) and a live `N tools -
+   <lastTool>` activity line, fed by a per-child forwarding `IToolLoopUi`
+   (`ChildActivityUi`) that replaces the headless `NullToolLoopUi`. Tier 3: each
+   `dispatch_agent` record carries a per-agent **View transcript** link
+   (`AgentTranscriptLinks` custom scheme) opening a read-only popup
+   (`AgentTranscriptViewerForm`) over the child's captured message list
+   (`AgentDispatcher.LastTranscripts` -> session-scoped `AgentTranscriptStore`,
+   keyed by the record id). Child tool activity is shown to the user, never fed to
+   the parent (A7); the viewer is a pure UI read (A3/A7 hold). **Per-agent Stop**
+   (stop one child, not the whole fan-out) remains deferred - group stop covers it.
 9. **Bundled agents + deploy** — ship a starter suite via an `agents/` source folder
    copied next to the exe (`AfterBuild` + setup `.vdproj`), like bundled skills. The
    OpenMono specialist set is a proven shape to seed with: **explore** (read-only
@@ -817,9 +825,9 @@ moves, it just retargets — so no new status-bar real estate is needed.
 
 | Tier | Surface | Phase |
 |------|---------|-------|
-| **1 — must-have** | `AgentActivityPanel` rows (glyph + slug + status) to **see** them + the **`Stop N agents`** button to stop all | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
-| **2 — better** | each row shows the child's **task/prompt** (the `dispatch_agent` `task` string, truncated, click/hover to expand) and a richer live **activity line** | §11 phase 8 |
-| **3 — best, later** | a **View transcript** link per row opening the child's full message list **read-only**; (and, if wanted) **per-agent Stop** | §11 phase 8/later |
+| **1 — must-have** *(shipped)* | `AgentActivityPanel` rows (glyph + slug + status) to **see** them + the **`Stop N agents`** button to stop all | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
+| **2 — better** *(shipped)* | each row shows the child's **task** (hover tooltip) and a live **activity line** (`N tools - <lastTool>`, fed by `ChildActivityUi`) | §11 phase 8 |
+| **3 — best** *(shipped; per-agent Stop deferred)* | a **View transcript** link per agent on the `dispatch_agent` record opening the child's full message list **read-only** (`AgentTranscriptViewerForm`); **per-agent Stop** still deferred | §11 phase 8 |
 
 The task string (tier 2) is free — already in the dispatch args. The full transcript
 (tier 3) is a pure **UI** read of the child's message list and does **not** touch the

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -3,7 +3,9 @@
 **Status:** Design (proposal). No implementation yet.
 **Branch:** `claude/compassionate-goldberg-5c9ccz`
 **Last updated:** 2026-06-18 (reconciled with PR #154 — workspace-wide file
-approval + flag-insensitive command-signature rules; see §7–§8)
+approval + flag-insensitive command-signature rules, see §7–§8; refined against
+OpenMonoAgent.ai prior art — `max_turns`, doom-loop detection, wildcard allowlists,
+see §13 and A17–A19)
 
 Delegated, context-isolated **agents** for GxPT: a sub-agent is a markdown file
 with YAML-style frontmatter (the `SKILL.md` convention, one level up) that defines
@@ -87,6 +89,9 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A14 | **Autonomy is a per-agent dial** (`gated` \| `auto-readonly`), approved **once at dispatch** (remember by agent name), bounded by `max_tier` | "Leeway to act autonomously" without surrendering the gate: an `auto-readonly` research agent, approved once, runs a long read-only dig unattended; the moment it reaches for Write/Destructive it re-enters the normal gate. The grant can't exceed the tier ceiling, and Write/Destructive never auto-approve from a dial (only an exact remembered rule does). |
 | A15 | **Enablement reuses the skills tri-state ladder** (`/agents`, `/agent <slug> on\|off\|reset [here\|global]`), default **OFF** for the feature, opt-in per agent | Same `SkillEnablement`/conversation-override machinery (S10), so the manifest/dispatch surface only appears when the user has turned agents on — agents are more powerful (they spawn loops + cost) than skills, so they lead **off** rather than all-on (the one deliberate departure from S6). |
 | A16 | **Catalog & frontmatter are pure logic** (`AgentCatalog`, `Services/Agents/`), no WinForms — net48 linked-source tests, like `SkillCatalog` | Same dual-world test pattern (§10). Discovery, allowlist resolution, tier ceiling, and the manifest are all testable without the UI or a live model. |
+| A17 | **Per-agent `max_turns` budget** feeds the child orchestrator's existing `maxIterations` ctor arg | The orchestrator *already* takes `maxIterations` as a constructor parameter — a per-agent budget is free plumbing. OpenMonoAgent.ai assigns distinct budgets per specialist (Explore 15, Plan 10, Coder 30, Verify 20); bounding an unattended explore agent lower than a coder is the right grain for cost control, and a tight budget is itself a safety bound on an autonomous (A14) run. |
+| A18 | **Doom-loop detection in the orchestrator**: N (default 3) consecutive *identical* (tool-name + canonical args) calls ⇒ abort the loop with a wrap-up | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget repeating one failed call — wasteful, and worse for an unattended sub-agent (A14) with no user watching. OpenMono aborts on "3 identical tool-call sequences in a row." Cheap to add (a small ring buffer of the last few `(name,args)` hashes in `RunTurn`), benefits the **main** agent too, and ends as content (the loop's existing failure stance), not a throw. |
+| A19 | **Allowlist `tools` supports glob wildcards** (`files__*`, `mcp__*`, `*__read`, `*`) matched against the qualified catalog | Server-qualified names (`files__read`, `git__status`) make prefix/suffix globs natural and far less brittle than enumerating every tool — "all file tools" is `files__*`, "everything a server exposes" is `mcp__myserver__*`. The OpenMono precedent ("allow-lists support `*`, `mcp__*`"). Still intersected with parent-available and `max_tier` (A11), so a wildcard never widens past the parent or the ceiling. |
 
 ---
 
@@ -124,6 +129,7 @@ name: Code Explorer
 description: Use to search and summarize unfamiliar code across the workspace before making changes. Read-only.
 tools: [files__read, files__list, files__search]
 max_tier: readonly
+max_turns: 15
 autonomy: auto-readonly
 model: anthropic/claude-sonnet-4-6
 ---
@@ -142,14 +148,19 @@ find something after a genuine search, say so and name where you looked.
   - `description` *(required)* — the **single-line** "use this agent when…" the
     parent reads in the manifest (A6).
   - `tools` *(optional)* — inline list `[a, b, c]` of server-qualified function
-    names the agent may use. **Omitted ⇒ inherit a conservative default set**
-    (all ReadOnly-tier tools available in the workspace), *not* everything (A5,
-    fail-safe). `tools: [*]` opts into the full parent-available set (still
-    capped by `max_tier` and the gate).
+    names the agent may use, **with glob wildcards** (`files__*`, `mcp__*`, `*__read`,
+    `*`) matched against the qualified catalog (A19, the OpenMono allowlist-wildcard
+    precedent). **Omitted ⇒ inherit a conservative default set** (all ReadOnly-tier
+    tools available in the workspace), *not* everything (A5, fail-safe). `tools: [*]`
+    opts into the full parent-available set (still capped by `max_tier` and the gate).
   - `max_tier` *(optional)* — `readonly` \| `write` \| `destructive` ceiling,
     classified via the existing `ToolClassifier`. Caps the allowlist regardless of
     what `tools` names. Default `write` (an agent can edit but the gate still
     confirms; `destructive` must be opted into explicitly).
+  - `max_turns` *(optional)* — per-agent iteration budget, fed straight into the
+    child orchestrator's `maxIterations` ctor arg (A17). Omitted ⇒ the host default
+    (`DefaultMaxIterations`). Lets an `explore` agent cap at ~15 while a `coder` runs
+    ~30, so an unattended specialist's cost is bounded *to its job*, not the parent's.
   - `autonomy` *(optional)* — `gated` (default) \| `auto-readonly` (§8 layer 3).
   - `model` *(optional)* — model id override; omitted ⇒ the parent turn's model.
 - The **body** is the agent's **system prompt** — it replaces `AgentSystemPrompt`'s
@@ -470,9 +481,15 @@ extend that, not rework it.
 - **UI:** each running child renders as a collapsible transcript block ("▸ Code
   Explorer — running… 3 tools"), its tool calls/results shown but *not* fed to the
   parent model (A7). On completion the block collapses to the returned summary.
-- **Cost guardrails:** `MaxParallelAgents` bounds concurrency; each child carries the
-  normal `MaxIterations` budget and wraps up (no continuation prompt) at its cap, so
-  a fan-out can't loop unbounded or stampede the API.
+- **Cost guardrails (three bounds, the unattended-run safety net):**
+  `MaxParallelAgents` bounds concurrency; each child carries its **`max_turns`**
+  budget (A17) and wraps up at its cap with **no continuation prompt** (the dispatch
+  is meant to be unattended — a child can't block the fan-out waiting on a user); and
+  **doom-loop detection** (A18) aborts a child that repeats one call N times rather
+  than draining the whole budget on a stuck step. Together these make an
+  `auto-readonly`, write-granted fan-out safe to leave running: bounded breadth
+  (allowlist/tier), bounded depth (`max_turns`), bounded repetition (doom-loop), and
+  the always-confirm gate on anything destructive.
 
 ---
 
@@ -484,9 +501,14 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
   project>user>bundled shadowing, inline-list `tools` parsing, `max_tier`/`autonomy`
   enum parsing, malformed/missing frontmatter, manifest assembly for an enabled set.
 - **`AgentToolResolver`** — `allowlist ∩ parent-available ∩ max_tier`; omitted
-  `tools` ⇒ ReadOnly-only; `tools: [*]` ⇒ full set tier-capped; an allowlisted tool
-  the parent lacks in this workdir is excluded (no escalation); `dispatch_agent`
-  always stripped from a child.
+  `tools` ⇒ ReadOnly-only; `tools: [*]` ⇒ full set tier-capped; **wildcard patterns**
+  (`files__*`, `mcp__*`, `*__read`) expand against the qualified catalog (A19); an
+  allowlisted tool the parent lacks in this workdir is excluded (no escalation);
+  `dispatch_agent` always stripped from a child.
+- **`max_turns` + doom-loop** (in the orchestrator, so the main agent is covered too)
+  — a child built with `max_turns` wraps up at that cap (A17); N consecutive identical
+  `(name, canonical-args)` calls abort with a wrap-up rather than draining the budget
+  (A18), and the abort returns as content, never a throw.
 - **Agent slash commands** (`AgentCommands` vs. a fake `ISlashCommandContext`) —
   list/toggle/reset across here/global; conversation override vs. `agents.json`;
   default-OFF feature; `/agent <slug> <task>` sends the hidden dispatch instruction;
@@ -530,9 +552,13 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
    per-connection mutex, cancellation propagation, usage aggregation.
 8. **Transcript UI** — collapsible per-child agent blocks (live tool activity shown,
    not fed to the parent), collapsing to the returned summary.
-9. **Bundled agents + deploy** — ship `code-explorer`, `test-runner`, `pr-reviewer`
-   via an `agents/` source folder copied next to the exe (`AfterBuild` + setup
-   `.vdproj`), like bundled skills.
+9. **Bundled agents + deploy** — ship a starter suite via an `agents/` source folder
+   copied next to the exe (`AfterBuild` + setup `.vdproj`), like bundled skills. The
+   OpenMono specialist set is a proven shape to seed with: **explore** (read-only
+   discovery, `auto-readonly`, low `max_turns`), **plan** (read-only architecture,
+   `max_tier: readonly`), **coder** (write, higher `max_turns`), **verify**
+   (read + build/test, adversarial), plus a **general-purpose** catch-all — alongside
+   the task-shaped `pr-reviewer`. Each is just an `AGENT.md`; nothing new in code.
 10. **(Optional/later)** an agent-authoring surface (an `agent-writer` skill, the
     skill-writer precedent); folder-form agents with bundled assets; user-global
     `scope` parity in any authoring flow.
@@ -568,4 +594,62 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 - **Folder-form agents + bundled assets**; **user-global authoring `scope`** parity.
 - **Per-agent model *routing policy*** beyond a static `model:` override (e.g. "use
   a cheaper model for explore agents") — the static override covers the common case.
-```
+
+---
+
+## 13. Prior art & external validation — OpenMonoAgent.ai
+
+[OpenMonoAgent.ai](https://github.com/StartupHakk/OpenMonoAgent.ai) is a .NET sub-agent
+coding system (local llama.cpp inference). It's a useful mirror because it solved the
+same problem in a comparable stack, and most of its choices **independently match**
+ours — which raises confidence — while a few sharpened this design (A17–A19, §9).
+
+### Where it confirms our choices (convergent design)
+| OpenMono | Our design | Note |
+|----------|-----------|------|
+| `AgentTool` "spawns an isolated session with a restricted tool set and a dedicated system prompt" | `dispatch_agent` → child orchestrator, fresh context, allowlist, body-as-system-prompt (A1–A5) | Nearly verbatim — the isolated-session-with-locked-tools shape is the consensus pattern. |
+| Sub-agent **reuses the parent's `PermissionEngine`** (preserves user consent) | Child reuses the parent's `ToolApprovalPolicy`/`IApprovalStore` (A13) | Strong validation of Layer 2: don't re-prompt or fork consent; the gate is shared. |
+| Returns **final text + artifacts** as a single tool response; parent never sees inner iterations | Only the final assistant message returns (A3/A7) | The context-firewall value is the agreed core. |
+| Sub-agent inherits parent context (`OPENMONO.md`, memory, git status) but its **own message list** | Standing guidance + workspace block + AGENTS.md + memory, in a fresh history (§5) | Same "shared standing context, isolated transcript." |
+| Hard-coded allowlists per agent type; **read-only vs write tiers** | `tools` ∩ `max_tier` (A5/A11), classified by `ToolClassifier` tiers | Same tiered-capability instinct; ours is author-declared per agent rather than five fixed types. |
+| **Spawn is a capability** (`AgentSpawnCap(type, task)`) routed through the permission engine | `dispatch_agent` itself goes through approval; autonomy grant remembered by agent name (A14) | Both gate the *spawn*, not just the spawned calls. |
+
+### Where it sharpened our design (adopted)
+- **Distinct turn budgets per specialist** (Explore 15 / Plan 10 / Coder 30 /
+  Verify 20) → adopted as **`max_turns`** (A17), free plumbing over the orchestrator's
+  existing `maxIterations` arg, and a real autonomy safety bound.
+- **Doom-loop detection** ("3 identical tool-call sequences → abort") → adopted as
+  A18; a gap in our prior draft, and exactly the valve an *unattended* agent needs so
+  it can't drain its budget on one stuck call. Benefits the main agent too.
+- **Allowlist wildcards** (`*`, `mcp__*`) → adopted as A19; natural over GxPT's
+  server-qualified names (`files__*`), far less brittle than enumerating tools.
+- **A proven bundled suite** (explore / plan / coder / verify / general) → seeds our
+  phase-9 starter agents — pure `AGENT.md` files, no new code.
+
+### Where we deliberately diverge (and why)
+- **Capability-based `PermissionEngine`** (`FileWriteCap`, `ProcessExecCap`,
+  `NetworkEgressCap`, …) is richer than our tier + argument-scope classifier. We
+  **keep the tier model**: it already ships, the approval spec is built on it, and
+  PR #154's workspace-write/command-signature grants extend it cleanly. A
+  capability-object refactor is a large change for marginal gain here — noted, not
+  adopted.
+- **Intra-turn read-only tool parallelism** (`Task.WhenAll`; "read-only tasks start
+  while the LLM is still streaming"). We **reject** this for GxPT: net35 has no
+  `async`/`Task`, and the tool loop is *deliberately serial* (`mcp35-toolloop-spec.md`
+  §6). We get the safe slice of the same idea at the **agent** grain — parallel
+  children (§9) with per-connection serialization (A10) — without touching the
+  per-turn loop. The principle "reads overlap, writes serialize" still holds, one
+  level up.
+- **Global "plan mode"** as a session state that forces read-only. Our per-agent
+  `max_tier: readonly` covers the same need for a *plan* agent without a new global
+  mode; a conversation-level plan toggle is a possible separate feature, not part of
+  the sub-agent system.
+
+### Worth tracking (not yet adopted)
+- **Context compaction inside a long-running child** (OpenMono: checkpoint at 65%,
+  compact at 80%). GxPT has `/compact` + the context meter; wiring auto-compaction
+  into a child that nears its window would help deep autonomous runs. Folds into the
+  existing compaction machinery — a §11 phase-8/UI follow-on, not new architecture.
+- **Artifact storage for large tool results** (>10 KB off to disk, referenced by
+  handle) to keep a child's context lean — orthogonal to sub-agents but a clean
+  companion to `FormatResult`'s existing length cap.


### PR DESCRIPTION
## Summary

Adds the **sub-agents system design** (`docs/subagents-design.md`) and its **phase 1** implementation — the pure-logic discovery layer. Opening this now primarily to get **CI to compile and run the phase-1 tests** (there's no dotnet/mono in the authoring environment, and the net35 app isn't buildable on a stock runner).

A sub-agent is a markdown file with frontmatter (the `SKILL.md` convention, one level up) that defines a specialist — a system prompt, a bounded tool allowlist, a tier ceiling, and an autonomy setting. The main agent delegates a self-contained task; the sub-agent runs its own orchestrator loop in a fresh context and returns only its final answer.

## Design doc (`docs/subagents-design.md`)

Decision-oriented, modeled on `skills-design.md`. Highlights:
- **Dispatch** is a host-synthesized `dispatch_agent` meta-tool (the `reveal_tools`/`open_skill` precedent) — no new MCP server; each child reuses `McpChatOrchestrator`.
- **Layered security** (reconciled with PR #154): static tool allowlist + `max_tier` ceiling → the existing approval gate (unchanged backstop) → a per-agent autonomy dial that can only loosen within the layers below it.
- **Concurrency:** read-only agents run concurrently, write-capable agents serialize.
- **Observability:** in-transcript dispatch panel + the turn's Stop button relabeled `Stop N agents` (stop-all, v1).
- **Slash surface (per PR #156/#157):** just `/toggle-agents <here|global> <on|off|inherit>` (global default in `settings.json`) and `/dispatch-agent <slug> <task>` — no per-agent management.
- Validated against OpenMonoAgent.ai (read from source): `max_turns`, periodic doom-loop detection, and wildcard allowlists were adopted from it.

## Phase 1 code (`GxPT/Services/Agents/`)

Mirrors the skills catalog:
- **`Agent`** — model + `AgentSource` / `AgentMaxTier` (default `write`) / `AgentAutonomy` (default `gated`) enums. One flat `<slug>.md` per agent (design A4).
- **`AgentFrontmatter`** — the `SkillFrontmatter` reader extended for `tools` (inline list: `[a, b]`, `[*]`, `[]`, bare, quoted), `max_tier`/`autonomy` (enums, lenient — unknown value falls back to default), and `model`. First-wins, unknown keys ignored, CRLF/BOM-tolerant.
- **`AgentCatalog`** — scans `<root>/<slug>.md` across bundled/user/project with project > user > bundled shadowing, slug from filename via `SkillSlug.Make`, requires a non-empty description, `BuildManifest()` emits the Level-1 lines. Guards the Win32 `*.md` wildcard quirk with an explicit extension check.
- **`AgentRoots`** — resolves `<exe>/agents`, `%AppData%/GxPT/agents`, `<workdir>/.gxpt/agents`.

## Tests (net48 linked-source)

`AgentFrontmatterTests`, `AgentCatalogTests`, `AgentRootsTests` cover parsing variants/defaults, tools-list edge cases, shadowing precedence, description gating, `.md`-only filtering, slug normalization, case-insensitive lookup, and manifest output. The four sources are registered in `GxPT.csproj` and as linked compiles in `GxPT.Tests.csproj`.

## Notes

- The net35 app can't be compiled on a stock runner and there's no dotnet/mono in the authoring environment, so the phase-1 tests were **not executed locally** — they run via `dotnet test` here on CI. That's the main reason for opening this PR.
- All new source is ASCII-only (the VS2008 source-open constraint).
- Subsequent phases (tool resolver, dispatch + child orchestrator, approval integration, slash commands, concurrent fan-out + observability, bundled agents) are scoped in the design doc's roadmap and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYvmaJGYC3WF2ChadTtwzB)_