### PR TITLE
Keep agentic turns from ending early on empty/narration-only responses

### DIFF
--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -503,23 +503,54 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Empty_response_twice_surfaces_a_notice()
+        public void Empty_response_after_retry_and_nudge_surfaces_a_notice()
         {
             RegistryFakeTransport ft;
             var reg = RegistryWith(out ft, "files", new ToolDef("read"));
 
             var streamer = new ScriptedStreamer();
-            streamer.Turns.Add(new ChatCompletionChunk[0]);
-            streamer.Turns.Add(new ChatCompletionChunk[0]);
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // initial: empty
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // bare retry: still empty
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // nudge-continue: still empty
 
             var history = new List<ChatMessage>();
             var ui = new RecordingUi();
             New(streamer, reg).RunTurn(history, "go", ui);
 
             Assert.True(ui.Completed);
-            Assert.Equal(2, streamer.Calls);   // initial + one retry, then surface
+            Assert.Equal(3, streamer.Calls);   // initial + bare retry + nudge, then surface
             Assert.Contains("empty response", history[history.Count - 1].Content.ToLowerInvariant());
             Assert.Contains("empty response", ui.Text.ToString().ToLowerInvariant());
+        }
+
+        [Fact]
+        public void Empty_after_retry_is_nudged_once_then_recovers()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // initial: empty
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // bare retry: still empty
+            streamer.Turns.Add(Chunks.Text("recovered"));     // nudge-continue: model answers
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "go", ui);
+
+            Assert.Equal(3, streamer.Calls);   // empty + retry + nudge(answer)
+            Assert.Equal("recovered", ui.Text.ToString());
+            Assert.True(ui.Completed);
+
+            // The nudge rides the third request as its last (user-role) message...
+            var nudgeReq = streamer.SeenMessages[2];
+            var last = nudgeReq[nudgeReq.Count - 1];
+            Assert.Equal("user", last.Role);
+            Assert.Equal(McpChatOrchestrator.EmptyResponseNudge, last.Content);
+
+            // ...but it is request-only: never written to history (not rendered or persisted).
+            foreach (var m in history)
+                Assert.NotEqual(McpChatOrchestrator.EmptyResponseNudge, m.Content);
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -554,6 +554,33 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Empty_response_recovery_is_skipped_when_cancelled()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var cancel = new RequestCancellation();
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // initial: empty
+            streamer.Turns.Add(new ChatCompletionChunk[0]);   // retry - must NOT run after cancel
+            // Simulate the user pressing Stop the moment the first (empty) response lands.
+            streamer.OnCall = delegate(int idx) { if (idx == 0) cancel.Cancel(); };
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            var orch = New(streamer, reg);
+            orch.Cancellation = cancel;
+            orch.RunTurn(history, "go", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(1, streamer.Calls);   // no recovery request issued once Stop was pressed
+            // A cancelled turn surfaces no empty-response notice.
+            foreach (var m in history)
+                Assert.False(m.Content != null
+                    && m.Content.ToLowerInvariant().Contains("empty response"));
+        }
+
+        [Fact]
         public void Tool_isError_result_is_fed_back_and_loop_continues()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -70,6 +70,7 @@ namespace GxPT.Tests.Mcp
         public decimal? ServeCost;
 
         public int Calls;
+        public Action<int> OnCall;   // invoked with the call index at the start of each StreamChat
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
         public readonly List<IList<JObject>> SeenTools = new List<IList<JObject>>();
         public readonly List<ClientProperties> SeenProps = new List<ClientProperties>();
@@ -82,6 +83,10 @@ namespace GxPT.Tests.Mcp
             SeenMessages.Add(messages);
             SeenTools.Add(tools);
             SeenProps.Add(props);
+
+            // Test hook fired with this call's index, e.g. to simulate the user pressing Stop
+            // mid-turn (cancel.Cancel()) after a particular streamed response.
+            if (OnCall != null) OnCall(idx);
 
             if (ServeAs != null && props != null && props.ResponseUsageCallback != null)
             {

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -29,6 +29,17 @@ namespace GxPT
         // references it.
         internal const string DeniedResultText = "[Call denied by user.]";
 
+        // Request-only "keep going" message used once when a response comes back empty even after the
+        // inline bare retry (see the empty-response handling in RunTurn). Appended to that one request
+        // as a user-role message - never added to history, so it is neither rendered nor persisted -
+        // to give a wedged model a different last token to react to than the prompt it just answered
+        // emptily. User-role (not system) because Anthropic via OpenRouter hoists in-array system
+        // messages to the top-level system parameter. Phrased to resume the task without forcing a
+        // tool call when the work is actually done.
+        internal const string EmptyResponseNudge =
+            "Your previous response came back empty. Continue with the task: if more work remains, "
+            + "make the next tool call; if the task is already complete, give your final answer.";
+
         // Agentic behavior guidance, prepended as a system message on tool-enabled turns only
         // (this orchestrator runs solely when at least one tool is available). Kept short to
         // limit token cost. Reinforces five things: act through the tools, don't return a null/
@@ -431,6 +442,28 @@ namespace GxPT
                     LogResponse(turnId, iter, asm);
                 }
 
