### PR TITLE
Add SkillScript approval scope for run_skill_script with two remember dimensions

### DIFF
--- a/GxPT.Tests/Mcp/ToolApprovalTests.cs
+++ b/GxPT.Tests/Mcp/ToolApprovalTests.cs
@@ -113,6 +113,12 @@ namespace GxPT.Tests.Mcp
             Assert.Equal(ToolTier.Destructive, sln.Tier);
             Assert.Equal(RememberScope.Argument, sln.Scope);
             Assert.Equal("solution", sln.ScopeArgPath);
+
+            // run_skill_script runs author-written code -> Destructive, but remember-eligible via the
+            // SkillScript scope (per-skill blanket or this-exact-script), not None.
+            var skill = c.Classify("extensions__run_skill_script", null, true);
+            Assert.Equal(ToolTier.Destructive, skill.Tier);
+            Assert.Equal(RememberScope.SkillScript, skill.Scope);
         }
 
         [Fact]
@@ -562,6 +568,103 @@ namespace GxPT.Tests.Mcp
             pol.Check("files__write", Args("{\"path\":\"a.txt\"}"));
             Assert.Equal(1, prompt.Calls);
             pol.Check("files__write", Args("{\"path\":\"a.txt\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        // ---- skill-script approvals (run_skill_script's two remember dimensions) ----
+
+        private const string SkillScript = "extensions__run_skill_script";
+
+        [Fact]
+        public void Skill_script_prompts_every_time_until_remembered()
+        {
+            // Destructive/SkillScript with nothing remembered behaves like None: prompts every call.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.AllowOnce };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(2, prompt.Calls); // AllowOnce never persists
+        }
+
+        [Fact]
+        public void Skill_script_remember_this_script_is_exact_and_slug_qualified()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberSkillScript };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // Same script, different args -> covered (args don't affect matching).
+            Assert.Equal(ApprovalDecision.Allow,
+                pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\",\"args\":[\"--prod\"]}")));
+            Assert.Equal(1, prompt.Calls);
+
+            // A different script in the SAME skill still prompts (exact, not per-skill).
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/other.bat\"}"));
+            Assert.Equal(2, prompt.Calls);
+
+            // The same relpath in a DIFFERENT skill must not collide -> prompts.
+            pol.Check(SkillScript, Args("{\"slug\":\"build\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(3, prompt.Calls);
+        }
+
+        [Fact]
+        public void Skill_script_remember_whole_skill_covers_every_script_in_it()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberSkillScripts };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // Any other script in the same skill is now covered.
+            Assert.Equal(ApprovalDecision.Allow,
+                pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/other.cmd\"}")));
+            Assert.Equal(1, prompt.Calls);
+
+            // A script in a different skill still prompts.
+            pol.Check(SkillScript, Args("{\"slug\":\"build\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Skill_script_keys_are_case_and_separator_insensitive()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberSkillScript };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+
+            pol.Check(SkillScript, Args("{\"slug\":\"Deploy\",\"relpath\":\"Scripts\\\\Run.bat\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            // Same skill+script spelled with different case/separators -> still matches.
+            Assert.Equal(ApprovalDecision.Allow,
+                pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}")));
+            Assert.Equal(1, prompt.Calls);
+        }
+
+        [Fact]
+        public void Skill_script_deny_and_allow_once_persist_nothing()
+        {
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.Deny };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            Assert.Equal(ApprovalDecision.Deny,
+                pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}")));
+            // Still prompts afterward (nothing remembered).
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(2, prompt.Calls);
+        }
+
+        [Fact]
+        public void Skill_script_injected_other_script_still_prompts_despite_existing_rule()
+        {
+            // Backstop (spec §6): approving one script never auto-allows a different one.
+            var prompt = new ScriptedPrompt { Next = ApprovalChoice.RememberSkillScript };
+            var pol = Policy(prompt, new InMemoryApprovalStore());
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/run.bat\"}"));
+            Assert.Equal(1, prompt.Calls);
+
+            pol.Check(SkillScript, Args("{\"slug\":\"deploy\",\"relpath\":\"scripts/evil.bat\"}"));
             Assert.Equal(2, prompt.Calls);
         }
 

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -333,13 +333,15 @@ namespace GxPT
                 }
                 else if (string.Equals(req.FunctionName, "extensions__run_skill_script", StringComparison.Ordinal))
                 {
-                    // Mirror command__run: the script and its literal arguments.
+                    // Mirror command__run: the script and its literal arguments, with the owning skill in
+                    // the header so the per-skill remember scope is clear before approving.
+                    string slug = req.Arguments.Value<string>("slug") ?? string.Empty;
                     string rel = req.Arguments.Value<string>("relpath") ?? string.Empty;
                     string scriptArgs = PathsOf(req.Arguments, "args");
                     string text = (rel + (scriptArgs.Length > 0 ? " " + scriptArgs : "")).Trim();
                     if (text.Length > 0)
                     {
-                        _diffPanel.SetContent(string.Empty, text, "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
+                        _diffPanel.SetContent(slug, text, "batch", dark, _monoFont, tc.CodeBack, tc.UiForeground);
                         _previewLabel.Text = "Run skill script:";
                         handled = true;
                     }
@@ -843,6 +845,19 @@ namespace GxPT
                 // the workspace blanket covers the "trust this working area" case more broadly.
                 AddButton("Allow all edits in this workspace", ApprovalChoice.RememberWorkdirWrites, false);
                 AddButton("Always allow this file", ApprovalChoice.RememberExactArg, false);
+            }
+            else if (scope == RememberScope.SkillScript)
+            {
+                // run_skill_script: a per-skill blanket and a per-script exact rule. Add the broader
+                // option first so (front-insertion, see AddButton) the more specific "this script" lands
+                // nearer "Allow once" and the broader "scripts for this skill" nearer Deny - mirroring
+                // the exact-vs-pattern ordering of the command buttons above.
+                AddButton("Always allow scripts for this skill", ApprovalChoice.RememberSkillScripts, false,
+                    "Allows running any script bundled with this skill, with any arguments. A script "
+                    + "belonging to a different skill still prompts.");
+                AddButton("Always allow this script", ApprovalChoice.RememberSkillScript, false,
+                    "Allows only this exact script (this skill + this script path), with any arguments. "
+                    + "Any other script - including a different one in the same skill - still prompts.");
             }
             // Scope == None: no remember buttons (Allow once / Deny only).
         }

