### PR TITLE
Unify settings defaults behind one schema; seed settings.json complete

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -55,6 +55,10 @@
     <Compile Include="..\GxPT\Services\Mcp\DefaultServerConnector.cs" Link="Linked\Mcp\DefaultServerConnector.cs" />
     <Compile Include="..\GxPT\Services\Logger.cs" Link="Linked\Logger.cs" />
     <Compile Include="..\GxPT\Services\AppSettings.cs" Link="Linked\AppSettings.cs" />
+    <!-- AppSettings now resolves defaults from the settings schema (issue #164); both are pure / -->
+    <!-- WinForms-free, so they compile into the headless test assembly. -->
+    <Compile Include="..\GxPT\Services\SettingsSchema.cs" Link="Linked\SettingsSchema.cs" />
+    <Compile Include="..\GxPT\Models\ModelDefaults.cs" Link="Linked\ModelDefaults.cs" />
     <Compile Include="..\GxPT\Services\ModelCatalogService.cs" Link="Linked\ModelCatalogService.cs" />
     <Compile Include="..\GxPT\Services\RecentWorkDirs.cs" Link="Linked\RecentWorkDirs.cs" />
     <Compile Include="..\GxPT\Services\Skills\SkillSlug.cs" Link="Linked\Skills\SkillSlug.cs" />

--- a/GxPT.Tests/SettingsSchemaTests.cs
+++ b/GxPT.Tests/SettingsSchemaTests.cs
@@ -1,0 +1,65 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Locks in the single-source-of-truth defaults (issue #164): the credential-free MCP servers
+    // default ON, the credential-gated ones and memory default OFF, and the schema's typed lookups
+    // agree with the declared table.
+    public sealed class SettingsSchemaTests
+    {
+        [Theory]
+        // Credential-free first-party servers default ON so they work out of the box. (git/msbuild are
+        // still gated at launch on the tool being installed; that gate lives at the call site.)
+        [InlineData("mcp_files_enabled", true)]
+        [InlineData("mcp_command_enabled", true)]
+        [InlineData("mcp_git_enabled", true)]
+        [InlineData("mcp_msbuild_enabled", true)]
+        // Sub-agents ship enabled.
+        [InlineData("agents_enabled", true)]
+        // Status bar visible by default.
+        [InlineData("statusbar_visible", true)]
+        // Credential-gated servers can't run without a key/PAT, so they default OFF.
+        [InlineData("mcp_web_enabled", false)]
+        [InlineData("mcp_github_enabled", false)]
+        // The command scratch sandbox is opt-in.
+        [InlineData("mcp_command_scratch_enabled", false)]
+        // Persistent memory (not strictly an MCP server) defaults OFF.
+        [InlineData("mcp_memory_enabled", false)]
+        // Logging and zero-data-retention default OFF.
+        [InlineData("enable_logging", false)]
+        [InlineData("provider_zdr", false)]
+        public void BoolDefaults_MatchPolicy(string key, bool expected)
+        {
+            Assert.Equal(expected, SettingsSchema.BoolDefault(key));
+
+            // BuildDefaults must declare the same value the typed lookup returns (no second source).
+            object raw;
+            Assert.True(SettingsSchema.BuildDefaults().TryGetValue(key, out raw));
+            Assert.IsType<bool>(raw);
+            Assert.Equal(expected, (bool)raw);
+        }
+
+        [Fact]
+        public void Defaults_AreComplete()
+        {
+            var d = SettingsSchema.BuildDefaults();
+            // A representative spread of keys from each section is present, so the seeded file is complete.
+            Assert.True(d.ContainsKey("openrouter_api_key"));
+            Assert.True(d.ContainsKey("models"));
+            Assert.True(d.ContainsKey("default_model"));
+            Assert.True(d.ContainsKey("theme"));
+            Assert.True(d.ContainsKey("mcp_memory_max_lines"));
+            // The legacy data-collection pref is intentionally NOT seeded (migration-only).
+            Assert.False(d.ContainsKey("provider_data_collection"));
+        }
+
+        [Fact]
+        public void NumericDefaults_AreSane()
+        {
+            Assert.Equal(40, SettingsSchema.DoubleDefault("mcp_memory_max_lines"));
+            Assert.Equal(1000, SettingsSchema.DoubleDefault("transcript_max_width"));
+            Assert.Equal(90, SettingsSchema.DoubleDefault("message_max_width"));
+        }
+    }
+}

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1503,21 +1503,23 @@ namespace GxPT
                 string caBundle = System.IO.Path.Combine(baseDir, "Lib\\curl-ca-bundle.crt");
 
                 var opts = new McpConfig.BuiltInOptions();
-                opts.WebEnabled = AppSettings.GetBool("mcp_web_enabled", false);
-                opts.FilesEnabled = AppSettings.GetBool("mcp_files_enabled", false);
+                // Defaults come from the schema (SettingsSchema) via the parameterless GetBool, so the
+                // launch decision can't disagree with the seeded settings.json.
+                opts.WebEnabled = AppSettings.GetBool("mcp_web_enabled");
+                opts.FilesEnabled = AppSettings.GetBool("mcp_files_enabled");
                 // Git defaults ON when git is installed and OFF when it isn't, and is force-disabled
                 // when git is missing regardless of the stored setting — so we never launch a git
                 // server whose tools could only return "git not found".
-                opts.GitEnabled = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
-                opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled", false);
+                opts.GitEnabled = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled");
+                opts.CommandEnabled = AppSettings.GetBool("mcp_command_enabled");
                 // MSBuild defaults ON when at least one MSBuild engine is found, OFF when none is, and is
                 // force-disabled when none is present regardless of the stored setting — so we never launch
                 // an MSBuild server whose tools would be an empty set.
-                opts.MsBuildEnabled = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled", true);
+                opts.MsBuildEnabled = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled");
                 // Memory is a feature toggle (off by default); its soft index cap is user-configurable
                 // (design sec.3/sec.6). Both the server launch and the system-prompt injection read this one
                 // setting, so they can never desync.
-                opts.MemoryEnabled = AppSettings.GetBool("mcp_memory_enabled", false);
+                opts.MemoryEnabled = AppSettings.GetBool("mcp_memory_enabled");
                 int memMaxLines = (int)AppSettings.GetDouble("mcp_memory_max_lines", 40);
                 opts.MemoryMaxLines = memMaxLines > 0 ? memMaxLines : 40;
                 // The Skills MCP server (authoring + execution tools) follows skill enablement: it runs
@@ -1541,7 +1543,7 @@ namespace GxPT
 
                 var specs = new List<McpServerSpec>(McpConfig.BuiltInSpecs(opts));
                 specs.Add(McpConfig.GitHubSpec(
-                    AppSettings.GetBool("mcp_github_enabled", false),
+                    AppSettings.GetBool("mcp_github_enabled"),
                     AppSettings.GetString("mcp_github_pat")));
 
                 // Custom servers from mcp.json (GitHub is configured above, not here).
@@ -3163,7 +3165,7 @@ namespace GxPT
 
                     // Inject the workspace's persistent memory index (rebuilt from .gxpt/memory.md each
                     // request) only when memory is enabled and this conversation has a workspace.
-                    if (AppSettings.GetBool("mcp_memory_enabled", false) && !string.IsNullOrEmpty(ctx.WorkingDir))
+                    if (AppSettings.GetBool("mcp_memory_enabled") && !string.IsNullOrEmpty(ctx.WorkingDir))
                     {
                         string memWorkdir = ctx.WorkingDir;
                         orch.MemorySystemMessageProvider = delegate { return MemoryInjection.Build(memWorkdir); };
@@ -5521,7 +5523,7 @@ namespace GxPT
                     this.ssMain.Height = oneRowHeight;
                 }
 
-                bool visible = AppSettings.GetBool("statusbar_visible", true);
+                bool visible = AppSettings.GetBool("statusbar_visible");
                 if (this.ssMain != null) this.ssMain.Visible = visible;
                 if (this.miStatusBar != null) this.miStatusBar.Checked = visible;
                 ApplyThemeToStatusBar();

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1367,9 +1367,10 @@ namespace GxPT
             target.mcp_files_enabled = this.chkMcpFiles.Checked;
             target.mcp_git_enabled = this.chkMcpGit.Checked;
             target.mcp_command_enabled = this.chkMcpCommand.Checked;
-            // Only meaningful when the command server itself is on; force-off otherwise so a stale
-            // setting can't enable scratch behavior for a disabled command server.
-            target.mcp_command_scratch_enabled = this.chkMcpCommand.Checked && this.chkMcpCommandScratch.Checked;
+            // Persist the scratch choice as-is, independent of the command server toggle, so disabling
+            // (then re-enabling) the command server doesn't wipe it. The runtime gates scratch behavior
+            // on the command server being on (ScratchWorkspace.IsEnabled), so this can't take effect alone.
+            target.mcp_command_scratch_enabled = this.chkMcpCommandScratch.Checked;
             target.mcp_msbuild_enabled = this.chkMcpMsBuild.Checked;
             target.mcp_github_enabled = this.chkMcpGithub.Checked;
             target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
@@ -1414,11 +1415,12 @@ namespace GxPT
             }
             catch { }
 