+                // Still empty after the bare retry: one nudge-continue before giving up. Resend the same
+                // request plus a request-only "keep going" user message (EmptyResponseNudge) - it changes
+                // the last token the model reacts to without touching history, so it is never rendered or
+                // persisted. Done inline (not a fresh loop iteration), so it does not consume the tool-loop
+                // budget. Whatever this returns - tool calls, a final answer, or another empty - flows into
+                // the normal handling below, where a third empty hits the resumable notice.
+                if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
+                {
+                    _log.Log("mcp", "[turn " + turnId + "] still empty after retry; nudging once (off budget)");
+                    List<ChatMessage> nudged = new List<ChatMessage>(requestMessages);
+                    nudged.Add(new ChatMessage("user", EmptyResponseNudge));
+                    asm = StreamOnce(nudged, tools, toolChoice, ui, out errored, out errMessage);
+                    if (errored)
+                    {
+                        _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
+                            + " (nudge): stream error: " + (errMessage ?? "(none)"));
+                        if (ui != null) ui.OnError(errMessage);
+                        return;
+                    }
+                    LogResponse(turnId, iter, asm);
+                }
+
                 // Stop requested during (or just after) the model stream: the stream was killed, so its
                 // tool calls are partial/unexecutable. Keep any text it produced and finalize - never
                 // act on a half-streamed tool call.