--- a/GxPT/Services/Mcp/ToolApproval.cs
+++ b/GxPT/Services/Mcp/ToolApproval.cs
@@ -4,7 +4,13 @@ namespace GxPT
 {
     // Approval tiers and remember-scope (approval spec §2).
     internal enum ToolTier { ReadOnly, Write, Destructive }
-    internal enum RememberScope { None, Tool, Argument }
+    //   None      - never remembered (always prompts), e.g. git__push.
+    //   Tool      - remember the whole function name.
+    //   Argument  - remember a rule over one argument (command/path), see ScopeArgPath.
+    //   SkillScript - extensions__run_skill_script only: two remember dimensions (the whole skill,
+    //                 or one exact script). Scoped on (slug) and (slug, relpath) rather than a single
+    //                 argument, so it gets its own scope rather than overloading Argument.
+    internal enum RememberScope { None, Tool, Argument, SkillScript }
 
     // The classification of a tool: how much friction (tier) and how an approval may be remembered.
     internal sealed class ToolPolicy
@@ -57,7 +63,9 @@ namespace GxPT
         RememberTool,        // Tool scope: remember the whole function name
         RememberExactArg,    // Argument scope: ExactArgs rule on ScopeArgPath
         RememberPrefixArg,   // Argument scope: Prefix rule (base+sub / directory-and-below)
-        RememberWorkdirWrites // Workdir scope: every Write-tier files__ tool in the active workspace
+        RememberWorkdirWrites, // Workdir scope: every Write-tier files__ tool in the active workspace
+        RememberSkillScripts, // SkillScript scope: every script bundled with this skill (by slug)
+        RememberSkillScript   // SkillScript scope: this exact script only (by slug + relpath)
     }
 
     // The confirmation surface the policy invokes when a call isn't already allowed. Implemented by

--- a/GxPT/Services/Mcp/ToolApprovalPolicy.cs
+++ b/GxPT/Services/Mcp/ToolApprovalPolicy.cs
@@ -102,6 +102,10 @@ namespace GxPT
                 return ApprovalDecision.Allow;
             if (pol.Scope == RememberScope.Argument && MatchesAnyRule(functionName, pol, args))
                 return ApprovalDecision.Allow;
