### PR TITLE
Fix StatusStrip tooltip flickering when positioned over taskbar

### DIFF
--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -36,12 +36,24 @@ namespace GxPT
             // Keep the native item tooltips; only their post-click flicker is the problem.
             strip.ShowItemToolTips = true;
 
-            strip.MouseDown += delegate
+            // Defer past the current click so menu mode is fully established before we drop it.
+            MouseEventHandler onDown = delegate
             {
                 if (!strip.IsHandleCreated) return;
-                // Defer past the current click so menu mode is fully established before we drop it.
                 try { strip.BeginInvoke((MethodInvoker)ExitMenuMode); }
                 catch { }
+            };
+
+            // Hook the strip AND every item: a click that lands directly on a ToolStripItem is
+            // routed to the item and does not reliably raise the strip's own MouseDown, so hooking
+            // only the strip would miss clicks on the labels (the common case) and leave them
+            // flickering. Items are static here, but ItemAdded keeps it correct if that changes.
+            strip.MouseDown += onDown;
+            foreach (ToolStripItem item in strip.Items)
+                item.MouseDown += onDown;
+            strip.ItemAdded += delegate(object sender, ToolStripItemEventArgs e)
+            {
+                if (e != null && e.Item != null) e.Item.MouseDown += onDown;
             };
         }
 

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -29,6 +29,7 @@ namespace GxPT
 
         private ToolStripItem _hotItem;    // item the cursor is currently over
         private ToolStripItem _shownItem;  // item the tip is currently displayed for
+        private Control _tipOwner;         // window Show()/Hide() are anchored to
         private Point _lastClientPos;
 
         internal static void Apply(ToolStrip strip)
@@ -83,14 +84,24 @@ namespace GxPT
             if (!HasTip(item) || item == _shownItem) return;
             if (!_strip.IsHandleCreated || !_strip.Visible) return;
 
-            // Anchor the tip above the strip so it can never land under the cursor (the condition
-            // that drives the native flicker). y is negative because it is relative to the strip's
-            // own top edge, and the strip sits at the bottom of the window.
-            Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
-            int x = _lastClientPos.X;
-            int y = -(sz.Height + 10);
+            // Anchor the tip to the FORM, not the strip, with on-screen positive coordinates. The
+            // strip is only ~22px tall and sits at the bottom of the window, so positioning the tip
+            // above it relative to the strip means negative coordinates -- which the framework can
+            // place off-screen, leaving the tip invisible. Converting the cursor position into the
+            // form's client area and lifting it by the tip height keeps the tip on screen, floating
+            // just above the status bar, where it can never overlap the cursor (the native overlap
+            // is what drove the original flicker).
+            Control owner = _strip.FindForm();
+            if (owner == null) owner = _strip;
+            _tipOwner = owner;
 
-            _toolTip.Show(item.ToolTipText, _strip, x, y, _toolTip.AutoPopDelay);
+            Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
+            Point pt = owner.PointToClient(_strip.PointToScreen(_lastClientPos));
+            pt.Y -= sz.Height + 14;
+            if (pt.Y < 0) pt.Y = 0;
+            if (pt.X < 0) pt.X = 0;
+
+            _toolTip.Show(item.ToolTipText, owner, pt.X, pt.Y, 5000);
             _shownItem = item;
         }
 
@@ -129,7 +140,8 @@ namespace GxPT
         {
             if (_shownItem != null)
             {
-                _toolTip.Hide(_strip);
+                // Hide against the same window the tip was shown on.
+                _toolTip.Hide(_tipOwner != null ? _tipOwner : _strip);
                 _shownItem = null;
             }
         }

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -111,12 +111,13 @@ namespace GxPT
             if (owner == null) owner = _strip;
             _tipOwner = owner;
 
-            // Anchor above the item: convert the item's top-left to screen, lift it clear of the bar
-            // by the tip height, then express it in the owner's client space. Positive, on-screen
-            // coordinates above the status bar -- never under the cursor, never over the taskbar.
+            // Anchor just above the cursor, not above the bar's top edge: the pointer can be anywhere
+            // down the ~22px-tall strip, so anchoring to the item top left small tips floating well
+            // above the mouse. Lifting from the cursor by the tip height puts the tip's bottom a few
+            // pixels above the pointer -- close to the mouse, never under it, never over the taskbar.
             Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
