### PR TITLE
Add Explain button to tool approval panel for command tools

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -62,6 +62,21 @@ namespace GxPT
         // fires and the initial blue focus border was missing until the user tabbed.
         private Button _defaultButton;
 
+        // A small "Explain" affordance pinned to the panel's top-right corner, shown only while a
+        // command-style tool (command__run or a discovered PowerShell tool) awaits approval. Clicking it
+        // asks the host to open a fresh chat tab that explains the pending command - it does NOT resolve
+        // the approval, which stays up for the user to Allow/Deny. The captured command + whether it's
+        // PowerShell are remembered so the deferred click knows what to explain.
+        private readonly Button _explainButton;
+        private string _explainCommand;
+        private bool _explainIsPowerShell;
+
+        // Raised (on the UI thread) when the user clicks Explain for the current command tool. The host
+        // (MainForm) opens a new tab seeded with an "explain this command" prompt, carrying over the
+        // source conversation's model + ZDR setting. Arguments: the command line, and whether it is a
+        // PowerShell (vs cmd) command so the prompt and code fence match. Null = no handler wired.
+        public Action<string, bool> ExplainRequested;
+
         public ToolApprovalPanel()
         {
             this.Dock = DockStyle.Bottom;
@@ -122,6 +137,18 @@ namespace GxPT
             _toolTip = new ToolTip();
             _toolTip.AutoPopDelay = 15000; // keep the multi-line rule explanation visible long enough to read
 
+            // The Explain affordance: a flat chrome button overlaid on the top-right corner (not docked),
+            // shown only for command tools. AutoSize so it fits "Explain" at any font/DPI; positioned and
+            // brought to the front in PositionExplainButton once a command prompt is shown.
+            _explainButton = new Button();
+            _explainButton.Text = "Explain";
+            _explainButton.AutoSize = true;
+            _explainButton.Visible = false;
+            _explainButton.Margin = new Padding(0);
+            _explainButton.Click += OnExplainClicked;
+            _explainButton.GotFocus += OnButtonFocusChanged;
+            _explainButton.LostFocus += OnButtonFocusChanged;
+
             // Order added (Fill must be added before docked siblings to lay out correctly):
             this.Controls.Add(_diffPanel);
             this.Controls.Add(_preview);
@@ -129,6 +156,7 @@ namespace GxPT
             this.Controls.Add(_tierBadge);
             this.Controls.Add(_header);
             this.Controls.Add(_buttons);
+            this.Controls.Add(_explainButton);
 
             // Theme the chrome up front so the panel isn't a stark white block before the first prompt.
             ApplyTheme();
@@ -186,6 +214,9 @@ namespace GxPT
                         if (b != null) ApplyButtonTheme(b, dark, tc);
                     }
                 }
+
+                // The overlaid Explain button shares the flat, theme-tinted button styling.
+                if (_explainButton != null) ApplyButtonTheme(_explainButton, dark, tc);
 
                 // Re-tint the syntax-highlighted diff/preview when it's the visible details control, so a
                 // live theme switch updates it too (it was themed once at SetContent time).
@@ -262,6 +293,9 @@ namespace GxPT
         public void ShowFor(ApprovalRequest req, Action<ApprovalChoice> choiceCallback)
         {
             _onChoose = choiceCallback;
+            // Cleared up front; the command-tool branch below re-arms it when this is a command prompt.
+            _explainCommand = null;
+            _explainIsPowerShell = false;
 
             _header.Text = (req.ServerName != null ? req.ServerName : "?") + "  ·  " +
                            (req.ToolName != null ? req.ToolName : req.FunctionName);
@@ -431,6 +465,10 @@ namespace GxPT
                             ? label + "   (pattern: " + sig + ")"
                             : label + ":";
                         handled = true;
+                        // Remember the command so the Explain button (shown below) can open a tab that
+                        // describes it.
+                        _explainCommand = cmd;
+                        _explainIsPowerShell = isPs;
                     }
                 }
                 else if (string.Equals(req.FunctionName, "files__write", StringComparison.Ordinal))
@@ -590,6 +628,11 @@ namespace GxPT
             AddButton("Allow once", ApprovalChoice.AllowOnce, tier == ToolTier.Write);
             SetButtonTabOrder();
 
