### PR TITLE
Show agent model name in the agent activity panel

### DIFF
--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -202,11 +202,22 @@ namespace GxPT.Tests
         {
             private readonly object _gate = new object();
             public int FanOutStarts, FanOutEnds, Starts, Finishes, Cancellations, LastFanOutCount;
-            public int Activities, LastFanOutTaskCount;
+            public int Activities, LastFanOutTaskCount, LastFanOutModelCount;
+            public string LastFanOutFirstModel;
 
             public void OnFanOutStart(System.Collections.Generic.IList<string> slugs,
-                                      System.Collections.Generic.IList<string> tasks)
-            { lock (_gate) { FanOutStarts++; LastFanOutCount = slugs.Count; LastFanOutTaskCount = (tasks != null ? tasks.Count : 0); } }
+                                      System.Collections.Generic.IList<string> tasks,
+                                      System.Collections.Generic.IList<string> models)
+            {
+                lock (_gate)
+                {
+                    FanOutStarts++;
+                    LastFanOutCount = slugs.Count;
+                    LastFanOutTaskCount = (tasks != null ? tasks.Count : 0);
+                    LastFanOutModelCount = (models != null ? models.Count : 0);
+                    LastFanOutFirstModel = (models != null && models.Count > 0) ? models[0] : null;
+                }
+            }
             public void OnAgentStart(int index, string slug, string task) { lock (_gate) { Starts++; } }
             public void OnAgentFinished(int index, string slug, bool cancelled)
             { lock (_gate) { Finishes++; if (cancelled) Cancellations++; } }
@@ -231,6 +242,8 @@ namespace GxPT.Tests
             Assert.Equal(1, ui.FanOutEnds);
             Assert.Equal(2, ui.LastFanOutCount);
             Assert.Equal(2, ui.LastFanOutTaskCount);   // tier 2: tasks travel with the slugs
+            Assert.Equal(2, ui.LastFanOutModelCount);  // tier 2: resolved models travel with the slugs
+            Assert.Equal("m", ui.LastFanOutFirstModel); // agents have no model override -> parent model
             Assert.Equal(2, ui.Starts);
             Assert.Equal(2, ui.Finishes);
         }

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -22,6 +22,7 @@ namespace GxPT
 
         private string[] _slugs;
         private int[] _state;
+        private string[] _models;       // tier 2: per-row resolved model slug, shown inline (author stripped)
         private string[] _tasks;        // tier 2: per-row task, shown as a hover tooltip
         private string[] _lastTool;     // tier 2: most recent tool the child called (null until first call)
         private int[] _toolCount;       // tier 2: how many tool calls the child has made
@@ -63,11 +64,12 @@ namespace GxPT
 
         // Start showing a fan-out of the given agents (in dispatch order), all queued. onStop (may be null)
         // is invoked when the user clicks the panel's Stop button.