-            // The scratch-dir option only applies to the command server, so it's enableable only while
-            // the command server itself is on; unchecked-and-disabled otherwise.
-            bool commandOn = this.chkMcpCommand.Checked;
-            this.chkMcpCommandScratch.Enabled = commandOn;
-            if (!commandOn) this.chkMcpCommandScratch.Checked = false;
+            // The scratch-dir option only applies to the command server, so the control is enableable
+            // only while the command server itself is on. Its checked state is left untouched when the
+            // command server is off (the value is preserved, just greyed out), so re-enabling the command
+            // server brings back the user's prior choice. The runtime (ScratchWorkspace.IsEnabled) gates
+            // on the command server too, so a preserved-on scratch setting can't take effect on its own.
+            this.chkMcpCommandScratch.Enabled = this.chkMcpCommand.Checked;
         }
 
         // Tavily keys look like "tvly-dev-XXXXXXXX" (or "tvly-XXXXXXXX"). Lenient prefix + length check.

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -21,12 +21,6 @@ namespace GxPT
         // In-memory working copy (unsaved until Save/CTRL+S)
         private SettingsData _working = new SettingsData();
 
-        // Free-form settings.json keys that SettingsData does not model (e.g. "agents_enabled", written by
-        // AppSettings via the /toggle-agents command). Captured on load and on JSON edits, then merged back
-        // into the JSON view and the saved file so the typed editor never silently drops them. Without this,
-        // saving Settings would wipe such keys (which is exactly how globally-enabled agents would turn off).
-        private Dictionary<string, object> _extraKeys = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-
         // Guard to prevent event loops during programmatic sync
         private bool _isSyncing = false;
 
