### PR TITLE
Make the tool approval prompt theme-aware

### DIFF
--- a/GxPT/Controls/DiffPreviewPanel.cs
+++ b/GxPT/Controls/DiffPreviewPanel.cs
@@ -49,6 +49,18 @@ namespace GxPT
             Invalidate();
         }
 
+        // Re-color the already-set content for a light<->dark switch without rebuilding it: keep the
+        // current header/body/language and just swap the palette, re-measure, and repaint.
+        public void ReapplyTheme(bool dark, Color codeBack, Color foreColor)
+        {
+            _dark = dark;
+            _codeBack = codeBack;
+            _foreColor = foreColor;
+            this.BackColor = codeBack;
+            UpdateScrollSize();
+            Invalidate();
+        }
+
         private int HeaderHeight
         {
             get { return string.IsNullOrEmpty(_header) ? 0 : (this.Font != null ? this.Font.Height : 14) + Pad; }

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -52,6 +52,10 @@ namespace GxPT
         private bool _handledDetails;
         private bool _inLayoutToContent;
 
+        // The current prompt's tier, remembered so ApplyTheme can re-tint the tier badge (its color is
+        // semantic) when the theme switches live. The continuation prompt reuses the Write color.
+        private ToolTier _currentTier = ToolTier.Write;
+
         public ToolApprovalPanel()
         {
             this.Dock = DockStyle.Bottom;
@@ -113,6 +117,100 @@ namespace GxPT
             this.Controls.Add(_tierBadge);
             this.Controls.Add(_header);
             this.Controls.Add(_buttons);
+
+            // Theme the chrome up front so the panel isn't a stark white block before the first prompt.
+            ApplyTheme();
+        }
+
+        // True when the active theme is dark. Mirrors AgentActivityPanel.IsDark.
+        private static bool IsDark()
+        {
+            try
+            {
+                string th = AppSettings.GetString("theme");
+                return !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        // The tier badge color, brightened in dark mode so it stays legible against the dark panel
+        // (matching how the agents panel lightens its status colors).
+        private static Color TierColor(ToolTier tier, bool dark)
+        {
+            switch (tier)
+            {
+                case ToolTier.Destructive: return dark ? Color.FromArgb(240, 120, 120) : Color.Firebrick;
+                case ToolTier.Write: return dark ? Color.FromArgb(226, 184, 80) : Color.DarkGoldenrod;
+                default: return dark ? Color.FromArgb(126, 204, 126) : Color.ForestGreen;
+            }
+        }
+
+        // Re-color the panel and all its child controls for the active theme, using the same palette as
+        // the agents activity panel (ThemeService), so the approval prompt isn't stark white in dark
+        // mode. Safe to call repeatedly: the host calls it again on a live light<->dark switch (see
+        // MainForm.ApplyThemeToAllApprovalPanels), and it re-tints the already-rendered diff/preview.
+        public void ApplyTheme()
+        {
+            try
+            {
+                bool dark = IsDark();
+                ThemeColors tc = ThemeService.GetColors(dark);
+
+                this.BackColor = tc.AssistantBubbleBack;
+                this.ForeColor = tc.UiForeground;
+
+                if (_header != null) { _header.BackColor = tc.AssistantBubbleBack; _header.ForeColor = tc.UiForeground; }
+                if (_tierBadge != null) { _tierBadge.BackColor = tc.AssistantBubbleBack; _tierBadge.ForeColor = TierColor(_currentTier, dark); }
+                if (_previewLabel != null) { _previewLabel.BackColor = tc.AssistantBubbleBack; _previewLabel.ForeColor = tc.UiForeground; }
+                // The raw-JSON fallback preview reads like a code block, so use the code palette.
+                if (_preview != null) { _preview.BackColor = tc.CodeBack; _preview.ForeColor = tc.UiForeground; }
+
+                if (_buttons != null)
+                {
+                    _buttons.BackColor = tc.AssistantBubbleBack;
+                    foreach (Control c in _buttons.Controls)
+                    {
+                        Button b = c as Button;
+                        if (b != null) ApplyButtonTheme(b, dark, tc);
+                    }
+                }
+
+                // Re-tint the syntax-highlighted diff/preview when it's the visible details control, so a
+                // live theme switch updates it too (it was themed once at SetContent time).
+                if (_diffPanel != null && _diffPanel.Visible)
+                    _diffPanel.ReapplyTheme(dark, tc.CodeBack, tc.UiForeground);
+
+                Invalidate(true);
+            }
+            catch { }
+        }
+
+        // Dark mode: a flat button tinted from the theme (the native themed button ignores BackColor).
+        // Light mode: restore the native system look.
+        private static void ApplyButtonTheme(Button b, bool dark, ThemeColors tc)
+        {
+            if (dark)
+            {
+                b.FlatStyle = FlatStyle.Flat;
+                b.UseVisualStyleBackColor = false;
+                b.BackColor = tc.CodeBack;
+                b.ForeColor = tc.UiForeground;
+                try
+                {
+                    b.FlatAppearance.BorderColor = tc.AssistantBubbleBorder;
+                    b.FlatAppearance.MouseOverBackColor = tc.CopyHover;
+                    b.FlatAppearance.MouseDownBackColor = tc.CopyPressed;
+                }
+                catch { }
+            }
+            else
+            {
+                // Restore the default themed (visual-styles) button look used in light mode.
+                b.FlatStyle = FlatStyle.Standard;
+                b.UseVisualStyleBackColor = true;
+                b.BackColor = SystemColors.Control;
+                b.ForeColor = SystemColors.ControlText;
+            }
         }
 
         // Populate + show for one request. choiceCallback is invoked (on the UI thread) with the
@@ -125,24 +223,19 @@ namespace GxPT
                            (req.ToolName != null ? req.ToolName : req.FunctionName);
 
             ToolTier tier = req.Policy != null ? req.Policy.Tier : ToolTier.Write;
+            _currentTier = tier;
             _tierBadge.Text = "Tier: " + tier;
-            _tierBadge.ForeColor = (tier == ToolTier.Destructive) ? Color.Firebrick
-                                  : (tier == ToolTier.Write ? Color.DarkGoldenrod : Color.ForestGreen);
+
+            // Theme palette for this prompt (the tier badge and diff/preview colors derive from it);
+            // ApplyTheme below colors the rest of the chrome.
+            bool dark = IsDark();
+            ThemeColors tc = ThemeService.GetColors(dark);
 
             // files__edit -> a colored diff (with a little live file context); command__run -> the
             // command line, syntax-highlighted. Either replaces the raw JSON preview.
             bool handled = false;
             if (req.Arguments != null)
             {
-                bool dark = false;
-                try
-                {
-                    string th = AppSettings.GetString("theme");
-                    dark = !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
-                }
-                catch { }
-                ThemeColors tc = ThemeService.GetColors(dark);
-
                 if (string.Equals(req.FunctionName, "files__edit", StringComparison.Ordinal))
                 {
                     string path = req.Arguments.Value<string>("path") ?? string.Empty;
@@ -393,6 +486,10 @@ namespace GxPT
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
 
+            // Color the panel + the freshly built buttons for the active theme before measuring, so the
+            // button metrics used by LayoutToContent reflect their themed style.
+            ApplyTheme();
+
             // Size to fit the content (buttons built above so their height is counted, including any
             // wrapping at the current width; LayoutToContent measures the details at the live width).
             _handledDetails = handled;
@@ -416,8 +513,8 @@ namespace GxPT
             _onContinue = callback;
 
             _header.Text = "Tool-call limit reached";
+            _currentTier = ToolTier.Write; // informational; reuse the Write (goldenrod) badge color
             _tierBadge.Text = "Paused after " + iterationsSoFar + " tool iteration(s) this turn";
-            _tierBadge.ForeColor = Color.DarkGoldenrod;
 
             _previewLabel.Text = "Details:";
             _preview.Text = "The agent has been working for a long time. Do you want to continue?\r\n\r\n"
@@ -430,6 +527,8 @@ namespace GxPT
             // Added first => rightmost in the RightToLeft flow.
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
+
+            ApplyTheme();
 
             _handledDetails = false;
             LayoutToContent();

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -485,11 +485,10 @@ namespace GxPT
             }
 
             _buttons.Controls.Clear();
-            // Deny is always present (added first => rightmost in RightToLeft flow). It is not auto-
-            // focused: a focused FlatStyle.Flat button draws a heavier border, which made the red Deny
-            // button's border look thicker than the others. Leaving it unfocused keeps every button's
-            // border the same 1px (no action is auto-selected, so this doesn't weaken the safe default).
-            AddButton("Deny", ApprovalChoice.Deny, false);
+            // Deny is always present (added first => rightmost in RightToLeft flow). Auto-focused on the
+            // Destructive tier so the keyboard default is the safe choice (it shows the focused flat
+            // button's heavier border).
+            AddButton("Deny", ApprovalChoice.Deny, tier == ToolTier.Destructive);
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
             SetButtonTabOrder();

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -474,8 +474,11 @@ namespace GxPT
             }
 
             _buttons.Controls.Clear();
-            // Deny is always present (added first => rightmost in RightToLeft flow).
-            AddButton("Deny", ApprovalChoice.Deny, tier == ToolTier.Destructive);
+            // Deny is always present (added first => rightmost in RightToLeft flow). It is not auto-
+            // focused: a focused FlatStyle.Flat button draws a heavier border, which made the red Deny
+            // button's border look thicker than the others. Leaving it unfocused keeps every button's
+            // border the same 1px (no action is auto-selected, so this doesn't weaken the safe default).
+            AddButton("Deny", ApprovalChoice.Deny, false);
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
 

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -490,7 +490,9 @@ namespace GxPT
             // button's heavier border).
             AddButton("Deny", ApprovalChoice.Deny, tier == ToolTier.Destructive);
             AddRememberButtons(req);
-            AddButton("Allow once", ApprovalChoice.AllowOnce, false);
+            // Write tier defaults to "Allow once" (the cautious default for the riskier Destructive tier
+            // is Deny, handled above).
+            AddButton("Allow once", ApprovalChoice.AllowOnce, tier == ToolTier.Write);
             SetButtonTabOrder();
 
             // Color the panel + the freshly built buttons for the active theme before measuring, so the

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -56,6 +56,11 @@ namespace GxPT
         // semantic) when the theme switches live. The continuation prompt reuses the Write color.
         private ToolTier _currentTier = ToolTier.Write;
 
+        // The button to focus once the panel is shown (the tier's default action). Focus is deferred to
+        // after Visible = true: focusing while the panel is still hidden does nothing, so GotFocus never
+        // fires and the initial blue focus border was missing until the user tabbed.
+        private Button _defaultButton;
+
         public ToolApprovalPanel()
         {
             this.Dock = DockStyle.Bottom;
@@ -512,6 +517,7 @@ namespace GxPT
             }
 
             _buttons.Controls.Clear();
+            _defaultButton = null;
             // Deny is always present (added first => rightmost in RightToLeft flow). Auto-focused on the
             // Destructive tier so the keyboard default is the safe choice (it shows the focused flat
             // button's heavier border).
@@ -538,6 +544,29 @@ namespace GxPT
             // bottom edge and its right-docked scrollbar). BringToFront would cause exactly that.
             this.SendToBack();
             SetPromptVisible(true);
+            FocusDefaultButton();
+        }
+
+        // Focus the tier's default button now that the panel is visible (focusing earlier is a no-op).
+        // Real focus fires GotFocus, which paints the blue focus border; deferring to BeginInvoke lets
+        // the just-shown panel settle so the focus reliably takes.
+        private void FocusDefaultButton()
+        {
+            Button b = _defaultButton;
+            if (b == null) return;
+            try
+            {
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try { if (b.IsHandleCreated && b.Visible) b.Focus(); }
+                    catch { }
+                });
+            }
+            catch
+            {
+                try { b.Focus(); }
+                catch { }
+            }
         }
 
         // Iteration-cap confirmation, reusing this docked panel so it reads like the tool-approval
