### PR TITLE
Fix word wrapping for tokens wider than available width

### DIFF
--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -1533,6 +1533,64 @@ namespace GxPT
                             int partWidth = (int)Math.Ceiling(szF.Width);
                             int partHeight = (int)Math.Ceiling(szF.Height);
 
+                            // A single token wider than the available width (e.g. a long URL with no
+                            // spaces) cannot be placed on one line. Break it at character boundaries so
+                            // it word-wraps instead of overflowing the bubble. Normal-sized tokens take
+                            // the cheap path below and are never re-measured per character.
+                            if (maxWidth > 0 && partWidth > maxWidth)
+                            {
+                                int idx = 0;
+                                while (idx < text.Length)
+                                {
+                                    // If the current line already has content and not even a single
+                                    // character fits in the remaining space, wrap to a fresh line first.
+                                    int oneW = (int)Math.Ceiling(g.MeasureString(text.Substring(idx, 1), f, PointF.Empty, fmt).Width);
+                                    if (x > 0 && x + oneW > maxWidth)
+                                    {
+                                        yield return new LayoutSeg { IsNewLine = true, LineWidth = lineWidth, IsHardBreak = false };
+                                        x = 0; lineWidth = 0; lineHeight = baseFont.Height;
+                                    }
+
+                                    // Greedily grow the chunk to fill the available width (at least one
+                                    // character so we always make progress, even in a very narrow bubble).
+                                    int count = 1;
+                                    int chunkWidth = oneW;
+                                    while (idx + count < text.Length)
+                                    {
+                                        int wNext = (int)Math.Ceiling(g.MeasureString(text.Substring(idx, count + 1), f, PointF.Empty, fmt).Width);
+                                        if (x + wNext > maxWidth) break;
+                                        count++;
+                                        chunkWidth = wNext;
+                                    }
+
+                                    string chunk = text.Substring(idx, count);
+                                    int chunkHeight = (int)Math.Ceiling(g.MeasureString(chunk, f, PointF.Empty, fmt).Height);
+                                    yield return new LayoutSeg
+                                    {
+                                        IsNewLine = false,
+                                        Font = f,
+                                        Text = chunk,
+                                        Rect = new Rectangle(x, 0, chunkWidth, chunkHeight),
+                                        IsInlineCode = isCode,
+                                        IsLink = isLink,
+                                        LinkUrl = isLink ? r.LinkUrl : null
+                                    };
+
+                                    x += chunkWidth;
+                                    lineWidth += chunkWidth;
+                                    lineHeight = Math.Max(lineHeight, chunkHeight);
+                                    idx += count;
+
+                                    // Wrap before placing the remainder of the token on the next line.
+                                    if (idx < text.Length)
+                                    {
+                                        yield return new LayoutSeg { IsNewLine = true, LineWidth = lineWidth, IsHardBreak = false };
+                                        x = 0; lineWidth = 0; lineHeight = baseFont.Height;
+                                    }
+                                }
+                                continue;
+                            }
+
                             bool needsBreak = (x > 0 && x + partWidth > maxWidth);
                             if (needsBreak)
                             {


### PR DESCRIPTION
## Summary
Added character-level word wrapping for oversized tokens (such as long URLs without spaces) that exceed the available bubble width. Previously, these tokens would overflow the chat bubble instead of wrapping to fit.

## Key Changes
- Implemented a new code path that detects when a single token is wider than the maximum available width
- When detected, the token is broken at character boundaries and wrapped across multiple lines
- The algorithm greedily fills each line with as many characters as possible while respecting the width constraint
- Ensures at least one character is placed per line to guarantee progress, even in very narrow bubbles
- Preserves formatting properties (font, inline code styling, link URLs) across wrapped segments

## Implementation Details
- The new logic is inserted before the existing line-break handling to intercept oversized tokens early
- Uses `MeasureString` to determine character widths and find optimal break points
- Yields `LayoutSeg` objects for each chunk with appropriate positioning and styling information
- Automatically wraps to a new line when the current line has content and the next character won't fit
- Continues processing the remainder of the token on subsequent lines until fully consumed

https://claude.ai/code/session_01DPvZXvmNkq2QGamyQNeABS