@@ -194,8 +188,6 @@ namespace GxPT
                 {
                     _working = BuildDefaultSettings();
                 }
-                // Remember any keys SettingsData doesn't model so they aren't dropped on save.
-                _extraKeys = ComputeExtraKeys(raw);
 
                 _isSyncing = true;
                 try
@@ -222,58 +214,12 @@ namespace GxPT
                 Directory.CreateDirectory(_settingsDir);
             }
 
-            if (!File.Exists(_settingsFile))
-            {
-                var defaultJson = BuildDefaultJson();
-                File.WriteAllText(_settingsFile, defaultJson, Encoding.UTF8);
-            }
+            // One seed path (issue #164): AppSettings fills every absent key from the schema and creates
+            // the file if needed, so the file we read below is always complete - no per-form default JSON.
+            AppSettings.EnsureSeeded();
         }
 
-        private static string BuildDefaultJson()
-        {
-            // defaults: empty key, sensible model list, default model, and font size from chat's default
-            float defaultFontSize = GetChatDefaultFontSize();
-            int defaultTranscriptW = 1000;
-            int defaultMessagePercent = 90;
-            var sb = new StringBuilder();
-            sb.AppendLine("{");
-            sb.AppendLine("  \"openrouter_api_key\": \"\",");
-            // Models come from the shared default catalog (ModelDefaults) so this seed, the strongly
-            // typed defaults, and the combo's fresh-install fallback can't drift apart.
-            sb.AppendLine("  \"models\": [");
-            for (int i = 0; i < ModelDefaults.Models.Length; i++)
-            {
-                bool last = (i == ModelDefaults.Models.Length - 1);
-                sb.AppendLine("    \"" + ModelDefaults.Models[i] + "\"" + (last ? "" : ","));
-            }
-            sb.AppendLine("  ],");
-            sb.AppendLine("  \"default_model\": \"" + ModelDefaults.DefaultModel + "\",");
-            // Seed the acknowledged-recommendations fingerprint so a fresh install (which already ships
-            // with the current catalog) doesn't immediately show the "updated models" banner.
-            sb.AppendLine("  \"recommended_hash_seen\": \"" + ModelDefaults.RecommendedHash() + "\",");
-            sb.AppendLine("  \"theme\": \"light\",");
-            // Default UI color theme
-            sb.AppendLine("  \"color_theme\": \"blue\",");
-            sb.AppendLine("  \"font_size\": " + defaultFontSize.ToString(System.Globalization.CultureInfo.InvariantCulture) + ",");
-            sb.AppendLine("  \"transcript_max_width\": " + defaultTranscriptW + ",");
-            // Store percent (50-100) under legacy key name
-            sb.AppendLine("  \"message_max_width\": " + defaultMessagePercent + ",");
-            sb.AppendLine("  \"enable_logging\": false,")
-            ;
-            // Default zero data retention off (new conversations may use any provider).
-            sb.AppendLine("  \"provider_zdr\": false,");
-            // First-party MCP servers enabled by default where no credential is required
-            // (files/command; they connect once a working folder is set).
-            sb.AppendLine("  \"mcp_files_enabled\": true,");
-            // Persistent project memory: off by default; soft index cap (lines) configurable.
-            sb.AppendLine("  \"mcp_memory_enabled\": false,");
-            sb.AppendLine("  \"mcp_memory_max_lines\": 40,");
-            sb.AppendLine("  \"mcp_command_enabled\": true");
-            sb.AppendLine("}");
-            return sb.ToString();
-        }
-
-        private static float GetChatDefaultFontSize()
+        internal static float GetChatDefaultFontSize()
         {
             try
             {
@@ -286,30 +232,20 @@ namespace GxPT
             catch { return 9f; }
         }
 
-        // Strongly-typed default object (mirrors BuildDefaultJson)
+        // Strongly-typed default object, derived from the one schema (SettingsSchema) so it can't drift
+        // from the seeded file. Used only as the in-memory fallback when settings.json fails to parse.
         private static SettingsData BuildDefaultSettings()
         {
-            return new SettingsData
+            SettingsData s = null;
+            try
             {
-                openrouter_api_key = "",
-                models = ModelDefaults.ModelList(),
-                default_model = ModelDefaults.DefaultModel,
-                recommended_hash_seen = ModelDefaults.RecommendedHash(),
-                enable_logging = false,
-                font_size = GetChatDefaultFontSize(),
-                theme = "light",
-                color_theme = "blue",
-                transcript_max_width = 1000,
-                // Percent (50-100) under legacy key name
-                message_max_width = 90,
-                provider_zdr = false,
-                // First-party MCP servers enabled by default where no credential is required.
-                mcp_files_enabled = true,
-                mcp_command_enabled = true,
-                // Persistent project memory: off by default; soft index cap (lines).
-                mcp_memory_enabled = false,
-                mcp_memory_max_lines = 40
-            };
+                var ser = new JavaScriptSerializer();
+                s = ser.Deserialize<SettingsData>(ser.Serialize(SettingsSchema.BuildDefaults()));
+            }
+            catch { }
+            if (s == null) s = new SettingsData();
+            PostProcess(s);
+            return s;
         }
 
         private bool SaveSettingsOnly()