@@ -444,11 +477,11 @@ namespace GxPT
                 {
                     if (IsEmptyText(asm.Text))
                     {
-                        // Still empty after a retry: surface a clear, resumable notice rather than
-                        // completing with a silent empty bubble.
+                        // Still empty after the bare retry and the nudge-continue: surface a clear,
+                        // resumable notice rather than completing with a silent empty bubble.
                         string emptyNotice = "The model returned an empty response. Please try again.";
                         history.Add(new ChatMessage("assistant", emptyNotice));
-                        _log.Log("mcp", "[turn " + turnId + "] still empty after retry; surfaced notice");
+                        _log.Log("mcp", "[turn " + turnId + "] still empty after retry + nudge; surfaced notice");
                         if (ui != null) { ui.AppendTextDelta(emptyNotice); ui.Complete(); }
                         return;
                     }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -44,6 +44,14 @@ namespace GxPT
             "Your previous response came back empty. Continue with the task: if more work remains, "
             + "make the next tool call; if the task is already complete, give your final answer.";
 
+        // Text-only variant of the nudge, used when the request is sent with tool_choice "none" (the
+        // post-user-stop wrap-up path, where the model cannot call tools and is expected to summarize
+        // and ask how to proceed). The default nudge tells the model to "make the next tool call",
+        // which would contradict tool_choice "none"; this one steers it to produce that text wrap-up.
+        internal const string EmptyResponseNudgeTextOnly =
+            "Your previous response came back empty. Briefly summarize what you have done so far and "
+            + "what remains, then ask how you would like to proceed.";
+
         // Agentic behavior guidance, prepended as a system message on tool-enabled turns only
         // (this orchestrator runs solely when at least one tool is available). Kept short to
         // limit token cost. Reinforces five things: act through the tools, don't return a null/
@@ -439,8 +447,12 @@ namespace GxPT
                     IList<ChatMessage> attemptMsgs = requestMessages;
                     if (nudge)
                     {
+                        // tool_choice "none" (post-user-stop wrap-up) forbids tool calls, so use the
+                        // text-only nudge there; otherwise the default nudge that steers toward a call.
+                        string nudgeText = (toolChoice == "none")
+                            ? EmptyResponseNudgeTextOnly : EmptyResponseNudge;
                         List<ChatMessage> nudged = new List<ChatMessage>(requestMessages);
-                        nudged.Add(new ChatMessage("user", EmptyResponseNudge));
+                        nudged.Add(new ChatMessage("user", nudgeText));
                         attemptMsgs = nudged;
                     }
                     _log.Log("mcp", "[turn " + turnId + "] empty response; "

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -20,6 +20,10 @@ namespace GxPT
     {
         public const int DefaultMaxIterations = 25;
         public const int DefaultCallTimeoutMs = 60000;
+        // Inline recovery attempts when a tool turn returns an empty completion (no text, no tool
+        // calls): a bare resend first, then a nudge-continue on the final attempt. These run inline
+        // (not fresh loop iterations), so they do not consume the iteration budget.
+        private const int EmptyRecoveryAttempts = 2;
         // Reveal-set cap, enforced only on models whose provider has no prompt caching (see the
         // eviction note on RevealedToolNames). Matches the old registry-global LRU cap.
         public const int RevealEvictionCap = 24;
@@ -410,59 +414,48 @@ namespace GxPT
                 if (!string.IsNullOrEmpty(ephemeralTail))
                     requestMessages.Add(new ChatMessage("user", ephemeralTail));
 
-                bool errored;
-                string errMessage;
                 // After a user-stopped fan-out, force a text-only answer (the dispatch result carries the
                 // "summarize and ask" directive); otherwise normal auto tool choice.
                 string toolChoice = forceTextThisCall ? "none" : null;
                 forceTextThisCall = false;
-                ToolCallAssembler asm = StreamOnce(requestMessages, tools, toolChoice, ui, out errored, out errMessage);
-                if (errored)
-                {
-                    _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
-                        + ": stream error: " + (errMessage ?? "(none)"));
-                    if (ui != null) ui.OnError(errMessage);
-                    return;
-                }
-                LogResponse(turnId, iter, asm);
+                ToolCallAssembler asm = StreamLogged(requestMessages, tools, toolChoice, ui, true, iter, turnId, null);
+                if (asm == null) return;   // stream error: UI already notified, turn is done
 
                 // Degenerate response (no tool calls AND no text, but no error): some providers emit an
-                // empty completion on a transient hiccup. Retry the same request once before giving up.
-                if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
+                // empty completion on a transient hiccup. Recover inline before giving up - a bare resend
+                // first, then a nudge-continue on the final attempt: the same request plus a request-only
+                // "keep going" user message (EmptyResponseNudge) that gives a wedged model a different last
+                // token to react to. The nudge is never added to history, so it is neither rendered nor
+                // persisted. All inline (not fresh loop iterations), so recovery never consumes the tool-loop
+                // budget. Recovery attempts are not streamed live (live == false) so a discarded empty
+                // attempt can't leave stray text in the bubble; a recovered answer is surfaced once, just
+                // below. The CancelRequested() guard means a Stop issues no further requests.
+                bool streamedLive = true;   // the initial response above streamed to the UI
+                for (int rec = 0; rec < EmptyRecoveryAttempts
+                                  && !asm.ProducedToolCalls && IsEmptyText(asm.Text)
+                                  && !CancelRequested(); rec++)
                 {
-                    _log.Log("mcp", "[turn " + turnId + "] empty response (no tool calls, no text); retrying once");
-                    asm = StreamOnce(requestMessages, tools, toolChoice, ui, out errored, out errMessage);
-                    if (errored)
+                    bool nudge = (rec == EmptyRecoveryAttempts - 1);
+                    IList<ChatMessage> attemptMsgs = requestMessages;
+                    if (nudge)
                     {
-                        _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
-                            + " (retry): stream error: " + (errMessage ?? "(none)"));
-                        if (ui != null) ui.OnError(errMessage);
-                        return;
+                        List<ChatMessage> nudged = new List<ChatMessage>(requestMessages);
+                        nudged.Add(new ChatMessage("user", EmptyResponseNudge));
+                        attemptMsgs = nudged;
                     }
-                    LogResponse(turnId, iter, asm);
+                    _log.Log("mcp", "[turn " + turnId + "] empty response; "
+                        + (nudge ? "nudging" : "retrying") + " (off budget)");
+                    asm = StreamLogged(attemptMsgs, tools, toolChoice, ui, false, iter, turnId,
+                                       nudge ? "nudge" : "retry");
+                    if (asm == null) return;
+                    streamedLive = false;
                 }
 
-                // Still empty after the bare retry: one nudge-continue before giving up. Resend the same
-                // request plus a request-only "keep going" user message (EmptyResponseNudge) - it changes
-                // the last token the model reacts to without touching history, so it is never rendered or
-                // persisted. Done inline (not a fresh loop iteration), so it does not consume the tool-loop
-                // budget. Whatever this returns - tool calls, a final answer, or another empty - flows into
-                // the normal handling below, where a third empty hits the resumable notice.
-                if (!asm.ProducedToolCalls && IsEmptyText(asm.Text))
-                {
-                    _log.Log("mcp", "[turn " + turnId + "] still empty after retry; nudging once (off budget)");
-                    List<ChatMessage> nudged = new List<ChatMessage>(requestMessages);
-                    nudged.Add(new ChatMessage("user", EmptyResponseNudge));
-                    asm = StreamOnce(nudged, tools, toolChoice, ui, out errored, out errMessage);
-                    if (errored)
-                    {
-                        _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
-                            + " (nudge): stream error: " + (errMessage ?? "(none)"));
-                        if (ui != null) ui.OnError(errMessage);
-                        return;
-                    }
-                    LogResponse(turnId, iter, asm);
-                }
+                // A recovered answer was not streamed live, so surface it once here to keep the live
+                // bubble in step with the message that gets persisted. A still-empty asm falls through to
+                // the resumable notice below.
+                if (!streamedLive && ui != null && !IsEmptyText(asm.Text))
+                    ui.AppendTextDelta(asm.Text);
 
                 // Stop requested during (or just after) the model stream: the stream was killed, so its
                 // tool calls are partial/unexecutable. Keep any text it produced and finalize - never