@@ -560,6 +589,7 @@ namespace GxPT
             _preview.Visible = true;
 
             _buttons.Controls.Clear();
+            _defaultButton = null;
             // Added first => rightmost in the RightToLeft flow.
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
@@ -573,6 +603,7 @@ namespace GxPT
             this.Visible = true;
             this.SendToBack();
             SetPromptVisible(true);
+            FocusDefaultButton();
         }
 
         public void HidePanel()
@@ -795,7 +826,7 @@ namespace GxPT
                 try { _toolTip.SetToolTip(b, tooltip); }
                 catch { }
             }
-            if (defaultFocus) { try { b.Select(); } catch { } }
+            if (defaultFocus) _defaultButton = b; // focused after the panel is shown (see FocusDefaultButton)
         }
 
         private void AddContinuationButton(string text, bool cont, bool defaultFocus)
@@ -813,7 +844,7 @@ namespace GxPT
             b.GotFocus += OnButtonFocusChanged;
             b.LostFocus += OnButtonFocusChanged;
             _buttons.Controls.Add(b);
-            if (defaultFocus) { try { b.Select(); } catch { } }
+            if (defaultFocus) _defaultButton = b; // focused after the panel is shown (see FocusDefaultButton)
         }
 
         // Reads a workspace-relative file for diff context. Mirrors the files sandbox: relative paths

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -199,9 +199,36 @@ namespace GxPT
             b.ForeColor = isDeny ? red : tc.UiForeground;
             try
             {
-                b.FlatAppearance.BorderColor = isDeny ? red : tc.AssistantBubbleBorder;
+                b.FlatAppearance.BorderColor = ButtonBorderColor(b, dark, tc);
                 b.FlatAppearance.MouseOverBackColor = tc.CopyHover;
                 b.FlatAppearance.MouseDownBackColor = tc.CopyPressed;
+            }
+            catch { }
+        }
+
+        // The border color for a button in its current focus state: a focused non-Deny button gets a blue
+        // border so the keyboard default is obvious - the flat button's subtle panel border barely
+        // changed when focused. A fixed blue (lightened in dark mode) rather than the theme accent, since
+        // some themes' accent is red/orange. Deny stays red whether focused or not.
+        private static Color ButtonBorderColor(Button b, bool dark, ThemeColors tc)
+        {
+            bool isDeny = (b.Tag is ApprovalChoice) && ((ApprovalChoice)b.Tag == ApprovalChoice.Deny);
+            if (isDeny) return TierColor(ToolTier.Destructive, dark);
+            if (!b.Focused) return tc.AssistantBubbleBorder;
+            return dark ? Color.FromArgb(120, 170, 255) : Color.FromArgb(0, 102, 204);
+        }
+
+        // Re-tint a button's border as it gains/loses focus (wired on every button), so the blue focus
+        // cue follows the keyboard default as the user tabs across the strip.
+        private void OnButtonFocusChanged(object sender, EventArgs e)
+        {
+            Button b = sender as Button;
+            if (b == null) return;
+            try
+            {
+                bool dark = IsDark();
+                b.FlatAppearance.BorderColor = ButtonBorderColor(b, dark, ThemeService.GetColors(dark));
+                b.Invalidate();
             }
             catch { }
         }
