### PR TITLE
Add discovery-gated PowerShell tools to the Command MCP server

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -326,6 +326,39 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Command_signature_keeps_a_quoted_token_with_spaces_whole()
+        {
+            // Regression: a quoted path with interior spaces must stay one token, not break at the
+            // first space. 2nd token is not a flag -> command + the whole quoted operand.
+            Assert.Equal("powershell \"C:\\Program Files\\app.ps1\"",
+                ToolApprovalPolicy.CommandSignature("powershell \"C:\\Program Files\\app.ps1\""));
+
+            // Quoted operand after flags: the .ps1 (inside quotes) is still found as the file operand,
+            // with its spaces intact.
+            Assert.Equal("powershell \"C:\\My Scripts\\run.ps1\"",
+                ToolApprovalPolicy.CommandSignature("powershell -File \"C:\\My Scripts\\run.ps1\" -Name \"Mary Read\""));
+
+            // Single-quoted spans count too (a quoted subcommand-position token isn't a flag).
+            Assert.Equal("sh 'a b.sh'",
+                ToolApprovalPolicy.CommandSignature("sh 'a b.sh' --flag"));
+        }
+
+        [Fact]
+        public void Command_pattern_rule_matches_across_quoted_path_with_spaces()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check("command__powershell", Args("{\"command\":\"& \\\"C:\\\\Program Files\\\\app.ps1\\\" -Verbose\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // Same quoted script, different trailing flags -> covered, no re-prompt.
+            Assert.Equal(ApprovalDecision.Allow,
+                pol.Check("command__powershell", Args("{\"command\":\"& \\\"C:\\\\Program Files\\\\app.ps1\\\" -WhatIf\"}")));
+            Assert.Equal(1, prompt.Calls);
+        }
+
+        [Fact]
         public void Command_pattern_rule_is_flag_insensitive_but_file_sensitive()
         {
             var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };

--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -344,6 +344,22 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Command_signature_matches_multiline_scripts_exactly()
+        {
+            // A multi-line script has no meaningful program+operand identity; it must match EXACTLY so
+            // two different scripts that merely share an opening line don't collapse to one signature
+            // (which would let a remembered approval silently auto-allow a script the user never saw).
+            string a = "hostname\r\ndel C:\\temp\\a.txt";
+            string b = "hostname\r\ndel C:\\Windows\\System32\\important";
+            Assert.Equal(a, ToolApprovalPolicy.CommandSignature(a));
+            Assert.Equal(b, ToolApprovalPolicy.CommandSignature(b));
+            Assert.NotEqual(ToolApprovalPolicy.CommandSignature(a), ToolApprovalPolicy.CommandSignature(b));
+            // A bare-newline variant is treated the same.
+            Assert.Equal("Get-Process\nStop-Process x",
+                ToolApprovalPolicy.CommandSignature("Get-Process\nStop-Process x"));
+        }
+
+        [Fact]
         public void Command_pattern_rule_matches_across_quoted_path_with_spaces()
         {
             var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberPrefixArg };

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -412,6 +412,26 @@ namespace GxPT
                         handled = true;
                     }
                 }
+                else if (string.Equals(req.FunctionName, "command__powershell", StringComparison.Ordinal)
+                      || string.Equals(req.FunctionName, "command__powershell_v1", StringComparison.Ordinal)
+                      || string.Equals(req.FunctionName, "command__pwsh", StringComparison.Ordinal))
+                {
+                    // Mirror command__run: show the script itself (PowerShell-highlighted) instead of the
+                    // raw JSON, and surface the command-pattern signature next to it when it differs from
+                    // the full script (i.e. flags/args were dropped), so the broader allow-scope is
+                    // visible without hovering the button's tooltip.
+                    string cmd = req.Arguments.Value<string>("command") ?? string.Empty;
+                    if (cmd.Trim().Length > 0)
+                    {
+                        _diffPanel.SetContent(string.Empty, cmd, "powershell", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        string sig = ToolApprovalPolicy.CommandSignature(cmd);
+                        _previewLabel.Text =
+                            (!string.IsNullOrEmpty(sig) && !string.Equals(sig, cmd.Trim(), StringComparison.Ordinal))
+                            ? "PowerShell   (pattern: " + sig + ")"
+                            : "PowerShell:";
+                        handled = true;
+                    }
+                }
                 else if (string.Equals(req.FunctionName, "files__write", StringComparison.Ordinal))
                 {
                     string path = req.Arguments.Value<string>("path") ?? string.Empty;

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -395,40 +395,25 @@ namespace GxPT
                         handled = true;
                     }
                 }