@@ -334,7 +270,7 @@ namespace GxPT
                 if (!TryValidateMcpJson(out mcpJsonText)) return false;
                 CaptureMcpControlsToWorking(_working);
 
-                var json = MergeExtraKeys(Serialize(_working));
+                var json = Serialize(_working);
                 File.WriteAllText(_settingsFile, json, Encoding.UTF8);
                 WriteMcpJson(mcpJsonText);
 
@@ -494,55 +430,11 @@ namespace GxPT
             return ser.Serialize(settings);
         }
 
-        // The settings.json keys SettingsData models (its property names are the JSON keys 1:1).
-        private static HashSet<string> KnownSettingKeys()
-        {
-            HashSet<string> known = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (System.Reflection.PropertyInfo p in typeof(SettingsData).GetProperties())
-                known.Add(p.Name);
-            return known;
-        }
-
-        // The free-form keys in a raw settings.json that SettingsData does not model (so they'd otherwise be
-        // lost on a typed round-trip). Returns an empty map on any parse error.
-        private static Dictionary<string, object> ComputeExtraKeys(string rawJson)
-        {
-            Dictionary<string, object> extra = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            try
-            {
-                var ser = new JavaScriptSerializer();
-                Dictionary<string, object> dict = ser.Deserialize<Dictionary<string, object>>(rawJson ?? string.Empty);
-                if (dict != null)
-                {
-                    HashSet<string> known = KnownSettingKeys();
-                    foreach (KeyValuePair<string, object> kv in dict)
-                        if (!known.Contains(kv.Key)) extra[kv.Key] = kv.Value;
-                }
-            }
-            catch { }
-            return extra;
-        }
-
-        // Overlay the captured free-form keys onto a typed-settings JSON string so they survive the round-trip
-        // (typed keys win; extras fill in). Used for both the JSON view and the saved file.
-        private string MergeExtraKeys(string typedJson)
-        {
-            if (_extraKeys == null || _extraKeys.Count == 0) return typedJson;
-            try
-            {
-                var ser = new JavaScriptSerializer();
-                Dictionary<string, object> dict = ser.Deserialize<Dictionary<string, object>>(typedJson ?? string.Empty)
-                    ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-                foreach (KeyValuePair<string, object> kv in _extraKeys)
-                    if (!dict.ContainsKey(kv.Key)) dict[kv.Key] = kv.Value;
-                return ser.Serialize(dict);
-            }
-            catch { return typedJson; }
-        }
-
         private void UpdateJsonEditorFromSettings(SettingsData settings)
         {
-            var json = MergeExtraKeys(Serialize(settings));
+            // SettingsData now models every global key, so the typed projection IS the file - no
+            // free-form merge needed (issue #164).
+            var json = Serialize(settings);
             this.rtbJson.Text = PrettyPrintJson(json);
             // Do not trigger highlight here; only on TextChanged
         }
