### PR TITLE
Replace wave-based parallel execution with sliding concurrency window

### DIFF
--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -258,35 +258,50 @@ namespace GxPT
             return true;
         }
 
-        // Runs the runnable slots concurrently in waves of at most MaxParallelAgents, each child writing
-        // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
-        // is valid here; no lock is held across the join, so the fan-out cannot deadlock.
+        // Runs the runnable slots concurrently with a sliding concurrency window of at most
+        // MaxParallelAgents: every child is queued up front, but a Semaphore gates how many run at once, so
+        // the moment one child finishes the next queued child starts (no wave barrier - a slow child no
+        // longer holds back the rest of its group). Each child writes its own result slot.
+        // WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it is valid here; no lock
+        // is held across the join, so the fan-out cannot deadlock. The batch is bounded by MaxAgentsPerCall
+        // (<= 8), well under WaitAll's 64-handle limit.
         private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results,
                                  AgentTranscript[] transcripts)
         {
-            int pos = 0;
-            while (pos < runnable.Count)
+            int count = runnable.Count;
+            System.Threading.Semaphore gate =
+                new System.Threading.Semaphore(MaxParallelAgents, MaxParallelAgents);
+            System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[count];
+            try
             {
-                int groupSize = Math.Min(MaxParallelAgents, runnable.Count - pos);
-                System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[groupSize];
-                for (int g = 0; g < groupSize; g++)
+                for (int r = 0; r < count; r++)
                 {
-                    int row = pos + g;          // panel row index (position among runnable)
+                    int row = r;                // panel row index (position among runnable)
                     int slot = runnable[row];   // entry slot (position in the full agents/tasks arrays)
                     Agent agent = agents[slot];
                     string task = tasks[slot];
                     System.Threading.ManualResetEvent done = new System.Threading.ManualResetEvent(false);
-                    dones[g] = done;
+                    dones[row] = done;
                     System.Threading.ThreadPool.QueueUserWorkItem(delegate
                     {
-                        try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
-                        catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
+                        // done.Set() is the outermost finally so WaitAll can never hang, even if acquiring
+                        // the gate throws. The gate is released only on the path where it was acquired.
+                        try
+                        {
+                            gate.WaitOne();   // block until a concurrency slot frees up
+                            try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
+                            catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
+                            finally { gate.Release(); }
+                        }
                         finally { done.Set(); }
                     });
                 }
                 System.Threading.WaitHandle.WaitAll(dones);
-                for (int g = 0; g < groupSize; g++) dones[g].Close();
-                pos += groupSize;
+            }
+            finally
+            {
+                for (int r = 0; r < count; r++) if (dones[r] != null) dones[r].Close();
+                gate.Close();
             }
         }
 

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -259,39 +259,42 @@ namespace GxPT
         }
 
         // Runs the runnable slots concurrently with a sliding concurrency window of at most