-                else if (string.Equals(req.FunctionName, "command__run", StringComparison.Ordinal))
+                else if (string.Equals(req.FunctionName, "command__run", StringComparison.Ordinal)
+                      || McpConfig.IsPowerShellTool(req.FunctionName))
                 {
+                    // command__run and the discovered PowerShell tools render identically: the command/
+                    // script itself (highlighted), with the "command pattern" signature surfaced next to
+                    // it when it differs from the full line (i.e. flags/args were dropped) so the broader
+                    // allow-scope is visible without hovering the button's tooltip. Only the highlight
+                    // language and label prefix differ between cmd and PowerShell.
+                    bool isPs = McpConfig.IsPowerShellTool(req.FunctionName);
                     string cmd = req.Arguments.Value<string>("command") ?? string.Empty;
                     if (cmd.Trim().Length > 0)
                     {
-                        _diffPanel.SetContent(string.Empty, cmd, "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
-                        // Surface the "command pattern" signature next to the command when it differs
-                        // from the full line (i.e. flags/args were dropped), so the broader allow-scope
-                        // is visible without hovering the button's tooltip.
+                        _diffPanel.SetContent(string.Empty, cmd, isPs ? "powershell" : "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        string label = isPs ? "PowerShell" : "Command";
                         string sig = ToolApprovalPolicy.CommandSignature(cmd);
                         _previewLabel.Text =
                             (!string.IsNullOrEmpty(sig) && !string.Equals(sig, cmd.Trim(), StringComparison.Ordinal))
-                            ? "Command   (pattern: " + sig + ")"
-                            : "Command:";
-                        handled = true;
-                    }
-                }
-                else if (string.Equals(req.FunctionName, "command__powershell", StringComparison.Ordinal)
-                      || string.Equals(req.FunctionName, "command__powershell_v1", StringComparison.Ordinal)
-                      || string.Equals(req.FunctionName, "command__pwsh", StringComparison.Ordinal))
-                {
-                    // Mirror command__run: show the script itself (PowerShell-highlighted) instead of the
-                    // raw JSON, and surface the command-pattern signature next to it when it differs from
-                    // the full script (i.e. flags/args were dropped), so the broader allow-scope is
-                    // visible without hovering the button's tooltip.
-                    string cmd = req.Arguments.Value<string>("command") ?? string.Empty;
-                    if (cmd.Trim().Length > 0)
-                    {
-                        _diffPanel.SetContent(string.Empty, cmd, "powershell", dark, _monoFont, tc.CodeBack, tc.UiForeground);
-                        string sig = ToolApprovalPolicy.CommandSignature(cmd);
-                        _previewLabel.Text =
-                            (!string.IsNullOrEmpty(sig) && !string.Equals(sig, cmd.Trim(), StringComparison.Ordinal))
-                            ? "PowerShell   (pattern: " + sig + ")"
-                            : "PowerShell:";
+                            ? label + "   (pattern: " + sig + ")"
+                            : label + ":";
                         handled = true;
                     }
                 }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4719,6 +4719,15 @@ namespace GxPT
                     string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
                     header = "Ran a command"; body = cmd; language = "batch"; return true;
                 }
+                case "command__powershell":
+                case "command__powershell_v1":
+                case "command__pwsh":
+                {
+                    // The PowerShell tools (registered per discovered host) all carry the script in
+                    // 'command'; show it with PowerShell highlighting so the user can review what ran.
+                    string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
+                    header = "Ran a PowerShell command"; body = cmd; language = "powershell"; return true;
+                }
                 case "dispatch_agent":
                 {
                     Newtonsoft.Json.Linq.JToken arr = args != null ? args["agents"] : null;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4674,6 +4674,18 @@ namespace GxPT
             if (name != null && name.StartsWith("msbuild__build_", StringComparison.Ordinal))
                 return BuildMsBuildRecord(name, args, out header, out body, out language);
 
+            // command__run and the discovered PowerShell tools render the same record: the command/
+            // script from 'command', highlighted (batch for cmd.exe, powershell otherwise). The
+            // PowerShell name set lives in McpConfig.IsPowerShellTool so this and the approval preview
+            // stay in agreement when hosts are added/renamed.
+            if (string.Equals(name, McpConfig.CommandName + "__run", StringComparison.Ordinal) || McpConfig.IsPowerShellTool(name))
+            {
+                string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
+                bool isPs = McpConfig.IsPowerShellTool(name);
+                header = isPs ? "Ran a PowerShell command" : "Ran a command";
+                body = cmd; language = isPs ? "powershell" : "batch"; return true;
+            }
+
             switch (name)
             {
                 case "files__edit":
@@ -4713,20 +4725,6 @@ namespace GxPT
                     string query = Str(args, "query"); if (query.Length == 0) return false;
                     header = "Searched files"; body = query;
                     language = Bool(args, "regex") ? "regex" : "text"; return true;
-                }
-                case "command__run":
-                {
-                    string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
-                    header = "Ran a command"; body = cmd; language = "batch"; return true;
-                }
-                case "command__powershell":
-                case "command__powershell_v1":
-                case "command__pwsh":
-                {
-                    // The PowerShell tools (registered per discovered host) all carry the script in
-                    // 'command'; show it with PowerShell highlighting so the user can review what ran.
-                    string cmd = Str(args, "command"); if (cmd.Trim().Length == 0) return false;
-                    header = "Ran a PowerShell command"; body = cmd; language = "powershell"; return true;
                 }
                 case "dispatch_agent":
                 {

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -28,6 +28,18 @@ namespace GxPT
         public const string GitHubName = "github";
         public const string GitHubUrl = "https://api.githubcopilot.com/mcp/";
 
+        // The PowerShell tools the command server surfaces per discovered host: one Windows-PowerShell
+        // tool (2.0-5.1 -> command__powershell, or 1.0 -> command__powershell_v1) plus an optional Core
+        // tool (command__pwsh). Centralized so every site that special-cases PowerShell rendering (the
+        // approval preview, the transcript record, ...) agrees on the set instead of each repeating the
+        // name list. The approval classification keys off the broader CommandName + "__" prefix.
+        public static bool IsPowerShellTool(string functionName)
+        {
+            return string.Equals(functionName, CommandName + "__powershell", System.StringComparison.Ordinal)
+                || string.Equals(functionName, CommandName + "__powershell_v1", System.StringComparison.Ordinal)
+                || string.Equals(functionName, CommandName + "__pwsh", System.StringComparison.Ordinal);
+        }
+
         // Env var names the host injects (servers spec §1).
         public const string EnvWorkdir = "GXPT_WORKDIR";
         public const string EnvWebSearchKey = "GXPT_WEB_SEARCH_KEY";

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -257,7 +258,8 @@ namespace GxPT
             if (command == null) return string.Empty;
             string trimmed = command.Trim();
             if (trimmed.Length == 0) return string.Empty;
-            string[] t = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] t = TokenizeCommand(trimmed);
+            if (t.Length == 0) return string.Empty;
             if (t.Length == 1) return t[0];
 
             if (!IsFlagToken(t[1])) return t[0] + " " + t[1];
@@ -270,6 +272,51 @@ namespace GxPT
             }
             // No concrete operand -> keep today's behavior (command + first flag).
             return t[0] + " " + t[1];
+        }
+
+        // Split a command line into whitespace-separated tokens, keeping a quoted span ("..." or
+        // '...') as ONE token (quotes preserved) so a path with interior spaces — e.g.
+        // powershell "C:\Program Files\app.ps1" — isn't broken at the first space. This is a
+        // signature/display heuristic, not a shell parser: it doesn't process backslash escapes or
+        // nested quotes, which the signature's downstream use (compare-for-equality, ignore flags)
+        // doesn't need. Quotes are kept in the token text so the displayed pattern stays unambiguous;
+        // the path/flag heuristics strip them where needed (LooksLikePath, IsFlagToken).
+        private static string[] TokenizeCommand(string command)
+        {
+            List<string> tokens = new List<string>();
+            if (string.IsNullOrEmpty(command)) return tokens.ToArray();
+
+            StringBuilder cur = new StringBuilder();
+            bool inToken = false;
+            char quote = '\0';
+            for (int i = 0; i < command.Length; i++)
+            {
+                char c = command[i];
+                if (quote != '\0')
+                {
+                    cur.Append(c);
+                    if (c == quote) quote = '\0';
+                }
+                else if (c == '"' || c == '\'')
+                {
+                    quote = c;
+                    cur.Append(c);
+                    inToken = true;
+                }
+                else if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                {
+                    // Newlines separate tokens too (outside quotes): a multi-line script's signature is
+                    // then its first line's command/operand, not a token with an embedded newline.
+                    if (inToken) { tokens.Add(cur.ToString()); cur.Length = 0; inToken = false; }
+                }
+                else
+                {
+                    cur.Append(c);
+                    inToken = true;
+                }
+            }
+            if (inToken) tokens.Add(cur.ToString());
+            return tokens.ToArray();
         }
 
         private static bool IsFlagToken(string tok)

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -258,6 +258,12 @@ namespace GxPT
             if (command == null) return string.Empty;
             string trimmed = command.Trim();
             if (trimmed.Length == 0) return string.Empty;
+            // A multi-line command (typically a PowerShell script) has no meaningful "program + first
+            // operand" identity - reducing it to its first line's leading tokens would let a DIFFERENT
+            // multi-line script that merely opens the same way match a remembered "command pattern" rule.
+            // Match such commands EXACTLY instead (the safe direction: re-prompt rather than silently
+            // auto-allow a script the user never approved).
+            if (trimmed.IndexOf('\n') >= 0 || trimmed.IndexOf('\r') >= 0) return trimmed;
             string[] t = TokenizeCommand(trimmed);
             if (t.Length == 0) return string.Empty;
             if (t.Length == 1) return t[0];
@@ -274,13 +280,15 @@ namespace GxPT
             return t[0] + " " + t[1];
         }
 
-        // Split a command line into whitespace-separated tokens, keeping a quoted span ("..." or
+        // Split a single-line command into whitespace-separated tokens, keeping a quoted span ("..." or
         // '...') as ONE token (quotes preserved) so a path with interior spaces — e.g.
-        // powershell "C:\Program Files\app.ps1" — isn't broken at the first space. This is a
-        // signature/display heuristic, not a shell parser: it doesn't process backslash escapes or
-        // nested quotes, which the signature's downstream use (compare-for-equality, ignore flags)
-        // doesn't need. Quotes are kept in the token text so the displayed pattern stays unambiguous;
-        // the path/flag heuristics strip them where needed (LooksLikePath, IsFlagToken).
+        // powershell "C:\Program Files\app.ps1" — isn't broken at the first space. Only space/tab
+        // separate tokens; multi-line commands never reach here (CommandSignature matches them exactly),
+        // so a newline is never a separator. This is a signature/display heuristic, not a shell parser:
+        // it doesn't process backslash escapes or nested quotes, which the signature's downstream use
+        // (compare-for-equality, ignore flags) doesn't need. Quotes are kept in the token text so the
+        // displayed pattern stays unambiguous; the path/flag heuristics strip them where needed
+        // (LooksLikePath, IsFlagToken).
         private static string[] TokenizeCommand(string command)
         {
             List<string> tokens = new List<string>();
@@ -303,10 +311,8 @@ namespace GxPT
                     cur.Append(c);
                     inToken = true;
                 }
-                else if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                else if (c == ' ' || c == '\t')
                 {
-                    // Newlines separate tokens too (outside quotes): a multi-line script's signature is
-                    // then its first line's command/operand, not a token with an embedded newline.
                     if (inToken) { tokens.Add(cur.ToString()); cur.Length = 0; inToken = false; }
                 }
                 else

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -115,6 +115,13 @@ namespace GxPT
                         ? "solution" : "project";
                     return new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, scopeArg);
                 }