@@ -554,8 +446,6 @@ namespace GxPT
                 var ser = new JavaScriptSerializer();
                 settings = ser.Deserialize<SettingsData>(this.rtbJson.Text ?? string.Empty) ?? new SettingsData();
                 PostProcess(settings);
-                // Re-capture free-form keys from the edited JSON so edits to them (e.g. agents_enabled) persist.
-                _extraKeys = ComputeExtraKeys(this.rtbJson.Text);
                 error = string.Empty;
                 return true;
             }
@@ -1456,20 +1346,17 @@ namespace GxPT
             if (s == null) return;
             this.chkMcpWeb.Checked = s.mcp_web_enabled;
             this.chkMcpFiles.Checked = s.mcp_files_enabled;
-            // Git defaults ON when git is installed and the user hasn't chosen otherwise; OFF (and
-            // disabled below) when git isn't on PATH.
-            this.chkMcpGit.Checked = GitProbe.IsInstalled() && AppSettings.GetBool("mcp_git_enabled", true);
+            // Git/MSBuild read straight from the typed model now that the file is always seeded complete
+            // (so an absent key can't read as false); still force-OFF below when the tool isn't installed.
+            this.chkMcpGit.Checked = GitProbe.IsInstalled() && s.mcp_git_enabled;
             this.chkMcpCommand.Checked = s.mcp_command_enabled;
             this.chkMcpCommandScratch.Checked = s.mcp_command_scratch_enabled;
-            // MSBuild, like Git, defaults ON when a build engine is found and the user hasn't chosen
-            // otherwise; OFF (and disabled below) when no MSBuild is present.
-            this.chkMcpMsBuild.Checked = MsBuildProbe.IsInstalled() && AppSettings.GetBool("mcp_msbuild_enabled", true);
+            this.chkMcpMsBuild.Checked = MsBuildProbe.IsInstalled() && s.mcp_msbuild_enabled;
             this.chkMcpGithub.Checked = s.mcp_github_enabled;
             this.txtWebSearchKey.Text = s.mcp_websearch_key != null ? s.mcp_websearch_key : string.Empty;
             this.txtGithubPat.Text = s.mcp_github_pat != null ? s.mcp_github_pat : string.Empty;
-            // Sub-agents: a free-form settings.json key (written by /toggle-agents), so read it via GetBool
-            // with the feature default - just like git/msbuild - so an absent key shows as on, not off.
-            this.chkAgents.Checked = AppSettings.GetBool(AgentEnablement.GlobalSettingKey, AgentEnablement.GlobalDefault);
+            // Sub-agents now lives in the typed model (agents_enabled) like every other toggle.
+            this.chkAgents.Checked = s.agents_enabled;
             UpdateMcpEnableStates();
         }
 
@@ -1487,10 +1374,8 @@ namespace GxPT
             target.mcp_github_enabled = this.chkMcpGithub.Checked;
             target.mcp_websearch_key = this.txtWebSearchKey.Text != null ? this.txtWebSearchKey.Text.Trim() : string.Empty;
             target.mcp_github_pat = this.txtGithubPat.Text != null ? this.txtGithubPat.Text.Trim() : string.Empty;
-            // Sub-agents lives in settings.json as a free-form key, so persist it through the merge map
-            // (SettingsData doesn't model it). Captured here so Save writes the checkbox state.
-            if (_extraKeys == null) _extraKeys = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            _extraKeys[AgentEnablement.GlobalSettingKey] = this.chkAgents.Checked;
+            // Sub-agents is a typed key now; Save writes the checkbox state through SettingsData.
+            target.agents_enabled = this.chkAgents.Checked;
         }
 
         // A web-search / GitHub toggle is only enableable when its key/PAT looks plausibly valid;
