### PR TITLE
Add support for Moonshot AI Kimi K2.7 Code model

### DIFF
--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -34,6 +34,7 @@ namespace GxPT
             "deepseek/deepseek-v4-pro",
             "deepseek/deepseek-v4-flash",
             "moonshotai/kimi-k2.6",
+            "moonshotai/kimi-k2.7-code",
             "qwen/qwen3.7-max",
             "qwen/qwen3.7-plus",
             "minimax/minimax-m3",


### PR DESCRIPTION
## Summary
Added support for the new Moonshot AI Kimi K2.7 Code model to the list of available models.

## Changes
- Added `"moonshotai/kimi-k2.7-code"` to the default models list in `ModelDefaults.cs`

## Details
This change extends the supported models by including the latest Kimi K2.7 Code variant from Moonshot AI, making it available alongside the existing Kimi K2.6 model. The new model is positioned in the model list following the K2.6 entry, maintaining logical grouping of Moonshot AI models.

https://claude.ai/code/session_017A6pxYTZVJAE8tZRVc2rwU