+                // The Command server also surfaces PowerShell tool(s) when a host is discovered at
+                // runtime (command__powershell, command__pwsh), so they aren't in the static table
+                // above. Like command__run, a PowerShell script runs arbitrary code, so it is
+                // Destructive and argument-scoped on the 'command' being run — "always allow this exact
+                // script", never a blanket "always allow PowerShell".
+                if (functionName.StartsWith(McpConfig.CommandName + "__", StringComparison.Ordinal))
+                    return new ToolPolicy(ToolTier.Destructive, RememberScope.Argument, "command");
                 // First-party but not in the table (shouldn't happen) -> conservative Write/Tool.
                 return new ToolPolicy(ToolTier.Write, RememberScope.Tool, null);
             }

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -247,19 +247,28 @@ own** — that's the host's argument-scoped gate (base+subcommand / exact,
 command **safely and observably**.
 
 On systems where PowerShell is present the server *also* registers a PowerShell
-tool per discovered host — `command__powershell` (Windows PowerShell) and/or
-`command__pwsh` (PowerShell 6+ Core) — exactly the way the MSBuild server surfaces
-a tool per discovered engine: **enabled only when discovered, never advertised
-when absent**. Discovery runs once at startup (defensive — a probe failure yields
-no tool, never a crash) and queries `$PSVersionTable.PSVersion`, folding the
-detected version into the tool description so the model uses cmdlets/syntax that
-version supports. These tools share `run`'s host classification (Destructive,
-argument-scoped on `command`).
+tool per discovered host — exactly the way the MSBuild server surfaces a tool per
+discovered engine: **enabled only when discovered, never advertised when absent**.
+Discovery runs once at startup (defensive — a probe failure yields no tool, never
+a crash), detects the version, and folds it into the tool description so the model
+uses cmdlets/syntax that version supports. There are three host shapes:
+
+- `command__powershell` — Windows PowerShell **2.0–5.1**; version via
+  `$PSVersionTable.PSVersion`; runs via `-EncodedCommand`.
+- `command__powershell_v1` — Windows PowerShell **1.0**, which predates
+  `$PSVersionTable`/`-EncodedCommand`/`-ExecutionPolicy`/`-NonInteractive`; version
+  confirmed via `(Get-Host).Version`; runs by feeding the script over **stdin**
+  (`-Command -`). A box's `powershell.exe` is one version, so exactly one of the
+  two Windows-PowerShell tools is registered — never both.
+- `command__pwsh` — PowerShell **6+ Core**; modern style, like `powershell`.
+
+These tools share `run`'s host classification (Destructive, argument-scoped on
+`command`).
 
 | Tool | Schema | Behavior |
 |------|--------|----------|
 | `run` | `command*`, `timeout_ms?` | Run `command` via the shell; capture stdout/stderr/exit. |
-| `powershell` / `pwsh` *(if discovered)* | `command*`, `timeout_ms?` | Run a PowerShell script on the discovered host; capture stdout/stderr/exit. |
+| `powershell` / `powershell_v1` / `pwsh` *(if discovered)* | `command*`, `timeout_ms?` | Run a PowerShell script on the discovered host; capture stdout/stderr/exit. |
 
 - Execution: `ProcessRunner` with `FileName = GXPT_CMD_SHELL` (`cmd.exe`) and
   `Arguments = "/c " + command` — the command string is handed to the shell as
@@ -276,12 +285,13 @@ argument-scoped on `command`).
 - The server treats **all** of `command` as opaque and never tries to "sanitize"
   it (sanitizing would give a false sense of safety); containment is the gate +
   the working-dir + the timeout, not string filtering.
-- PowerShell tools run the interpreter directly (not through `cmd.exe`) with
-  `-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand <base64>`,
-  where the base64 is the **UTF-16LE** script. `-EncodedCommand` removes shell
-  quoting from the equation entirely (the whole script crosses as one opaque
-  token), the same "don't let the shell re-interpret model text" goal the `run`
-  tool meets with `cmd /s /c "<command>"`.
+- PowerShell tools run the interpreter directly (not through `cmd.exe`). For
+  2.0+/Core: `-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand
+  <base64>`, where the base64 is the **UTF-16LE** script. For 1.0 (whose host
+  lacks those switches): `-NoProfile -Command -` with the script written to the
+  child's **stdin**. Both remove shell quoting from the equation entirely (the
+  whole script crosses as one opaque token), the same "don't let the shell
+  re-interpret model text" goal the `run` tool meets with `cmd /s /c "<command>"`.
 
 ---
 

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -240,15 +240,26 @@ ReadOnly, `commit` Write, `push` Destructive(`Scope=None`).
 
 ## 5. CommandMcpServer (server name `command`) — the sharpest edge
 
-One tool, `run` (→ `command__run`, Destructive, argument-scoped). Executes an
-arbitrary command line. This server has **no allowlist of its own** — that's the
-host's argument-scoped gate (base+subcommand / exact, `mcp35-approval-spec.md`).
-The server's job is to execute the *already-approved* command **safely and
-observably**.
+The always-present tool is `run` (→ `command__run`, Destructive, argument-scoped).
+It executes an arbitrary command line. This server has **no allowlist of its
+own** — that's the host's argument-scoped gate (base+subcommand / exact,
+`mcp35-approval-spec.md`). The server's job is to execute the *already-approved*
+command **safely and observably**.
+
+On systems where PowerShell is present the server *also* registers a PowerShell
+tool per discovered host — `command__powershell` (Windows PowerShell) and/or
+`command__pwsh` (PowerShell 6+ Core) — exactly the way the MSBuild server surfaces
+a tool per discovered engine: **enabled only when discovered, never advertised
+when absent**. Discovery runs once at startup (defensive — a probe failure yields
+no tool, never a crash) and queries `$PSVersionTable.PSVersion`, folding the
+detected version into the tool description so the model uses cmdlets/syntax that
+version supports. These tools share `run`'s host classification (Destructive,
+argument-scoped on `command`).
 
 | Tool | Schema | Behavior |
 |------|--------|----------|
 | `run` | `command*`, `timeout_ms?` | Run `command` via the shell; capture stdout/stderr/exit. |
+| `powershell` / `pwsh` *(if discovered)* | `command*`, `timeout_ms?` | Run a PowerShell script on the discovered host; capture stdout/stderr/exit. |
 
 - Execution: `ProcessRunner` with `FileName = GXPT_CMD_SHELL` (`cmd.exe`) and
   `Arguments = "/c " + command` — the command string is handed to the shell as
@@ -265,6 +276,12 @@ observably**.
 - The server treats **all** of `command` as opaque and never tries to "sanitize"
   it (sanitizing would give a false sense of safety); containment is the gate +
   the working-dir + the timeout, not string filtering.
+- PowerShell tools run the interpreter directly (not through `cmd.exe`) with
+  `-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand <base64>`,
+  where the base64 is the **UTF-16LE** script. `-EncodedCommand` removes shell
+  quoting from the equation entirely (the whole script crosses as one opaque
+  token), the same "don't let the shell re-interpret model text" goal the `run`
+  tool meets with `cmd /s /c "<command>"`.
 
 ---
 

--- a/servers/CommandMcpServer/CommandMcpServer.csproj
+++ b/servers/CommandMcpServer/CommandMcpServer.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="CommandConfig.cs" />
+    <Compile Include="CommandToolHelpers.cs" />
     <Compile Include="CommandTools.cs" />
     <Compile Include="PowerShellDiscovery.cs" />
     <Compile Include="PowerShellTools.cs" />

--- a/servers/CommandMcpServer/CommandMcpServer.csproj
+++ b/servers/CommandMcpServer/CommandMcpServer.csproj
@@ -42,6 +42,8 @@
     <Compile Include="Program.cs" />
     <Compile Include="CommandConfig.cs" />
     <Compile Include="CommandTools.cs" />
+    <Compile Include="PowerShellDiscovery.cs" />
+    <Compile Include="PowerShellTools.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/servers/CommandMcpServer/CommandToolHelpers.cs
+++ b/servers/CommandMcpServer/CommandToolHelpers.cs
@@ -1,0 +1,53 @@
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// Helpers shared by the Command server's tools (run + the PowerShell tools) so the timeout
+    /// coercion, the per-stream output cap, and the result JSON shape stay identical across them - a
+    /// change here updates every command tool at once instead of drifting copy-by-copy.
+    /// </summary>
+    internal static class CommandToolHelpers
+    {
+        public const int OutputCap = 100000; // chars per stream
+
+        // Read an integer argument, clamped to [min,max], falling back when absent/null/unparseable.
+        public static int IntArg(JObject args, string name, int fallback, int min, int max)
+        {
+            JToken t = args != null ? args[name] : null;
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        // Truncate a captured stream to OutputCap, reporting whether it was cut.
+        public static string Cap(string s, out bool truncated)
+        {
+            truncated = false;
+            if (s == null) return string.Empty;
+            if (s.Length <= OutputCap) return s;
+            truncated = true;
+            return s.Substring(0, OutputCap);
+        }
+
+        // The shared result shape: { [version], exitCode, stdout, stderr, timedOut, [truncated] }.
+        // 'version' is emitted only when non-empty (the PowerShell tools set it; run passes null).
+        public static JObject BuildResult(ProcessResult result, string version)
+        {
+            bool outTrunc, errTrunc;
+            JObject o = new JObject();
+            if (!string.IsNullOrEmpty(version)) o["version"] = version;
+            o["exitCode"] = result.ExitCode;
+            o["stdout"] = Cap(result.StdOut, out outTrunc);
+            o["stderr"] = Cap(result.StdErr, out errTrunc);
+            o["timedOut"] = result.TimedOut;
+            if (outTrunc || errTrunc) o["truncated"] = true;
+            return o;
+        }
+    }
+}