-            Point onScreen = _strip.PointToScreen(item.Bounds.Location);
-            onScreen.Y -= sz.Height + 12;
+            Point onScreen = Cursor.Position;
+            onScreen.Y -= sz.Height + 8;
             Point pt = owner.PointToClient(onScreen);
             if (pt.X < 0) pt.X = 0;
             if (pt.Y < 0) pt.Y = 0;

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // Works around a long-standing WinForms quirk behind the flickering status-bar tooltips:
+    // clicking anywhere on a ToolStrip/StatusStrip puts the strip into the same "modal menu"
+    // navigation mode that a real menu bar uses (ToolStripManager.ModalMenuFilter latches onto
+    // the strip as the active ToolStrip). A StatusStrip is a passive info bar with nothing to
+    // navigate, but while it is stuck in that mode the built-in item tooltips (ShowItemToolTips)
+    // fight with the menu-mode mouse tracking: every mouse move over the strip resets the
+    // currently-active tooltip item, so the native tooltip hides and re-shows on each move --
+    // the rapid on/off/on/off flashing. The mode only tears down when a mouse-down lands on some
+    // OTHER window (e.g. the chat transcript), which is why clicking elsewhere reliably ends it.
+    //
+    // The fix replays that teardown ourselves: after a click on the strip we call the framework's
+    // own ModalMenuFilter.ExitMenuMode() -- the exact path a click elsewhere would take -- leaving
+    // the strip idle so tooltips show for their normal duration again. That method is internal, so
+    // we reach it by reflection; if the lookup ever fails the call degrades to a no-op (the
+    // pre-existing flicker), never an exception.
+    internal static class StatusStripTooltipFix
+    {
+        private static bool _resolved;
+        private static MethodInfo _exitMenuMode;
+
+        // Wire a strip so a click on it can't leave it stuck in menu mode.
+        internal static void Apply(ToolStrip strip)
+        {
+            if (strip == null) return;
+            strip.MouseUp += delegate { ExitMenuMode(); };
+        }
+
+        private static void ExitMenuMode()
+        {
+            try
+            {
+                MethodInfo m = ResolveExitMenuMode();
+                if (m != null) m.Invoke(null, null);
+            }
+            catch { }
+        }
+
+        private static MethodInfo ResolveExitMenuMode()
+        {
+            if (_resolved) return _exitMenuMode;
+            _resolved = true;
+            try
+            {
+                Type filter = typeof(ToolStripManager).GetNestedType(
+                    "ModalMenuFilter", BindingFlags.NonPublic);
+                if (filter != null)
+                {
+                    _exitMenuMode = filter.GetMethod("ExitMenuMode",
+                        BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
+                        null, Type.EmptyTypes, null);
+                }
+            }
+            catch { _exitMenuMode = null; }
+            return _exitMenuMode;
+        }
+    }
+}

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -1,89 +1,160 @@
 using System;
