### PR TITLE
Keep input text color themed when accepting a slash completion

### DIFF
--- a/GxPT/Managers/InputManager.cs
+++ b/GxPT/Managers/InputManager.cs
@@ -72,6 +72,20 @@ namespace GxPT
             catch { }
         }
 
+        // The themed foreground color for real (non-hint) input text. Used whenever text is set
+        // programmatically so it doesn't revert to black under the dark theme; falls back to the system
+        // window text color if the theme manager isn't available yet (early init).
+        private Color GetThemedForeColor()
+        {
+            try
+            {
+                var theme = _mainForm != null ? _mainForm.GetThemeManager() : null;
+                if (theme != null) return theme.GetUiForeColor();
+            }
+            catch { }
+            return SystemColors.WindowText;
+        }
+
         // Programmatically set the input text and optionally focus the input box.
         public void SetInputText(string text, bool focus)
         {
@@ -79,7 +93,7 @@ namespace GxPT
             {
                 if (_txtMessage == null) return;
                 TextIsHint = false;
-                _txtMessage.ForeColor = SystemColors.WindowText;
+                _txtMessage.ForeColor = GetThemedForeColor();
                 _txtMessage.Text = text ?? string.Empty;
                 try { _txtMessage.SelectionStart = _txtMessage.TextLength; _txtMessage.SelectionLength = 0; }
                 catch { }
@@ -414,7 +428,7 @@ namespace GxPT
             if (_txtMessage.Focused)
             {
                 TextIsHint = false;
-                _txtMessage.ForeColor = SystemColors.WindowText;
+                _txtMessage.ForeColor = GetThemedForeColor();
                 return;
             }
             _txtMessage.Text = InputHintText;

--- a/GxPT/Managers/ThemeManager.cs
+++ b/GxPT/Managers/ThemeManager.cs
@@ -172,12 +172,7 @@ namespace GxPT
         {
             try
             {
-                string theme = null;
-                try { theme = AppSettings.GetString("theme"); }
-                catch { theme = null; }
-
-                bool dark = !string.IsNullOrEmpty(theme) &&
-                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+                bool dark = IsDarkTheme();
 
                 if (_txtMessage != null)
                 {
@@ -189,6 +184,27 @@ namespace GxPT
                 }
             }
             catch { }
+        }
+
+        // True when the active theme is dark.
+        public bool IsDarkTheme()
+        {
+            try
+            {
+                string theme = AppSettings.GetString("theme");
+                return !string.IsNullOrEmpty(theme) &&
+                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        // The input box's foreground color for real (non-hint) text under the active theme. Callers that
+        // programmatically replace the input text - e.g. accepting a slash-command completion - use this
+        // instead of SystemColors.WindowText so the text keeps the dark-mode color rather than turning black.
+        public Color GetUiForeColor()
+        {
+            try { return ThemeService.GetColors(IsDarkTheme()).UiForeground; }
+            catch { return SystemColors.WindowText; }
         }
     }
 }


### PR DESCRIPTION
## Problem

In dark mode, autocompleting a slash command changed the message textbox text color to black instead of keeping the dark-mode foreground color.

## Root cause

Accepting an autocomplete entry (`SlashAutocompleteController.AcceptSelected`) calls `InputManager.SetInputText`, which set the textbox `ForeColor` to `SystemColors.WindowText` (black) before replacing the text:

```csharp
TextIsHint = false;
_txtMessage.ForeColor = SystemColors.WindowText;   // black, even in dark mode
_txtMessage.Text = text ?? string.Empty;
```

Under the dark theme this overrode the themed foreground, so the completed text rendered black on the dark background. The focused branch of `SetHintText` had the same hardcoded color.

## Fix

- Add `ThemeManager.GetUiForeColor()` returning the active theme's UI foreground, plus a shared `IsDarkTheme()` helper (also used to de-duplicate the theme check in `ApplyThemeToTextBox`).
- `InputManager` now resolves the textbox foreground through a small `GetThemedForeColor()` helper that delegates to the theme manager, falling back to `SystemColors.WindowText` if the theme manager isn't available yet (early init).

Both hardcoded `SystemColors.WindowText` assignments in `InputManager` (in `SetInputText` and the focused branch of `SetHintText`) now use the themed color, so programmatically-set input text keeps the correct color in both light and dark themes.

## Testing

Note: the project targets .NET Framework 3.5 WinForms, which can't be built or run in the Linux CI container, so this was reasoned through rather than verified via an automated build. Worth a quick manual check in dark mode: type `/`, accept a completion, and confirm the inserted text stays light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c87yS2Hi7EvckBM733T6b

---
_Generated by [Claude Code](https://claude.ai/code/session_011c87yS2Hi7EvckBM733T6b)_