+            // Offer Explain only for a command prompt (the branch above captured the command). The
+            // button overlays the header's top-right corner; reserve header space so its text never
+            // runs under the button.
+            UpdateExplainButton(!string.IsNullOrEmpty(_explainCommand));
+
             // Color the panel + the freshly built buttons for the active theme before measuring, so the
             // button metrics used by LayoutToContent reflect their themed style.
             ApplyTheme();
@@ -607,6 +650,52 @@ namespace GxPT
             this.SendToBack();
             SetPromptVisible(true);
             FocusDefaultButton();
+        }
+
+        // Show or hide the top-right Explain button for the current prompt, reserving room in the header
+        // so its (possibly long) "server · tool" text never draws under the button.
+        private void UpdateExplainButton(bool show)
+        {
+            if (_explainButton == null) return;
+            _explainButton.Visible = show;
+            if (show)
+            {
+                int reserve = _explainButton.PreferredSize.Width + 8;
+                _header.Padding = new Padding(0, 0, reserve, 0);
+                PositionExplainButton();
+                _explainButton.BringToFront(); // paint over the docked header it overlaps
+            }
+            else
+            {
+                _header.Padding = Padding.Empty;
+            }
+        }
+
+        // Pin the Explain button to the panel's inner top-right corner (inside the panel padding),
+        // aligned with the header row. Re-run on resize because the panel width changes with the window.
+        private void PositionExplainButton()
+        {
+            if (_explainButton == null || !_explainButton.Visible) return;
+            int bw = _explainButton.PreferredSize.Width;
+            int x = this.ClientSize.Width - this.Padding.Right - bw;
+            int y = this.Padding.Top;
+            if (x < this.Padding.Left) x = this.Padding.Left;
+            _explainButton.Location = new Point(x, y);
+        }
+
+        // Explain click: hand the captured command to the host so it can open a fresh chat tab that
+        // explains it. Deliberately does NOT hide the panel - the approval stays up for the user to
+        // Allow/Deny after reading the explanation.
+        private void OnExplainClicked(object sender, EventArgs e)
+        {
+            string cmd = _explainCommand;
+            bool isPs = _explainIsPowerShell;
+            Action<string, bool> h = ExplainRequested;
+            if (h != null && !string.IsNullOrEmpty(cmd))
+            {
+                try { h(cmd, isPs); }
+                catch { }
+            }
         }
 
         // Focus the tier's default button now that the panel is visible (focusing earlier is a no-op).
@@ -638,6 +727,10 @@ namespace GxPT
         {
             _onChoose = null;
             _onContinue = callback;
+            // The iteration-cap prompt is not a command tool: never offer Explain here.
+            _explainCommand = null;
+            _explainIsPowerShell = false;
+            UpdateExplainButton(false);
 
             _header.Text = "Tool-call limit reached";
             _currentTier = ToolTier.Write; // informational; reuse the Write (goldenrod) badge color
@@ -770,6 +863,8 @@ namespace GxPT
             base.OnSizeChanged(e);
             // Width changes (parent resize) can re-wrap the buttons; keep the panel tall enough.
             if (this.Visible) LayoutToContent();
+            // Keep the overlaid Explain button anchored to the (now moved) right edge.
+            PositionExplainButton();
         }
 
         // Approximate wrapped height of the raw-JSON preview text at the current width. Best-effort:

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -145,6 +145,10 @@ namespace GxPT
             _explainButton.AutoSize = true;
             _explainButton.Visible = false;
             _explainButton.Margin = new Padding(0);
+            // Keep Explain at the end of the tab cycle so it never intercepts focus ahead of the
+            // Allow/Deny strip (which owns the keyboard default). It lives on the panel, not in the
+            // _buttons strip that SetButtonTabOrder manages, so it needs its own high TabIndex.
+            _explainButton.TabIndex = 1000;
             _explainButton.Click += OnExplainClicked;
             _explainButton.GotFocus += OnButtonFocusChanged;
             _explainButton.LostFocus += OnButtonFocusChanged;
@@ -673,9 +677,13 @@ namespace GxPT
 
         // Pin the Explain button to the panel's inner top-right corner (inside the panel padding),
         // aligned with the header row. Re-run on resize because the panel width changes with the window.