-using System.Reflection;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace GxPT
 {
-    // Stops the status-bar tooltips from flickering after the strip is clicked, while keeping the
-    // normal (native) ToolStrip tooltips that work fine the rest of the time.
+    // Replaces the StatusStrip's native item tooltips with manually driven ones to stop the flicker.
     //
-    // Clicking a ToolStrip/StatusStrip latches it into the framework's "modal menu" navigation mode
-    // (ToolStripManager.ModalMenuFilter) -- the same state a menu bar uses. A status bar has nothing
-    // to navigate, but while it is stuck there the strip continuously re-tracks the mouse; combined
-    // with the well-known bottom-docked-ToolStrip tooltip quirk (the native tip is positioned under
-    // the cursor, which the strip then reads as a mouse-leave and immediately re-shows), that churn
-    // produces the rapid on/off/on/off flashing. The mode only ends when a mouse-down lands on some
-    // other window (e.g. the chat transcript) -- exactly the user-visible "click elsewhere to fix it".
+    // Root cause: the native ToolStrip tooltip is positioned just under the cursor. With the strip at
+    // the very bottom of the screen the tip lands on/over the Windows taskbar and under the cursor;
+    // the strip then registers a mouse-leave, hides the tip, and immediately re-shows it -- the rapid
+    // on/off/on/off loop. The framework's positioning (UpdateToolTip) is internal and cannot be
+    // overridden or corrected in place.
     //
-    // We replay that teardown ourselves: after each mouse-down on the strip we exit menu mode through
-    // the framework's own ModalMenuFilter.ExitMenuMode(). It is internal, so we reach it by
-    // reflection; if the lookup ever fails the call degrades to a no-op (the pre-existing flicker),
-    // never a throw.
+    // The fix turns the native tooltips off and shows a plain ToolTip ourselves, with the three
+    // things that make the loop impossible:
+    //   1. Triggered by per-item MouseHover/MouseEnter (NOT MouseMove). MouseMove fires constantly and
+    //      re-shows the tip under the cursor on every pixel of movement, which is itself a flicker
+    //      source; hover fires once when the pointer settles on an item.
+    //   2. Shown ABOVE the status bar, where it can never overlap the cursor or the taskbar.
+    //   3. Shown at most once per item (guarded), and hidden only on a real MouseLeave/MouseDown.
     //
-    // Why MouseDOWN, not MouseUp: once menu mode is active its message filter swallows the mouse-up
-    // before the strip can raise a MouseUp event, so a MouseUp handler would never run. The mouse-down
-    // that ENTERS menu mode still raises normally; we BeginInvoke the exit so it runs after the strip
-    // has finished entering menu mode for that click.
-    internal static class StatusStripTooltipFix
+    // ToolTip.Show prerequisites that the earlier attempts got wrong and that are required for it to
+    // display at all: Active and ShowAlways true, a positive duration (AutoPopDelay defaults to 0 on a
+    // code-created ToolTip, which suppresses display), and on-screen client coordinates.
+    internal sealed class StatusStripTooltipFix
     {
-        private static bool _resolved;
-        private static MethodInfo _exitMenuMode;
+        private readonly ToolStrip _strip;
+        private readonly ToolTip _toolTip;
+        private readonly Timer _hoverTimer;
+
+        private ToolStripItem _hotItem;    // item the pointer is currently over
+        private ToolStripItem _shownItem;  // item the tip is currently displayed for
+        private Control _tipOwner;         // window Show()/Hide() are anchored to
 
         internal static void Apply(ToolStrip strip)
         {
             if (strip == null) return;
+            // The instance keeps itself alive through the event subscriptions below.
+            new StatusStripTooltipFix(strip);
+        }
 
-            // Keep the native item tooltips; only their post-click flicker is the problem.
-            strip.ShowItemToolTips = true;
+        private StatusStripTooltipFix(ToolStrip strip)
+        {
+            _strip = strip;
 
-            // Defer past the current click so menu mode is fully established before we drop it.
-            MouseEventHandler onDown = delegate
-            {
-                if (!strip.IsHandleCreated) return;
-                try { strip.BeginInvoke((MethodInvoker)ExitMenuMode); }
-                catch { }
-            };
+            // Turn off the buggy native tooltips; everything below replaces them.
+            _strip.ShowItemToolTips = false;
 
-            // Hook the strip AND every item: a click that lands directly on a ToolStripItem is
-            // routed to the item and does not reliably raise the strip's own MouseDown, so hooking
-            // only the strip would miss clicks on the labels (the common case) and leave them
-            // flickering. Items are static here, but ItemAdded keeps it correct if that changes.
-            strip.MouseDown += onDown;
-            foreach (ToolStripItem item in strip.Items)
-                item.MouseDown += onDown;
+            _toolTip = new ToolTip();
+            _toolTip.Active = true;
+            _toolTip.ShowAlways = true;
+            _toolTip.UseAnimation = false;
+            _toolTip.UseFading = false;
+            _toolTip.AutoPopDelay = 5000;
+            _toolTip.InitialDelay = 500;
+            _toolTip.ReshowDelay = 100;
+
+            // Fallback delay timer in case a given item doesn't raise MouseHover; MouseEnter always
+            // fires, so this guarantees the tip appears after the system hover delay regardless.
+            _hoverTimer = new Timer();
+            _hoverTimer.Interval = Math.Max(1, SystemInformation.MouseHoverTime);
+            _hoverTimer.Tick += HoverTimer_Tick;
+
+            foreach (ToolStripItem item in strip.Items) HookItem(item);
             strip.ItemAdded += delegate(object sender, ToolStripItemEventArgs e)
             {
-                if (e != null && e.Item != null) e.Item.MouseDown += onDown;
+                if (e != null && e.Item != null) HookItem(e.Item);
+            };
+            strip.Disposed += delegate
+            {
+                try { _hoverTimer.Dispose(); } catch { }
+                try { _toolTip.Dispose(); } catch { }
             };
         }
 
-        private static void ExitMenuMode()
+        private void HookItem(ToolStripItem item)
         {
-            try
-            {
-                MethodInfo m = ResolveExitMenuMode();
-                if (m != null) m.Invoke(null, null);
-            }
-            catch { }
+            item.MouseEnter += Item_MouseEnter;
+            item.MouseHover += Item_MouseHover;
+            item.MouseLeave += Item_MouseLeave;
+            item.MouseDown += Item_MouseDown;
         }
 
-        private static MethodInfo ResolveExitMenuMode()
+        private void Item_MouseEnter(object sender, EventArgs e)
         {
-            if (_resolved) return _exitMenuMode;
-            _resolved = true;
-            try
+            _hotItem = sender as ToolStripItem;
+            _hoverTimer.Stop();
+            if (HasTip(_hotItem)) _hoverTimer.Start();
+        }
+
+        // Either trigger (the system hover event, or our fallback timer) shows the tip; the
+        // once-per-item guard inside ShowTipFor keeps them from fighting.
+        private void Item_MouseHover(object sender, EventArgs e)
+        {
+            ShowTipFor(sender as ToolStripItem);
+        }
+
+        private void HoverTimer_Tick(object sender, EventArgs e)
+        {
+            _hoverTimer.Stop();
+            ShowTipFor(_hotItem);
+        }
+
+        private void ShowTipFor(ToolStripItem item)
+        {
+            if (!HasTip(item) || item != _hotItem || item == _shownItem) return;
+            if (!_strip.IsHandleCreated || !_strip.Visible) return;
+
+            Control owner = _strip.FindForm();
+            if (owner == null) owner = _strip;
+            _tipOwner = owner;
+
+            // Anchor above the item: convert the item's top-left to screen, lift it clear of the bar
+            // by the tip height, then express it in the owner's client space. Positive, on-screen
+            // coordinates above the status bar -- never under the cursor, never over the taskbar.
+            Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
+            Point onScreen = _strip.PointToScreen(item.Bounds.Location);
+            onScreen.Y -= sz.Height + 12;
+            Point pt = owner.PointToClient(onScreen);
+            if (pt.X < 0) pt.X = 0;
+            if (pt.Y < 0) pt.Y = 0;
+
+            _toolTip.Show(item.ToolTipText, owner, pt, 5000);
+            _shownItem = item;
+        }
+
+        private void Item_MouseLeave(object sender, EventArgs e)
+        {
+            ToolStripItem item = sender as ToolStripItem;
+            if (item == _hotItem)
             {
-                Type filter = typeof(ToolStripManager).GetNestedType(
-                    "ModalMenuFilter", BindingFlags.NonPublic);
-                if (filter != null)
-                {
-                    _exitMenuMode = filter.GetMethod("ExitMenuMode",
-                        BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
-                        null, Type.EmptyTypes, null);
-                }
+                _hoverTimer.Stop();
+                _hotItem = null;
             }
-            catch { _exitMenuMode = null; }
-            return _exitMenuMode;
+            HideTip();
+        }
+
+        private void Item_MouseDown(object sender, MouseEventArgs e)
+        {
+            // A click shouldn't strand a tip on screen.
+            _hoverTimer.Stop();
+            HideTip();
+        }
+
+        private static bool HasTip(ToolStripItem item)
+        {
+            return item != null && !string.IsNullOrEmpty(item.ToolTipText);
+        }
+
+        private void HideTip()
+        {
+            if (_shownItem != null)
+            {
+                _toolTip.Hide(_tipOwner != null ? _tipOwner : _strip);
+                _shownItem = null;
+            }
         }
     }
 }

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -1,149 +1,77 @@
 using System;
