### PR TITLE
Bundle agent transcripts in conversation export/import

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="..\GxPT\Services\MarkdownParser.cs" Link="Linked\MarkdownParser.cs" />
     <Compile Include="..\GxPT\Utilities\ZipSafe.cs" Link="Linked\ZipSafe.cs" />
     <Compile Include="..\GxPT\Services\SkillImportExportService.cs" Link="Linked\SkillImportExportService.cs" />
+    <Compile Include="..\GxPT\Services\ImportExportService.cs" Link="Linked\ImportExportService.cs" />
     <Compile Include="..\GxPT\Utilities\FileSafe.cs" Link="Linked\FileSafe.cs" />
     <Compile Include="..\GxPT\Data\ConversationStore.cs" Link="Linked\ConversationStore.cs" />
     <Compile Include="..\GxPT\Models\Conversation.cs" Link="Linked\Conversation.cs" />

--- a/GxPT.Tests/ImportExportTranscriptTests.cs
+++ b/GxPT.Tests/ImportExportTranscriptTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Verifies that child-agent transcripts are bundled into conversation archives and restored on
+    // import. Transcripts persist under %AppData%/GxPT/AgentTranscripts/<convId>; tests use a random
+    // convId and clean it up so they never touch a real user's stored transcripts.
+    public sealed class ImportExportTranscriptTests : IDisposable
+    {
+        private readonly string _dir;
+        private readonly List<string> _convIds = new List<string>();
+
+        public ImportExportTranscriptTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gxpt_iexport_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            foreach (string id in _convIds)
+            {
+                try { AgentTranscriptPersistence.DeleteConversation(id); } catch { }
+            }
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        private string NewConvId()
+        {
+            string id = "iexport-" + Guid.NewGuid().ToString("N");
+            _convIds.Add(id);
+            return id;
+        }
+
+        private static AgentTranscript[] SampleTranscripts()
+        {
+            var msgs = new List<ChatMessage>
+            {
+                new ChatMessage("system", "persona"),
+                new ChatMessage("user", "do it"),
+                new ChatMessage("assistant", "ok"),
+            };
+            return new AgentTranscript[] { new AgentTranscript("ra", "do it", msgs), null };
+        }
+
+        [Fact]
+        public void ExportSingle_BundlesTranscripts_RestoredOnImport()
+        {
+            string convId = NewConvId();
+            string rec = "rec1";
+
+            // A conversation file (name == conv id) plus its persisted transcripts.
+            string convFile = Path.Combine(_dir, convId + ".json");
+            File.WriteAllText(convFile, "{\"Id\":\"" + convId + "\"}");
+            AgentTranscriptPersistence.Save(convId, rec, SampleTranscripts());
+
+            string archive = Path.Combine(_dir, "single.gxcv");
+            ImportExportService.ExportSingle(convFile, archive, convId);
+
+            // Drop the on-disk transcripts, then import into a fresh Conversations folder.
+            AgentTranscriptPersistence.DeleteConversation(convId);
+            Assert.False(AgentTranscriptPersistence.LoadAll(convId).ContainsKey(rec));
+
+            string target = Path.Combine(_dir, "imported");
+            ImportExportService.ImportAll(archive, target, true);
+
+            Assert.True(File.Exists(Path.Combine(target, convId + ".json")));
+            var map = AgentTranscriptPersistence.LoadAll(convId);
+            Assert.True(map.ContainsKey(rec));
+            Assert.Equal("ra", map[rec][0].Slug);
+            Assert.Equal("do it", map[rec][0].Task);
+        }
+
+        [Fact]
+        public void ExportSingle_WithoutConvId_OmitsTranscripts()
+        {
+            string convId = NewConvId();
+            string convFile = Path.Combine(_dir, convId + ".json");
+            File.WriteAllText(convFile, "{}");
+            AgentTranscriptPersistence.Save(convId, "rec1", SampleTranscripts());
+
+            string archive = Path.Combine(_dir, "no-transcripts.gxcv");
+            ImportExportService.ExportSingle(convFile, archive); // 2-arg overload: no convId
+
+            AgentTranscriptPersistence.DeleteConversation(convId);
+            string target = Path.Combine(_dir, "imported2");
+            ImportExportService.ImportAll(archive, target, true);
+
+            Assert.True(File.Exists(Path.Combine(target, convId + ".json")));
+            Assert.False(AgentTranscriptPersistence.LoadAll(convId).ContainsKey("rec1"));
+        }
+    }
+}

