### PR TITLE
Propagate parent privacy settings to child agent requests

### DIFF
--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -60,6 +60,40 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void Dispatch_PropagatesParentPrivacyToChildRequests()
+        {
+            // A ZDR conversation must stay ZDR inside its sub-agents: the child orchestrator would
+            // otherwise default to no ZDR and leak the conversation's data to a non-ZDR endpoint.
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.Zdr = true;
+            d.ProviderDataCollectionAllowed = false;
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.True(streamer.SeenProps.Count > 0);
+            Assert.Equal(true, streamer.SeenProps[0].Zdr);
+            Assert.Equal(false, streamer.SeenProps[0].ProviderDataCollectionAllowed);
+        }
+
+        [Fact]
+        public void Dispatch_LeavesChildPrivacyUnsetByDefault()
+        {
+            // No parent privacy settings -> the child request carries neither (provider default).
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, a).Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.True(streamer.SeenProps.Count > 0);
+            Assert.Null(streamer.SeenProps[0].Zdr);
+            Assert.Null(streamer.SeenProps[0].ProviderDataCollectionAllowed);
+        }
+
+        [Fact]
         public void UnknownAgent_ReturnsNote_KnownStillRuns()
         {
             Agent a = WriteAgent("explorer", "Explore.", "You explore.");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3354,6 +3354,12 @@ namespace GxPT
                                     LoggerSink.Instance, tierOf,
                                     McpChatOrchestrator.DefaultMaxIterations, McpChatOrchestrator.DefaultCallTimeoutMs);
                                 dispatcher.Cancellation = ctx.Cancellation;
+                                // Propagate the parent turn's privacy posture to every child request: a ZDR
+                                // conversation must stay ZDR inside its sub-agents (the context firewall
+                                // isolates the transcript, not the data-retention guarantee). Mirrors what
+                                // the parent orchestrator was configured with above.
+                                dispatcher.Zdr = orch.Zdr;
+                                dispatcher.ProviderDataCollectionAllowed = orch.ProviderDataCollectionAllowed;
                                 // Child usage adds to cost/token totals but must NOT move the parent's context
                                 // gauge (the child has its own isolated context) - so it routes through the
                                 // updateContextGauge=false overload, not orch.UsageReported.

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -42,6 +42,14 @@ namespace GxPT
         public Action<ResponseUsage> UsageReported { get; set; }
         public RequestCancellation Cancellation { get; set; }
 
+        // The parent turn's privacy settings, propagated to every child request (set by the host). A
+        // sub-agent runs in a fresh orchestrator that would otherwise default to no ZDR / provider
+        // default - so without this, a child would send the conversation's data to a non-ZDR endpoint
+        // even when the user enabled Zero Data Retention. Inheriting the parent's settings keeps the
+        // privacy guarantee across the firewall. Null leaves the provider default (the headless default).
+        public bool? Zdr { get; set; }
+        public bool? ProviderDataCollectionAllowed { get; set; }
+
         // Optional observability hooks (design sec.14): the dispatcher reports fan-out / per-child lifecycle
         // so the host can show the activity panel and relabel the Stop button. Null => headless.
         public IAgentActivityUi ActivityUi { get; set; }
@@ -360,6 +368,12 @@ namespace GxPT
             // host hasn't set one, fall back to the parent turn's handle so a plain Stop still cancels.
             child.Cancellation = GroupCancellation != null ? GroupCancellation : Cancellation;
             child.UsageReported = UsageReported;
+            // Inherit the parent turn's privacy posture: a ZDR conversation must stay ZDR inside its
+            // sub-agents (A3's firewall isolates the transcript, not the data-handling guarantee). If
+            // the child's model has no ZDR-capable endpoint the request fails rather than silently
+            // downgrading - the correct, safe failure for a retention guarantee.
+            child.Zdr = Zdr;
+            child.ProviderDataCollectionAllowed = ProviderDataCollectionAllowed;
 
             // Restrict the child to the agent's effective tool set by hiding everything else the parent can
             // call (no escalation, A11). Not setting an AgentDispatcher on the child means it has no


### PR DESCRIPTION
## Summary
This change ensures that privacy settings (Zero Data Retention and provider data collection preferences) are propagated from parent orchestrators to child agent requests. This maintains the user's privacy guarantees across agent boundaries and prevents unintended data leakage when sub-agents are invoked.

## Key Changes
- **AgentDispatcher**: Added `Zdr` and `ProviderDataCollectionAllowed` properties to store parent privacy settings, with detailed comments explaining why inheritance is necessary for security
- **AgentDispatcher.RunChild()**: Modified to propagate parent privacy settings to child dispatchers, ensuring sub-agents respect the parent conversation's privacy posture
- **MainForm.BeginToolSend()**: Updated to pass the orchestrator's privacy settings to child agent dispatchers when creating them
- **Tests**: Added two comprehensive test cases:
  - `Dispatch_PropagatesParentPrivacyToChildRequests()`: Verifies that parent ZDR and data collection settings are correctly inherited by child requests
  - `Dispatch_LeavesChildPrivacyUnsetByDefault()`: Confirms that when no parent settings are configured, child requests default to provider defaults (null values)

## Implementation Details
The privacy settings are nullable (`bool?`) to distinguish between three states:
- `true`: Privacy setting explicitly enabled
- `false`: Privacy setting explicitly disabled  
- `null`: Use provider default (no explicit setting)

This design allows child agents to inherit parent privacy guarantees while still respecting explicit parent configuration. The implementation includes safeguards: if a child's model lacks a ZDR-capable endpoint when ZDR is required, the request fails safely rather than silently downgrading the retention guarantee.

https://claude.ai/code/session_0119bnupL3vho9S9rtyNh4XL