### PR TITLE
Clean up rename-tool follow-ups from the code review

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -395,6 +395,22 @@ namespace GxPT
                         handled = true;
                     }
                 }
+                else if (string.Equals(req.FunctionName, "extensions__rename_skill", StringComparison.Ordinal)
+                      || string.Equals(req.FunctionName, "extensions__rename_agent", StringComparison.Ordinal))
+                {
+                    // Show the handle change (old slug -> new slug), plus the new name when one was given.
+                    string slug = req.Arguments.Value<string>("slug") ?? string.Empty;
+                    string ns = req.Arguments.Value<string>("new_slug") ?? string.Empty;
+                    string nn = req.Arguments.Value<string>("new_name") ?? string.Empty;
+                    if (slug.Length > 0 && ns.Length > 0)
+                    {
+                        string text = slug + " -> " + ns + (nn.Length > 0 ? "  (name: " + nn + ")" : "");
+                        _diffPanel.SetContent(string.Empty, text, "text", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _previewLabel.Text = string.Equals(req.FunctionName, "extensions__rename_skill", StringComparison.Ordinal)
+                            ? "Rename skill:" : "Rename agent:";
+                        handled = true;
+                    }
+                }
                 else if (string.Equals(req.FunctionName, "command__run", StringComparison.Ordinal))
                 {
                     string cmd = req.Arguments.Value<string>("command") ?? string.Empty;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4983,6 +4983,12 @@ namespace GxPT
                     string slug = Str(args, "slug"); if (slug.Length == 0) return false;
                     header = "Validated skill " + slug; return true;
                 }
+                case "extensions__rename_skill":
+                {
+                    string slug = Str(args, "slug"); string ns = Str(args, "new_slug");
+                    if (slug.Length == 0 || ns.Length == 0) return false;
+                    header = "Renamed skill " + slug + " to " + ns; return true;
+                }
                 case "extensions__create_agent":
                 {
                     string slug = Str(args, "slug"); string agentName = Str(args, "name");
@@ -5021,6 +5027,12 @@ namespace GxPT
                 {
                     string slug = Str(args, "slug"); if (slug.Length == 0) return false;
                     header = "Deleted agent " + slug; return true;
+                }
+                case "extensions__rename_agent":
+                {
+                    string slug = Str(args, "slug"); string ns = Str(args, "new_slug");
+                    if (slug.Length == 0 || ns.Length == 0) return false;
+                    header = "Renamed agent " + slug + " to " + ns; return true;
                 }
                 case "extensions__validate_agent":
                 {

--- a/servers/ExtensionsMcpServer/AgentWriter.cs
+++ b/servers/ExtensionsMcpServer/AgentWriter.cs
@@ -46,7 +46,7 @@ namespace ExtensionsMcpServer
             RequireSingleLine(name, "name");
             RequireSingleLine(description, "description");
             if (!WriterIo.NameMatchesSlug(name, slug))
-                throw new AgentWriteException(WriterIo.NameSlugMismatchMessage("agent", name, slug, true, "create_agent"));
+                throw new AgentWriteException(WriterIo.NameSlugMismatchMessage("agent", name, slug, true));
 
             string toolsValue = FormatTools(tools);            // null => omit the key
             string tierValue = NormalizeTier(maxTier);          // null => omit (host defaults to write)
@@ -82,7 +82,7 @@ namespace ExtensionsMcpServer
             // A new name must still reduce to this agent's slug (the slug is the fixed handle); renaming is
             // create-new + delete-old, not an in-place name swap that would leave name and slug diverged.
             if (!IsBlank(name) && !WriterIo.NameMatchesSlug(name, slug))
-                throw new AgentWriteException(WriterIo.NameSlugMismatchMessage("agent", name, slug, false, "create_agent"));
+                throw new AgentWriteException(WriterIo.NameSlugMismatchMessage("agent", name, slug, false));
 
             AgentFrontmatter fm = AgentFrontmatter.Parse(existing);
             // A present-but-blank scalar means "keep" (same as omitting it): only a non-blank value changes
@@ -172,7 +172,15 @@ namespace ExtensionsMcpServer
             if (IsBlank(fm.Description))
                 throw new AgentWriteException("agent '" + oldSlug + "' has no description; fix it with update_agent before renaming");
 
-            string resolvedName = ResolveRenameName("agent", newName, newSlug, fm.Name);
+            // A given new_name must reduce to the new slug; otherwise fall back to deriving one. The throw
+            // stays here (not in WriterIo) because the exception type is agent-specific.
+            if (!IsBlank(newName))
+            {
+                RequireSingleLine(newName, "new_name");
+                if (!WriterIo.NameMatchesSlug(newName, newSlug))
+                    throw new AgentWriteException(WriterIo.NameSlugMismatchMessage("agent", newName, newSlug, true));
+            }
+            string resolvedName = WriterIo.ResolveRenamedName(newName, newSlug, fm.Name);
 
             // Write the new file first, then remove the old one. The collision guard above means the new path
             // never overwrites another agent, and the content is preserved (this is a move, not a rewrite).
@@ -181,28 +189,14 @@ namespace ExtensionsMcpServer
             try { File.Delete(oldFile); }
             catch (Exception ex)
             {
-                throw new AgentWriteException("renamed to '" + newSlug + "' but could not remove the old '"
-                    + oldSlug + "': " + ex.Message);
+                // Roll back the just-written copy so a failed delete doesn't leave two agents (the old one
+                // still loadable, plus a duplicate at the new slug).
+                try { File.Delete(newFile); } catch { }
+                throw new AgentWriteException("could not rename '" + oldSlug + "' to '" + newSlug
+                    + "' (removing the old file failed): " + ex.Message);
             }
             return "Renamed agent '" + oldSlug + "' to '" + newSlug + "'. Anything that dispatched '" + oldSlug
                 + "' must now use '" + newSlug + "'.";
-        }
-
-        // The display name a rename should write: an explicit newName (validated against the new slug), else
-        // the current name if it still aligns, else a Title Case name derived from the new slug. Shared shape
-        // with the skill writer (kept here, not in WriterIo, because the domain exception type differs).
-        private static string ResolveRenameName(string noun, string newName, string newSlug, string currentName)
-        {
-            if (!IsBlank(newName))
-            {
-                RequireSingleLine(newName, "new_name");
-                if (!WriterIo.NameMatchesSlug(newName, newSlug))
-                    throw new AgentWriteException(WriterIo.NameSlugMismatchMessage(noun, newName, newSlug, true, "create_agent"));
-                return newName;
-            }
-            if (!IsBlank(currentName) && WriterIo.NameMatchesSlug(currentName, newSlug))
-                return currentName;
-            return WriterIo.TitleCaseFromSlug(newSlug);
         }
 
         // read_agent (ReadOnly): the full <slug>.md text. Reads from ANY root - project, user, or the

--- a/servers/ExtensionsMcpServer/SkillWriter.cs
+++ b/servers/ExtensionsMcpServer/SkillWriter.cs
@@ -58,7 +58,7 @@ namespace ExtensionsMcpServer
             RequireSingleLine(name, "name");
             RequireSingleLine(description, "description");
             if (!WriterIo.NameMatchesSlug(name, slug))
-                throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", name, slug, true, "create_skill"));
+                throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", name, slug, true));
 
             string file = Path.Combine(Path.Combine(root, slug), "SKILL.md");
             if (File.Exists(file))
@@ -113,7 +113,7 @@ namespace ExtensionsMcpServer
             // A new name must still reduce to this skill's slug (the slug is the fixed handle/folder name);
             // renaming is create-new + delete-old, not an in-place name swap that diverges name from slug.
             if (!IsBlank(name) && !WriterIo.NameMatchesSlug(name, slug))
-                throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", name, slug, false, "create_skill"));
+                throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", name, slug, false));
 
             SkillFrontmatter fm = SkillFrontmatter.Parse(existing);
             // A present-but-blank scalar means "keep" (same as omitting it): passing "" never silently wipes
@@ -155,30 +155,30 @@ namespace ExtensionsMcpServer
             if (IsBlank(fm.Description))
                 throw new SkillWriteException("skill '" + oldSlug + "' has no description; fix it with update_skill before renaming");
 
-            string resolvedName = ResolveRenameName(newName, newSlug, fm.Name);
-
-            // Move the whole folder (assets and scripts come along), then rewrite SKILL.md's name in place.
-            try { Directory.Move(oldDir, newDir); }
-            catch (Exception ex) { throw new SkillWriteException("could not rename skill folder: " + ex.Message); }
-            AtomicWrite(Path.Combine(newDir, "SKILL.md"), BuildSkillMd(resolvedName, fm.Description, fm.Body));
-            return "Renamed skill '" + oldSlug + "' to '" + newSlug + "'. Anything that referenced '" + oldSlug
-                + "' must now use '" + newSlug + "'.";
-        }
-
-        // The display name a rename should write: an explicit newName (validated against the new slug), else
-        // the current name if it still aligns, else a Title Case name derived from the new slug.
-        private static string ResolveRenameName(string newName, string newSlug, string currentName)
-        {
+            // A given new_name must reduce to the new slug; otherwise fall back to deriving one. The throw
+            // stays here (not in WriterIo) because the exception type is skill-specific.
             if (!IsBlank(newName))
             {
                 RequireSingleLine(newName, "new_name");
                 if (!WriterIo.NameMatchesSlug(newName, newSlug))
-                    throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", newName, newSlug, true, "create_skill"));
-                return newName;
+                    throw new SkillWriteException(WriterIo.NameSlugMismatchMessage("skill", newName, newSlug, true));
             }
-            if (!IsBlank(currentName) && WriterIo.NameMatchesSlug(currentName, newSlug))
-                return currentName;
-            return WriterIo.TitleCaseFromSlug(newSlug);
+            string resolvedName = WriterIo.ResolveRenamedName(newName, newSlug, fm.Name);
+
+            // Move the whole folder (assets and scripts come along), then rewrite SKILL.md's name. If the
+            // rewrite fails after the move, roll the folder back so we don't leave it at the new slug with a
+            // stale (now-misaligned) name in its frontmatter.
+            try { Directory.Move(oldDir, newDir); }
+            catch (Exception ex) { throw new SkillWriteException("could not rename skill folder: " + ex.Message); }
+            try { AtomicWrite(Path.Combine(newDir, "SKILL.md"), BuildSkillMd(resolvedName, fm.Description, fm.Body)); }
+            catch (Exception ex)
+            {
+                try { Directory.Move(newDir, oldDir); } catch { }
+                throw new SkillWriteException("could not rename '" + oldSlug + "' to '" + newSlug
+                    + "' (updating SKILL.md failed): " + ex.Message);
+            }
+            return "Renamed skill '" + oldSlug + "' to '" + newSlug + "'. Anything that referenced '" + oldSlug
+                + "' must now use '" + newSlug + "'.";
         }
 
         // edit_skill_file (tier 2): targeted string replace in a supporting file (files__edit parity). For

--- a/servers/ExtensionsMcpServer/WriterIo.cs
+++ b/servers/ExtensionsMcpServer/WriterIo.cs
@@ -72,14 +72,17 @@ namespace ExtensionsMcpServer
         }
 
         // The shared "name and slug must stay aligned" message, worded once so the two writers can't drift.
