### PR TITLE
Add dirty state tracking and Apply button to Settings form

### DIFF
--- a/GxPT/Forms/SettingsForm.Designer.cs
+++ b/GxPT/Forms/SettingsForm.Designer.cs
@@ -30,7 +30,9 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.btnSave = new System.Windows.Forms.Button();
+            this.btnOk = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnApply = new System.Windows.Forms.Button();
             this.rtbJson = new System.Windows.Forms.RichTextBox();
             this.tblSettings = new System.Windows.Forms.TableLayoutPanel();
             this.grpAccount = new System.Windows.Forms.GroupBox();
@@ -134,24 +136,49 @@
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.Controls.Add(this.btnSave);
+            // RightToLeft flow lays children out from the right edge, so add Apply first (rightmost),
+            // then Cancel, then OK to get the standard Windows left-to-right order: OK | Cancel | Apply.
+            this.flowLayoutPanel1.Controls.Add(this.btnApply);
+            this.flowLayoutPanel1.Controls.Add(this.btnCancel);
+            this.flowLayoutPanel1.Controls.Add(this.btnOk);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 437);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(604, 23);
-            this.flowLayoutPanel1.TabIndex = 0;
-            // 
-            // btnSave
-            // 
-            this.btnSave.Location = new System.Drawing.Point(529, 0);
-            this.btnSave.Margin = new System.Windows.Forms.Padding(0);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(75, 23);
-            this.btnSave.TabIndex = 0;
-            this.btnSave.Text = "Save";
-            this.btnSave.UseVisualStyleBackColor = true;
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(0, 3, 3, 3);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(604, 29);
+            this.flowLayoutPanel1.TabIndex = 4;
+            //
+            // btnOk
+            //
+            this.btnOk.Margin = new System.Windows.Forms.Padding(6, 0, 0, 0);
+            this.btnOk.Name = "btnOk";
+            this.btnOk.Size = new System.Drawing.Size(75, 23);
+            this.btnOk.TabIndex = 0;
+            this.btnOk.Text = "OK";
+            this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
+            //
+            // btnCancel
+            //
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(6, 0, 0, 0);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 1;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            //
+            // btnApply
+            //
+            this.btnApply.Enabled = false;
+            this.btnApply.Margin = new System.Windows.Forms.Padding(6, 0, 0, 0);
+            this.btnApply.Name = "btnApply";
+            this.btnApply.Size = new System.Drawing.Size(75, 23);
+            this.btnApply.TabIndex = 2;
+            this.btnApply.Text = "Apply";
+            this.btnApply.UseVisualStyleBackColor = true;
+            this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
             // 
             // rtbJson
             // 
@@ -1015,7 +1042,8 @@
             //
             // SettingsForm
             // 
-            this.AcceptButton = this.btnSave;
+            this.AcceptButton = this.btnOk;
+            this.CancelButton = this.btnCancel;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(604, 576);
@@ -1076,7 +1104,9 @@
         #endregion
 
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnApply;
         private System.Windows.Forms.RichTextBox rtbJson;
         private System.Windows.Forms.TableLayoutPanel tblSettings;
         private System.Windows.Forms.GroupBox grpAccount;

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -24,6 +24,10 @@ namespace GxPT
         // Guard to prevent event loops during programmatic sync
         private bool _isSyncing = false;
 
+        // True once the user edits any control (and not yet saved). Drives the Apply button's enabled
+        // state; cleared on a successful Apply/OK save and reset to false after the initial load.
+        private bool _isDirty = false;
+
         // Debounce timer for JSON syntax highlighting
         private Timer _jsonHighlightTimer;
 
@@ -168,6 +172,54 @@ namespace GxPT
                 this.chkMcpCommand.CheckedChanged += McpCredential_TextChanged;
             }
             catch { }