-using System.Drawing;
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace GxPT
 {
-    // Fixes the flickering status-bar tooltips by replacing the ToolStrip's built-in tooltip with a
-    // manually driven one.
+    // Stops the status-bar tooltips from flickering after the strip is clicked, while keeping the
+    // normal (native) ToolStrip tooltips that work fine the rest of the time.
     //
-    // Root cause of the flicker: ToolStrip.ShowItemToolTips positions the native tooltip directly
-    // below the cursor (cursor position + cursor height). ssMain is docked at the very bottom of the
-    // window, so there is no room below; Windows flips the tooltip up ONTO the cursor. The tooltip
-    // window now sits under the pointer, the strip receives a synthetic WM_MOUSELEAVE, hides the
-    // tooltip, the pointer is over the strip again, it re-shows -- the rapid on/off/on/off loop the
-    // user sees. The framework's UpdateToolTip is internal and sealed against override/reflection, so
-    // the position can't be corrected in place; the only reliable fix is to stop using it.
+    // Clicking a ToolStrip/StatusStrip latches it into the framework's "modal menu" navigation mode
+    // (ToolStripManager.ModalMenuFilter) -- the same state a menu bar uses. A status bar has nothing
+    // to navigate, but while it is stuck there the strip continuously re-tracks the mouse; combined
+    // with the well-known bottom-docked-ToolStrip tooltip quirk (the native tip is positioned under
+    // the cursor, which the strip then reads as a mouse-leave and immediately re-shows), that churn
+    // produces the rapid on/off/on/off flashing. The mode only ends when a mouse-down lands on some
+    // other window (e.g. the chat transcript) -- exactly the user-visible "click elsewhere to fix it".
     //
-    // This manager turns ShowItemToolTips off and shows a plain ToolTip itself, with two properties
-    // that make the loop impossible:
-    //   1. It shows a tip only when the cursor moves to a DIFFERENT item, never while hovering within
-    //      one -- so there is no per-mouse-move re-show to flicker.
-    //   2. It anchors the tip ABOVE the strip, where it can never overlap the cursor, and ignores the
-    //      synthetic mouse-leave the tip window would otherwise trigger.
-    internal sealed class StatusStripTooltipFix
+    // We replay that teardown ourselves: after each mouse-down on the strip we exit menu mode through
+    // the framework's own ModalMenuFilter.ExitMenuMode(). It is internal, so we reach it by
+    // reflection; if the lookup ever fails the call degrades to a no-op (the pre-existing flicker),
+    // never a throw.
+    //
+    // Why MouseDOWN, not MouseUp: once menu mode is active its message filter swallows the mouse-up
+    // before the strip can raise a MouseUp event, so a MouseUp handler would never run. The mouse-down
+    // that ENTERS menu mode still raises normally; we BeginInvoke the exit so it runs after the strip
+    // has finished entering menu mode for that click.
+    internal static class StatusStripTooltipFix
     {
-        private readonly ToolStrip _strip;
-        private readonly ToolTip _toolTip;
-        private readonly Timer _showTimer;
-
-        private ToolStripItem _hotItem;    // item the cursor is currently over
-        private ToolStripItem _shownItem;  // item the tip is currently displayed for
-        private Control _tipOwner;         // window Show()/Hide() are anchored to
-        private Point _lastClientPos;
+        private static bool _resolved;
+        private static MethodInfo _exitMenuMode;
 
         internal static void Apply(ToolStrip strip)
         {
             if (strip == null) return;
-            // Construction wires the handlers; the instance is kept alive by those subscriptions
-            // (and torn down when the strip is disposed).
-            new StatusStripTooltipFix(strip);
-        }
 
-        private StatusStripTooltipFix(ToolStrip strip)
-        {
-            _strip = strip;
+            // Keep the native item tooltips; only their post-click flicker is the problem.
+            strip.ShowItemToolTips = true;
 
-            // Drop the buggy native tooltips; everything below replaces them.
-            _strip.ShowItemToolTips = false;
-
-            _toolTip = new ToolTip();
-            _toolTip.ShowAlways = true;
-
-            _showTimer = new Timer();
-            // Match the system hover delay so tips feel the same as before, just without the flicker.
-            _showTimer.Interval = Math.Max(1, SystemInformation.MouseHoverTime);
-            _showTimer.Tick += ShowTimer_Tick;
-
-            _strip.MouseMove += Strip_MouseMove;
-            _strip.MouseLeave += Strip_MouseLeave;
-            _strip.MouseDown += Strip_MouseDown;
-            _strip.Disposed += Strip_Disposed;
-        }
-
-        private void Strip_MouseMove(object sender, MouseEventArgs e)
-        {
-            _lastClientPos = e.Location;
-
-            ToolStripItem item = _strip.GetItemAt(e.Location);
-            // Same region as last move: leave any shown tip exactly as-is. This is what kills the
-            // flicker -- a stationary or in-region move never re-shows the tip.
-            if (item == _hotItem) return;
-
-            _hotItem = item;
-            HideTip();
-            _showTimer.Stop();
-            if (HasTip(item)) _showTimer.Start();
-        }
-
-        private void ShowTimer_Tick(object sender, EventArgs e)
-        {
-            _showTimer.Stop();
-
-            ToolStripItem item = _hotItem;
-            if (!HasTip(item) || item == _shownItem) return;
-            if (!_strip.IsHandleCreated || !_strip.Visible) return;
-
-            // Anchor the tip to the FORM, not the strip, with on-screen positive coordinates. The
-            // strip is only ~22px tall and sits at the bottom of the window, so positioning the tip
-            // above it relative to the strip means negative coordinates -- which the framework can
-            // place off-screen, leaving the tip invisible. Converting the cursor position into the
-            // form's client area and lifting it by the tip height keeps the tip on screen, floating
-            // just above the status bar, where it can never overlap the cursor (the native overlap
-            // is what drove the original flicker).
-            Control owner = _strip.FindForm();
-            if (owner == null) owner = _strip;
-            _tipOwner = owner;
-
-            Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
-            Point pt = owner.PointToClient(_strip.PointToScreen(_lastClientPos));
-            pt.Y -= sz.Height + 14;
-            if (pt.Y < 0) pt.Y = 0;
-            if (pt.X < 0) pt.X = 0;
-
-            _toolTip.Show(item.ToolTipText, owner, pt.X, pt.Y, 5000);
-            _shownItem = item;
-        }
-
-        private void Strip_MouseLeave(object sender, EventArgs e)
-        {
-            // The tip window can raise a leave while the pointer is still physically over the strip;
-            // ignore those so we don't hide-then-reshow. Only tear down on a genuine exit.
-            Point p = _strip.PointToClient(Cursor.Position);
-            if (_strip.ClientRectangle.Contains(p)) return;
-
-            _showTimer.Stop();
-            _hotItem = null;
-            HideTip();
-        }
-
-        private void Strip_MouseDown(object sender, MouseEventArgs e)
-        {
-            // A click shouldn't strand a tip on screen.
-            _showTimer.Stop();
-            _hotItem = null;
-            HideTip();
-        }
-
-        private void Strip_Disposed(object sender, EventArgs e)
-        {
-            try { _showTimer.Dispose(); } catch { }
-            try { _toolTip.Dispose(); } catch { }
-        }
-
-        private static bool HasTip(ToolStripItem item)
-        {
-            return item != null && !string.IsNullOrEmpty(item.ToolTipText);
-        }
-
-        private void HideTip()
-        {
-            if (_shownItem != null)
+            strip.MouseDown += delegate
             {
-                // Hide against the same window the tip was shown on.
-                _toolTip.Hide(_tipOwner != null ? _tipOwner : _strip);
-                _shownItem = null;
+                if (!strip.IsHandleCreated) return;
+                // Defer past the current click so menu mode is fully established before we drop it.
+                try { strip.BeginInvoke((MethodInvoker)ExitMenuMode); }
+                catch { }
+            };
+        }
+
+        private static void ExitMenuMode()
+        {
+            try
+            {
+                MethodInfo m = ResolveExitMenuMode();
+                if (m != null) m.Invoke(null, null);
             }
+            catch { }
+        }
+
+        private static MethodInfo ResolveExitMenuMode()
+        {
+            if (_resolved) return _exitMenuMode;
+            _resolved = true;
+            try
+            {
+                Type filter = typeof(ToolStripManager).GetNestedType(
+                    "ModalMenuFilter", BindingFlags.NonPublic);
+                if (filter != null)
+                {
+                    _exitMenuMode = filter.GetMethod("ExitMenuMode",
+                        BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
+                        null, Type.EmptyTypes, null);
+                }
+            }
+            catch { _exitMenuMode = null; }
+            return _exitMenuMode;
         }
     }
 }

