### PR TITLE
Derive cache-discount reconcile from the producing model, not the parent's

### DIFF
--- a/GxPT.Tests/Mcp/OpenRouterClientTests.cs
+++ b/GxPT.Tests/Mcp/OpenRouterClientTests.cs
@@ -270,6 +270,20 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Response_usage_carries_the_producing_model()
+        {
+            // The model is stamped onto the usage record so a consumer judges caching from the model
+            // that ACTUALLY produced the request - a sub-agent may override the parent turn's model,
+            // and the discount reconcile must follow the child's model, not the parent's.
+            var u = new ChatCompletionChunk.UsageInfo { prompt_tokens = 100, completion_tokens = 10, cost = 0.002m };
+            var usage = OpenRouterClient.BuildResponseUsage("gen-1", "deepseek/deepseek-v4-flash", "DeepSeek", u, null);
+            Assert.Equal("deepseek/deepseek-v4-flash", usage.Model);
+            Assert.Equal("gen-1", usage.Id);
+            Assert.Equal("DeepSeek", usage.Provider);
+            Assert.Equal(0.002m, usage.Cost);
+        }
+
+        [Fact]
         public void Extracts_generation_stats_for_cost_reconciliation()
         {
             var stats = OpenRouterClient.ExtractGenerationStats(JObject.Parse(

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -6007,11 +6007,18 @@ namespace GxPT
             NotifyUsageUpdated(convo);
 
             if (string.IsNullOrEmpty(u.Id) || _client == null) return;
+            // Caching capability follows the model that ACTUALLY produced this usage (u.Model), not
+            // the caller's flag - which is the parent turn's model and is wrong for a sub-agent that
+            // overrode its model (e.g. a caching child under a non-caching parent: the parent-model
+            // flag would skip the discount fetch and "Saved" would never move for that child). Falls
+            // back to the caller's flag when the streamer didn't stamp a model (e.g. scripted tests).
+            bool caching = !string.IsNullOrEmpty(u.Model)
+                ? OpenRouterClient.ModelSupportsPromptCaching(u.Model) : cachingModel;
             // Stream-first, fetch-as-fallback: the fetch exists for cache_discount (and as a cost
             // correction). When a stream ever carries both, there is nothing left to fetch - this
             // self-cancels the extra GETs if OpenRouter adds cache_discount to SSE chunks.
             if (u.CacheDiscount.HasValue && u.Cost.HasValue) return;
-            if (!cachingModel && u.Cost.HasValue) return;
+            if (!caching && u.Cost.HasValue) return;
             // A dedicated background thread, not the ThreadPool: the fetch can sleep for up to
             // ~2 minutes waiting for a slow generation record, and the app's sends/naming also run
             // on the pool - a tool loop's worth of sleeping fetches must not starve them.
@@ -6026,7 +6033,7 @@ namespace GxPT
                     // gate; a nonzero billed discount is the same proof of cache activity,
                     // observed late. Latch the conversation-level preference here - the next
                     // turn emits it (mid-turn iterations still rely on stream counters).
-                    if (cachingModel && stats.CacheDiscount.HasValue && stats.CacheDiscount.Value != 0)
+                    if (caching && stats.CacheDiscount.HasValue && stats.CacheDiscount.Value != 0)
                     {
                         string prov = !string.IsNullOrEmpty(u.Provider) ? u.Provider : stats.ProviderName;
                         if (!string.IsNullOrEmpty(prov)) convo.CacheWarmProvider = prov;

--- a/GxPT/Services/OpenRouterClient.cs
+++ b/GxPT/Services/OpenRouterClient.cs
@@ -521,7 +521,7 @@ namespace GxPT
             if (props == null) props = new ClientProperties();
             if (!props.Stream.HasValue) props.Stream = true;
             string body = BuildRequestBody(model, messages, tools, props);
-            StreamRawChunks(body, WrapWithProviderReport(props, onChunk), onError, cancel);
+            StreamRawChunks(body, WrapWithProviderReport(model, props, onChunk), onError, cancel);
         }
 
         // Decorates a chunk sink to report (once, on the final usage-bearing chunk) the response's
@@ -529,7 +529,7 @@ namespace GxPT
         // chunk but the usage counters only on the last, so the report waits for usage. Identity
         // when no callback is registered.
         private static Action<ChatCompletionChunk> WrapWithProviderReport(
-            ClientProperties props, Action<ChatCompletionChunk> onChunk)
+            string model, ClientProperties props, Action<ChatCompletionChunk> onChunk)
         {
             if (props == null || props.ResponseUsageCallback == null) return onChunk;
             Action<ResponseUsage> report = props.ResponseUsageCallback;
@@ -548,7 +548,7 @@ namespace GxPT
                     if (!reported[0] && chunk.usage != null)
                     {
                         reported[0] = true;
-                        try { report(BuildResponseUsage(genId[0], provider[0], chunk.usage, discount[0])); }
+                        try { report(BuildResponseUsage(genId[0], model, provider[0], chunk.usage, discount[0])); }
                         catch { }
                     }
                 }
@@ -556,11 +556,12 @@ namespace GxPT
             };
         }
 