--- a/servers/CommandMcpServer/CommandTools.cs
+++ b/servers/CommandMcpServer/CommandTools.cs
@@ -17,7 +17,6 @@ namespace CommandMcpServer
     {
         private const int DefaultTimeoutMs = 60000;
         private const int MaxTimeoutMs = 600000;
-        private const int OutputCap = 100000; // chars per stream
 
         public static void Register(McpServer server, CommandConfig config)
         {
@@ -40,7 +39,7 @@ namespace CommandMcpServer
             string command = ctx.Arguments.Value<string>("command");
             if (string.IsNullOrEmpty(command)) return ToolResults.Error("command is required");
 
-            int timeout = IntArg(ctx, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
+            int timeout = CommandToolHelpers.IntArg(ctx.Arguments, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
 
             ProcessRequest req = new ProcessRequest();
             req.FileName = config.Shell;
@@ -68,35 +67,7 @@ namespace CommandMcpServer
                 return ToolResults.Error("failed to run command: " + ex.Message);
             }
 
-            bool outTrunc, errTrunc;
-            JObject outp = new JObject();
-            outp["exitCode"] = result.ExitCode;
-            outp["stdout"] = Cap(result.StdOut, out outTrunc);
-            outp["stderr"] = Cap(result.StdErr, out errTrunc);
-            outp["timedOut"] = result.TimedOut;
-            if (outTrunc || errTrunc) outp["truncated"] = true;
-            return ToolResults.Json(outp);
-        }
-
-        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
-        {
-            JToken t = ctx.Arguments[name];
-            if (t == null || t.Type == JTokenType.Null) return fallback;
-            int n;
-            try { n = t.Value<int>(); }
-            catch { return fallback; }
-            if (n < min) return min;
-            if (n > max) return max;
-            return n;
-        }
-
-        private static string Cap(string s, out bool truncated)
-        {
-            truncated = false;
-            if (s == null) return string.Empty;
-            if (s.Length <= OutputCap) return s;
-            truncated = true;
-            return s.Substring(0, OutputCap);
+            return ToolResults.Json(CommandToolHelpers.BuildResult(result, null));
         }
     }
 }

--- a/servers/CommandMcpServer/PowerShellDiscovery.cs
+++ b/servers/CommandMcpServer/PowerShellDiscovery.cs
@@ -33,6 +33,13 @@ namespace CommandMcpServer
     /// </summary>
     internal static class PowerShellDiscovery
     {
+        // Version detection is best-effort (it only enriches the tool description), so each probe is
+        // kept short: discovery runs synchronously before the server answers its initialize handshake,
+        // and the host tears the connection down if that handshake exceeds its open timeout (~15s). A
+        // probe that overruns just leaves the version unknown; it must never blow the startup budget and
+        // take the always-present `run` tool down with it.
+        private const int ProbeTimeoutMs = 4000;
+
         public static IList<PowerShellInstall> Discover(ILogSink log)
         {
             List<PowerShellInstall> result = new List<PowerShellInstall>();
@@ -59,9 +66,10 @@ namespace CommandMcpServer
             string exe = Path.Combine(windir, Path.Combine("System32", Path.Combine("WindowsPowerShell", Path.Combine("v1.0", "powershell.exe"))));
             if (!Exists(exe)) return null;
 
+            // Only Windows PowerShell can be the legacy 1.0 line, so it is the only host that probes for it.
             string version;
             bool legacy;
-            DetectVersion(exe, log, out version, out legacy);
+            DetectVersion(exe, log, true, out version, out legacy);
 
             // 1.0 gets its own tool (stdin invocation); 2.0-5.1 keep the standard -EncodedCommand tool.
             return new PowerShellInstall
@@ -75,73 +83,95 @@ namespace CommandMcpServer
         }
 
         // PowerShell 6+ (Core, cross-platform): pwsh.exe, installed out-of-band under
-        // %ProgramFiles%\PowerShell\<major>\pwsh.exe (prefer 7, then 6). Optional — absent on most
+        // <ProgramFiles>\PowerShell\<major>\pwsh.exe (prefer 7, then 6). Optional — absent on most
         // XP/7 boxes, present alongside Windows PowerShell on newer ones.
         private static PowerShellInstall DiscoverPowerShellCore(ILogSink log)
         {
-            string pf = Environment.GetEnvironmentVariable("ProgramFiles");
-            if (string.IsNullOrEmpty(pf)) return null;
+            // %ProgramFiles% resolves to the 32-bit "Program Files (x86)" dir when this process runs
+            // under WOW64 (a 32-bit host on 64-bit Windows), where pwsh.exe (64-bit only) is not
+            // installed; %ProgramW6432% always points at the real 64-bit Program Files. Check both,
+            // de-duped, so Core is found regardless of the server's bitness.
+            List<string> roots = new List<string>();
+            AddRoot(roots, Environment.GetEnvironmentVariable("ProgramW6432"));
+            AddRoot(roots, Environment.GetEnvironmentVariable("ProgramFiles"));
+            if (roots.Count == 0) return null;
 
             string[] majors = new string[] { "7", "6" };
-            foreach (string major in majors)
+            foreach (string root in roots)
             {
-                string exe = Path.Combine(pf, Path.Combine("PowerShell", Path.Combine(major, "pwsh.exe")));
-                if (!Exists(exe)) continue;
-
-                string version;
-                bool legacy;
-                DetectVersion(exe, log, out version, out legacy);
-                return new PowerShellInstall
+                foreach (string major in majors)
                 {
-                    ToolName = "pwsh",
-                    Label = "PowerShell",
-                    Exe = exe,
-                    Version = version,
-                    LegacyStdin = legacy   // always false for Core (6+), which supports -EncodedCommand
-                };
+                    string exe = Path.Combine(root, Path.Combine("PowerShell", Path.Combine(major, "pwsh.exe")));
+                    if (!Exists(exe)) continue;
+
+                    // Core (6+) always has $PSVersionTable and -EncodedCommand, so it never needs the
+                    // 1.0 fallback probe (probeLegacy: false) and is never a stdin host.
+                    string version;
+                    bool legacy;
+                    DetectVersion(exe, log, false, out version, out legacy);
+                    return new PowerShellInstall
+                    {
+                        ToolName = "pwsh",
+                        Label = "PowerShell",
+                        Exe = exe,
+                        Version = version,
+                        LegacyStdin = false
+                    };
+                }
             }
             return null;
         }
 
-        // Detect the interpreter's version and which invocation style its tool must use:
-        //   * 2.0+ : $PSVersionTable.PSVersion gives the exact version; the tool uses -EncodedCommand.
-        //   * 1.0  : $PSVersionTable doesn't exist and -EncodedCommand/-ExecutionPolicy/-NonInteractive
-        //            aren't supported, so we confirm the version via (Get-Host).Version fed over stdin
-        //            and flag the host for the stdin (`-Command -`) invocation style.
+        // Detect the interpreter's version and whether its tool must use the legacy stdin invocation:
+        //   * 2.0+ / Core : $PSVersionTable.PSVersion gives the exact version; the tool uses -EncodedCommand.
+        //   * 1.0         : $PSVersionTable doesn't exist and -EncodedCommand/-ExecutionPolicy/
+        //                   -NonInteractive aren't supported, so the version is read via (Get-Host).Version
+        //                   fed over stdin and the host is flagged for the stdin (`-Command -`) style.
         // Both probes are short, time-boxed, and never throw — a probe failure just leaves version null
         // (modern style), so a wedged or unexpected interpreter can't stall or crash startup discovery.
-        private static void DetectVersion(string exe, ILogSink log, out string version, out bool legacyStdin)
+        private static void DetectVersion(string exe, ILogSink log, bool probeLegacy, out string version, out bool legacyStdin)
         {
             version = null;
             legacyStdin = false;
 
+            bool timedOut;
             string modern = RunProbe(exe,
-                "-NoProfile -NonInteractive -Command \"$PSVersionTable.PSVersion.ToString()\"", null, log);
-            if (!string.IsNullOrEmpty(modern)) { version = modern; return; }
+                "-NoProfile -NonInteractive -Command \"$PSVersionTable.PSVersion.ToString()\"", null, out timedOut, log);
+            if (!string.IsNullOrEmpty(modern)) { version = modern; return; }   // 2.0+ / Core
 