+            // Skill-script approvals: either a per-skill blanket (any script in the skill) or this one
+            // exact script (skill + relpath). An injected call for a different skill/script won't match.
+            if (pol.Scope == RememberScope.SkillScript && MatchesSkillScriptRule(functionName, args))
+                return ApprovalDecision.Allow;
 
             // Not remembered (or Scope==None) -> prompt.
             if (_prompt == null) return ApprovalDecision.Deny; // no UI available -> safe default
@@ -151,6 +155,52 @@ namespace GxPT
                 }
             }
             return false;
+        }
+
+        // ---- skill-script rule matching (run_skill_script's two remember dimensions) ----
+
+        // True when a remembered skill-script rule covers this (slug, relpath) call. Two rule shapes,
+        // both stored as ExactArgs (see Persist):
+        //   ArgPath "slug"    -> blanket for the whole skill: matches any relpath in that slug.
+        //   ArgPath "relpath" -> this exact script: Pattern is "<slugKey>\0<relKey>" so a script with
+        //                        the same relative path in a DIFFERENT skill never collides.
+        // Both keys are normalized the same way here and in Persist, so storage and lookup agree.
+        private bool MatchesSkillScriptRule(string functionName, JObject args)
+        {
+            string slug = SkillSlugKey(ArgValue(args, "slug"));
+            if (slug.Length == 0) return false;
+            string exactKey = slug + "\0" + NormalizeRelpath(ArgValue(args, "relpath"));
+
+            IList<ApprovalRule> rules = _store.RulesFor(functionName);
+            for (int i = 0; i < rules.Count; i++)
+            {
+                ApprovalRule r = rules[i];
+                if (r == null || r.Kind != RuleKind.ExactArgs) continue;
+                if (r.ArgPath == "slug")
+                {
+                    if (string.Equals(slug, r.Pattern, StringComparison.Ordinal)) return true;
+                }
+                else if (r.ArgPath == "relpath")
+                {
+                    if (string.Equals(exactKey, r.Pattern, StringComparison.Ordinal)) return true;
+                }
+            }
+            return false;
+        }
+
+        // Stable comparison key for a skill slug: trimmed + lowercased. The host doesn't run the
+        // server's SkillSlug.Make, but a slug is already kebab-case by contract, so this only reconciles
+        // incidental case/whitespace so the stored rule and a later call agree.
+        private static string SkillSlugKey(string slug)
+        {
+            return string.IsNullOrEmpty(slug) ? string.Empty : slug.Trim().ToLowerInvariant();
+        }
+
+        // Stable comparison key for a script's relpath: '/'-normalized (NormalizePath) and lowercased,
+        // since the relpath confines to a folder and Windows paths compare case-insensitively.
+        private static string NormalizeRelpath(string rel)
+        {
+            return NormalizePath(rel).ToLowerInvariant();
         }
 
         // Boundary-aware prefix match (security, spec §3):
@@ -217,6 +267,24 @@ namespace GxPT
                     // workdir (nothing to scope the blanket approval to).
                     if (_workdirKey != null) _store.AddApprovedWorkdir(req.ServerName, _workdirKey);
                     break;
+                case ApprovalChoice.RememberSkillScripts:
+                {
+                    // Blanket for the whole skill: an ExactArgs rule on the slug (any relpath matches).
+                    string slug = SkillSlugKey(ArgValue(req.Arguments, "slug"));
+                    if (slug.Length > 0)
+                        _store.AddRule(new ApprovalRule(req.FunctionName, RuleKind.ExactArgs, "slug", slug));
+                    break;
+                }
+                case ApprovalChoice.RememberSkillScript:
+                {
+                    // This exact script: an ExactArgs rule on relpath, keyed by "<slug>\0<relpath>" so a
+                    // same-named script in another skill never matches. No-op without a slug.
+                    string slug = SkillSlugKey(ArgValue(req.Arguments, "slug"));
+                    if (slug.Length > 0)
+                        _store.AddRule(new ApprovalRule(req.FunctionName, RuleKind.ExactArgs, "relpath",
+                            slug + "\0" + NormalizeRelpath(ArgValue(req.Arguments, "relpath"))));
+                    break;
+                }
                 // AllowOnce / Deny: nothing persisted.
             }
         }