@@ -760,6 +787,8 @@ namespace GxPT
                 HidePanel();
                 if (cb != null) cb(choice);
             };
+            b.GotFocus += OnButtonFocusChanged;
+            b.LostFocus += OnButtonFocusChanged;
             _buttons.Controls.Add(b);
             if (!string.IsNullOrEmpty(tooltip) && _toolTip != null)
             {
@@ -781,6 +810,8 @@ namespace GxPT
                 HidePanel();
                 if (cb != null) cb(cont);
             };
+            b.GotFocus += OnButtonFocusChanged;
+            b.LostFocus += OnButtonFocusChanged;
             _buttons.Controls.Add(b);
             if (defaultFocus) { try { b.Select(); } catch { } }
         }

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -206,6 +206,17 @@ namespace GxPT
             catch { }
         }
 
+        // Order the button strip so Tab moves left->right and Shift+Tab right->left (e.g. Deny->Allow).
+        // The strip flows RightToLeft, so a button's visual left-to-right position is the reverse of its
+        // index in the Controls collection; assign TabIndex to follow the visual order.
+        private void SetButtonTabOrder()
+        {
+            if (_buttons == null) return;
+            int n = _buttons.Controls.Count;
+            for (int i = 0; i < n; i++)
+                _buttons.Controls[i].TabIndex = n - 1 - i;
+        }
+
         // Populate + show for one request. choiceCallback is invoked (on the UI thread) with the
         // user's decision. Builds the scope-appropriate buttons per approval spec §4.
         public void ShowFor(ApprovalRequest req, Action<ApprovalChoice> choiceCallback)