-        private static ResponseUsage BuildResponseUsage(
-            string generationId, string provider, ChatCompletionChunk.UsageInfo u, decimal? cacheDiscount)
+        internal static ResponseUsage BuildResponseUsage(
+            string generationId, string model, string provider, ChatCompletionChunk.UsageInfo u, decimal? cacheDiscount)
         {
             ResponseUsage r = new ResponseUsage();
             r.Id = generationId;
+            r.Model = model;
             r.Provider = provider;
             r.PromptTokens = u.prompt_tokens.HasValue ? u.prompt_tokens.Value : 0;
             r.CompletionTokens = u.completion_tokens.HasValue ? u.completion_tokens.Value : 0;
@@ -593,7 +594,7 @@ namespace GxPT
 
             bool failed = false;
             StreamRawChunks(body,
-                WrapWithProviderReport(props, delegate(ChatCompletionChunk chunk)
+                WrapWithProviderReport(model, props, delegate(ChatCompletionChunk chunk)
                 {
                     if (chunk != null && chunk.choices != null)
                     {
@@ -1001,6 +1002,8 @@ namespace GxPT
         // (FetchGenerationStats) keyed by Id - the delta-based reconcile is a no-op when the
         // stream was already accurate.
         public string Id;              // OpenRouter generation id (chunk.id); keys the generation record
+        public string Model;           // the model this request was sent to; lets a consumer judge caching
+                                       // from the actual producer (a sub-agent may override the parent's model)
         public string Provider;        // serving endpoint (e.g. "Anthropic"); null when not reported
         public int PromptTokens;       // total prompt tokens (cached + written + uncached)
         public int CompletionTokens;   // output tokens, reasoning included


### PR DESCRIPTION
## Problem

Sub-agent costs and savings aggregate onto the parent conversation's status-bar totals via `RecordUsageAndReconcile(..., updateContextGauge: false)` — the context gauge stays isolated (correct), while cost/savings are cumulative.

**Cost** always recorded fine (it comes straight off the stream). **Savings** ("Saved") did not, for some sub-agents. The `cache_discount` figure behind "Saved" only comes from a follow-up fetch of OpenRouter's billed generation record, and whether that fetch ran was gated on the **parent turn's** model:

```csharp
OpenRouterClient.ModelSupportsPromptCaching(model)  // parent model
```

When a sub-agent overrides its model — the bundled `explore` and `web-research` agents use `deepseek/deepseek-v4-flash` — and the parent model is judged non-caching, the gate skipped the discount fetch for the child's requests. The child's cache discount never landed, so **Saved** stayed flat for sub-agents even though the child model supported caching. The bug surfaces specifically when the primary and sub-agent models diverge in caching capability.

## Fix

Make the usage record self-describe the model that produced it:

- Add `ResponseUsage.Model`, stamped at the single source (`BuildResponseUsage`).
- `RecordUsageAndReconcile` derives its caching gate from `u.Model` — the model that *actually produced* the request — falling back to the caller's flag only when a streamer didn't stamp one (scripted tests).

This fixes parent and child uniformly and removes the parent/child model assumption entirely. Cache breakpoints and reveal-set eviction were already correct here (the child orchestrator keys those off its own `_model`).

## Tests

- `Response_usage_carries_the_producing_model` — asserts the model is stamped onto the usage record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119bnupL3vho9S9rtyNh4XL)_