-        public void BeginFanOut(IList<string> slugs, IList<string> tasks, Action onStop, Action<int> onViewTranscript)
+        public void BeginFanOut(IList<string> slugs, IList<string> tasks, IList<string> models, Action onStop, Action<int> onViewTranscript)
         {
             int n = slugs != null ? slugs.Count : 0;
             _slugs = new string[n];
             _state = new int[n];
+            _models = new string[n];
             _tasks = new string[n];
             _lastTool = new string[n];
             _toolCount = new int[n];
@@ -76,6 +78,7 @@ namespace GxPT
             {
                 _slugs[i] = slugs[i];
                 _state[i] = StateQueued;
+                _models[i] = (models != null && i < models.Count) ? models[i] : null;
                 _tasks[i] = (tasks != null && i < tasks.Count) ? tasks[i] : null;
             }
             _onStop = onStop;
@@ -110,6 +113,7 @@ namespace GxPT
             this.Visible = false;
             _slugs = null;
             _state = null;
+            _models = null;
             _tasks = null;
             _lastTool = null;
             _toolCount = null;
@@ -218,23 +222,31 @@ namespace GxPT
             for (int i = 0; i < _slugs.Length; i++)
             {
                 int rowX = Pad + RowIndent;
-                TextRenderer.DrawText(g, _slugs[i], this.Font, new Point(rowX, y), tc.UiForeground, TextFormatFlags.NoPadding);
-                int slugW = TextRenderer.MeasureText(g, _slugs[i], this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
 
+                // Status tag first: "[status] agent-slug (model-name): X tools - last_tool".
                 string tag; Color tagColor;
                 if (_state[i] == StateDone) { tag = "[done]"; tagColor = cDone; }
                 else if (_state[i] == StateRunning) { tag = "[running]"; tagColor = cRunning; }
                 else if (_state[i] == StateCancelled) { tag = "[cancelled]"; tagColor = cCancelled; }
                 else { tag = "[queued]"; tagColor = cQueued; }
-                int tagX = rowX + slugW + 8;
-                TextRenderer.DrawText(g, tag, this.Font, new Point(tagX, y), tagColor, TextFormatFlags.NoPadding);
+                TextRenderer.DrawText(g, tag, this.Font, new Point(rowX, y), tagColor, TextFormatFlags.NoPadding);
+                int tagW = TextRenderer.MeasureText(g, tag, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+
+                // Agent slug, optionally followed by its model in parentheses.
+                int x = rowX + tagW + 8;
+                string model = ShortModel(i);
+                string label = string.IsNullOrEmpty(model) ? _slugs[i] : _slugs[i] + " (" + model + ")";
+                TextRenderer.DrawText(g, label, this.Font, new Point(x, y), tc.UiForeground, TextFormatFlags.NoPadding);
+                int labelW = TextRenderer.MeasureText(g, label, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
 
                 // Live activity line (tier 2): tool count, plus the latest tool while the child runs.
                 string activity = BuildActivity(i);
                 if (activity.Length > 0)
                 {
-                    int tagW = TextRenderer.MeasureText(g, tag, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
-                    TextRenderer.DrawText(g, activity, this.Font, new Point(tagX + tagW + 8, y), cQueued, TextFormatFlags.NoPadding);
+                    string sep = ": ";
+                    int sepW = TextRenderer.MeasureText(g, sep, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+                    TextRenderer.DrawText(g, sep, this.Font, new Point(x + labelW, y), tc.UiForeground, TextFormatFlags.NoPadding);
+                    TextRenderer.DrawText(g, activity, this.Font, new Point(x + labelW + sepW, y), cQueued, TextFormatFlags.NoPadding);
                 }
 
                 // Per-row "View transcript" link (tier 3 "watch live"), right-aligned. Shown once the child
@@ -245,7 +257,7 @@ namespace GxPT
                     string vt = "View transcript";
                     int vtW = TextRenderer.MeasureText(g, vt, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
                     int vtX = this.ClientRectangle.Width - Pad - vtW - 1;
-                    if (vtX < tagX) vtX = tagX;
+                    if (vtX < x) vtX = x;
                     Rectangle vr = new Rectangle(vtX, y, vtW, LineH());
                     if (_viewRects != null && i < _viewRects.Length) _viewRects[i] = vr;
                     Color vc = (_hoverView == i) ? tc.UiForeground : tc.Link;
@@ -267,6 +279,17 @@ namespace GxPT
             if (_state[i] == StateRunning && _lastTool != null && !string.IsNullOrEmpty(_lastTool[i]))
                 s += " - " + ShortTool(_lastTool[i]);
             return s;
+        }
+
+        // The model name without its author prefix (e.g. "anthropic/claude-opus-4.8" -> "claude-opus-4.8"),
+        // so the row stays short. Empty when no model is known for the row.
+        private string ShortModel(int i)
+        {
+            if (_models == null || i < 0 || i >= _models.Length) return string.Empty;
+            string m = _models[i];
+            if (string.IsNullOrEmpty(m)) return string.Empty;
+            int idx = m.IndexOf('/');
+            return idx >= 0 && idx + 1 < m.Length ? m.Substring(idx + 1) : m;
         }
 
         // The unqualified tool name (drop the "server__" prefix) so the activity line stays short.

--- a/GxPT/Controls/AgentActivityPanel.cs
+++ b/GxPT/Controls/AgentActivityPanel.cs
@@ -232,12 +232,18 @@ namespace GxPT
                 TextRenderer.DrawText(g, tag, this.Font, new Point(rowX, y), tagColor, TextFormatFlags.NoPadding);
                 int tagW = TextRenderer.MeasureText(g, tag, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
 
-                // Agent slug, optionally followed by its model in parentheses.
+                // Agent slug, optionally followed by its model in parentheses (model drawn muted, the same
+                // grey as the activity line).
                 int x = rowX + tagW + 8;
+                TextRenderer.DrawText(g, _slugs[i], this.Font, new Point(x, y), tc.UiForeground, TextFormatFlags.NoPadding);
+                int labelW = TextRenderer.MeasureText(g, _slugs[i], this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
                 string model = ShortModel(i);
-                string label = string.IsNullOrEmpty(model) ? _slugs[i] : _slugs[i] + " (" + model + ")";
-                TextRenderer.DrawText(g, label, this.Font, new Point(x, y), tc.UiForeground, TextFormatFlags.NoPadding);
-                int labelW = TextRenderer.MeasureText(g, label, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+                if (!string.IsNullOrEmpty(model))
+                {
+                    string modelText = " (" + model + ")";
+                    TextRenderer.DrawText(g, modelText, this.Font, new Point(x + labelW, y), cQueued, TextFormatFlags.NoPadding);
+                    labelW += TextRenderer.MeasureText(g, modelText, this.Font, Size.Empty, TextFormatFlags.NoPadding).Width;
+                }
 
                 // Live activity line (tier 2): tool count, plus the latest tool while the child runs.
                 string activity = BuildActivity(i);

--- a/GxPT/Forms/AgentActivityUiBridge.cs
+++ b/GxPT/Forms/AgentActivityUiBridge.cs
@@ -23,18 +23,19 @@ namespace GxPT
             _dispatcher = dispatcher;
         }
 
-        public void OnFanOutStart(IList<string> slugs, IList<string> tasks)
+        public void OnFanOutStart(IList<string> slugs, IList<string> tasks, IList<string> models)
         {
             // Copy the lists: they are the dispatcher's and may change; the UI thread reads them later.
             List<string> slugCopy = slugs != null ? new List<string>(slugs) : new List<string>();
             List<string> taskCopy = tasks != null ? new List<string>(tasks) : new List<string>();
+            List<string> modelCopy = models != null ? new List<string>(models) : new List<string>();
             RequestCancellation group = _group;
             AgentDispatcher dispatcher = _dispatcher;
             Marshal(delegate
             {
                 AgentActivityPanel p = Panel();
                 if (p != null)
-                    p.BeginFanOut(slugCopy, taskCopy,
+                    p.BeginFanOut(slugCopy, taskCopy, modelCopy,
                         delegate { if (group != null) group.Cancel(); },
                         delegate(int row)
                         {

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -184,12 +184,15 @@ namespace GxPT
             {
                 List<string> slugs = new List<string>(runnable.Count);
                 List<string> taskList = new List<string>(runnable.Count);
+                List<string> modelList = new List<string>(runnable.Count);
                 for (int k = 0; k < runnable.Count; k++)
                 {
-                    slugs.Add(agents[runnable[k]].Slug);
+                    Agent a = agents[runnable[k]];
+                    slugs.Add(a.Slug);
                     taskList.Add(tasks[runnable[k]]);
+                    modelList.Add(!string.IsNullOrEmpty(a.Model) ? a.Model : _parentModel);
                 }
-                ui.OnFanOutStart(slugs, taskList);
+                ui.OnFanOutStart(slugs, taskList, modelList);
             }
             // Fresh live-stream table for this fan-out (tier 3 "watch live"); the panel looks streams up by
             // row while the children run, and it is dropped when the fan-out ends.

--- a/GxPT/Services/Agents/IAgentActivityUi.cs
+++ b/GxPT/Services/Agents/IAgentActivityUi.cs
@@ -11,9 +11,11 @@ namespace GxPT
     internal interface IAgentActivityUi
     {
         // A fan-out is beginning with `slugs.Count` agents (in dispatch order); `tasks[i]` is the task
-        // string handed to `slugs[i]` (parallel lists, same length), shown per-row (tier 2, truncated /
-        // hover-to-expand). The host shows the panel and relabels Stop. Always paired with one OnFanOutEnd.
-        void OnFanOutStart(IList<string> slugs, IList<string> tasks);
+        // string handed to `slugs[i]` and `models[i]` is the resolved model slug it runs on (parallel
+        // lists, same length). The task is shown per-row (tier 2, truncated / hover-to-expand) and the
+        // model is shown inline on the row. The host shows the panel and relabels Stop. Always paired with
+        // one OnFanOutEnd.
+        void OnFanOutStart(IList<string> slugs, IList<string> tasks, IList<string> models);
 
         // One child began / finished (index is its slot in the dispatch order). cancelled is true when the
         // fan-out was stopped by the user before this child completed (its result is partial/empty). Under

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -597,11 +597,11 @@ Same dual-world pattern (net48 linked-source via `dotnet test`):
 7. **Concurrent fan-out + must-have observability** — batch `dispatch_agent`,
    read-concurrent/write-serial execution on bounded `ThreadPool` work items,
    per-connection mutex, usage aggregation; the **group cancellation** + the
-   `Stop N agents` button; and the tier-1 **`AgentActivityPanel`** (glyph + slug +
-   status). Observability ships *with* the fan-out — it is not a follow-on (§14 tier 1).
+   `Stop N agents` button; and the tier-1 **`AgentActivityPanel`** (status + slug +
+   model). Observability ships *with* the fan-out — it is not a follow-on (§14 tier 1).
 8. **Transcript UI tiers 2-3** *(done; per-agent Stop deferred)* — tier 2: each
-   `AgentActivityPanel` row shows its task (hover tooltip) and a live `N tools -
-   <lastTool>` activity line, fed by a per-child forwarding `IToolLoopUi`
+   `AgentActivityPanel` row reads `[status] slug (model): N tools - <lastTool>`,
+   with its task on a hover tooltip and the live activity line fed by a per-child forwarding `IToolLoopUi`
    (`ChildActivityUi`) that replaces the headless `NullToolLoopUi`. Tier 3: each
    `dispatch_agent` record carries a per-agent **View transcript** link
    (`AgentTranscriptLinks` custom scheme) opening a read-only popup
@@ -827,7 +827,7 @@ moves, it just retargets — so no new status-bar real estate is needed.
 
 | Tier | Surface | Phase |
 |------|---------|-------|
-| **1 — must-have** *(shipped)* | `AgentActivityPanel` rows (glyph + slug + status) to **see** them + the **`Stop N agents`** button to stop all | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
+| **1 — must-have** *(shipped)* | `AgentActivityPanel` rows (`[status] slug (model)`) to **see** them + the **`Stop N agents`** button to stop all | with the **concurrent fan-out** (§11 phase 7) — observability is not optional for an unattended feature |
 | **2 — better** *(shipped)* | each row shows the child's **task** (hover tooltip) and a live **activity line** (`N tools - <lastTool>`, fed by `ChildActivityUi`) | §11 phase 8 |
 | **3 — best** *(shipped; per-agent Stop deferred)* | a **View transcript** link per agent on the `dispatch_agent` record opening the child's full message list **read-only** (`AgentTranscriptViewerForm`); **per-agent Stop** still deferred | §11 phase 8 |
 


### PR DESCRIPTION
## Summary

Updates each `AgentActivityPanel` row to surface the model each sub-agent is running on, and reorders the row so the status leads.

Row format changed from:

```
agent-slug [status] X tools - last_tool
```

to:

```
[status] agent-slug (model-name): X tools - last_tool
```

`model-name` is the model slug with its author prefix stripped (e.g. `anthropic/claude-opus-4.8` → `claude-opus-4.8`). The `(model-name)` portion is drawn in the same muted grey as the tool count / last-call activity text; the slug stays in the normal foreground. Parentheses are omitted when no model is known for the row.

## Changes

- **`AgentActivityPanel.cs`** — reordered the row (status tag first), added a `_models[]` field and a `models` parameter to `BeginFanOut`, and added a `ShortModel` helper that strips everything up to and including the first `/`. The model is rendered in the muted activity grey.
- **`AgentDispatcher.cs`** — resolves each runnable agent's effective model (its own `Model` override, else the parent model — the same resolution `RunChild` already uses) and passes the parallel list to `OnFanOutStart`.
- **`IAgentActivityUi.cs` / `AgentActivityUiBridge.cs`** — threaded the new `models` list through the interface and the UI bridge (with a defensive copy, matching the existing slug/task handling).
- **`AgentDispatcherTests.cs`** — updated the fake UI to the new signature and added assertions that the resolved models flow through.
- **`docs/subagents-design.md`** — updated the row-format descriptions.

## Notes

- The model shown is the *resolved* model: an agent without a `model:` override displays the parent conversation's model rather than blank.
- Not built locally — the main project targets .NET 3.5 and this environment has no `dotnet`/`msbuild`; CI exercises the build/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017rcaNG4vNZtA2bmgzG3FYi)_