@@ -1597,6 +1482,12 @@ namespace GxPT
             // "updated recommended models" banner relies on. Not surfaced in the visual editor.
             public string recommended_hash_seen { get; set; }
             public bool enable_logging { get; set; }
+            // Show/hide the bottom status bar (toggled from the main window; modeled here so saving the
+            // settings form preserves it instead of dropping it).
+            public bool statusbar_visible { get; set; }
+            // Global sub-agents feature default (also written by /toggle-agents). Modeled here so it
+            // round-trips through the form like any other toggle.
+            public bool agents_enabled { get; set; }
             public double font_size { get; set; }
             public string theme { get; set; }
             public string color_theme { get; set; }

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Managers\ImportExportManager.cs" />
     <Compile Include="Managers\SkillImportExportManager.cs" />
     <Compile Include="Services\AppSettings.cs" />
+    <Compile Include="Services\SettingsSchema.cs" />
     <Compile Include="Services\RecentWorkDirs.cs" />
     <Compile Include="Services\ScratchWorkspace.cs" />
     <Compile Include="Services\Skills\SkillSlug.cs" />

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -6,11 +6,11 @@ using System.Text;
 namespace GxPT
 {
     // Single source of truth for the models shipped to NEW installs and the default selection.
-    // The seed settings.json (SettingsForm.BuildDefaultJson), the in-memory fallback
-    // (SettingsForm.BuildDefaultSettings), and the model dropdown's fresh-install fallback
-    // (MainForm.PopulateModelsFromSettings) all pull from here, so the list is defined once and the
-    // three can't drift apart. Existing users' configured models live in their own settings.json and
-    // are never overwritten by this.
+    // The settings schema (SettingsSchema.BuildDefaults, which seeds settings.json and backs the
+    // form's typed fallback) and the model dropdown's fresh-install fallback
+    // (MainForm.PopulateModelsFromSettings) both pull from here, so the list is defined once and they
+    // can't drift apart. Existing users' configured models live in their own settings.json and are
+    // never overwritten by this.
     internal static class ModelDefaults
     {
         // Selected by default on a fresh install. Must be one of Models below.

--- a/GxPT/Program.cs
+++ b/GxPT/Program.cs
@@ -15,6 +15,21 @@ namespace GxPT
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            // Settings defaults live in one place (SettingsSchema). Point its font-size default at the
+            // live chat control's font (computed once, outside AppSettings' lock), then seed any absent
+            // keys into settings.json so the file is complete before any component reads it (issue #164).
+            try
+            {
+                double chatFont = 9.0;
+                try { chatFont = SettingsForm.GetChatDefaultFontSize(); }
+                catch { }
+                SettingsSchema.DefaultFontSizeProvider = delegate { return chatFont; };
+            }
+            catch { }
+            try { AppSettings.EnsureSeeded(); }
+            catch { }
+
             // Install global hover-to-scroll router (keeps focus where it is)
             try { HoverWheelRouter.Install(); }
             catch { }

--- a/GxPT/Services/AppSettings.cs
+++ b/GxPT/Services/AppSettings.cs
@@ -44,6 +44,37 @@ namespace GxPT
             }
         }
 
