### PR TITLE
Make agent transcript windows modeless and unowned

### DIFF
--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -35,11 +35,16 @@ namespace GxPT
         private void Init(string title)
         {
             this.Text = title;
-            this.StartPosition = FormStartPosition.CenterParent;
+            // Positioned by the caller (centered on the main form) because the window is shown modeless and
+            // unowned - CenterParent only applies to owned/dialog windows, so it would otherwise land at the
+            // screen's default spot.
+            this.StartPosition = FormStartPosition.Manual;
             this.FormBorderStyle = FormBorderStyle.Sizable;
             this.MinimizeBox = false;
             this.MaximizeBox = true;
-            this.ShowInTaskbar = false;
+            // Independent top-level window (no owner), so show it in the taskbar/Alt-Tab - that's how the
+            // user gets back to it once the main form has been brought to the front.
+            this.ShowInTaskbar = true;
             this.ClientSize = new Size(720, 560);
             this.MinimumSize = new Size(360, 240);
             this.KeyPreview = true;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -2904,7 +2904,7 @@ namespace GxPT
             try
             {
                 AgentTranscriptViewerForm viewer = new AgentTranscriptViewerForm(stream);
-                viewer.Show(this);
+                ShowAgentTranscriptWindow(viewer);
             }
             catch { }
         }
@@ -2927,10 +2927,30 @@ namespace GxPT
             }
             try
             {
-                using (AgentTranscriptViewerForm viewer = new AgentTranscriptViewerForm(t))
-                    viewer.ShowDialog(this);
+                AgentTranscriptViewerForm viewer = new AgentTranscriptViewerForm(t);
+                ShowAgentTranscriptWindow(viewer);
             }
             catch { }
+        }
+
+        // Show a sub-agent transcript window the same way for both the live and finished viewers: modeless
+        // (so the main form stays interactive - no modal "ding" when the user clicks it) and unowned (so the
+        // main form can be brought back to the front instead of being pinned behind the transcript). Centered
+        // on the main form by hand, since an unowned window ignores CenterParent. The form disposes itself
+        // when closed, so there's no using/Dispose to manage here.
+        private void ShowAgentTranscriptWindow(AgentTranscriptViewerForm viewer)
+        {
+            if (viewer == null) return;
+            try
+            {
+                Rectangle b = this.Bounds;
+                Size s = viewer.Size;
+                viewer.Location = new Point(
+                    b.Left + Math.Max(0, (b.Width - s.Width) / 2),
+                    b.Top + Math.Max(0, (b.Height - s.Height) / 2));
+            }
+            catch { }
+            viewer.Show();
         }
 
         internal void RetryLastTurn(TabManager.ChatTabContext ctx)


### PR DESCRIPTION
## Summary
Changed agent transcript viewer windows to display as modeless, unowned windows instead of modal dialogs. This allows the main form to remain interactive and be brought to the front without the transcript window blocking interaction.

## Key Changes
- **MainForm.cs**: 
  - Replaced `viewer.Show(this)` and `viewer.ShowDialog(this)` calls with a new `ShowAgentTranscriptWindow()` helper method
  - Added `ShowAgentTranscriptWindow()` method that displays the transcript window modeless and unowned, with manual centering on the main form
  - Removed `using` statement since the form now manages its own disposal

- **AgentTranscriptViewerForm.cs**:
  - Changed `StartPosition` from `CenterParent` to `Manual` (CenterParent only works for owned/modal windows)
  - Changed `ShowInTaskbar` from `false` to `true` (allows users to access the window via taskbar/Alt-Tab when main form is brought to front)
  - Updated comments to explain the positioning and visibility behavior

## Implementation Details
The new `ShowAgentTranscriptWindow()` method manually centers the transcript window on the main form's bounds before showing it, since unowned windows ignore the `CenterParent` positioning. The window is shown modeless (non-blocking) and unowned (no parent), allowing the main form to remain interactive and be brought to the front without the "ding" modal behavior.

https://claude.ai/code/session_01LNz282dEZtAAdeyDmAPZHd