-        // noun is "agent"/"skill"; createTool is "create_agent"/"create_skill". On CREATE both sides are
-        // still free, so it offers to fix either; on UPDATE the slug is the fixed identity, so it points at
-        // rename_<noun> for a handle change (update only re-cases the display name).
-        public static string NameSlugMismatchMessage(string noun, string name, string slug, bool isCreate,
-            string createTool)
+        // noun is "agent"/"skill". On CREATE both sides are still free, so it offers to fix either; on UPDATE
+        // the slug is the fixed identity, so it points at rename_<noun> for a handle change (update only
+        // re-cases the display name).
+        public static string NameSlugMismatchMessage(string noun, string name, string slug, bool isCreate)
         {
             string derived = SkillSlug.Make(name);
-            if (string.IsNullOrEmpty(derived)) derived = slug;
+            // A name with no [A-Za-z0-9] yields no slug at all - the real problem isn't a mismatch but that
+            // the name has nothing to align on, so say that instead of the circular "set slug to <slug>".
+            if (string.IsNullOrEmpty(derived))
+                return "name '" + name + "' has no letters or digits to form a handle from - choose a name "
+                    + "whose kebab-case is the slug '" + slug + "'.";
             if (isCreate)
                 return "name '" + name + "' and slug '" + slug + "' don't match - the slug must be the name "
                     + "in kebab-case so the two stay aligned. Either set slug to '" + derived
@@ -87,6 +90,19 @@ namespace ExtensionsMcpServer
             return "name '" + name + "' doesn't match this " + noun + "'s slug '" + slug + "' - the display "
                 + "name must stay aligned with the slug. update_" + noun + " only re-cases the name; to change "
                 + "the handle, use rename_" + noun + " (e.g. new_slug '" + derived + "').";
+        }
+
+        // The display name a rename writes: an explicit newName when given, else the current name if it still
+        // aligns with the new slug, else a Title Case name derived from the slug. PURE - it assumes newName
+        // (when given) was already single-line-checked and alignment-validated by the caller (the throw stays
+        // in each writer because the domain exception type differs). Shared so the decision lives once.
+        public static string ResolveRenamedName(string newName, string newSlug, string currentName)
+        {
+            if (!string.IsNullOrEmpty(newName) && newName.Trim().Length > 0) return newName;
+            if (!string.IsNullOrEmpty(currentName) && currentName.Trim().Length > 0
+                && NameMatchesSlug(currentName, newSlug))
+                return currentName;
+            return TitleCaseFromSlug(newSlug);
         }
 
         // Normalizes a scope arg to "project"/"user", applying the writer's default for null/blank. (RootFor

