### PR TITLE
Fix status bar growing in height and clipping input controls

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5484,6 +5484,20 @@ namespace GxPT
         {
             try
             {
+                // The status strip is a single, fixed-height row by design (its item fonts are never
+                // rescaled). Left to AutoSize, its Table layout recomputes height from whatever width it
+                // is queried with during a layout pass; the re-entrant layout produced by collapsing the
+                // history sidebar while the input box is expanded can measure it at a too-small width,
+                // wrap the items onto a second row, and leave the strip permanently taller - overlapping
+                // the Send button, model selector, and ZDR checkbox. Pin the height (keeping the current,
+                // already DPI-scaled one-row value) so the strip can never grow.
+                if (this.ssMain != null)
+                {
+                    int oneRowHeight = this.ssMain.Height;
+                    this.ssMain.AutoSize = false;
+                    this.ssMain.Height = oneRowHeight;
+                }
+
                 bool visible = AppSettings.GetBool("statusbar_visible", true);
                 if (this.ssMain != null) this.ssMain.Visible = visible;
                 if (this.miStatusBar != null) this.miStatusBar.Checked = visible;


### PR DESCRIPTION
## Problem

When the history sidebar is open, typing a long message expands the input box, and *then* collapsing the sidebar, the status bar (`ssMain`) grew in height. The taller strip overlapped the bottom of the input area — the Send button, model selector, and ZDR checkbox got clipped while the message box appeared pushed up.

## Root cause

`ssMain` used the default `AutoSize = true` with a `Table` layout containing a `Spring` item (`tslSpring`). The strip's height is derived from its preferred size, which WinForms recomputes from whatever width the strip is queried with during a layout pass.

The repro sequence produces re-entrant layout passes:
- Expanding the input grows `pnlInput`/`pnlBottom` (both `AutoSize`).
- Collapsing the sidebar runs the splitter animation, which repeatedly calls `SuspendLayout`/`ResumeLayout`, plus the `Panel2.Resize → AdjustInputBoxHeight → pnlBottom` AutoSize cascade.

During one of those nested passes the strip is measured at a too-small width, the `Table` layout wraps its items onto a second row, and that taller height sticks.

## Fix

The status strip is a single fixed-height row by design (its item fonts are never rescaled anywhere in the app). In `InitUsageStatusBar()`, capture the current already-DPI-scaled one-row height and turn `AutoSize` off so the height can never be recomputed:

```csharp
if (this.ssMain != null)
{
    int oneRowHeight = this.ssMain.Height;
    this.ssMain.AutoSize = false;
    this.ssMain.Height = oneRowHeight;
}
```

The strip stays docked `Bottom` (full width) and its items lay out normally — only the height is pinned. The height is captured at runtime rather than hardcoded so it stays correct across DPI scaling.

## Testing

Verified by the reporter that the fix resolves the bug. Note: the project targets .NET Framework 3.5 WinForms, which can't be built or run in the Linux CI container, so this was verified manually rather than via an automated build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c87yS2Hi7EvckBM733T6b

---
_Generated by [Claude Code](https://claude.ai/code/session_011c87yS2Hi7EvckBM733T6b)_