@@ -481,6 +492,7 @@ namespace GxPT
             AddButton("Deny", ApprovalChoice.Deny, false);
             AddRememberButtons(req);
             AddButton("Allow once", ApprovalChoice.AllowOnce, false);
+            SetButtonTabOrder();
 
             // Color the panel + the freshly built buttons for the active theme before measuring, so the
             // button metrics used by LayoutToContent reflect their themed style.
@@ -523,6 +535,7 @@ namespace GxPT
             // Added first => rightmost in the RightToLeft flow.
             AddContinuationButton("Stop", false, false);
             AddContinuationButton("Continue", true, true);
+            SetButtonTabOrder();
 
             ApplyTheme();
 

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -185,32 +185,25 @@ namespace GxPT
             catch { }
         }
 
-        // Dark mode: a flat button tinted from the theme (the native themed button ignores BackColor).
-        // Light mode: restore the native system look.
+        // Flat, theme-tinted buttons in both light and dark mode so the two themes match (a native
+        // visual-styles button ignores BackColor, so flat is the only way to tint it consistently).
+        // The Deny button is called out with a red (firebrick) border and text.
         private static void ApplyButtonTheme(Button b, bool dark, ThemeColors tc)
         {
-            if (dark)
+            bool isDeny = (b.Tag is ApprovalChoice) && ((ApprovalChoice)b.Tag == ApprovalChoice.Deny);
+            Color red = TierColor(ToolTier.Destructive, dark);
+
+            b.FlatStyle = FlatStyle.Flat;
+            b.UseVisualStyleBackColor = false;
+            b.BackColor = tc.CodeBack;
+            b.ForeColor = isDeny ? red : tc.UiForeground;
+            try
             {
-                b.FlatStyle = FlatStyle.Flat;
-                b.UseVisualStyleBackColor = false;
-                b.BackColor = tc.CodeBack;
-                b.ForeColor = tc.UiForeground;
-                try
-                {
-                    b.FlatAppearance.BorderColor = tc.AssistantBubbleBorder;
-                    b.FlatAppearance.MouseOverBackColor = tc.CopyHover;
-                    b.FlatAppearance.MouseDownBackColor = tc.CopyPressed;
-                }
-                catch { }
+                b.FlatAppearance.BorderColor = isDeny ? red : tc.AssistantBubbleBorder;
+                b.FlatAppearance.MouseOverBackColor = tc.CopyHover;
+                b.FlatAppearance.MouseDownBackColor = tc.CopyPressed;
             }
-            else
-            {
-                // Restore the default themed (visual-styles) button look used in light mode.
-                b.FlatStyle = FlatStyle.Standard;
-                b.UseVisualStyleBackColor = true;
-                b.BackColor = SystemColors.Control;
-                b.ForeColor = SystemColors.ControlText;
-            }
+            catch { }
         }
 
         // Populate + show for one request. choiceCallback is invoked (on the UI thread) with the

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -829,6 +829,24 @@ namespace GxPT
             catch { }
         }
 