-            // No $PSVersionTable → likely 1.0. (Get-Host).Version works there; feed it over stdin via
-            // `-Command -` so no switch or quoting a 1.0 host might reject is involved. Only a 1.x answer
-            // flips to the legacy style; anything else is treated as a normal (modern) host.
+            // The modern probe came back empty. Only Windows PowerShell needs the 1.0 fallback, and only
+            // when modern failed FAST: a real 1.0 host rejects -NonInteractive/$PSVersionTable
+            // immediately, whereas a host that HUNG is wedged — probing it again would just double the
+            // startup delay for no benefit.
+            if (!probeLegacy || timedOut) return;
+
+            // 1.0-style invocation: (Get-Host).Version (which exists in 1.0) fed over stdin via
+            // `-Command -`, avoiding any switch a 1.0 host rejects. Reaching a non-empty result here
+            // means the host couldn't answer the modern probe yet accepts the old stdin form — i.e. it
+            // IS the legacy line, regardless of how its version string is spelled (so a non-"1." spelling
+            // no longer misclassifies it as modern, which would invoke it with switches 1.0 rejects).
             string legacy = RunProbe(exe, "-NoProfile -Command -",
-                "(Get-Host).Version.ToString()" + Environment.NewLine, log);
+                "(Get-Host).Version.ToString()" + Environment.NewLine, out timedOut, log);
             if (!string.IsNullOrEmpty(legacy))
             {
                 version = legacy;
-                legacyStdin = legacy.StartsWith("1.", StringComparison.Ordinal);
+                legacyStdin = true;
             }
         }
 
-        private static string RunProbe(string exe, string args, string stdin, ILogSink log)
+        private static string RunProbe(string exe, string args, string stdin, out bool timedOut, ILogSink log)
         {
+            timedOut = false;
             try
             {
                 ProcessRequest req = new ProcessRequest();
                 req.FileName = exe;
                 req.Arguments = args;
                 req.StdinText = stdin;
-                req.TimeoutMs = 15000;
+                req.TimeoutMs = ProbeTimeoutMs;
 
                 ProcessResult res = new ProcessRunner(null).Run(req);
+                timedOut = res.TimedOut;
                 if (res.TimedOut || res.ExitCode != 0) return null;
                 string v = (res.StdOut ?? string.Empty).Trim();
                 return string.IsNullOrEmpty(v) ? null : v;
@@ -151,6 +181,11 @@ namespace CommandMcpServer
                 Note(log, "version probe failed for " + exe + ": " + ex.Message);
                 return null;
             }
+        }
+
+        private static void AddRoot(List<string> roots, string path)
+        {
+            if (!string.IsNullOrEmpty(path) && !roots.Contains(path)) roots.Add(path);
         }
 
         private static bool Exists(string path)

--- a/servers/CommandMcpServer/PowerShellDiscovery.cs
+++ b/servers/CommandMcpServer/PowerShellDiscovery.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mcp35.Core.Diagnostics;
+using Mcp35.Server.Process;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// One discovered PowerShell host. <see cref="Exe"/> is the interpreter; <see cref="Version"/> is
+    /// the detected $PSVersionTable.PSVersion (or null when it could not be queried). Windows PowerShell
+    /// (the .NET Framework "Desktop" edition, powershell.exe) and PowerShell 6+ Core (pwsh.exe) are
+    /// distinct hosts with different cmdlet sets and language levels, so each is surfaced as its own tool.
+    /// </summary>
+    internal sealed class PowerShellInstall
+    {
+        public string ToolName;   // "powershell" or "pwsh"
+        public string Label;      // "Windows PowerShell" / "PowerShell"
+        public string Exe;        // full path to powershell.exe / pwsh.exe
+        public string Version;    // "5.1.19041.4046", "7.4.1", or null when unknown
+    }
+
+    /// <summary>
+    /// Probes the system for installed PowerShell hosts. Mirrors MsBuildDiscovery's posture: every probe
+    /// is defensive (a failure for one source yields no entry for it, never an exception — discovery must
+    /// not crash startup), it runs once at startup, and the resulting tool set is static for the life of
+    /// the process. When nothing is found the Command server simply registers no PowerShell tool, so it
+    /// is never advertised on a system without PowerShell.
+    /// </summary>
+    internal static class PowerShellDiscovery
+    {
+        public static IList<PowerShellInstall> Discover(ILogSink log)
+        {
+            List<PowerShellInstall> result = new List<PowerShellInstall>();
+
+            try { PowerShellInstall ps = DiscoverWindowsPowerShell(log); if (ps != null) result.Add(ps); }
+            catch (Exception ex) { Note(log, "windows powershell probe failed: " + ex.Message); }
+
+            try { PowerShellInstall core = DiscoverPowerShellCore(log); if (core != null) result.Add(core); }
+            catch (Exception ex) { Note(log, "powershell core probe failed: " + ex.Message); }
+
+            return result;
+        }
+
+        // Windows PowerShell (Desktop): %WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe. Present
+        // on every Windows from 7 onward (and on XP/Vista once the WMF add-on is installed). The "v1.0"
+        // folder name is historical — the engine version it ships is whatever the OS/WMF provides, which
+        // is exactly why we query it rather than assume.
+        private static PowerShellInstall DiscoverWindowsPowerShell(ILogSink log)
+        {
+            string windir = Environment.GetEnvironmentVariable("WINDIR");
+            if (string.IsNullOrEmpty(windir)) windir = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrEmpty(windir)) return null;
+
+            string exe = Path.Combine(windir, Path.Combine("System32", Path.Combine("WindowsPowerShell", Path.Combine("v1.0", "powershell.exe"))));
+            if (!Exists(exe)) return null;
+
+            return new PowerShellInstall
+            {
+                ToolName = "powershell",
+                Label = "Windows PowerShell",
+                Exe = exe,
+                Version = QueryVersion(exe, log)
+            };
+        }
+
+        // PowerShell 6+ (Core, cross-platform): pwsh.exe, installed out-of-band under
+        // %ProgramFiles%\PowerShell\<major>\pwsh.exe (prefer 7, then 6). Optional — absent on most
+        // XP/7 boxes, present alongside Windows PowerShell on newer ones.
+        private static PowerShellInstall DiscoverPowerShellCore(ILogSink log)
+        {
+            string pf = Environment.GetEnvironmentVariable("ProgramFiles");
+            if (string.IsNullOrEmpty(pf)) return null;
+
+            string[] majors = new string[] { "7", "6" };
+            foreach (string major in majors)
+            {
+                string exe = Path.Combine(pf, Path.Combine("PowerShell", Path.Combine(major, "pwsh.exe")));
+                if (!Exists(exe)) continue;
+                return new PowerShellInstall
+                {
+                    ToolName = "pwsh",
+                    Label = "PowerShell",
+                    Exe = exe,
+                    Version = QueryVersion(exe, log)
+                };
+            }
+            return null;
+        }
+
+        // Ask the interpreter its own version. $PSVersionTable exists from PowerShell 2.0 onward; on the
+        // (vanishingly rare) 1.0 the command yields nothing and Version stays null. Kept short with a
+        // tight timeout so a wedged interpreter can't stall startup discovery.
+        private static string QueryVersion(string exe, ILogSink log)
+        {
+            try
+            {
+                ProcessRequest req = new ProcessRequest();
+                req.FileName = exe;
+                req.Arguments = "-NoProfile -NonInteractive -Command \"$PSVersionTable.PSVersion.ToString()\"";
+                req.TimeoutMs = 15000;
+
+                ProcessResult res = new ProcessRunner(null).Run(req);
+                if (res.TimedOut || res.ExitCode != 0) return null;
+                string v = (res.StdOut ?? string.Empty).Trim();
+                return string.IsNullOrEmpty(v) ? null : v;
+            }
+            catch (Exception ex)
+            {
+                Note(log, "version query failed for " + exe + ": " + ex.Message);
+                return null;
+            }
+        }
+
+        private static bool Exists(string path)
+        {
+            try { return !string.IsNullOrEmpty(path) && File.Exists(path); }
+            catch { return false; }
+        }
+
+        private static void Note(ILogSink log, string msg)
+        {
+            if (log != null) log.Log("command", msg);
+        }
+    }
+}

--- a/servers/CommandMcpServer/PowerShellDiscovery.cs
+++ b/servers/CommandMcpServer/PowerShellDiscovery.cs
@@ -14,10 +14,14 @@ namespace CommandMcpServer
     /// </summary>
     internal sealed class PowerShellInstall
     {
-        public string ToolName;   // "powershell" or "pwsh"
+        public string ToolName;   // "powershell", "powershell_v1", or "pwsh"
         public string Label;      // "Windows PowerShell" / "PowerShell"
         public string Exe;        // full path to powershell.exe / pwsh.exe
-        public string Version;    // "5.1.19041.4046", "7.4.1", or null when unknown
+        public string Version;    // "5.1.19041.4046", "1.0", "7.4.1", or null when unknown
+
+        // PowerShell 1.0 predates -EncodedCommand/-ExecutionPolicy/-NonInteractive, so its tool feeds
+        // the script over stdin (`-Command -`) instead. False for every 2.0+ / Core host.
+        public bool LegacyStdin;
     }
 
     /// <summary>