--- a/GxPT/Services/Mcp/ToolClassifier.cs
+++ b/GxPT/Services/Mcp/ToolClassifier.cs
@@ -96,10 +96,13 @@ namespace GxPT
             t["extensions__list_agents"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             t["extensions__validate_agent"] = new ToolPolicy(ToolTier.ReadOnly, RememberScope.Tool, null);
             t["extensions__delete_agent"] = new ToolPolicy(ToolTier.Destructive, RememberScope.None, null);
-            // Skills execution (design S9/S11): running a skill's batch is Destructive and confirmed every
-            // time (like git push / command__run's heavier siblings) - the model can run only a named
-            // skill's declared .bat with literal args, never an arbitrary command.
-            t["extensions__run_skill_script"] = new ToolPolicy(ToolTier.Destructive, RememberScope.None, null);
+            // Skills execution (design S9/S11): running a skill's batch is Destructive (the script body is
+            // author-written and can do anything the user can), so it stays gated - the model can run only a
+            // named skill's declared .bat with literal args, never an arbitrary command. SkillScript scope
+            // offers two narrow remember options (this exact script, or all scripts for this skill) so a
+            // trusted skill needn't be re-confirmed on every run, while a script from any OTHER skill - or a
+            // different script in the same skill, under "this exact script" - still prompts.
+            t["extensions__run_skill_script"] = new ToolPolicy(ToolTier.Destructive, RememberScope.SkillScript, null);
             return t;
         }
 