+        // Re-theme every tab's tool-approval panel after a light<->dark switch: a currently-visible
+        // prompt updates immediately, and hidden ones are already correct when next shown (they also
+        // re-theme themselves in ShowFor). Mirrors how transcripts are refreshed on a theme change.
+        private void ApplyThemeToAllApprovalPanels()
+        {
+            try
+            {
+                if (_tabManager == null) return;
+                foreach (var kv in _tabManager.TabContexts)
+                {
+                    var ctx = kv.Value;
+                    if (ctx != null && ctx.ApprovalPanel != null)
+                        ctx.ApprovalPanel.ApplyTheme();
+                }
+            }
+            catch { }
+        }
+
         // The per-tab sub-agents activity panel (design sec.14), docked at the bottom like the approval
         // panel. Shown only while a dispatch_agent fan-out runs; updated via AgentActivityUiBridge.
         internal void AttachAgentActivityPanel(TabManager.ChatTabContext ctx)
@@ -3821,6 +3839,8 @@ namespace GxPT
                 UpdateApiKeyBanner();
                 try { if (_themeManager != null) _themeManager.ApplyThemeToAllTranscripts(); }
                 catch { }
+                // Theme may have changed in Settings; keep open approval prompts in sync.
+                ApplyThemeToAllApprovalPanels();
             }
         }
 
