### PR TITLE
fix: grow message bubble to fit wide attachment pills (#182)

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1089,6 +1089,11 @@ namespace GxPT
 
             h += BubblePadding; // bottom padding
 
+            // Attachment pills can be wider than the message text. Fold the widest desired pill
+            // width (clamped to the available content width) into the content width so the bubble
+            // grows to fit the pills instead of letting them overflow past its right edge.
+            wUsed = Math.Max(wUsed, MeasureAttachmentsMaxPillWidth(it, textMax));
+
             // Compute bubble width based on measured text content
             // Ensure minimum content width for visual consistency
             int wContent = Math.Max(wUsed, 100);
@@ -1126,6 +1131,23 @@ namespace GxPT
             }
             y += lineH;
             return y;
+        }
+
+        // Returns the width of the widest attachment pill, clamped to the available content width.
+        // Pill width matches DrawAttachmentPills: text width + ~16px padding. Used so the bubble's
+        // content width can grow to accommodate pills that are wider than the message text.
+        private int MeasureAttachmentsMaxPillWidth(MessageItem it, int contentWidth)
+        {
+            if (it.Attachments == null || it.Attachments.Count == 0) return 0;
+            int maxW = 0;
+            for (int i = 0; i < it.Attachments.Count; i++)
+            {
+                string name = it.Attachments[i] != null ? (it.Attachments[i].FileName ?? "(file)") : "(file)";
+                Size sz = TextRenderer.MeasureText(name, _baseFont, new Size(int.MaxValue / 4, int.MaxValue / 4), TextFormatFlags.NoPadding);
+                int pillW = Math.Min(contentWidth, sz.Width + 16);
+                if (pillW > maxW) maxW = pillW;
+            }
+            return maxW;
         }
 
         private Size MeasureBlock(Block blk, int maxWidth, Dictionary<int, int> numberedCounters)


### PR DESCRIPTION
## Summary

Fixes #182. An attachment pill whose filename is wider than the message text would extend past the bubble's right edge, because the bubble's width was derived from the wrapped message text alone.

## Root cause

In `GxPT/Controls/ChatTranscriptControl.cs`, `MeasureBubble` computed the bubble content width (`wUsed`) only from the text blocks. Attachment pills contributed to the bubble *height* (`MeasureAttachmentsHeight`) but never to its *width*, so a short message (e.g. `hi`) with a long-filename pill produced a bubble sized to the text, and the pill drawn afterward in `DrawAttachmentPills` overflowed.

## Changes

- Added `MeasureAttachmentsMaxPillWidth(it, contentWidth)` — returns the widest attachment pill width using the same formula as `DrawAttachmentPills` (`TextRenderer.MeasureText(fileName, ...) + 16px`), clamped to the available content width.
- In `MeasureBubble`, folded that value into `wUsed` before computing the bubble width, so the bubble width becomes `max(wrapped text width, widest pill)`, capped at the max content width.

Long single filenames clamp to the content-width cap and ellipsize via the existing pill draw (`EndEllipsis`/clamped text rects), as described in the issue.

## Testing

This is a Windows WinForms (.NET Framework) project and the CI/dev environment here is Linux without `msbuild`/`dotnet`/`mono`, so it was not compiled locally. The change is small and mirrors the existing `MeasureAttachmentsHeight` logic. A quick visual check on Windows with a long-filename attachment on a short message is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbChgedMmyjaHSK3N6NVNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbChgedMmyjaHSK3N6NVNu)_