--- a/GxPT/Controls/StatusStripTooltipFix.cs
+++ b/GxPT/Controls/StatusStripTooltipFix.cs
@@ -1,63 +1,137 @@
 using System;
-using System.Reflection;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace GxPT
 {
-    // Works around a long-standing WinForms quirk behind the flickering status-bar tooltips:
-    // clicking anywhere on a ToolStrip/StatusStrip puts the strip into the same "modal menu"
-    // navigation mode that a real menu bar uses (ToolStripManager.ModalMenuFilter latches onto
-    // the strip as the active ToolStrip). A StatusStrip is a passive info bar with nothing to
-    // navigate, but while it is stuck in that mode the built-in item tooltips (ShowItemToolTips)
-    // fight with the menu-mode mouse tracking: every mouse move over the strip resets the
-    // currently-active tooltip item, so the native tooltip hides and re-shows on each move --
-    // the rapid on/off/on/off flashing. The mode only tears down when a mouse-down lands on some
-    // OTHER window (e.g. the chat transcript), which is why clicking elsewhere reliably ends it.
+    // Fixes the flickering status-bar tooltips by replacing the ToolStrip's built-in tooltip with a
+    // manually driven one.
     //
-    // The fix replays that teardown ourselves: after a click on the strip we call the framework's
-    // own ModalMenuFilter.ExitMenuMode() -- the exact path a click elsewhere would take -- leaving
-    // the strip idle so tooltips show for their normal duration again. That method is internal, so
-    // we reach it by reflection; if the lookup ever fails the call degrades to a no-op (the
-    // pre-existing flicker), never an exception.
-    internal static class StatusStripTooltipFix
+    // Root cause of the flicker: ToolStrip.ShowItemToolTips positions the native tooltip directly
+    // below the cursor (cursor position + cursor height). ssMain is docked at the very bottom of the
+    // window, so there is no room below; Windows flips the tooltip up ONTO the cursor. The tooltip
+    // window now sits under the pointer, the strip receives a synthetic WM_MOUSELEAVE, hides the
+    // tooltip, the pointer is over the strip again, it re-shows -- the rapid on/off/on/off loop the
+    // user sees. The framework's UpdateToolTip is internal and sealed against override/reflection, so
+    // the position can't be corrected in place; the only reliable fix is to stop using it.
+    //
+    // This manager turns ShowItemToolTips off and shows a plain ToolTip itself, with two properties
+    // that make the loop impossible:
+    //   1. It shows a tip only when the cursor moves to a DIFFERENT item, never while hovering within
+    //      one -- so there is no per-mouse-move re-show to flicker.
+    //   2. It anchors the tip ABOVE the strip, where it can never overlap the cursor, and ignores the
+    //      synthetic mouse-leave the tip window would otherwise trigger.
+    internal sealed class StatusStripTooltipFix
     {
-        private static bool _resolved;
-        private static MethodInfo _exitMenuMode;
+        private readonly ToolStrip _strip;
+        private readonly ToolTip _toolTip;
+        private readonly Timer _showTimer;
 
-        // Wire a strip so a click on it can't leave it stuck in menu mode.
+        private ToolStripItem _hotItem;    // item the cursor is currently over
+        private ToolStripItem _shownItem;  // item the tip is currently displayed for
+        private Point _lastClientPos;
+
         internal static void Apply(ToolStrip strip)
         {
             if (strip == null) return;
-            strip.MouseUp += delegate { ExitMenuMode(); };
+            // Construction wires the handlers; the instance is kept alive by those subscriptions
+            // (and torn down when the strip is disposed).
+            new StatusStripTooltipFix(strip);
         }
 
-        private static void ExitMenuMode()
+        private StatusStripTooltipFix(ToolStrip strip)
         {
-            try
-            {
-                MethodInfo m = ResolveExitMenuMode();
-                if (m != null) m.Invoke(null, null);
-            }
-            catch { }
+            _strip = strip;
+
+            // Drop the buggy native tooltips; everything below replaces them.
+            _strip.ShowItemToolTips = false;
+
+            _toolTip = new ToolTip();
+            _toolTip.ShowAlways = true;
+
+            _showTimer = new Timer();
+            // Match the system hover delay so tips feel the same as before, just without the flicker.
+            _showTimer.Interval = Math.Max(1, SystemInformation.MouseHoverTime);
+            _showTimer.Tick += ShowTimer_Tick;
+
+            _strip.MouseMove += Strip_MouseMove;
+            _strip.MouseLeave += Strip_MouseLeave;
+            _strip.MouseDown += Strip_MouseDown;
+            _strip.Disposed += Strip_Disposed;
         }
 
-        private static MethodInfo ResolveExitMenuMode()
+        private void Strip_MouseMove(object sender, MouseEventArgs e)
         {
-            if (_resolved) return _exitMenuMode;
-            _resolved = true;
-            try
+            _lastClientPos = e.Location;
+
+            ToolStripItem item = _strip.GetItemAt(e.Location);
+            // Same region as last move: leave any shown tip exactly as-is. This is what kills the
+            // flicker -- a stationary or in-region move never re-shows the tip.
+            if (item == _hotItem) return;
+
+            _hotItem = item;
+            HideTip();
+            _showTimer.Stop();
+            if (HasTip(item)) _showTimer.Start();
+        }
+
+        private void ShowTimer_Tick(object sender, EventArgs e)
+        {
+            _showTimer.Stop();
+
+            ToolStripItem item = _hotItem;
+            if (!HasTip(item) || item == _shownItem) return;
+            if (!_strip.IsHandleCreated || !_strip.Visible) return;
+
+            // Anchor the tip above the strip so it can never land under the cursor (the condition
+            // that drives the native flicker). y is negative because it is relative to the strip's
+            // own top edge, and the strip sits at the bottom of the window.
+            Size sz = TextRenderer.MeasureText(item.ToolTipText, SystemFonts.DefaultFont);
+            int x = _lastClientPos.X;
+            int y = -(sz.Height + 10);
+
+            _toolTip.Show(item.ToolTipText, _strip, x, y, _toolTip.AutoPopDelay);
+            _shownItem = item;
+        }
+
+        private void Strip_MouseLeave(object sender, EventArgs e)
+        {
+            // The tip window can raise a leave while the pointer is still physically over the strip;
+            // ignore those so we don't hide-then-reshow. Only tear down on a genuine exit.
+            Point p = _strip.PointToClient(Cursor.Position);
+            if (_strip.ClientRectangle.Contains(p)) return;
+
+            _showTimer.Stop();
+            _hotItem = null;
+            HideTip();
+        }
+
+        private void Strip_MouseDown(object sender, MouseEventArgs e)
+        {
+            // A click shouldn't strand a tip on screen.
+            _showTimer.Stop();
+            _hotItem = null;
+            HideTip();
+        }
+
+        private void Strip_Disposed(object sender, EventArgs e)
+        {
+            try { _showTimer.Dispose(); } catch { }
+            try { _toolTip.Dispose(); } catch { }
+        }
+
+        private static bool HasTip(ToolStripItem item)
+        {
+            return item != null && !string.IsNullOrEmpty(item.ToolTipText);
+        }
+
+        private void HideTip()
+        {
+            if (_shownItem != null)
             {
-                Type filter = typeof(ToolStripManager).GetNestedType(
-                    "ModalMenuFilter", BindingFlags.NonPublic);
-                if (filter != null)
-                {
-                    _exitMenuMode = filter.GetMethod("ExitMenuMode",
-                        BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
-                        null, Type.EmptyTypes, null);
-                }
+                _toolTip.Hide(_strip);
+                _shownItem = null;
             }
-            catch { _exitMenuMode = null; }
-            return _exitMenuMode;
         }
     }
 }

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -573,7 +573,9 @@
             this.tslSavedValue});
             this.ssMain.Location = new System.Drawing.Point(0, 744);
             this.ssMain.Name = "ssMain";
