### PR TITLE
Bump extensions server to 1.3.0.0 for rename_agent/rename_skill

### DIFF
--- a/servers/ExtensionsMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/ExtensionsMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c1d2e3f4-a5b6-47c8-99da-0b1c2d3e4f50")]
 
-[assembly: AssemblyVersion("1.2.1.0")]
-[assembly: AssemblyFileVersion("1.2.1.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
Follow-up to #201, which added the `rename_agent`/`rename_skill` tools, name↔slug alignment enforcement, and several tool-description changes in the extensions server but didn't bump its assembly version.

Bumps `ExtensionsMcpServer` from `1.2.1.0` → **`1.3.0.0`** (a feature addition — two new tools), consistent with this repo's convention of versioning the extensions server alongside its tool surface (e.g. `1.2.0.0` for agent authoring, `1.2.1.0` for a `write_skill_file` description tweak).

Touches only `servers/ExtensionsMcpServer/Properties/AssemblyInfo.cs` (`AssemblyVersion` + `AssemblyFileVersion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkrWhDfeW3Pb7jWWgdWdsD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkrWhDfeW3Pb7jWWgdWdsD)_