@@ -55,12 +59,18 @@ namespace CommandMcpServer
             string exe = Path.Combine(windir, Path.Combine("System32", Path.Combine("WindowsPowerShell", Path.Combine("v1.0", "powershell.exe"))));
             if (!Exists(exe)) return null;
 
+            string version;
+            bool legacy;
+            DetectVersion(exe, log, out version, out legacy);
+
+            // 1.0 gets its own tool (stdin invocation); 2.0-5.1 keep the standard -EncodedCommand tool.
             return new PowerShellInstall
             {
-                ToolName = "powershell",
+                ToolName = legacy ? "powershell_v1" : "powershell",
                 Label = "Windows PowerShell",
                 Exe = exe,
-                Version = QueryVersion(exe, log)
+                Version = version,
+                LegacyStdin = legacy
             };
         }
 
@@ -77,27 +87,58 @@ namespace CommandMcpServer
             {
                 string exe = Path.Combine(pf, Path.Combine("PowerShell", Path.Combine(major, "pwsh.exe")));
                 if (!Exists(exe)) continue;
+
+                string version;
+                bool legacy;
+                DetectVersion(exe, log, out version, out legacy);
                 return new PowerShellInstall
                 {
                     ToolName = "pwsh",
                     Label = "PowerShell",
                     Exe = exe,
-                    Version = QueryVersion(exe, log)
+                    Version = version,
+                    LegacyStdin = legacy   // always false for Core (6+), which supports -EncodedCommand
                 };
             }
             return null;
         }
 
-        // Ask the interpreter its own version. $PSVersionTable exists from PowerShell 2.0 onward; on the
-        // (vanishingly rare) 1.0 the command yields nothing and Version stays null. Kept short with a
-        // tight timeout so a wedged interpreter can't stall startup discovery.
-        private static string QueryVersion(string exe, ILogSink log)
+        // Detect the interpreter's version and which invocation style its tool must use:
+        //   * 2.0+ : $PSVersionTable.PSVersion gives the exact version; the tool uses -EncodedCommand.
+        //   * 1.0  : $PSVersionTable doesn't exist and -EncodedCommand/-ExecutionPolicy/-NonInteractive
+        //            aren't supported, so we confirm the version via (Get-Host).Version fed over stdin
+        //            and flag the host for the stdin (`-Command -`) invocation style.
+        // Both probes are short, time-boxed, and never throw — a probe failure just leaves version null
+        // (modern style), so a wedged or unexpected interpreter can't stall or crash startup discovery.
+        private static void DetectVersion(string exe, ILogSink log, out string version, out bool legacyStdin)
+        {
+            version = null;
+            legacyStdin = false;
+
+            string modern = RunProbe(exe,
+                "-NoProfile -NonInteractive -Command \"$PSVersionTable.PSVersion.ToString()\"", null, log);
+            if (!string.IsNullOrEmpty(modern)) { version = modern; return; }
+
+            // No $PSVersionTable → likely 1.0. (Get-Host).Version works there; feed it over stdin via
+            // `-Command -` so no switch or quoting a 1.0 host might reject is involved. Only a 1.x answer
+            // flips to the legacy style; anything else is treated as a normal (modern) host.
+            string legacy = RunProbe(exe, "-NoProfile -Command -",
+                "(Get-Host).Version.ToString()" + Environment.NewLine, log);
+            if (!string.IsNullOrEmpty(legacy))
+            {
+                version = legacy;
+                legacyStdin = legacy.StartsWith("1.", StringComparison.Ordinal);
+            }
+        }
+
+        private static string RunProbe(string exe, string args, string stdin, ILogSink log)
         {
             try
             {
                 ProcessRequest req = new ProcessRequest();
                 req.FileName = exe;
-                req.Arguments = "-NoProfile -NonInteractive -Command \"$PSVersionTable.PSVersion.ToString()\"";
+                req.Arguments = args;
+                req.StdinText = stdin;
                 req.TimeoutMs = 15000;
 
                 ProcessResult res = new ProcessRunner(null).Run(req);
@@ -107,7 +148,7 @@ namespace CommandMcpServer
             }
             catch (Exception ex)
             {
-                Note(log, "version query failed for " + exe + ": " + ex.Message);
+                Note(log, "version probe failed for " + exe + ": " + ex.Message);
                 return null;
             }
         }