-            this.ssMain.ShowItemToolTips = true;
+            // Item tooltips are driven manually by StatusStripTooltipFix (the native ones flicker
+            // when positioned over the taskbar at the bottom of the screen). Keep this false.
+            this.ssMain.ShowItemToolTips = false;
             this.ssMain.Size = new System.Drawing.Size(892, 22);
             this.ssMain.SizingGrip = false;
             this.ssMain.TabIndex = 3;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -573,9 +573,7 @@
             this.tslSavedValue});
             this.ssMain.Location = new System.Drawing.Point(0, 744);
             this.ssMain.Name = "ssMain";
-            // Item tooltips are driven manually by StatusStripTooltipFix; the native ones flicker on
-            // a bottom-docked strip (see that class). Keep this false so they never engage.
-            this.ssMain.ShowItemToolTips = false;
+            this.ssMain.ShowItemToolTips = true;
             this.ssMain.Size = new System.Drawing.Size(892, 22);
             this.ssMain.SizingGrip = false;
             this.ssMain.TabIndex = 3;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -573,7 +573,9 @@
             this.tslSavedValue});
             this.ssMain.Location = new System.Drawing.Point(0, 744);
             this.ssMain.Name = "ssMain";
-            this.ssMain.ShowItemToolTips = true;
+            // Item tooltips are driven manually by StatusStripTooltipFix; the native ones flicker on
+            // a bottom-docked strip (see that class). Keep this false so they never engage.
+            this.ssMain.ShowItemToolTips = false;
             this.ssMain.Size = new System.Drawing.Size(892, 22);
             this.ssMain.SizingGrip = false;
             this.ssMain.TabIndex = 3;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5939,9 +5939,9 @@ namespace GxPT
                     this.ssMain.AutoSize = false;
                     this.ssMain.Height = oneRowHeight;
 