+        // Fill any settings.json key absent on disk with its declared default (SettingsSchema), then
+        // persist - so the on-disk file is always complete and behavior never depends on whether a key
+        // happens to be present (issue #164). Idempotent: writes only when something was actually added,
+        // so it's cheap to call on every startup. Creating the file and its directory is handled by the
+        // persist path (FileSafe). Call once early (Program.Main) before any component reads settings.
+        public static void EnsureSeeded()
+        {
+            lock (_gate)
+            {
+                EnsureLoadedLocked();
+                if (_cache == null) _cache = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+                bool changed = false;
+                var defaults = SettingsSchema.BuildDefaults();
+                foreach (var kv in defaults)
+                {
+                    if (_cache.ContainsKey(kv.Key)) continue;
+                    object value = kv.Value;
+                    // provider_zdr is special: when absent, derive its seed from the legacy
+                    // data-collection pref so an older file migrates correctly instead of being pinned to
+                    // the static default. (GetGlobalZdrDefault re-enters the lock, which is fine.)
+                    if (string.Equals(kv.Key, "provider_zdr", StringComparison.OrdinalIgnoreCase))
+                        value = GetGlobalZdrDefault();
+                    _cache[kv.Key] = value;
+                    changed = true;
+                }
+
+                if (changed) PersistLocked();
+            }
+        }
+
         // Ensure _cache reflects the current on-disk file. Must be called while holding _gate.
         private static void EnsureLoadedLocked()
         {
@@ -256,6 +287,13 @@ namespace GxPT
         public static double GetDouble(string key)
         {
             return GetDouble(key, 0);
+        }
+
+        // Overload that sources the default from the schema (SettingsSchema) - the single source of
+        // truth - so call sites don't each pass a literal that could drift from the seeded value.
+        public static bool GetBool(string key)
+        {
+            return GetBool(key, SettingsSchema.BoolDefault(key));
         }
 
         // Read boolean values (accepts true/false, 1/0, yes/no, on/off, strings or numbers)

--- a/GxPT/Services/ScratchWorkspace.cs
+++ b/GxPT/Services/ScratchWorkspace.cs
@@ -29,8 +29,8 @@ namespace GxPT
         {
             try
             {
-                return AppSettings.GetBool("mcp_command_enabled", false)
-                    && AppSettings.GetBool("mcp_command_scratch_enabled", false);
+                return AppSettings.GetBool("mcp_command_enabled")
+                    && AppSettings.GetBool("mcp_command_scratch_enabled");
             }
             catch { return false; }
         }

--- a/GxPT/Services/SettingsSchema.cs
+++ b/GxPT/Services/SettingsSchema.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // Single source of truth for every global settings.json key and its default value (issue #164).
+    //
+    // Defaults used to live in three places that drifted apart: SettingsForm.BuildDefaultJson (the seed
+    // file), SettingsForm.BuildDefaultSettings (the typed fallback), and each runtime GetBool(key,
+    // <literal>) call site. They could - and did - disagree, so behavior depended on whether
+    // settings.json happened to contain a key (e.g. files/command seeded ON in the file but read with a
+    // default of OFF, so a user who never opened Settings got them off). Now every default is declared
+    // here once:
+    //   - AppSettings.EnsureSeeded fills any absent key from this table, so the on-disk file is always
+    //     complete and the missing-key upgrade path matches a fresh seed.
+    //   - AppSettings.GetBool(key) resolves its default from here (no per-call-site literal to drift).
+    //   - The settings form derives both its seed JSON and its typed default from BuildDefaults().
+    //
+    // Pure / WinForms-free so it can be linked into the headless test project alongside AppSettings.
+    internal static class SettingsSchema
+    {
+        // Resolves the default chat font size. The WinForms layer points this at the live
+        // ChatTranscriptControl font during startup (Program.Main); the pure fallback used by tests and
+        // any headless path is 9.
+        public static Func<double> DefaultFontSizeProvider = delegate { return 9.0; };
+
+        // Every key that belongs in a complete settings.json, mapped to its default value. The value's
+        // CLR type is the type the key is stored as (bool / int / double / string / string[]).
+        //
+        // Note: provider_data_collection (legacy) is intentionally absent - it exists only so older files
+        // can migrate to provider_zdr (see AppSettings.GetGlobalZdrDefault) and is never seeded anew.
+        public static Dictionary<string, object> BuildDefaults()
+        {
+            var d = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            // --- Core ---
+            d["openrouter_api_key"] = "";
+            // Models / default model / acknowledged-recommendations fingerprint come from the shared
+            // catalog so this seed can't drift from the combo's fresh-install fallback.
+            d["models"] = (string[])ModelDefaults.Models.Clone();
+            d["default_model"] = ModelDefaults.DefaultModel;
+            d["recommended_hash_seen"] = ModelDefaults.RecommendedHash();
+
+            // --- Appearance ---
+            d["theme"] = "light";
+            d["color_theme"] = "blue";
+            d["font_size"] = ResolveFontSize();
+            d["transcript_max_width"] = 1000;
+            d["message_max_width"] = 90; // percent (50-100), stored under the legacy key name
+
+            // --- Behavior ---
+            d["enable_logging"] = false;
+            d["statusbar_visible"] = true;
+            // Sub-agents: on by default now that a first-party agent suite ships with the app
+            // (mirrors AgentEnablement.GlobalDefault).
+            d["agents_enabled"] = true;
+            // Global zero-data-retention default for new conversations. EnsureSeeded overrides this seed
+            // with the migrated value when an older file only carries provider_data_collection.
+            d["provider_zdr"] = false;
+
+            // --- First-party MCP servers ---
+            // The credential-free servers default ON so they work out of the box. git/msbuild are still
+            // gated at launch on the underlying tool being installed; files/command connect once a
+            // working folder (or scratch dir) is set. The credential-gated servers (web/github) default
+            // OFF because they can't run without a key/PAT.
+            d["mcp_files_enabled"] = true;
+            d["mcp_command_enabled"] = true;
+            d["mcp_command_scratch_enabled"] = false;
+            d["mcp_git_enabled"] = true;
+            d["mcp_msbuild_enabled"] = true;
+            d["mcp_web_enabled"] = false;
+            d["mcp_github_enabled"] = false;
+            d["mcp_websearch_key"] = "";
+            d["mcp_github_pat"] = "";
+            // Persistent project memory is NOT strictly an MCP server toggle; off by default, with a
+            // user-configurable soft index cap (lines).
+            d["mcp_memory_enabled"] = false;
+            d["mcp_memory_max_lines"] = 40;
+
+            return d;
+        }
+
+        private static double ResolveFontSize()
+        {
+            try
+            {
+                Func<double> f = DefaultFontSizeProvider;
+                return f != null ? f() : 9.0;
+            }
+            catch { return 9.0; }
+        }
+
+        // Typed default lookups - the single source the runtime reads through.
+        public static bool BoolDefault(string key)
+        {
+            object v;
+            if (BuildDefaults().TryGetValue(key, out v) && v is bool) return (bool)v;
+            return false;
+        }
+
+        public static double DoubleDefault(string key)
+        {
+            object v;
+            if (BuildDefaults().TryGetValue(key, out v) && v != null)
+            {
+                try { return Convert.ToDouble(v); }
+                catch { }
+            }
+            return 0;
+        }
+
+        public static string StringDefault(string key)
+        {
+            object v;
+            if (BuildDefaults().TryGetValue(key, out v) && v != null) return Convert.ToString(v);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #164.

## Problem

Global settings defaults lived in three places that drifted apart: `SettingsForm.BuildDefaultJson` (the seed file), `BuildDefaultSettings` (the typed fallback), and each runtime `GetBool(key, <literal>)` call site. The headline symptom: `files`/`command` were seeded **on** in the file but read with a runtime default of **off**, so whether they ran depended on whether the user had ever opened the Settings dialog.

## Approach — one source of truth + a complete on-disk file

- **`SettingsSchema`** (new): every global key declares its default exactly once.
- **`AppSettings.EnsureSeeded()`**: fills any absent key from the schema and persists, so `settings.json` is always complete. The missing-key upgrade path now resolves to the *same* value as a fresh seed — the file-existence ambiguity is gone. Seeded once at startup (`Program.Main`) before anything reads settings.
- **Schema-backed reads**: `AppSettings.GetBool(key)` resolves its default from the schema, so the runtime MCP/statusbar read sites stop passing literals that could drift.
- **`provider_zdr`** is seeded via the existing data-collection migration, so older files migrate correctly instead of being pinned to the static default.

## Default policy

| Server | Default | Why |
|---|---|---|
| files, command, git, msbuild | **enabled** | credential-free; git/msbuild still gated at launch on the tool being installed |
| web, github | **disabled** | can't run without a key/PAT |
| memory | **disabled** | not strictly an MCP toggle |

## Cleanup

- Folded the free-form keys (`agents_enabled`, `statusbar_visible`) into the typed `SettingsData` and **removed the `ComputeExtraKeys`/`MergeExtraKeys` band-aid**. The Settings **JSON tab now shows the real, complete file** rather than a partial typed projection.
- The form derives both its seed and its typed fallback from the schema, so they can't drift.

## Follow-up refinement

Disabling the command server now only greys out the scratch-dir control instead of unchecking/wiping it — the setting survives a disable/re-enable. Runtime already gates scratch on the command server being on (`ScratchWorkspace.IsEnabled`), so a preserved-on value can't take effect alone.

## Scope decisions

- **Skills enablement keeps its own `skills.json`** — its tri-state per-skill semantics don't fit the flat settings model.
- web/github default off rather than "on but gated."

## Testing

- New `SettingsSchemaTests` locks in the default policy and schema completeness/consistency (the main regression surface — changing any default fails a test).
- Smoke-tested end-to-end by the maintainer.
- Not unit-covered: `EnsureSeeded` mechanism + `zdr` migration and the WinForms form, since `AppSettings` is a static singleton over `%APPDATA%` and the form is WinForms — neither fits the project's pure-logic harness, consistent with the existing codebase.

## Notes / caveats

- Built and verified by inspection only — no .NET 3.5 toolchain in the dev environment; worth a local build.
- **Behavior change:** existing users who never explicitly enabled files/command will get them **on** after upgrade — which is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxGdtNhV1f976SJBDprbTB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxGdtNhV1f976SJBDprbTB)_