--- a/servers/CommandMcpServer/PowerShellTools.cs
+++ b/servers/CommandMcpServer/PowerShellTools.cs
@@ -9,16 +9,20 @@ using Newtonsoft.Json.Linq;
 namespace CommandMcpServer
 {
     /// <summary>
-    /// Registers one PowerShell tool per discovered host (Windows PowerShell → command__powershell,
-    /// PowerShell Core → command__pwsh), mirroring how the MSBuild server surfaces one tool per
-    /// discovered engine: the tool exists only when PowerShell is found and is simply absent — never
-    /// advertised — on a system without it. The detected $PSVersionTable.PSVersion is woven into the
-    /// tool description so the model can choose cmdlets and language features the installed version
-    /// actually supports.
+    /// Registers one PowerShell tool per discovered host, mirroring how the MSBuild server surfaces one
+    /// tool per discovered engine: the tool exists only when PowerShell is found and is simply absent —
+    /// never advertised — on a system without it. The detected version is woven into the tool
+    /// description so the model can choose cmdlets and language features the installed version supports.
+    ///
+    ///   * command__powershell    — Windows PowerShell 2.0-5.1
+    ///   * command__powershell_v1 — Windows PowerShell 1.0 (a system's powershell.exe is one version, so
+    ///                              exactly one of these is registered, never both)
+    ///   * command__pwsh          — PowerShell 6+ Core
     ///
     /// Like the Command server's run tool, the script is opaque and runs already-approved (the host gate
-    /// showed the user the exact script). It is handed to PowerShell via -EncodedCommand (base64 of the
-    /// UTF-16LE script), so no quoting, newline, or special character in the model's script can be
+    /// showed the user the exact script). For 2.0+ / Core it is handed over via -EncodedCommand (base64
+    /// of the UTF-16LE script); 1.0 predates that switch, so its tool feeds the script over stdin
+    /// (`-Command -`). Either way no quoting, newline, or special character in the model's script can be
     /// misparsed by the shell — the whole script crosses as one opaque token. See servers-spec §5.
     /// </summary>
     internal static class PowerShellTools
@@ -73,11 +77,23 @@ namespace CommandMcpServer
 
             ProcessRequest req = new ProcessRequest();
             req.FileName = ps.Exe;
-            // -EncodedCommand takes base64 of the UTF-16LE script, sidestepping shell quoting entirely
-            // (the host already showed the user the exact script at the approval gate). -NoProfile keeps
-            // a user's $PROFILE from changing behavior; -NonInteractive fails fast rather than hanging on
-            // a prompt; -ExecutionPolicy Bypass lets the inline script run regardless of machine policy.
-            req.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + Encode(command);
+            if (ps.LegacyStdin)
+            {
+                // PowerShell 1.0: no -EncodedCommand / -ExecutionPolicy / -NonInteractive. Feed the
+                // script over stdin via `-Command -` (read commands from standard input), which 1.0
+                // supports and which sidesteps shell quoting just as -EncodedCommand does for 2.0+.
+                req.Arguments = "-NoProfile -Command -";
+                req.StdinText = command + Environment.NewLine;
+            }
+            else
+            {
+                // 2.0+: -EncodedCommand takes base64 of the UTF-16LE script, sidestepping shell quoting
+                // entirely (the host already showed the user the exact script at the approval gate).
+                // -NoProfile keeps a user's $PROFILE from changing behavior; -NonInteractive fails fast
+                // rather than hanging on a prompt; -ExecutionPolicy Bypass lets the inline script run
+                // regardless of machine policy.
+                req.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + Encode(command);
+            }
             req.WorkingDirectory = config.WorkDir;
             req.TimeoutMs = timeout;
 

--- a/servers/CommandMcpServer/PowerShellTools.cs
+++ b/servers/CommandMcpServer/PowerShellTools.cs
@@ -29,7 +29,6 @@ namespace CommandMcpServer
     {
         private const int DefaultTimeoutMs = 60000;
         private const int MaxTimeoutMs = 600000;
-        private const int OutputCap = 100000; // chars per stream
 
         public static void Register(McpServer server, CommandConfig config)
         {
@@ -73,7 +72,7 @@ namespace CommandMcpServer
             string command = ctx.Arguments.Value<string>("command");
             if (string.IsNullOrEmpty(command)) return ToolResults.Error("command is required");
 
-            int timeout = IntArg(ctx, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
+            int timeout = CommandToolHelpers.IntArg(ctx.Arguments, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
 
             ProcessRequest req = new ProcessRequest();
             req.FileName = ps.Exe;
@@ -82,8 +81,13 @@ namespace CommandMcpServer
                 // PowerShell 1.0: no -EncodedCommand / -ExecutionPolicy / -NonInteractive. Feed the
                 // script over stdin via `-Command -` (read commands from standard input), which 1.0
                 // supports and which sidesteps shell quoting just as -EncodedCommand does for 2.0+.
+                // Write the bytes in the system code page (what a legacy console host reads) rather than
+                // .NET's ambiguous default StandardInput encoding. Characters outside the system code
+                // page can't be represented to a non-Unicode 1.0 host - an inherent 1.0 limitation, not
+                // something the modern -EncodedCommand path shares.
                 req.Arguments = "-NoProfile -Command -";
                 req.StdinText = command + Environment.NewLine;
+                req.StdinEncoding = Encoding.Default;
             }
             else
             {
@@ -111,15 +115,7 @@ namespace CommandMcpServer
                 return ToolResults.Error("failed to run " + ps.Label + ": " + ex.Message);
             }
 
-            bool outTrunc, errTrunc;
-            JObject outp = new JObject();
-            if (!string.IsNullOrEmpty(ps.Version)) outp["version"] = ps.Version;
-            outp["exitCode"] = result.ExitCode;
-            outp["stdout"] = Cap(result.StdOut, out outTrunc);
-            outp["stderr"] = Cap(result.StdErr, out errTrunc);
-            outp["timedOut"] = result.TimedOut;
-            if (outTrunc || errTrunc) outp["truncated"] = true;
-            return ToolResults.Json(outp);
+            return ToolResults.Json(CommandToolHelpers.BuildResult(result, ps.Version));
         }
 
         // PowerShell's -EncodedCommand expects base64 of the UTF-16LE (little-endian) bytes of the
@@ -128,27 +124,6 @@ namespace CommandMcpServer
         {
             byte[] bytes = Encoding.Unicode.GetBytes(command ?? string.Empty);
             return Convert.ToBase64String(bytes);
-        }
-
-        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
-        {
-            JToken t = ctx.Arguments[name];
-            if (t == null || t.Type == JTokenType.Null) return fallback;
-            int n;
-            try { n = t.Value<int>(); }
-            catch { return fallback; }
-            if (n < min) return min;
-            if (n > max) return max;
-            return n;
-        }
-
-        private static string Cap(string s, out bool truncated)
-        {
-            truncated = false;
-            if (s == null) return string.Empty;
-            if (s.Length <= OutputCap) return s;
-            truncated = true;
-            return s.Substring(0, OutputCap);
         }
     }
 }

--- a/servers/CommandMcpServer/PowerShellTools.cs
+++ b/servers/CommandMcpServer/PowerShellTools.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Mcp35.Core.Protocol;
+using Mcp35.Server;
+using Mcp35.Server.Process;
+using Newtonsoft.Json.Linq;
+
+namespace CommandMcpServer
+{
+    /// <summary>
+    /// Registers one PowerShell tool per discovered host (Windows PowerShell → command__powershell,
+    /// PowerShell Core → command__pwsh), mirroring how the MSBuild server surfaces one tool per
+    /// discovered engine: the tool exists only when PowerShell is found and is simply absent — never
+    /// advertised — on a system without it. The detected $PSVersionTable.PSVersion is woven into the
+    /// tool description so the model can choose cmdlets and language features the installed version
+    /// actually supports.
+    ///
+    /// Like the Command server's run tool, the script is opaque and runs already-approved (the host gate
+    /// showed the user the exact script). It is handed to PowerShell via -EncodedCommand (base64 of the
+    /// UTF-16LE script), so no quoting, newline, or special character in the model's script can be
+    /// misparsed by the shell — the whole script crosses as one opaque token. See servers-spec §5.
+    /// </summary>
+    internal static class PowerShellTools
+    {
+        private const int DefaultTimeoutMs = 60000;
+        private const int MaxTimeoutMs = 600000;
+        private const int OutputCap = 100000; // chars per stream
+
+        public static void Register(McpServer server, CommandConfig config)
+        {
+            ProcessRunner runner = new ProcessRunner(null);
+            // Discovery diagnostics go to stderr (never stdout — that carries the JSON-RPC stream).
+            IList<PowerShellInstall> installs = PowerShellDiscovery.Discover(new StdErrLogSink());
+
+            foreach (PowerShellInstall install in installs)
+            {
+                PowerShellInstall ps = install; // capture a per-iteration copy for the closure
+                server.AddTool(ps.ToolName, Description(ps), BuildSchema(ps),
+                    ToolAnnotations.Destructive(),
+                    delegate(ToolCallContext ctx) { return Run(config, runner, ps, ctx); });
+            }
+        }
+
+        private static JObject BuildSchema(PowerShellInstall ps)
+        {
+            return SchemaBuilder.Object()
+                .Str("command", true, "The " + ps.Label + " script to run. Provide it exactly as you would type it at a "
+                    + ps.Label + " prompt; multiple lines and any quoting are fine.")
+                .Int("timeout_ms", false, "Kill the script after this many milliseconds (default 60000, max 600000).")
+                .Build();
+        }
+
+        private static string Description(PowerShellInstall ps)
+        {
+            string d = "Run a " + ps.Label + " script and capture its stdout, stderr, and exit code. ";
+            if (!string.IsNullOrEmpty(ps.Version))
+                d += ps.Label + " version " + ps.Version + " is installed - use cmdlets and language "
+                   + "features supported by that version. ";
+            else
+                d += "(The installed version could not be determined.) ";
+            d += "The script runs in the conversation's working directory (the project folder), so it "
+               + "operates on that folder directly - do NOT cd into it; relative paths resolve against it.";
+            return d;
+        }
+
+        private static CallToolResult Run(CommandConfig config, ProcessRunner runner, PowerShellInstall ps, ToolCallContext ctx)
+        {
+            string command = ctx.Arguments.Value<string>("command");
+            if (string.IsNullOrEmpty(command)) return ToolResults.Error("command is required");
+
+            int timeout = IntArg(ctx, "timeout_ms", DefaultTimeoutMs, 1, MaxTimeoutMs);
+
+            ProcessRequest req = new ProcessRequest();
+            req.FileName = ps.Exe;
+            // -EncodedCommand takes base64 of the UTF-16LE script, sidestepping shell quoting entirely
+            // (the host already showed the user the exact script at the approval gate). -NoProfile keeps
+            // a user's $PROFILE from changing behavior; -NonInteractive fails fast rather than hanging on
+            // a prompt; -ExecutionPolicy Bypass lets the inline script run regardless of machine policy.
+            req.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + Encode(command);
+            req.WorkingDirectory = config.WorkDir;
+            req.TimeoutMs = timeout;
+
+            ProcessResult result;
+            try
+            {
+                result = runner.Run(req);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                return ToolResults.Error(ps.Label + " could not be launched (" + ps.Exe + ").");
+            }
+            catch (Exception ex)
+            {
+                return ToolResults.Error("failed to run " + ps.Label + ": " + ex.Message);
+            }
+
+            bool outTrunc, errTrunc;
+            JObject outp = new JObject();
+            if (!string.IsNullOrEmpty(ps.Version)) outp["version"] = ps.Version;
+            outp["exitCode"] = result.ExitCode;
+            outp["stdout"] = Cap(result.StdOut, out outTrunc);
+            outp["stderr"] = Cap(result.StdErr, out errTrunc);
+            outp["timedOut"] = result.TimedOut;
+            if (outTrunc || errTrunc) outp["truncated"] = true;
+            return ToolResults.Json(outp);
+        }
+
+        // PowerShell's -EncodedCommand expects base64 of the UTF-16LE (little-endian) bytes of the
+        // script. Pure (no I/O) so it is unit-testable without the MCP runtime or an installed shell.
+        internal static string Encode(string command)
+        {
+            byte[] bytes = Encoding.Unicode.GetBytes(command ?? string.Empty);
+            return Convert.ToBase64String(bytes);
+        }
+
+        private static int IntArg(ToolCallContext ctx, string name, int fallback, int min, int max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            int n;
+            try { n = t.Value<int>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        private static string Cap(string s, out bool truncated)
+        {
+            truncated = false;
+            if (s == null) return string.Empty;
+            if (s.Length <= OutputCap) return s;
+            truncated = true;
+            return s.Substring(0, OutputCap);
+        }
+    }
+}

--- a/servers/CommandMcpServer/Program.cs
+++ b/servers/CommandMcpServer/Program.cs
@@ -4,8 +4,8 @@ using Mcp35.Server;
 namespace CommandMcpServer
 {
     /// <summary>
-    /// First-party Command MCP server: run an already-approved shell command line. The standard
-    /// five lines around the single run tool (servers-spec §1, §5).
+    /// First-party Command MCP server: run an already-approved shell command line, plus — when a
+    /// PowerShell host is discovered on the system — a PowerShell tool per host (servers-spec §1, §5).
     /// </summary>
     internal static class Program
     {
@@ -17,8 +17,12 @@ namespace CommandMcpServer
             info.Name = "command";
             info.Version = "1.0";
 
+            CommandConfig config = CommandConfig.FromEnvironment(log);
             McpServer server = new McpServer(info, log);
-            CommandTools.Register(server, CommandConfig.FromEnvironment(log));
+            CommandTools.Register(server, config);
+            // PowerShell tool(s) are added only when a host is discovered on this system; on a box
+            // without PowerShell none are registered, so the server advertises just `run`.
+            PowerShellTools.Register(server, config);
             server.Run(); // blocks until stdin EOF
             return 0;
         }

--- a/servers/CommandMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/CommandMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8b1149e6-9c3e-4860-a946-95989d4fd4d2")]
 
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]

--- a/servers/CommandMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/CommandMcpServer/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("CommandMcpServer")]
-[assembly: AssemblyDescription("First-party MCP server: run an already-approved shell command line, capturing output.")]
+[assembly: AssemblyDescription("First-party MCP server: run an already-approved shell command line - either CMD or PowerShell - capturing output.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Mcp35")]

--- a/src/Mcp35.Server/Process/ProcessRequest.cs
+++ b/src/Mcp35.Server/Process/ProcessRequest.cs
@@ -22,6 +22,14 @@ namespace Mcp35.Server.Process
         /// <summary>Optional text to write to the child's stdin (then stdin is closed).</summary>
         public string StdinText;
 
+        /// <summary>
+        /// Encoding for <see cref="StdinText"/>. When null, the process's default StandardInput writer
+        /// is used. Set it when the child reads stdin in a specific code page (e.g. a legacy console
+        /// app) so non-ASCII bytes are written deliberately rather than via .NET's ambiguous default
+        /// StandardInput encoding (which is not settable on .NET 3.5).
+        /// </summary>
+        public System.Text.Encoding StdinEncoding;
+
         /// <summary>Kill the process if it runs longer than this. 0 or less = no timeout.</summary>
         public int TimeoutMs;
     }

--- a/src/Mcp35.Server/Process/ProcessRunner.cs
+++ b/src/Mcp35.Server/Process/ProcessRunner.cs
@@ -66,7 +66,19 @@ namespace Mcp35.Server.Process
                 {
                     try
                     {
-                        proc.StandardInput.Write(req.StdinText);
+                        if (req.StdinEncoding != null)
+                        {
+                            // The StandardInput StreamWriter's encoding isn't settable on .NET 3.5, so
+                            // to control how non-ASCII stdin bytes are emitted we write them ourselves in
+                            // the requested encoding via the underlying stream.
+                            byte[] bytes = req.StdinEncoding.GetBytes(req.StdinText);
+                            proc.StandardInput.BaseStream.Write(bytes, 0, bytes.Length);
+                            proc.StandardInput.BaseStream.Flush();
+                        }
+                        else
+                        {
+                            proc.StandardInput.Write(req.StdinText);
+                        }
                     }
                     finally
                     {

--- a/src/Mcp35.Server/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Server/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("dca697a6-1b4c-430c-bc45-134cb5f90072")]
 
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.2.0")]
+[assembly: AssemblyFileVersion("0.1.2.0")]

--- a/tests/CommandMcpServer.Tests/PowerShellToolsTests.cs
+++ b/tests/CommandMcpServer.Tests/PowerShellToolsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Text;
+using Xunit;
+
+namespace CommandMcpServer.Tests
+{
+    /// <summary>
+    /// Pure tests for the PowerShell -EncodedCommand encoder. PowerShell expects base64 of the
+    /// UTF-16LE (little-endian) bytes of the script; getting the encoding (UTF-16LE, not UTF-8) right
+    /// is the whole point, so these pin it down without needing PowerShell installed. Live discovery
+    /// and execution are install-specific and not exercised here.
+    /// </summary>
+    public class PowerShellToolsTests
+    {
+        [Fact]
+        public void Encodes_as_base64_of_utf16le()
+        {
+            // "dir" → 64 00 69 00 72 00 (UTF-16LE) → base64 "ZABpAHIA".
+            Assert.Equal("ZABpAHIA", PowerShellTools.Encode("dir"));
+        }
+
+        [Fact]
+        public void Roundtrips_back_to_the_original_script()
+        {
+            string script = "Get-ChildItem -Path 'C:\\Program Files' |\r\n  Where-Object { $_.Length -gt 0 }";
+            byte[] raw = Convert.FromBase64String(PowerShellTools.Encode(script));
+            Assert.Equal(script, Encoding.Unicode.GetString(raw));
+        }
+
+        [Fact]
+        public void Preserves_non_ascii_characters()
+        {
+            string script = "Write-Output 'café — déjà vu ✓'";
+            byte[] raw = Convert.FromBase64String(PowerShellTools.Encode(script));
+            Assert.Equal(script, Encoding.Unicode.GetString(raw));
+        }
+
+        [Fact]
+        public void Empty_and_null_encode_to_empty()
+        {
+            Assert.Equal(string.Empty, PowerShellTools.Encode(""));
+            Assert.Equal(string.Empty, PowerShellTools.Encode(null));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds PowerShell support to the first-party **Command** MCP server, mirroring how the MSBuild server surfaces a tool per discovered engine: enabled only when PowerShell is found on the system, never advertised when it's absent, with the detected version woven into the tool description so the model uses version-appropriate cmdlets.

Because a machine's `powershell.exe` is exactly one version, discovery registers **one** Windows-PowerShell tool plus an optional Core tool — never overlapping:

- `command__powershell` — Windows PowerShell **2.0–5.1** (runs via `-EncodedCommand`, base64 UTF-16LE)
- `command__powershell_v1` — Windows PowerShell **1.0** (predates `-EncodedCommand`/`-ExecutionPolicy`/`-NonInteractive`, so it feeds the script over stdin via `-Command -`)
- `command__pwsh` — PowerShell **6+ Core**

`command__run` (cmd.exe) is unchanged. Both encodings remove shell quoting from the equation entirely — the whole script crosses as one opaque token.

## What's included

- **Discovery** (`PowerShellDiscovery`): defensive, run-once probing for Windows PowerShell and PowerShell Core (incl. `%ProgramW6432%` so `pwsh` is found under WOW64). Version detection is time-boxed (4s/probe, legacy fallback skipped when the modern probe times out) so a slow/wedged interpreter can't blow the host's connection-open budget and take `command__run` down with it.
- **Approval UX**: the approval prompt renders the script with PowerShell syntax highlighting (not raw JSON) and surfaces the command-pattern signature in the label, matching `command__run`.
- **Quote-aware command signatures**: `CommandSignature` now keeps a quoted path with interior spaces as one token, and matches multi-line scripts **exactly** so two different scripts sharing an opening line can't collapse onto one remembered "always allow this pattern" rule.
- **Transcript records**: finished PowerShell calls show as a collapsible "Ran a PowerShell command" record so the script is reviewable after the fact.
- **Shared helpers** (`CommandToolHelpers`): `IntArg`/`Cap`/`BuildResult` shared between `run` and the PowerShell tools; the PS tool-name set is centralized in `McpConfig.IsPowerShellTool`.
- **`ProcessRequest.StdinEncoding`**: lets the 1.0 stdin path write its script in the system code page rather than .NET's ambiguous default.

## Versioning

- `CommandMcpServer` → `0.2.0.0` (new tool family) + updated assembly description
- `Mcp35.Server` → `0.1.2.0` (additive `StdinEncoding`)
- `GxPT` and the setup project intentionally left untouched

## Tests & docs

- Unit tests for the `-EncodedCommand` encoder and the quote-aware / multi-line / cross-quoted-path signature behavior.
- `docs/mcp35-servers-spec.md` §5 documents all three host shapes and both invocation styles.

## Notes

- A full high-effort code review was run on this branch and all surfaced findings were addressed (startup-timeout teardown, approval-scope widening, WOW64 discovery, 1.0 detection robustness, encoding, plus reuse/altitude cleanups).
- **Not built/run in CI here**: these are net35/net48 Windows projects and the dev environment has no .NET toolchain, so the changes were reviewed by hand against callers and existing tests rather than compiled.
- We considered renaming `command__run` → `command__cmd` for symmetry but decided against it: it would break user-authored agent/skill `tools:` allowlists that name `command__run`, for a purely cosmetic gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgRh4FGK16H8UXHyCR44dU)_