-        // MaxParallelAgents: every child is queued up front, but a Semaphore gates how many run at once, so
-        // the moment one child finishes the next queued child starts (no wave barrier - a slow child no
-        // longer holds back the rest of its group). Each child writes its own result slot.
-        // WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it is valid here; no lock
-        // is held across the join, so the fan-out cannot deadlock. The batch is bounded by MaxAgentsPerCall
-        // (<= 8), well under WaitAll's 64-handle limit.
+        // MaxParallelAgents: a small pool of worker threads pulls the next row from a shared cursor, so the
+        // moment one child finishes that worker starts the next-in-order child (no wave barrier - a slow
+        // child no longer holds back the rest of its group). Interlocked.Increment hands out row indices in
+        // strict order, so the lowest-numbered queued row is always the next to start (FIFO start order, so
+        // the panel never shows a later row running while an earlier one is still queued). Each child writes
+        // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
+        // is valid here; no lock is held across the join, so the fan-out cannot deadlock. At most
+        // MaxParallelAgents worker handles are joined, well under WaitAll's 64-handle limit.
         private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results,
                                  AgentTranscript[] transcripts)
         {
             int count = runnable.Count;
-            System.Threading.Semaphore gate =
-                new System.Threading.Semaphore(MaxParallelAgents, MaxParallelAgents);
-            System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[count];
+            int workerCount = Math.Min(MaxParallelAgents, count);
+            int next = -1;   // shared cursor; Interlocked.Increment yields 0,1,2,... in order across workers
+            System.Threading.ManualResetEvent[] dones = new System.Threading.ManualResetEvent[workerCount];
             try
             {
-                for (int r = 0; r < count; r++)
+                for (int w = 0; w < workerCount; w++)
                 {
-                    int row = r;                // panel row index (position among runnable)
-                    int slot = runnable[row];   // entry slot (position in the full agents/tasks arrays)
-                    Agent agent = agents[slot];
-                    string task = tasks[slot];
                     System.Threading.ManualResetEvent done = new System.Threading.ManualResetEvent(false);
-                    dones[row] = done;
+                    dones[w] = done;
                     System.Threading.ThreadPool.QueueUserWorkItem(delegate
                     {
-                        // done.Set() is the outermost finally so WaitAll can never hang, even if acquiring
-                        // the gate throws. The gate is released only on the path where it was acquired.
+                        // done.Set() is the outermost finally so WaitAll can never hang, even on an
+                        // unexpected throw. Each worker loops, claiming the next row until the batch is drained.
                         try
                         {
-                            gate.WaitOne();   // block until a concurrency slot frees up
-                            try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
-                            catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
-                            finally { gate.Release(); }
+                            int row;
+                            while ((row = System.Threading.Interlocked.Increment(ref next)) < count)
+                            {
+                                int slot = runnable[row];   // entry slot (position in the agents/tasks arrays)
+                                Agent agent = agents[slot];
+                                string task = tasks[slot];
+                                try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
+                                catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
+                            }
                         }
                         finally { done.Set(); }
                     });
@@ -300,8 +303,7 @@ namespace GxPT
             }
             finally
             {
-                for (int r = 0; r < count; r++) if (dones[r] != null) dones[r].Close();
-                gate.Close();
+                for (int w = 0; w < workerCount; w++) if (dones[w] != null) dones[w].Close();
             }
         }
 


### PR DESCRIPTION
## Summary
Refactored the parallel agent execution model from a wave-based approach (where all agents in a group must complete before the next group starts) to a sliding concurrency window model (where a pool of worker threads continuously pulls the next available task from a shared queue).

## Key Changes
- **Replaced wave barrier with shared cursor**: Changed from processing agents in fixed-size groups (`groupSize` waves) to using a shared `next` counter with `Interlocked.Increment` to hand out row indices in strict FIFO order
- **Worker pool model**: Instead of creating one worker per agent in a wave, now creates a fixed pool of `workerCount` workers that loop and claim tasks until the batch is exhausted
- **Improved throughput**: Eliminates idle time where fast-completing agents wait for slower ones in the same wave; workers immediately start the next task as soon as they finish
- **Maintained ordering guarantees**: FIFO start order is preserved via `Interlocked.Increment`, ensuring the panel never shows a later row running while an earlier one is queued
- **Enhanced safety**: Added outer try-finally block to ensure all handles are properly closed even if exceptions occur during worker creation

## Implementation Details
- Worker threads loop internally, calling `Interlocked.Increment(ref next)` to atomically claim the next row index
- Each worker continues processing until `next >= count`, naturally draining the batch
- The `done.Set()` is placed in the innermost finally to guarantee WaitAll never hangs
- Handle cleanup is now defensive (`if (dones[w] != null)`) to handle partial initialization scenarios
- Updated comments to explain the new sliding window concurrency model and clarify WaitAll's 64-handle limit is not a concern with bounded `MaxParallelAgents`

https://claude.ai/code/session_0166ThBy39Hb6aXB6CmUJmqe