@@ -477,11 +470,11 @@ namespace GxPT
                 {
                     if (IsEmptyText(asm.Text))
                     {
-                        // Still empty after the bare retry and the nudge-continue: surface a clear,
-                        // resumable notice rather than completing with a silent empty bubble.
+                        // Still empty after every recovery attempt: surface a clear, resumable notice
+                        // rather than completing with a silent empty bubble.
                         string emptyNotice = "The model returned an empty response. Please try again.";
                         history.Add(new ChatMessage("assistant", emptyNotice));
-                        _log.Log("mcp", "[turn " + turnId + "] still empty after retry + nudge; surfaced notice");
+                        _log.Log("mcp", "[turn " + turnId + "] still empty after recovery; surfaced notice");
                         if (ui != null) { ui.AppendTextDelta(emptyNotice); ui.Complete(); }
                         return;
                     }
@@ -525,8 +518,35 @@ namespace GxPT
             }
         }
 
-        // One streamed model request into a fresh assembler. Shared by the main loop, the
-        // empty-response retry, and (with toolChoice = "none") the cap wrap-up.
+        // Streams one model request, logs the response, and returns the assembler. On a stream error
+        // it notifies the UI and returns null - the caller must end the turn. attemptTag annotates the
+        // abort log (null/empty for the initial call, "retry"/"nudge" for empty-response recovery).
+        // 'live' controls only whether text deltas stream into the transcript: false for discardable
+        // empty-response recovery attempts (so a discarded attempt leaves no stray text), while errors
+        // still surface on the real ui either way. Shared by the initial per-iteration request and the
+        // recovery attempts so the stream -> error-check -> log sequence lives in one place.
+        private ToolCallAssembler StreamLogged(IList<ChatMessage> requestMessages, IList<JObject> tools,
+                                               string toolChoice, IToolLoopUi ui, bool live, int iter,
+                                               string turnId, string attemptTag)
+        {
+            bool errored;
+            string errMessage;
+            ToolCallAssembler asm = StreamOnce(requestMessages, tools, toolChoice,
+                                               live ? ui : null, out errored, out errMessage);
+            if (errored)
+            {
+                _log.Log("mcp", "[turn " + turnId + "] aborted on iteration " + (iter + 1)
+                    + (string.IsNullOrEmpty(attemptTag) ? string.Empty : " (" + attemptTag + ")")
+                    + ": stream error: " + (errMessage ?? "(none)"));
+                if (ui != null) ui.OnError(errMessage);
+                return null;
+            }
+            LogResponse(turnId, iter, asm);
+            return asm;
+        }
+
+        // One streamed model request into a fresh assembler. Shared by StreamLogged (the main loop and
+        // empty-response recovery) and (with toolChoice = "none") the cap wrap-up.
         private ToolCallAssembler StreamOnce(IList<ChatMessage> requestMessages, IList<JObject> tools,
                                              string toolChoice, IToolLoopUi ui, out bool errored,
                                              out string errMessage)

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -31,8 +31,9 @@ namespace GxPT
 
         // Agentic behavior guidance, prepended as a system message on tool-enabled turns only
         // (this orchestrator runs solely when at least one tool is available). Kept short to
-        // limit token cost. Reinforces four things: act through the tools, don't return a null/
-        // evasive answer when a tool could resolve the question, treat a denial as scoped to that
+        // limit token cost. Reinforces five things: act through the tools, don't return a null/
+        // evasive answer when a tool could resolve the question, keep working through multi-step
+        // tasks instead of stopping to narrate while work remains, treat a denial as scoped to that
         // one call rather than a permanent ban, and don't volunteer a rundown of tools unasked.
         internal const string AgentSystemPrompt =
             "You are an AI assistant operating as an agent with access to tools. Use them "