@@ -5474,6 +5494,9 @@ namespace GxPT
 
                 // Status bar follows the UI theme
                 ApplyThemeToStatusBar();
+
+                // Re-theme any open tool-approval prompts so they switch with the rest of the UI
+                ApplyThemeToAllApprovalPanels();
             }
             catch { }
         }


### PR DESCRIPTION
## Problem

The tool-approval prompt rendered with default system colors, so it was a stark white block in dark mode. Only the diff/preview details area was themed — the panel background, header, tier badge, "Details" label, raw-JSON preview textbox, and the buttons were not. This PR also tidies up the button styling, keyboard behavior, and focus affordance while in there.

## Theming

**`ToolApprovalPanel.ApplyTheme()`** colors the panel and all its child controls from the active theme, using the same `ThemeService` palette as the agents activity panel (`AssistantBubbleBack`/`AssistantBubbleBorder`, `UiForeground`, `CodeBack`):

- Panel background/foreground, header, "Details:" label → `AssistantBubbleBack` / `UiForeground`.
- Raw-JSON fallback preview → code palette (`CodeBack` / `UiForeground`).
- Tier badge keeps its semantic color (red/gold/green) but is brightened in dark mode for legibility.

`ApplyTheme()` runs at construction (no white flash) and whenever a prompt is shown (`ShowFor` / `ShowContinuation`).

### Redraw on theme change
- **`MainForm.ApplyThemeToAllApprovalPanels()`** re-applies the theme to every tab's panel from both theme-change entry points: the **Dark Mode menu toggle** and the **Settings dialog**.
- **`DiffPreviewPanel.ReapplyTheme()`** re-colors already-rendered diff/preview content (keeps the current header/body, swaps the palette, re-measures) so a live switch updates it too.
- Both paths `Invalidate` so the panel redraws immediately on dark↔light.

## Buttons

- **Flat in both themes** so light and dark match (a native visual-styles button ignores `BackColor`, so flat is the only way to tint consistently).
- **Deny** is called out with a red (firebrick, brightened in dark) border and text.
- **Blue focus border** on non-Deny buttons: a focused flat button only thickened its border in the same subtle color, so the keyboard default wasn't obvious. Focused non-Deny buttons now get a fixed blue border (lightened in dark; fixed rather than the theme accent because some themes' accent is red/orange), updated via `GotFocus`/`LostFocus` so the cue follows the focus as you Tab.

## Keyboard

- **Tab order** follows visual left→right (the strip flows `RightToLeft`, so add-order indexes ran right→left). Tab moves left→right; Shift+Tab moves Deny→Allow.
- **Default focus per tier**: Destructive → Deny (cautious), Write → Allow once. Focusing is deferred to after the panel is shown (`FocusDefaultButton` via `BeginInvoke`) — it was previously done via `Select()` while the panel was still hidden, which was a no-op, so neither the focus nor its blue border landed until the user tabbed in. This also makes Enter actually act on the default button on first show.

## Notes / testing

The project targets .NET Framework 3.5 WinForms, which can't be built or run in the Linux CI container, so this was implemented by mirroring the existing `AgentActivityPanel` theming rather than verified via an automated build. Worth a manual check: trigger an approval prompt (e.g. a `command__run`) in dark mode, confirm the panel is dark and the focused button shows a blue border immediately, toggle the theme while it's open to confirm it switches, and Tab/Shift+Tab through the buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011c87yS2Hi7EvckBM733T6b