+
+            // Track edits across every input so the Apply button can light up only when there are
+            // unsaved changes. Wired generically (by control type) so new controls are covered too.
+            try { WireDirtyTracking(this); }
+            catch { }
+            UpdateDialogButtons();
+        }
+
+        // Recursively subscribe to the relevant "changed" event of each input control. The handler is
+        // guarded by _isSyncing, so programmatic population (load, tab sync, post-save refresh) doesn't
+        // count as a user edit.
+        private void WireDirtyTracking(Control root)
+        {
+            if (root == null) return;
+            foreach (Control c in root.Controls)
+            {
+                if (c is TextBox || c is RichTextBox)
+                    c.TextChanged += AnyInput_Changed;
+                else if (c is CheckBox)
+                    ((CheckBox)c).CheckedChanged += AnyInput_Changed;
+                else if (c is ComboBox)
+                    ((ComboBox)c).SelectedIndexChanged += AnyInput_Changed;
+                else if (c is NumericUpDown)
+                    ((NumericUpDown)c).ValueChanged += AnyInput_Changed;
+
+                if (c.HasChildren) WireDirtyTracking(c);
+            }
+        }
+
+        private void AnyInput_Changed(object sender, EventArgs e)
+        {
+            if (_isSyncing) return;
+            MarkDirty();
+        }
+
+        private void MarkDirty()
+        {
+            if (_isSyncing) return;
+            _isDirty = true;
+            UpdateDialogButtons();
+        }
+
+        // OK and Cancel are always enabled (standard Windows practice); Apply only when there are
+        // unsaved changes.
+        private void UpdateDialogButtons()
+        {
+            try { if (this.btnApply != null) this.btnApply.Enabled = _isDirty; }
+            catch { }
         }
 
         private void McpCredential_TextChanged(object sender, EventArgs e)
@@ -200,6 +252,11 @@ namespace GxPT
 
                 // mcp.json lives in its own file beside settings.json.
                 LoadMcpJsonEditor();
+
+                // Nothing the user did yet: clear any dirty marks left by populating the controls
+                // (LoadMcpJsonEditor runs outside the _isSyncing block) so Apply starts disabled.
+                _isDirty = false;
+                UpdateDialogButtons();
             }
             catch (Exception ex)
             {
@@ -295,13 +352,35 @@ namespace GxPT
             }
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
+        // OK: save and close.
+        private void btnOk_Click(object sender, EventArgs e)
         {
             if (SaveSettingsOnly())
             {
+                _isDirty = false;
                 this.DialogResult = DialogResult.OK;
                 this.Close();
             }
+        }
+
+        // Apply: save without closing. Disabled (so unreachable) unless there are unsaved changes.
+        private void btnApply_Click(object sender, EventArgs e)
+        {
+            ApplyChanges();
+        }
+
+        // Persist the working settings, then clear the dirty state on success so Apply greys out again.
+        // Shared by the Apply button and Ctrl+S. Cancel needs no handler: it neither saves nor leaves a
+        // dirty file (the form only writes on save), so closing simply discards the unsaved edits.
+        private bool ApplyChanges()
+        {
+            bool ok = SaveSettingsOnly();
+            if (ok)
+            {
+                _isDirty = false;
+                UpdateDialogButtons();
+            }
+            return ok;
         }
 
         private void SettingsForm_KeyDown(object sender, KeyEventArgs e)
@@ -309,7 +388,7 @@ namespace GxPT
             if (e.Control && e.KeyCode == Keys.S)
             {
                 e.SuppressKeyPress = true; // prevent ding
-                SaveSettingsOnly(); // Save without closing the form
+                ApplyChanges(); // Save without closing the form
             }
         }
 

--- a/GxPT/Forms/SettingsForm.resx
+++ b/GxPT/Forms/SettingsForm.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="btnSave.Locked" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
## Summary
Refactored the SettingsForm dialog to follow standard Windows conventions by replacing the single "Save" button with OK, Cancel, and Apply buttons. The Apply button is intelligently enabled only when there are unsaved changes, providing better UX feedback.

## Key Changes
- **Dirty state tracking**: Added `_isDirty` flag that tracks whether any control has been edited by the user since the last save
- **Generic change detection**: Implemented `WireDirtyTracking()` method that recursively subscribes to change events (TextChanged, CheckedChanged, SelectedIndexChanged, ValueChanged) across all input controls in the form
- **Smart button management**: 
  - OK button saves and closes the form
  - Cancel button closes without saving
  - Apply button saves without closing and is only enabled when `_isDirty` is true
- **Guarded event handling**: All change detection is guarded by the existing `_isSyncing` flag to prevent programmatic control population (during load or tab sync) from incorrectly marking the form as dirty
- **Ctrl+S support**: Updated keyboard shortcut handler to use the new `ApplyChanges()` method
- **State cleanup**: Dirty flag is cleared after successful saves and after initial form load completes

## Implementation Details
- The `WireDirtyTracking()` method recursively walks the control hierarchy and wires up change handlers generically by control type, ensuring new controls are automatically covered without additional code
- `UpdateDialogButtons()` centralizes button state management
- The `ApplyChanges()` method is shared between the Apply button and Ctrl+S, ensuring consistent behavior
- Dialog buttons follow standard Windows layout: OK | Cancel | Apply (achieved via RightToLeft FlowLayoutPanel)

https://claude.ai/code/session_01UdqBqErDP6Z87Z4aAmfpSP