+        // Deliberately NOT gated on _explainButton.Visible: ShowFor positions the button while the panel
+        // itself is still hidden, and the Control.Visible getter reports false whenever a parent is
+        // hidden - so a Visible check here would skip the very placement ShowFor needs, leaving the
+        // button at its default top-left location. Positioning a hidden button is harmless.
         private void PositionExplainButton()
         {
-            if (_explainButton == null || !_explainButton.Visible) return;
+            if (_explainButton == null) return;
             int bw = _explainButton.PreferredSize.Width;
             int x = this.ClientSize.Width - this.Padding.Right - bw;
             int y = this.Padding.Top;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -875,9 +875,64 @@ namespace GxPT
                 // While this tab's prompt awaits the user, pause the status-bar marquee and swap the
                 // Stop button for an "awaiting user..." label (only when this is the active tab).
                 panel.PromptVisibleChanged += delegate { SyncGenerationIndicatorFromActiveTab(); };
+                // The approval panel's Explain button opens a fresh tab that describes the pending
+                // command, carrying over this conversation's model + ZDR. The approval itself stays up.
+                panel.ExplainRequested = delegate(string command, bool isPowerShell)
+                {
+                    OpenCommandExplainTab(ctxRef, command, isPowerShell);
+                };
                 ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
+        }
+
+        // Open a new chat tab that asks the model to explain a pending command (from the approval
+        // panel's Explain button), then send it. The new conversation inherits the source tab's model
+        // and ZDR setting so the explanation routes through the same provider/privacy choice; it gets
+        // NO working directory, so it's a plain chat turn that won't itself trigger tool approvals.
+        // The source tab's approval prompt is untouched - it stays up for the user to Allow/Deny.
+        internal void OpenCommandExplainTab(TabManager.ChatTabContext sourceCtx, string command, bool isPowerShell)
+        {
+            try
+            {
+                if (_tabManager == null || string.IsNullOrEmpty(command)) return;
+
+                // Snapshot the source conversation's model + effective ZDR before we switch tabs.
+                string model = sourceCtx != null ? sourceCtx.SelectedModel : null;
+                bool zdr = sourceCtx != null && sourceCtx.Conversation != null
+                           && (sourceCtx.Conversation.Zdr || sourceCtx.Conversation.ZdrFirstMessageIndex >= 0);
+
+                var ctx = _tabManager.CreateConversationTab(); // creates and selects the new tab
+                if (ctx == null) return;
+
+                if (!string.IsNullOrEmpty(model))
+                {
+                    ctx.SelectedModel = model;
+                    if (ctx.Conversation != null) ctx.Conversation.SelectedModel = model;
+                }
+                if (ctx.Conversation != null) ctx.Conversation.Zdr = zdr;
+
+                // Reflect the carried-over model + ZDR on the toolbar now that this tab is active, so the
+                // send below (which reads the combo) uses them.
+                SyncComboModelFromActiveTab();
+                SyncZdrCheckboxFromActiveTab();
+
+                string prompt = BuildCommandExplainPrompt(command, isPowerShell);
+                if (_inputManager != null) _inputManager.SetInputText(prompt, true);
+                btnSend_Click(this, EventArgs.Empty);
+            }
+            catch { }
+        }
+
+        // The user prompt seeded into an Explain tab: ask for a plain-language walkthrough of the command
+        // without running it, fenced in the matching language so it renders as a code block.
+        private static string BuildCommandExplainPrompt(string command, bool isPowerShell)
+        {
+            string kind = isPowerShell ? "PowerShell" : "Windows command-line";
+            string fence = isPowerShell ? "powershell" : "batch";
+            return "Explain, in plain language, what the following " + kind + " command does, "
+                + "step by step. Call out anything destructive or risky. Do not run it.\r\n\r\n"
+                + "```" + fence + "\r\n" + (command ?? string.Empty) + "\r\n```";
         }
 
         // Re-theme every tab's tool-approval panel after a light<->dark switch: a currently-visible

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -924,14 +924,29 @@ namespace GxPT
             catch { }
         }
 