--- a/docs/mcp35-approval-spec.md
+++ b/docs/mcp35-approval-spec.md
@@ -50,7 +50,8 @@ Classification yields a **tier** (how much friction) and a **remember scope**
 
 ```csharp
 public enum ToolTier      { ReadOnly, Write, Destructive }
-public enum RememberScope { None, Tool, Argument }     // Argument → pattern over one arg
+public enum RememberScope { None, Tool, Argument, SkillScript } // Argument → pattern over one arg;
+                                                               // SkillScript → run_skill_script only
 
 public sealed class ToolPolicy {
     public ToolTier      Tier;
@@ -78,6 +79,11 @@ public interface IToolClassifier {
   get **granular** allowlisting — never "allow all commands."
 - **None** — never remembered; always prompt (Destructive tools with no
   meaningful scoping arg, e.g. `git__push`).
+- **SkillScript** — `extensions__run_skill_script` only. The call has two
+  remember dimensions, so it gets a dedicated scope rather than overloading
+  `Argument`: a per-skill blanket (keyed by `slug`) **or** this exact script
+  (keyed by `slug` + `relpath`). Both are stored as `ExactArgs` rules; an
+  injected call for a different skill/script never matches.
 
 **Sources, in precedence order:**
 1. `reveal_tools` → exempt.
@@ -95,6 +101,7 @@ public interface IToolClassifier {
    | `web__extract` | ReadOnly | Tool |
    | `web__get` | ReadOnly | Tool |
    | `web__http` | Destructive | None |
+   | `extensions__run_skill_script` | Destructive | **SkillScript** (`slug` / `slug`+`relpath`) |
 3. **Third-party → annotations** (advisory): `destructiveHint:true` →
    Destructive/None; `readOnlyHint:true` → ReadOnly/Tool; otherwise → Write/Tool.
    We can't infer a third-party server's argument semantics, so third-party
@@ -182,6 +189,7 @@ surface.
   | Tool (ReadOnly/Write) | `Allow once` · `Always allow this tool` · `Deny` |
   | Argument · command (`command__run`) | `Allow once` · `Always allow this exact command` · `` Always allow `<base> <sub>` `` · `Deny` |
   | Argument · path (`files__*`) | `Allow once` · `Always allow this path` · `Always allow this directory and below` · `Deny` |
+  | SkillScript (`run_skill_script`) | `Allow once` · `Always allow this script` · `Always allow scripts for this skill` · `Deny` |
   | None (`git__push`, …) | `Allow once` · `Deny` |
 - "this exact command/path" creates an **`ExactArgs`** rule; "base+subcommand" /
   "directory and below" create a **`Prefix`** rule. These fixed buttons are the

--- a/docs/skills-design.md
+++ b/docs/skills-design.md
@@ -388,10 +388,15 @@ the default for any skill with no per-skill setting.
   first open with the approval prompt so the user sees what's being loaded.
 - **Execution is a *narrowed* surface, not `command__run` (S9).** `run_skill_script`
   lets the model run only the **declared entry of a named skill** with **literal
-  args** — it cannot compose an arbitrary command or name a path. It is **Destructive
-  (always-confirm)** but **remember-eligible by exact `(slug, relpath)`** (S15): a
-  remembered allow is narrow and auditable, so it's *less* friction than `command__run`
-  while *more* locked down. The prompt is human-readable ("skill `release-notes` wants
+  args** — it cannot compose an arbitrary command or name a path. It is **Destructive**
+  but **remember-eligible** via the `SkillScript` scope (S15): the prompt offers
+  **"Always allow this script"** (an exact `(slug, relpath)` rule) and the broader
+  **"Always allow scripts for this skill"** (a per-`slug` rule that covers every script
+  the skill bundles). Args are shown each run but are **not** part of the remembered
+  grain. A remembered allow is narrow and auditable, so it's *less* friction than
+  `command__run` while *more* locked down — and a script from any other skill (or, under
+  the exact rule, a different script in the same skill) still prompts. The prompt is
+  human-readable ("skill `release-notes` wants
   to run `scripts/gen.bat --since v1.2` — *bundled*") and distinguishes bundled vs.
   project source.
 - **Skills never operate on their own dir (S14).** cwd is the workspace; the skill


### PR DESCRIPTION
## Summary
Implements a new `SkillScript` approval scope for `extensions__run_skill_script` that offers two granular remember options: approving all scripts for a specific skill, or approving only an exact script within that skill. This allows trusted skills to run without re-confirmation while maintaining security boundaries between skills and scripts.

## Key Changes

- **New RememberScope enum value**: Added `SkillScript` scope to distinguish skill-script approvals from generic argument-based scoping, since this tool has two independent remember dimensions (skill slug and script relpath).

- **New ApprovalChoice values**: Added `RememberSkillScripts` (per-skill blanket) and `RememberSkillScript` (exact script) to support the two remember options.

- **Approval matching logic**: Implemented `MatchesSkillScriptRule()` in `ToolApprovalPolicy` that:
  - Matches per-skill rules keyed by normalized slug
  - Matches exact-script rules keyed by `slug\0relpath` composite key to prevent collision across skills
  - Normalizes both slug (case-insensitive) and relpath (case and separator-insensitive) for stable comparison

- **Persistence logic**: Updated `Persist()` to store skill-script approvals as `ExactArgs` rules with either `"slug"` or `"relpath"` ArgPath, encoding the composite key for exact-script rules.

- **UI updates**: Modified `ToolApprovalPanel` to:
  - Display the skill slug in the approval prompt header for context
  - Add two remember buttons with clear descriptions of their scope (all scripts in skill vs. this exact script only)
  - Order buttons to show broader option first, mirroring command-approval button layout

- **Classifier update**: Changed `extensions__run_skill_script` from `RememberScope.None` to `RememberScope.SkillScript` in the first-party tool table.

- **Documentation**: Updated approval spec and skills design doc to explain the two-dimensional remember scope and security boundaries.

## Implementation Details

- **Normalization**: Slug keys use `Trim().ToLowerInvariant()`; relpath keys use path-normalized + lowercased form to handle Windows path separators and case-insensitivity.
- **Composite keying**: Exact-script rules use `slug\0relpath` pattern to ensure a script with the same relpath in a different skill never matches.
- **Args not scoped**: Script arguments are shown in the prompt but are not part of the remembered rule grain—any arguments are allowed once a script is approved.
- **Security backstop**: An injected call for a different skill or script (under exact-script rules) will not match existing approvals, ensuring the model cannot bypass approval by modifying arguments.

## Tests
Added comprehensive test coverage for:
- Prompting behavior until remembered
- Exact-script rule matching (slug + relpath qualified)
- Per-skill blanket rule matching (any relpath in slug)
- Case and path-separator insensitivity
- Deny/AllowOnce not persisting
- Injection backstop (different script still prompts despite existing rule)

https://claude.ai/code/session_01CnS5tbjqf9zb1BDYz6n7SW