--- a/tests/ExtensionsMcpServer.Tests/AgentWriterTests.cs
+++ b/tests/ExtensionsMcpServer.Tests/AgentWriterTests.cs
@@ -80,6 +80,17 @@ namespace ExtensionsMcpServer.Tests
         }
 
         [Fact]
+        public void CreateAgent_RejectsNameWithNoAlphanumerics()
+        {
+            // A name with no letters/digits can't form a handle - the error should say so, not give the
+            // circular "set slug to <slug>" guidance.
+            AgentWriteException ex = Assert.Throws<AgentWriteException>(() =>
+                _writer.CreateAgent(null, "my-agent", "!!!", "desc", null, null, null, 0, "body"));
+            Assert.Contains("no letters or digits", ex.Message);
+            Assert.False(File.Exists(AgentFile("my-agent")));
+        }
+
+        [Fact]
         public void CreateAgent_AllowsAcronymNameAlignment()
         {
             // 'GitHub Researcher' kebab-splits oddly, but ignoring word boundaries it matches the slug.


### PR DESCRIPTION
Follow-up to #201, addressing the six findings from a code review of the rename-tool work.

## Correctness / robustness
1. **Transcript rendering** (`MainForm.cs`) — added record cases for `extensions__rename_agent`/`rename_skill`; they were falling through to the generic "using extensions: …" marker instead of a "Renamed agent X → Y" header like every sibling tool.
2. **Approval preview** (`ToolApprovalPanel.cs`) — added a preview for the rename tools showing `old-slug -> new-slug` (and the new name when given) instead of the generic fallback.
3. **`RenameSkill` partial failure** — if the `SKILL.md` rewrite fails after `Directory.Move` succeeds, roll the folder back so it isn't left at the new slug with a stale, now-misaligned `name` (the exact invariant the feature enforces).
4. **`RenameAgent` partial failure** — if deleting the old file fails after the new one is written, roll back the new copy so a rename never leaves two coexisting agents.

## Cleanup
5. **De-duplicate `ResolveRenameName`** — the two near-identical copies (one carrying a dead `noun` param) are replaced by one pure `WriterIo.ResolveRenamedName`; the per-writer validation throw stays inline because the exception type differs. This matches `WriterIo`'s "shared logic lives once" convention.
6. **Clearer error for an alphanumeric-free name** — `NameSlugMismatchMessage` now says the name has no letters/digits to form a handle, instead of the circular "set slug to '\<slug>'" guidance. Covered by a new test.

Also removes the now-dead `createTool` parameter of `NameSlugMismatchMessage` (its last use disappeared in #201 when the update-branch message switched to recommending `rename_X`).

## Notes
- Touches the extensions server assembly, but its version is already `1.3.0.0` in `main` (from #202), so no further bump.
- **Not compiled here** (no .NET Framework toolchain in this environment) — verified by manual trace and a reference sweep. Please run `ExtensionsMcpServer.Tests` / `GxPT.Tests` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkrWhDfeW3Pb7jWWgdWdsD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkrWhDfeW3Pb7jWWgdWdsD)_