-                    // Clicking the strip latches it into the framework's modal-menu navigation
-                    // mode, which makes the item tooltips flicker on every mouse move until a click
-                    // lands elsewhere. Replay that teardown after each click so tooltips stay sane.
+                    // The native ToolStrip tooltips flash on/off over a bottom-docked strip (the
+                    // tip gets placed under the cursor, which the strip reads as a mouse-leave and
+                    // re-shows in a loop). Drive the tooltips manually instead.
                     StatusStripTooltipFix.Apply(this.ssMain);
                 }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5939,9 +5939,9 @@ namespace GxPT
                     this.ssMain.AutoSize = false;
                     this.ssMain.Height = oneRowHeight;
 
-                    // Clicking the strip latches it into the framework's modal-menu mode, which
-                    // makes the native item tooltips flicker until a click lands elsewhere. Tear
-                    // that mode down after each click so the tooltips behave normally again.
+                    // The native ToolStrip tooltips flicker when shown over the taskbar at the
+                    // bottom of the screen. Drive the item tooltips manually instead (shown above
+                    // the bar, on hover rather than mouse-move).
                     StatusStripTooltipFix.Apply(this.ssMain);
                 }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5938,6 +5938,11 @@ namespace GxPT
                     int oneRowHeight = this.ssMain.Height;
                     this.ssMain.AutoSize = false;
                     this.ssMain.Height = oneRowHeight;