@@ -42,6 +43,13 @@ namespace GxPT
             + "answer the question - if so, use it. Do not return an empty or evasive response when "
             + "investigation is possible; make a genuine attempt with the tools available before "
             + "reporting that something cannot be done.\n\n"
+            + "Work through multi-step tasks to completion before ending your turn. A turn with no "
+            + "tool call hands control back to the user, so do not just announce what you are about "
+            + "to do and then stop - when more work remains, make the next tool call in the same "
+            + "turn as any narration, and never send an empty message. Reserve a reply that has no "
+            + "tool call for when the task is genuinely finished or you need the user to decide "
+            + "something. This is not a push to over-call: once the request is satisfied, give your "
+            + "final answer and stop rather than making needless calls.\n\n"
             + "When a tool call is denied or cancelled, treat it as a refusal of that specific "
             + "call in that specific moment, not a permanent ban on the tool. You may try the same "
             + "tool again later with adjusted arguments or once the situation changes.\n\n"


### PR DESCRIPTION
## Why

Some models (e.g. Gemini Flash) intermittently end an agentic turn early — either by emitting an empty completion or a narration-only message with no tool call — which terminates the tool-calling loop and forces the user to manually reprompt ("keep going"). This adds both a prompt-level and a loop-level backstop, without pushing the model to over-call when a task is genuinely done.

## What

**1. System-prompt guidance** (`AgentSystemPrompt`)
Adds a paragraph telling the model to work multi-step tasks to completion: a turn with no tool call hands control back to the user, so don't announce-then-stop — make the next call in the same turn as any narration, and never send an empty message. Explicitly scoped so it does **not** encourage needless calls: once the request is satisfied, give the final answer and stop. This is the only lever that can address the *narration-only* case, which is mechanically indistinguishable from a legitimate final answer.

**2. Empty-response recovery in the tool loop** (`RunTurn`)
On a genuinely empty completion (no text, no tool calls), the loop now recovers inline before giving up:
- a **bare retry** (resend, catches transient hiccups), then
- one **nudge-continue** — the same request plus a request-only "keep going" user message (`EmptyResponseNudge`) that gives a wedged model a different last token to react to.

The nudge is never written to history (not rendered or persisted — only the model's response to it is), and recovery runs inline so it does **not** consume the tool-loop iteration budget. A third consecutive empty falls through to the existing resumable notice.

## Review hardening (findings from `/code-review`)

The recovery code went through review; the following were fixed in this PR:

1. **Honor Stop** — recovery attempts are guarded on `!CancelRequested()`, so a Stop pressed mid-turn no longer dispatches extra (billable) requests before cancellation is honored.
2. **De-duplication** — the three near-identical `stream → error-check → log` blocks collapse into one `StreamLogged` helper driven by a bounded loop over `EmptyRecoveryAttempts`.
3. **UI/history consistency** — recovery attempts no longer stream live (so a discarded empty/whitespace attempt can't pollute the bubble); a recovered answer is surfaced once after the loop so the transcript matches the persisted message. Errors still route to the real UI.
4. **`tool_choice "none"` correctness** — on the post-user-stop wrap-up path (where tool calls are forbidden), the nudge uses a text-only variant that steers toward a summary instead of contradicting the constraint with "make the next tool call."

## Behavioral notes

- The common first-try path is unchanged and still streams token-by-token. Only a *recovered* answer renders as a single block (the deliberate trade for not streaming discardable attempts) — this only affects the rare empty-response path.
- Sub-agents inherit all of this, since `AgentDispatcher` reuses the same orchestrator and `AgentSystemPrompt`.

## Tests

- Updated the twice-empty test to the new retry → nudge → notice ladder.
- Added coverage for nudge recovery (and that the nudge stays out of history), plus a test that recovery is skipped once cancellation is requested (with a new `ScriptedStreamer.OnCall` hook to simulate pressing Stop mid-turn).
- The `tool_choice "none"` nudge branch is verified by inspection; an automated test there would require full `AgentDispatcher` + agent-file scaffolding, disproportionate for a three-line branch.

> Note: this is a Windows .NET 3.5 / VS2008 project, so it could not be compiled or run in the Linux CI environment used to author the change. Please build and run `GxPT.Tests` on Windows before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZQk7CrKUksk7QfkivGriF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZQk7CrKUksk7QfkivGriF)_