--- a/GxPT/Managers/ImportExportManager.cs
+++ b/GxPT/Managers/ImportExportManager.cs
@@ -110,7 +110,7 @@ namespace GxPT
                 if (sfd.ShowDialog(owner) != DialogResult.OK) return false;
                 try
                 {
-                    ImportExportService.ExportSingle(info.Path, sfd.FileName);
+                    ImportExportService.ExportSingle(info.Path, sfd.FileName, info.Id);
                     try { MessageBox.Show(owner, "Export completed.", "Export Conversation", MessageBoxButtons.OK, MessageBoxIcon.Information); }
                     catch { }
                     return true;

--- a/GxPT/Managers/ImportExportManager.cs
+++ b/GxPT/Managers/ImportExportManager.cs
@@ -53,7 +53,7 @@ namespace GxPT
                     if (ConversationStore.ListAll().Count > 0)
                     {
                         var dr = MessageBox.Show(owner,
-                            "Importing will overwrite existing files with the same names. Continue?",
+                            "Importing will overwrite existing conversations with the same ID. Continue?",
                             "Import Conversations", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                         if (dr != DialogResult.Yes) return false;
                     }

--- a/GxPT/Services/Agents/AgentTranscriptPersistence.cs
+++ b/GxPT/Services/Agents/AgentTranscriptPersistence.cs
@@ -36,6 +36,13 @@ namespace GxPT
             return string.IsNullOrEmpty(id) ? null : Path.Combine(Root(), id);
         }
 
+        // Public path accessors so import/export can bundle and restore transcripts alongside
+        // conversations. RootDir is the store root (%AppData%/GxPT/AgentTranscripts); ConvDirPath is
+        // the per-conversation folder. Both return null when the input is empty.
+        public static string RootDir() { return Root(); }
+
+        public static string ConvDirPath(string convId) { return ConvDir(convId); }
+
         // Persist one dispatch call's transcripts (slot-indexed; null slots are kept as null placeholders so
         // the on-reload slot indices line up with the record body).
         public static void Save(string convId, string recKey, AgentTranscript[] transcripts)

--- a/GxPT/Services/ImportExportService.cs
+++ b/GxPT/Services/ImportExportService.cs
@@ -8,6 +8,12 @@ namespace GxPT
 {
     internal static class ImportExportService
     {
+        // Child-agent transcripts (stored separately from conversations on disk) are bundled into the
+        // archive under this folder so they travel with the conversation. Conversation JSONs stay at the
+        // archive root; on import this prefix is routed to the transcript store instead of the
+        // Conversations folder. Archives written before this existed simply have no such folder.
+        private const string TranscriptsArchivePrefix = "AgentTranscripts";
+
         // Core operations (no UI): throw on failure so callers can handle UX.
         public static void ExportAll(string sourceDir, string archivePath)
         {
@@ -25,6 +31,17 @@ namespace GxPT
                 zip.AlternateEncodingUsage = ZipOption.AsNecessary;
                 zip.CompressionLevel = Ionic.Zlib.CompressionLevel.BestCompression;
                 zip.AddDirectory(sourceDir, "");
+                // Bundle every conversation's agent transcripts (best-effort; absent folder is fine).
+                string transcriptsRoot = AgentTranscriptPersistence.RootDir();
+                if (!string.IsNullOrEmpty(transcriptsRoot) && Directory.Exists(transcriptsRoot))
+                {
+                    try
+                    {
+                        if (Directory.GetFileSystemEntries(transcriptsRoot).Length > 0)
+                            zip.AddDirectory(transcriptsRoot, TranscriptsArchivePrefix);
+                    }
+                    catch { }
+                }
                 zip.Save(archivePath);
             }
         }
@@ -36,10 +53,56 @@ namespace GxPT
             if (string.IsNullOrEmpty(targetDir))
                 throw new ArgumentException("Target folder is required.", "targetDir");
             Directory.CreateDirectory(targetDir);
-            ZipSafe.SafeExtract(zipPath, targetDir, overwriteExisting);
+
+            // Extract to a temp staging folder so we can route the bundled AgentTranscripts subtree to the
+            // transcript store while conversation JSONs (at the archive root) go to the Conversations folder.
+            string staging = Path.Combine(Path.GetTempPath(), "GxPT-Import-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                // Staging is fresh, so overwriting within it never clobbers user data; the caller's
+                // overwriteExisting choice is honored when merging into the real destinations below.
+                ZipSafe.SafeExtract(zipPath, staging, true);
+
+                string transcriptsStaging = Path.Combine(staging, TranscriptsArchivePrefix);
+                bool hasTranscripts = Directory.Exists(transcriptsStaging);
+
+                // Conversation files (and any other root content) -> Conversations folder. The bundled
+                // AgentTranscripts folder is handled separately and skipped here.
+                foreach (string entry in Directory.GetFileSystemEntries(staging))
+                {
+                    string name = Path.GetFileName(entry);
+                    if (hasTranscripts && Directory.Exists(entry) &&
+                        string.Equals(name, TranscriptsArchivePrefix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (Directory.Exists(entry))
+                        MergeDirectory(entry, Path.Combine(targetDir, name), overwriteExisting);
+                    else
+                        File.Copy(entry, Path.Combine(targetDir, name), overwriteExisting);
+                }
+
+                // Restore bundled transcripts into the store root (%AppData%/GxPT/AgentTranscripts).
+                if (hasTranscripts)
+                {
+                    string transcriptsRoot = AgentTranscriptPersistence.RootDir();
+                    if (!string.IsNullOrEmpty(transcriptsRoot))
+                        MergeDirectory(transcriptsStaging, transcriptsRoot, overwriteExisting);
+                }
+            }
+            finally
+            {
+                try { if (Directory.Exists(staging)) Directory.Delete(staging, true); }
+                catch { }
+            }
         }
 
         public static void ExportSingle(string conversationFilePath, string archivePath)
+        {
+            ExportSingle(conversationFilePath, archivePath, null);
+        }
+
+        // convId lets us bundle just this conversation's agent transcripts (folder name == conversation
+        // id). When null/empty or the folder is absent, only the conversation JSON is archived.
+        public static void ExportSingle(string conversationFilePath, string archivePath, string convId)
         {
             if (string.IsNullOrEmpty(conversationFilePath) || !File.Exists(conversationFilePath))
                 throw new FileNotFoundException("Conversation file not found.", conversationFilePath);
@@ -49,8 +112,33 @@ namespace GxPT
                 zip.AlternateEncodingUsage = ZipOption.AsNecessary;
                 zip.CompressionLevel = Ionic.Zlib.CompressionLevel.BestCompression;
                 zip.AddFile(conversationFilePath, "");
+                if (!string.IsNullOrEmpty(convId))
+                {
+                    string convDir = AgentTranscriptPersistence.ConvDirPath(convId);
+                    if (!string.IsNullOrEmpty(convDir) && Directory.Exists(convDir))
+                    {
+                        try
+                        {
+                            if (Directory.GetFileSystemEntries(convDir).Length > 0)
+                                zip.AddDirectory(convDir, TranscriptsArchivePrefix + "/" + Path.GetFileName(convDir));
+                        }
+                        catch { }
+                    }
+                }
                 zip.Save(archivePath);
             }
+        }
+
+        // Recursively copy every file from sourceDir into destDir, creating subdirectories as needed.
+        // File.Copy with overwriteExisting=false throws on a name clash, preserving the prior import
+        // semantics (CreateNew) for callers that opt out of overwriting.
+        private static void MergeDirectory(string sourceDir, string destDir, bool overwriteExisting)
+        {
+            Directory.CreateDirectory(destDir);
+            foreach (string file in Directory.GetFiles(sourceDir))
+                File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwriteExisting);
+            foreach (string sub in Directory.GetDirectories(sourceDir))
+                MergeDirectory(sub, Path.Combine(destDir, Path.GetFileName(sub)), overwriteExisting);
         }
 
         // Helpers


### PR DESCRIPTION
## Summary

Conversation export/import previously carried only the conversation JSON. Child-agent transcripts (stored separately under `%AppData%/GxPT/AgentTranscripts/<convId>`) were left behind, so an imported conversation's `dispatch_agent` records had no transcript to view.

This PR bundles transcripts into the archive so they travel with the conversation, and restores them on import.

## Changes

- **`ImportExportService.cs`**
  - **Export All** now also bundles the whole transcript store under an `AgentTranscripts/` folder in the archive.
  - **Export Single** bundles just the selected conversation's transcripts (`AgentTranscripts/<convId>/…`) via a new optional `convId` parameter; the original 2-arg overload is preserved.
  - **Import** extracts to a temp staging folder, then routes the `AgentTranscripts/` subtree into the transcript store (`%AppData%/GxPT/AgentTranscripts`) while conversation JSONs go to the Conversations folder. Archives without that folder (older exports) import unchanged.
- **`AgentTranscriptPersistence.cs`** — exposes `RootDir()` and `ConvDirPath(convId)` so export/import can locate transcript files.
- **`ImportExportManager.cs`** — passes the conversation id through to `ExportSingle`; also clarifies the import overwrite warning to say it overwrites "existing conversations with the same ID" (conversations are stored as `<id>.json` and overwrite is keyed by id, not display name).
- **Tests** — adds `ImportExportTranscriptTests.cs` (round-trip: transcripts survive export → delete → import for Export Single, and are correctly omitted when no `convId` is given) and links `ImportExportService.cs` into the test project.

## Restore behavior

Imported conversations aren't open at import time, so nothing in-memory needs changing — opening an imported conversation hits the existing `AgentTranscriptPersistence.LoadAll(convId)` path, which picks up the restored files so the **View transcript** links work.

## Compatibility

- **Old archives** (no `AgentTranscripts/` folder) import exactly as before.
- **New archives in old app versions**: conversations still import and work fine. The old `ImportAll` doesn't know to lift the `AgentTranscripts/` folder out, so it lands one level too deep at `…/GxPT/Conversations/AgentTranscripts/` — harmless, unreferenced cruft (not listed as conversations since `ListAll` is top-directory only, and not loaded as transcripts since the store reads from `…/GxPT/AgentTranscripts`). Transcripts simply aren't restored on old versions, with no errors.
- The skill-vs-conversation archive router (`ArchiveContainsSkill`) is unaffected — transcript files contain no `SKILL.md`.

## Testing notes

The container has no `dotnet`/`msbuild`/`mono`, and the test project targets net48 for the Windows CI runner, so the suite was not executed locally. The code was reviewed for .NET 3.5 / C# 3.0 compatibility (the main project's target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFG589RKyRaki31T2DzC4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFG589RKyRaki31T2DzC4n)_