+
+                    // Clicking the strip latches it into the framework's modal-menu navigation
+                    // mode, which makes the item tooltips flicker on every mouse move until a click
+                    // lands elsewhere. Replay that teardown after each click so tooltips stay sane.
+                    StatusStripTooltipFix.Apply(this.ssMain);
                 }
 
                 bool visible = AppSettings.GetBool("statusbar_visible");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5939,9 +5939,9 @@ namespace GxPT
                     this.ssMain.AutoSize = false;
                     this.ssMain.Height = oneRowHeight;
 
-                    // The native ToolStrip tooltips flash on/off over a bottom-docked strip (the
-                    // tip gets placed under the cursor, which the strip reads as a mouse-leave and
-                    // re-shows in a loop). Drive the tooltips manually instead.
+                    // Clicking the strip latches it into the framework's modal-menu mode, which
+                    // makes the native item tooltips flicker until a click lands elsewhere. Tear
+                    // that mode down after each click so the tooltips behave normally again.
                     StatusStripTooltipFix.Apply(this.ssMain);
                 }
 

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -99,6 +99,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\SafeToolStripRenderer.cs" />
+    <Compile Include="Controls\StatusStripTooltipFix.cs" />
     <Compile Include="Managers\ImportExportManager.cs" />
     <Compile Include="Managers\SkillImportExportManager.cs" />
     <Compile Include="Services\AppSettings.cs" />


### PR DESCRIPTION
## Summary
Replaces the native StatusStrip item tooltips with manually-driven tooltips to eliminate flickering when the status bar is positioned at the bottom of the screen over the Windows taskbar.

## Problem
The native ToolStrip tooltip positioning logic places tooltips directly under the cursor. When the status bar is at the screen's bottom edge, tooltips overlap the taskbar and cursor, causing the strip to register mouse-leave events that hide the tooltip, which immediately re-shows it—creating a rapid flicker loop. The framework's internal positioning logic cannot be overridden.

## Solution
Implemented `StatusStripTooltipFix` class that:
- Disables native tooltips (`ShowItemToolTips = false`)
- Manually manages tooltip display using a custom `ToolTip` control
- Triggers tooltips on `MouseHover`/`MouseEnter` events (not `MouseMove`) to avoid constant re-triggering
- Positions tooltips **above** the status bar (never overlapping cursor or taskbar)
- Guards tooltip display to show at most once per item
- Hides tooltips only on genuine `MouseLeave` or `MouseDown` events

## Key Changes
- **New file**: `Controls/StatusStripTooltipFix.cs` - Core fix implementation with detailed comments explaining the root cause and solution
- **Modified**: `Forms/MainForm.cs` - Applies the fix to the main status bar during initialization
- **Modified**: `Forms/MainForm.Designer.cs` - Sets `ShowItemToolTips = false` with explanatory comment
- **Modified**: `GxPT.csproj` - Adds the new control file to the project

## Implementation Details
- Uses a fallback timer (system hover delay) to guarantee tooltip appearance even if `MouseHover` doesn't fire
- Measures tooltip text to position it precisely above the cursor with proper spacing
- Properly handles edge cases: form boundaries, missing handles, invisible strips
- Cleans up resources on strip disposal
- Hooks all existing items and dynamically hooks newly-added items

https://claude.ai/code/session_01VJ5B2KgmM7S2NnkiQzfrM8