### PR TITLE
Add OpenRouter app-attribution headers to model requests

### DIFF
--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -10,6 +10,13 @@ namespace GxPT
 {
     internal sealed class OpenRouterClient : IChatStreamer
     {
+        // OpenRouter app-attribution headers, sent on every model request. HTTP-Referer is the
+        // primary identifier for rankings; X-OpenRouter-Title sets the display name; and
+        // X-OpenRouter-Categories assigns marketplace categories (comma-separated, lowercase).
+        private const string AttributionReferer = "https://www.imclerran.com/gxpt/";
+        private const string AttributionTitle = "GxPT";
+        private const string AttributionCategories = "general-chat";
+
         private readonly string _apiKey;
         private readonly string _curlPath;
 
@@ -848,6 +855,10 @@ namespace GxPT
             // -sS: silent but still show errors; --fail-with-body: fail on HTTP errors but keep body on stdout
             sb.Append("-sS --fail-with-body https://openrouter.ai/api/v1/chat/completions ");
             sb.Append("-H \"Content-Type: application/json\" ");
+            // OpenRouter app-attribution headers (rankings, display name, marketplace categories).
+            sb.Append("-H \"HTTP-Referer: ").Append(AttributionReferer).Append("\" ");
+            sb.Append("-H \"X-OpenRouter-Title: ").Append(AttributionTitle).Append("\" ");
+            sb.Append("-H \"X-OpenRouter-Categories: ").Append(AttributionCategories).Append("\" ");
             if (configWritten)
             {
                 // -K/--config reads the Authorization header from the temp file (off the command line).

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -15,7 +15,9 @@ namespace GxPT
         // X-OpenRouter-Categories assigns marketplace categories (comma-separated, lowercase).
         private const string AttributionReferer = "https://www.imclerran.com/gxpt/";
         private const string AttributionTitle = "GxPT";
-        private const string AttributionCategories = "general-chat";
+
+        // Up to 2 marketplace categories (comma-separated, lowercase) per OpenRouter's limit.
+        private const string AttributionCategories = "programming-app,personal-agent";
 
         private readonly string _apiKey;
         private readonly string _curlPath;


### PR DESCRIPTION
## Summary

Sends OpenRouter app-attribution headers on every model (chat completion) request so GxPT is identified for OpenRouter rankings and the marketplace.

Added in `BuildCurlArgs` (the single method every chat call funnels through — both streaming via `StreamRawChunks` and non-streaming via `CreateCompletion`):

- `HTTP-Referer: https://www.imclerran.com/gxpt/` — primary identifier for rankings
- `X-OpenRouter-Title: GxPT` — display name
- `X-OpenRouter-Categories: programming-app,personal-agent` — marketplace categories

Values live in named constants at the top of `OpenRouterClient` for easy maintenance.

## Notes

- Scoped to the chat-completions endpoint (actual model inference requests). The auxiliary generation-stats and model-catalog GETs are intentionally untouched.
- OpenRouter caps categories at 2 per request, which `programming-app,personal-agent` satisfies.
- Not compiled in this environment (no `dotnet`/`msbuild` available); the change is plain string concatenation matching the surrounding code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLgQs3CGfx5UYXsigafy6S)_