-        // The user prompt seeded into an Explain tab: ask for a plain-language walkthrough of the command
-        // without running it, fenced in the matching language so it renders as a code block.
+        // The user prompt seeded into an Explain tab: ask for a plain-language walkthrough of the
+        // command, an evaluation of the risks it carries (both to the user's system and from sharing
+        // any data it contains), and a short summary at the end. Fenced in the matching language so the
+        // command renders as a code block.
         private static string BuildCommandExplainPrompt(string command, bool isPowerShell)
         {
             string kind = isPowerShell ? "PowerShell" : "Windows command-line";
             string fence = isPowerShell ? "powershell" : "batch";
-            return "Explain, in plain language, what the following " + kind + " command does, "
-                + "step by step. Call out anything destructive or risky. Do not run it.\r\n\r\n"
+            return "Explain, in plain language, what the following " + kind + " command does. "
+                + "Do not run it. Cover these in order:\r\n\r\n"
+                + "1. **What it does** - walk through the command step by step, including each program, "
+                + "flag, argument, pipe, and redirection, and the overall effect.\r\n"
+                + "2. **Risks to the system** - evaluate what could go wrong on the machine that runs it: "
+                + "data loss or overwrites, irreversible or destructive actions, changes to files or "
+                + "system state outside the working directory, elevated-privilege or security-sensitive "
+                + "operations, network access (downloading or uploading data), and anything unexpected or "
+                + "obfuscated. Note if it looks safe.\r\n"
+                + "3. **Risks from sharing the data** - the command text may embed sensitive data (for "
+                + "example a tool result being passed along) that leaves the machine when this request is "
+                + "sent to the model. Point out any secrets, credentials, personal data, or otherwise "
+                + "sensitive content present in the command, and flag the privacy risk of disclosing it.\r\n"
+                + "4. **Summary** - finish with a brief one- or two-sentence summary of the command and "
+                + "its overall risk level.\r\n\r\n"
                 + "```" + fence + "\r\n" + (command ?? string.Empty) + "\r\n```";
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -888,14 +888,20 @@ namespace GxPT
 
         // Open a new chat tab that asks the model to explain a pending command (from the approval
         // panel's Explain button), then send it. The new conversation inherits the source tab's model
-        // and ZDR setting so the explanation routes through the same provider/privacy choice; it gets
-        // NO working directory, so it's a plain chat turn that won't itself trigger tool approvals.
-        // The source tab's approval prompt is untouched - it stays up for the user to Allow/Deny.
+        // and ZDR setting so the explanation routes through the same provider/privacy choice. The new
+        // tab gets NO working directory, so it normally runs as a plain chat turn; note that if a
+        // scratch workspace is globally enabled, StartModelTurn can still route folderless tabs through
+        // the tool loop, in which case the explanation could itself call a tool. The source tab's
+        // approval prompt is untouched - it stays up for the user to Allow/Deny.
         internal void OpenCommandExplainTab(TabManager.ChatTabContext sourceCtx, string command, bool isPowerShell)
         {
             try
             {
                 if (_tabManager == null || string.IsNullOrEmpty(command)) return;
+
+                // The message input is a single shared box; capture the source tab's unsent draft so the
+                // overwrite-and-send below doesn't silently discard it (restored at the end).
+                string priorDraft = _inputManager != null ? _inputManager.GetInputText() : null;
 
                 // Snapshot the source conversation's model + effective ZDR before we switch tabs.
                 string model = sourceCtx != null ? sourceCtx.SelectedModel : null;
@@ -920,6 +926,11 @@ namespace GxPT
                 string prompt = BuildCommandExplainPrompt(command, isPowerShell);
                 if (_inputManager != null) _inputManager.SetInputText(prompt, true);
                 btnSend_Click(this, EventArgs.Empty);
+
+                // btnSend_Click cleared the shared input on a successful send; put the user's prior draft
+                // back so switching to the explain tab didn't cost them their typed-but-unsent message.
+                if (!string.IsNullOrEmpty(priorDraft) && _inputManager != null)
+                    _inputManager.SetInputText(priorDraft, false);
             }
             catch { }
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -925,9 +925,9 @@ namespace GxPT
         }
 
         // The user prompt seeded into an Explain tab: ask for a plain-language walkthrough of the
-        // command, an evaluation of the risks it carries (both to the user's system and from sharing
-        // any data it contains), and a short summary at the end. Fenced in the matching language so the
-        // command renders as a code block.
+        // command, an evaluation of the risks it carries (both to the user's system and from the data
+        // its results would expose / send off the machine), and a short summary at the end. Fenced in
+        // the matching language so the command renders as a code block.
         private static string BuildCommandExplainPrompt(string command, bool isPowerShell)
         {
             string kind = isPowerShell ? "PowerShell" : "Windows command-line";
@@ -939,12 +939,15 @@ namespace GxPT
                 + "2. **Risks to the system** - evaluate what could go wrong on the machine that runs it: "
                 + "data loss or overwrites, irreversible or destructive actions, changes to files or "
                 + "system state outside the working directory, elevated-privilege or security-sensitive "
-                + "operations, network access (downloading or uploading data), and anything unexpected or "
-                + "obfuscated. Note if it looks safe.\r\n"
-                + "3. **Risks from sharing the data** - the command text may embed sensitive data (for "
-                + "example a tool result being passed along) that leaves the machine when this request is "
-                + "sent to the model. Point out any secrets, credentials, personal data, or otherwise "
-                + "sensitive content present in the command, and flag the privacy risk of disclosing it.\r\n"
+                + "operations, and anything unexpected or obfuscated. Note if it looks safe.\r\n"
+                + "3. **Data-sharing / exfiltration risk** - this is about what running the command would "
+                + "*expose or send*, not about the command text itself. Two things to evaluate: (a) does "
+                + "the command move data off the machine - uploading, posting, or otherwise transmitting "
+                + "data to a network or external service? and (b) would its output or results surface "
+                + "sensitive data (secrets, credentials, keys, tokens, personal data, private file "
+                + "contents)? Such results are returned to the model and could be retained, so flag any "
+                + "sensitive data the command would read or emit, and any external destination it would "
+                + "send data to.\r\n"
                 + "4. **Summary** - finish with a brief one- or two-sentence summary of the command and "
                 + "its overall risk level.\r\n\r\n"
                 + "```" + fence + "\r\n" + (command ?? string.Empty) + "\r\n```";


### PR DESCRIPTION
## Summary
This change adds an "Explain" affordance to the tool approval panel that allows users to request an explanation of a pending command before approving or denying it. When clicked, the button opens a new chat tab with a detailed prompt asking the model to explain what the command does, its risks, and data-sharing implications.

## Key Changes

**ToolApprovalPanel.cs:**
- Added `_explainButton` control positioned at the top-right corner of the panel, visible only for command-style tools
- Added `ExplainRequested` event that fires when the user clicks Explain, passing the command and whether it's PowerShell
- Added `_explainCommand` and `_explainIsPowerShell` fields to capture command details when a command tool is shown
- Implemented `UpdateExplainButton()` to show/hide the button and reserve header space so the tool name doesn't overlap it
- Implemented `PositionExplainButton()` to anchor the button to the panel's top-right corner, repositioning on resize
- Implemented `OnExplainClicked()` handler to invoke the `ExplainRequested` event with the captured command
- Updated `ShowFor()` to capture command details and show the Explain button only for command tools
- Updated `ShowContinuation()` to hide the Explain button (iteration-cap prompts are not command tools)
- Updated `OnSizeChanged()` to reposition the button when the panel is resized
- Updated `ApplyTheme()` to apply button styling to the Explain button

**MainForm.cs:**
- Wired the `ExplainRequested` event in `AttachApprovalPanel()` to call `OpenCommandExplainTab()`
- Implemented `OpenCommandExplainTab()` to create a new chat tab that inherits the source conversation's model and ZDR setting, then sends an explanation prompt
- Implemented `BuildCommandExplainPrompt()` to generate a detailed prompt asking for a walkthrough of the command, system risks, data-sharing risks, and a summary, with the command fenced in the appropriate language (PowerShell or batch)

## Notable Implementation Details

- The Explain button does NOT resolve the approval—the panel stays visible so the user can still Allow/Deny after reading the explanation
- The button is positioned as an overlay on the header with high TabIndex (1000) so it doesn't intercept keyboard focus ahead of Allow/Deny buttons
- The button is repositioned on every panel resize to stay anchored to the right edge
- The explanation prompt is comprehensive, covering what the command does, system risks, data exfiltration risks, and a summary
- The new explanation tab inherits the source conversation's model and ZDR setting to ensure consistent routing and privacy handling
- The user's unsent draft message is preserved when switching to the explanation tab

https://claude.ai/code/session_01Uq12tJbpxxgjaA8xFQad2w