### PR TITLE
Add ask_user tool for model-driven multiple-choice questions

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -43,6 +43,8 @@
     <Compile Include="..\GxPT\Services\RequestCancellation.cs" Link="Linked\RequestCancellation.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolCallAssembler.cs" Link="Linked\Mcp\ToolCallAssembler.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IToolApprovalPolicy.cs" Link="Linked\Mcp\IToolApprovalPolicy.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\IQuestionPrompt.cs" Link="Linked\Mcp\IQuestionPrompt.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\AskUserTool.cs" Link="Linked\Mcp\AskUserTool.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolApproval.cs" Link="Linked\Mcp\ToolApproval.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolClassifier.cs" Link="Linked\Mcp\ToolClassifier.cs" />
     <Compile Include="..\GxPT\Services\Mcp\ToolApprovalPolicy.cs" Link="Linked\Mcp\ToolApprovalPolicy.cs" />

--- a/GxPT.Tests/Mcp/AskUserToolTests.cs
+++ b/GxPT.Tests/Mcp/AskUserToolTests.cs
@@ -7,13 +7,19 @@ namespace GxPT.Tests.Mcp
 {
     public class AskUserToolTests
     {
-        // A scripted IQuestionPrompt: records the request it was shown and returns a canned answer.
+        // A scripted IQuestionPrompt: records the requests it was shown and returns a canned answer.
         private sealed class StubPrompt : IQuestionPrompt
         {
             public QuestionRequest LastRequest;
+            public readonly List<QuestionRequest> Requests = new List<QuestionRequest>();
             public readonly QuestionAnswer Next;
             public StubPrompt(QuestionAnswer next) { Next = next; }
-            public QuestionAnswer Ask(QuestionRequest request) { LastRequest = request; return Next; }
+            public QuestionAnswer Ask(QuestionRequest request)
+            {
+                LastRequest = request;
+                Requests.Add(request);
+                return Next;
+            }
         }
 
         private sealed class DenyAllPolicy : IToolApprovalPolicy
@@ -203,6 +209,52 @@ namespace GxPT.Tests.Mcp
             foreach (JObject def in streamer.SeenTools[0])
                 if ((string)def["function"]["name"] == "ask_user") offered = true;
             Assert.True(offered);
+        }
+
+        [Fact]
+        public void Orchestrator_threads_position_and_total_for_a_batch_of_questions()
+        {
+            // One assistant turn emitting TWO ask_user calls -> the orchestrator should report them as
+            // "1 of 2" and "2 of 2" so the panel can show "Question X of Y".
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(new[]
+            {
+                Chunks.ToolChunk(0, "c1", "ask_user", TwoOptionArgs(), null),
+                Chunks.ToolChunk(1, "c2", "ask_user", TwoOptionArgs(), "tool_calls")
+            });
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var stub = new StubPrompt(Pick("A"));
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.AskUser = new AskUserTool(stub);
+
+            orch.RunTurn(new List<ChatMessage>(), "ask me two things", new RecordingUi());
+
+            Assert.Equal(2, stub.Requests.Count);
+            Assert.Equal(1, stub.Requests[0].Position);
+            Assert.Equal(2, stub.Requests[0].Total);
+            Assert.Equal(2, stub.Requests[1].Position);
+            Assert.Equal(2, stub.Requests[1].Total);
+        }
+
+        [Fact]
+        public void Single_question_reports_total_of_one()
+        {
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "ask_user", TwoOptionArgs()));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var stub = new StubPrompt(Pick("A"));
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.AskUser = new AskUserTool(stub);
+
+            orch.RunTurn(new List<ChatMessage>(), "ask me one thing", new RecordingUi());
+
+            Assert.Single(stub.Requests);
+            Assert.Equal(1, stub.Requests[0].Position);
+            Assert.Equal(1, stub.Requests[0].Total);
         }
     }
 }

--- a/GxPT.Tests/Mcp/AskUserToolTests.cs
+++ b/GxPT.Tests/Mcp/AskUserToolTests.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class AskUserToolTests
+    {
+        // A scripted IQuestionPrompt: records the request it was shown and returns a canned answer.
+        private sealed class StubPrompt : IQuestionPrompt
+        {
+            public QuestionRequest LastRequest;
+            public readonly QuestionAnswer Next;
+            public StubPrompt(QuestionAnswer next) { Next = next; }
+            public QuestionAnswer Ask(QuestionRequest request) { LastRequest = request; return Next; }
+        }
+
+        private sealed class DenyAllPolicy : IToolApprovalPolicy
+        {
+            public ApprovalDecision Check(string functionName, JObject args) { return ApprovalDecision.Deny; }
+        }
+
+        private static QuestionAnswer Pick(params string[] labels)
+        {
+            return new QuestionAnswer { Selected = new List<string>(labels) };
+        }
+
+        private static string TwoOptionArgs()
+        {
+            return "{\"question\":\"Pick one\",\"options\":[{\"label\":\"A\"},{\"label\":\"B\"}]}";
+        }
+
+        // ---- definition ----
+
+        [Fact]
+        public void Def_has_name_and_required_fields()
+        {
+            var tool = new AskUserTool(new StubPrompt(Pick("A")));
+            JObject def = tool.AskUserDef();
+
+            Assert.Equal("function", (string)def["type"]);
+            JObject fn = (JObject)def["function"];
+            Assert.Equal("ask_user", (string)fn["name"]);
+
+            JObject schema = (JObject)fn["parameters"];
+            var required = new List<string>();
+            foreach (JToken t in (JArray)schema["required"]) required.Add((string)t);
+            Assert.Contains("question", required);
+            Assert.Contains("options", required);
+            Assert.Equal("boolean", (string)schema["properties"]["multi_select"]["type"]);
+            Assert.Equal("array", (string)schema["properties"]["options"]["type"]);
+        }
+
+        // ---- argument parsing / formatting ----
+
+        [Fact]
+        public void Single_select_preset_formats_as_selected_label()
+        {
+            var stub = new StubPrompt(Pick("B"));
+            var tool = new AskUserTool(stub);
+            bool isError;
+            string result = tool.Ask(TwoOptionArgs(), out isError);
+
+            Assert.False(isError);
+            Assert.Equal("Selected: B", result);
+            Assert.False(stub.LastRequest.MultiSelect);
+            Assert.Equal(2, stub.LastRequest.Options.Count);
+        }
+
+        [Fact]
+        public void Single_select_custom_text_is_marked()
+        {
+            var stub = new StubPrompt(new QuestionAnswer { Selected = new List<string>(), CustomText = "my own answer" });
+            var tool = new AskUserTool(stub);
+            bool isError;
+            string result = tool.Ask(TwoOptionArgs(), out isError);
+
+            Assert.False(isError);
+            Assert.Equal("Selected (custom): my own answer", result);
+        }
+
+        [Fact]
+        public void Multi_select_lists_picks_and_custom_line()
+        {
+            var ans = new QuestionAnswer { Selected = new List<string> { "A", "B" }, CustomText = "C" };
+            var stub = new StubPrompt(ans);
+            var tool = new AskUserTool(stub);
+            bool isError;
+            string result = tool.Ask(
+                "{\"question\":\"Pick any\",\"multi_select\":true,\"options\":[{\"label\":\"A\"},{\"label\":\"B\"}]}",
+                out isError);
+
+            Assert.False(isError);
+            Assert.True(stub.LastRequest.MultiSelect);
+            Assert.Equal("Selected:\n- A\n- B\n- (custom): C", result);
+        }
+
+        [Fact]
+        public void Options_are_capped_to_max()
+        {
+            var stub = new StubPrompt(Pick("o1"));
+            var tool = new AskUserTool(stub);
+            bool isError;
+            tool.Ask(
+                "{\"question\":\"Q\",\"options\":[{\"label\":\"o1\"},{\"label\":\"o2\"},{\"label\":\"o3\"},"
+                + "{\"label\":\"o4\"},{\"label\":\"o5\"},{\"label\":\"o6\"}]}",
+                out isError);
+
+            Assert.Equal(AskUserTool.MaxOptions, stub.LastRequest.Options.Count);
+            Assert.Equal("o4", stub.LastRequest.Options[3].Label);
+        }
+
+        [Fact]
+        public void Bare_string_options_and_descriptions_are_parsed()
+        {
+            var stub = new StubPrompt(Pick("plain"));
+            var tool = new AskUserTool(stub);
+            bool isError;
+            tool.Ask(
+                "{\"question\":\"Q\",\"options\":[\"plain\",{\"label\":\"rich\",\"description\":\"why\"}]}",
+                out isError);
+
+            Assert.Equal(2, stub.LastRequest.Options.Count);
+            Assert.Equal("plain", stub.LastRequest.Options[0].Label);
+            Assert.Null(stub.LastRequest.Options[0].Description);
+            Assert.Equal("rich", stub.LastRequest.Options[1].Label);
+            Assert.Equal("why", stub.LastRequest.Options[1].Description);
+        }
+
+        [Fact]
+        public void Dismissed_returns_sentinel_not_error()
+        {
+            var stub = new StubPrompt(QuestionAnswer.DismissedAnswer());
+            var tool = new AskUserTool(stub);
+            bool isError;
+            string result = tool.Ask(TwoOptionArgs(), out isError);
+
+            Assert.False(isError);
+            Assert.Equal(AskUserTool.DismissedResultText, result);
+        }
+
+        [Theory]
+        [InlineData("{\"options\":[{\"label\":\"A\"}]}")]            // no question
+        [InlineData("{\"question\":\"Q\"}")]                          // no options
+        [InlineData("{\"question\":\"Q\",\"options\":[]}")]          // empty options
+        [InlineData("not json at all")]                               // malformed
+        public void Invalid_arguments_set_error(string args)
+        {
+            // The prompt should never even be shown for invalid arguments.
+            var stub = new StubPrompt(Pick("A"));
+            var tool = new AskUserTool(stub);
+            bool isError;
+            string result = tool.Ask(args, out isError);
+
+            Assert.True(isError);
+            Assert.Equal(AskUserTool.InvalidArgsText, result);
+            Assert.Null(stub.LastRequest);
+        }
+
+        // ---- FormatAnswer guards (the panel enforces these in the UI; verify the logic directly) ----
+
+        [Fact]
+        public void Empty_custom_with_no_picks_is_dismissed()
+        {
+            var a = new QuestionAnswer { Selected = new List<string>(), CustomText = "" };
+            Assert.Equal(AskUserTool.DismissedResultText, AskUserTool.FormatAnswer(a, false));
+            Assert.Equal(AskUserTool.DismissedResultText, AskUserTool.FormatAnswer(a, true));
+        }
+
+        // ---- orchestrator integration ----
+
+        [Fact]
+        public void Orchestrator_dispatches_ask_user_locally_and_feeds_back_answer()
+        {
+            // A deny-all approval policy proves ask_user bypasses the approval gate (the user IS the
+            // one acting) and an empty registry proves it needs no MCP round-trip.
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "ask_user", TwoOptionArgs()));
+            streamer.Turns.Add(Chunks.Text("Going with A."));
+
+            var orch = new McpChatOrchestrator(streamer, reg, new DenyAllPolicy(), "test-model", null);
+            orch.AskUser = new AskUserTool(new StubPrompt(Pick("A")));
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            orch.RunTurn(history, "decide for me", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(new[] { "ask_user" }, ui.ToolCalls.ToArray());
+            Assert.Equal("Selected: A", ui.ToolResults[0]);   // not the deny sentinel
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Equal("Going with A.", ui.Text.ToString());
+
+            // The answer is recorded as a tool-role message so the model reasons with it / it replays.
+            ChatMessage toolMsg = history.Find(delegate(ChatMessage m) { return m.Role == "tool"; });
+            Assert.NotNull(toolMsg);
+            Assert.Equal("Selected: A", toolMsg.Content);
+
+            // ask_user was offered in the tools array on the first request.
+            bool offered = false;
+            foreach (JObject def in streamer.SeenTools[0])
+                if ((string)def["function"]["name"] == "ask_user") offered = true;
+            Assert.True(offered);
+        }
+    }
+}

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -16,7 +16,7 @@ namespace GxPT
     internal sealed class QuestionPanel : Panel
     {
         private readonly Label _header;            // the question (wraps)
-        private readonly Label _counter;           // "Question X of Y", pinned top-right (multi-question turns)
+        private readonly Label _counter;           // "Question X of Y", pinned bottom-left (multi-question turns)
         private readonly FlowLayoutPanel _options; // option rows (radios/checks + descriptions + Other)
         private readonly FlowLayoutPanel _buttons;  // Submit / Skip
         private readonly TextBox _otherText;
@@ -70,9 +70,9 @@ namespace GxPT
             // _header.Font (bold) is built per show in ShowQuestion from the live UI font, so it tracks
             // the user-chosen font size; all other controls inherit this.Font ambiently.
 
-            // "Question X of Y" indicator, overlaid on the panel's top-right corner (not docked), shown
-            // only when the model asked several questions this turn. Mirrors ToolApprovalPanel's Explain
-            // button placement (PositionCounter / reserved header padding).
+            // "Question X of Y" indicator, overlaid on the panel's bottom-left corner (not docked, on the
+            // button row), shown only when the model asked several questions this turn. Kept off the
+            // header row so it never steals width from the (wrapping) question text.
             _counter = new Label();
             _counter.AutoSize = true;
             _counter.Visible = false;
@@ -446,9 +446,9 @@ namespace GxPT
             }
         }
 
-        // Show/hide the top-right "Question X of Y" indicator (only when the model asked more than one
-        // question this turn) and reserve header space on the right so a long question doesn't draw under
-        // it. Mirrors ToolApprovalPanel.UpdateExplainButton.
+        // Show/hide the bottom-left "Question X of Y" indicator (only when the model asked more than one
+        // question this turn). Deliberately not on the header row, so it never reserves width from the
+        // wrapping question text.
         private void UpdateCounter(int position, int total)
         {
             if (_counter == null) return;
@@ -457,26 +457,20 @@ namespace GxPT
             if (show)
             {
                 _counter.Text = "Question " + position + " of " + total;
-                int reserve = _counter.PreferredSize.Width + 8;
-                _header.Padding = new Padding(0, 0, reserve, 0);
                 PositionCounter();
-                _counter.BringToFront(); // paint over the docked header it overlaps
-            }
-            else
-            {
-                _header.Padding = Padding.Empty;
+                _counter.BringToFront(); // paint over the docked button strip's empty left area
             }
         }
 
-        // Pin the counter to the panel's inner top-right corner, aligned with the header row. Re-run on
-        // resize. Positioning a hidden label is harmless (same rationale as PositionExplainButton).
+        // Pin the counter to the panel's inner bottom-left corner (on the button row). Re-run on resize.
+        // Positioning a hidden label is harmless.
         private void PositionCounter()
         {
             if (_counter == null) return;
-            int w = _counter.PreferredSize.Width;
-            int x = this.ClientSize.Width - this.Padding.Right - w;
-            int y = this.Padding.Top;
-            if (x < this.Padding.Left) x = this.Padding.Left;
+            int h = _counter.PreferredSize.Height;
+            int x = this.Padding.Left;
+            int y = this.ClientSize.Height - this.Padding.Bottom - h;
+            if (y < this.Padding.Top) y = this.Padding.Top;
             _counter.Location = new Point(x, y);
         }
 

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -23,6 +23,7 @@ namespace GxPT
         private readonly Button _submit;
         private readonly Button _skip;
         private Font _headerFont;          // bold header font, rebuilt per show from the live UI font
+        private Font _uiFont;              // panel-created UI font assigned to this.Font (NOT the inherited one)
 
         // Tracks the Other text box's empty state so multi-select can auto-(un)check on the
         // empty<->non-empty transition only (leaving manual toggles untouched), and a build guard so
@@ -219,6 +220,14 @@ namespace GxPT
             // Suppress the Other-row auto-select/toggle side effects while we (re)populate the panel.
             _building = true;
 
+            // Dispose the prior question's selector/description controls before clearing - Controls.Clear
+            // only detaches, it does not Dispose, so without this each shown question would leak its
+            // controls' window handles. The reused _otherText is a field (never in these lists), so it
+            // survives the clear and is re-added below.
+            for (int i = 0; i < _selectors.Count; i++)
+                if (_selectors[i] != null) { try { _selectors[i].Dispose(); } catch { } }
+            for (int i = 0; i < _descriptions.Count; i++)
+                if (_descriptions[i] != null) { try { _descriptions[i].Dispose(); } catch { } }
             _options.Controls.Clear();
             _selectors.Clear();
             _descriptions.Clear();
@@ -266,6 +275,16 @@ namespace GxPT
             this.SendToBack();
             SetPromptVisible(true);
             FocusFirstSelector();
+
+            // Reposition the counter once the docked layout has settled (the button strip's bounds are
+            // only final after layout). The early PositionCounter in UpdateCounter may have run against
+            // stale/zero button bounds; this deferred pass lands it on the button row. Guarded by
+            // visibility so a single-question panel does no work.
+            if (_counter != null && _counter.Visible)
+            {
+                try { BeginInvoke((MethodInvoker)delegate { try { PositionCounter(); } catch { } }); }
+                catch { }
+            }
         }
 
         // Build a selector for the current mode: a RadioButton (single-select; auto-grouped because all
@@ -538,8 +557,11 @@ namespace GxPT
                 }
                 int hScroll = (widest > avail) ? SystemInformation.HorizontalScrollBarHeight : 0;
 
+                // Raise the cap by the scrollbar's height when one is reserved, so content that was just
+                // under the cap doesn't get clamped below (content + scrollbar) and force a vertical
+                // scrollbar anyway - the whole point of reserving hScroll.
                 int optionsContent = _options.GetPreferredSize(new Size(avail, 0)).Height + 6 + hScroll;
-                int optionsH = Math.Max(MinOptionsHeight, Math.Min(MaxOptionsHeight, optionsContent));
+                int optionsH = Math.Max(MinOptionsHeight, Math.Min(MaxOptionsHeight + hScroll, optionsContent));
 
                 int buttonsH = _buttons.GetPreferredSize(new Size(avail, 0)).Height;
                 if (buttonsH < 28) buttonsH = 34;
@@ -575,9 +597,14 @@ namespace GxPT
                 double fs = AppSettings.GetDouble("font_size", 0);
                 if (fs <= 0) return;
                 float size = (float)Math.Max(6, Math.Min(48, fs));
-                if (this.Font == null || Math.Abs(this.Font.Size - size) > 0.01f)
-                    this.Font = new Font(this.Font != null ? this.Font.FontFamily : new Font("Tahoma", size).FontFamily,
-                                         size, this.Font != null ? this.Font.Style : FontStyle.Regular);
+                // Control.Font is never null (ambient default), so no null-guard needed here.
+                if (Math.Abs(this.Font.Size - size) <= 0.01f) return; // already the right size
+                Font created = new Font(this.Font.FontFamily, size, this.Font.Style);
+                this.Font = created;
+                // Dispose only a font WE created previously - never the first inherited/ambient font
+                // (_uiFont starts null, so the inherited one is left alone).
+                if (_uiFont != null) { try { _uiFont.Dispose(); } catch { } }
+                _uiFont = created;
             }
             catch { }
         }
@@ -597,6 +624,7 @@ namespace GxPT
                     catch { }
                 }
                 if (_headerFont != null) { try { _headerFont.Dispose(); } catch { } _headerFont = null; }
+                if (_uiFont != null) { try { _uiFont.Dispose(); } catch { } _uiFont = null; }
             }
             base.Dispose(disposing);
         }

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -21,7 +21,18 @@ namespace GxPT
         private readonly TextBox _otherText;
         private readonly Button _submit;
         private readonly Button _skip;
-        private readonly Font _descFont;   // shared by all description subtitles (created once)
+        private Font _headerFont;          // bold header font, rebuilt per show from the live UI font
+
+        // Tracks the Other text box's empty state so multi-select can auto-(un)check on the
+        // empty<->non-empty transition only (leaving manual toggles untouched), and a build guard so
+        // populating the panel doesn't fire the auto-select/toggle side effects.
+        private bool _otherWasEmpty = true;
+        private bool _building;
+
+        // Left indent (px) for content that should align under an option's TITLE text rather than its
+        // radio/checkbox glyph: the description subtitles and the Other text box. Approximates the glyph
+        // width plus the selector's left margin.
+        private const int LabelIndent = 18;
 
         // The option selectors in display order (RadioButton when single-select, CheckBox when multi);
         // Tag carries the option label. _otherSelector is the always-present free-text row's selector.
@@ -55,8 +66,8 @@ namespace GxPT
             _header.Dock = DockStyle.Top;
             _header.AutoSize = false;
             _header.Height = 20;
-            _header.Font = new Font(this.Font, FontStyle.Bold);
-            _descFont = new Font(this.Font.FontFamily, Math.Max(7f, this.Font.Size - 1f));
+            // _header.Font (bold) is built per show in ShowQuestion from the live UI font, so it tracks
+            // the user-chosen font size; all other controls inherit this.Font ambiently.
 
             _options = new FlowLayoutPanel();
             _options.Dock = DockStyle.Fill;
@@ -64,10 +75,13 @@ namespace GxPT
             _options.WrapContents = false;
             _options.AutoScroll = true;
 
+            // The Other text box is always enabled so the user can click/type in it directly: focusing it
+            // selects the Other option (single-select), and typing auto-checks it (multi-select). Aligned
+            // under the option title text (LabelIndent); width is set to the full panel in LayoutToContent.
             _otherText = new TextBox();
-            _otherText.Width = 240;
-            _otherText.Enabled = false; // enabled only while the Other row is selected
-            _otherText.TextChanged += delegate { UpdateSubmitEnabled(); };
+            _otherText.Margin = new Padding(LabelIndent, 2, 8, 4);
+            _otherText.TextChanged += OnOtherTextChanged;
+            _otherText.Enter += OnOtherTextEnter;
 
             _buttons = new FlowLayoutPanel();
             _buttons.Dock = DockStyle.Bottom;
@@ -184,6 +198,17 @@ namespace GxPT
             _onAnswer = answerCallback;
             _multi = req != null && req.MultiSelect;
 
+            // Adopt the user-chosen font size before building, so every control (which inherits this.Font
+            // ambiently) and the bold header below render at that size.
+            ApplyUserFont();
+            Font oldHeader = _headerFont;
+            _headerFont = new Font(this.Font, FontStyle.Bold);
+            _header.Font = _headerFont;
+            if (oldHeader != null) { try { oldHeader.Dispose(); } catch { } }
+
+            // Suppress the Other-row auto-select/toggle side effects while we (re)populate the panel.
+            _building = true;
+
             _options.Controls.Clear();
             _selectors.Clear();
             _descriptions.Clear();
@@ -215,10 +240,11 @@ namespace GxPT
             _otherSelector.Tag = null; // null Tag distinguishes the custom row from a preset option
             _selectors.Add(_otherSelector);
             _options.Controls.Add(_otherSelector);
-            _otherText.Enabled = false;
             _otherText.Text = string.Empty;
+            _otherWasEmpty = true;
             _options.Controls.Add(_otherText);
 
+            _building = false;
             UpdateSubmitEnabled();
             ApplyTheme();
             LayoutToContent();
@@ -259,8 +285,8 @@ namespace GxPT
             Label d = new Label();
             d.Text = text;
             d.AutoSize = true;
-            d.Margin = new Padding(22, 0, 2, 4); // indented under the selector
-            d.Font = _descFont;
+            d.Margin = new Padding(LabelIndent, 0, 2, 4); // aligned under the option title text
+            // No explicit Font: inherits this.Font (the user-chosen size); distinguished by a muted color.
             return d;
         }
 
@@ -272,16 +298,54 @@ namespace GxPT
             return cb != null && cb.Checked;
         }
 
+        private void SetChecked(ButtonBase b, bool value)
+        {
+            RadioButton rb = b as RadioButton;
+            if (rb != null) { rb.Checked = value; return; }
+            CheckBox cb = b as CheckBox;
+            if (cb != null) cb.Checked = value;
+        }
+
         private void OnSelectionChanged(object sender, EventArgs e)
         {
-            // Enable the Other text box only while its row is selected; clear it when deselected so a
-            // stale custom answer can't ride along.
-            if (_otherSelector != null)
+            if (_building) return;
+            // When the Other row becomes selected, focus its text box so the user can type immediately.
+            // The text box stays enabled regardless, so typing/clicking it can also drive the selection
+            // (see OnOtherTextEnter / OnOtherTextChanged); we never clear the text on deselect, so a
+            // manual toggle off and back on keeps what they typed.
+            if (_otherSelector != null && ReferenceEquals(sender, _otherSelector) && IsChecked(_otherSelector))
             {
-                bool otherOn = IsChecked(_otherSelector);
-                _otherText.Enabled = otherOn;
-                if (otherOn) { try { _otherText.Focus(); } catch { } }
+                try { _otherText.Focus(); }
+                catch { }
             }
+            UpdateSubmitEnabled();
+        }
+
+        // Single-select: focusing (clicking or tabbing into) the Other text box selects the Other radio,
+        // so the user doesn't have to click the radio separately. Multi-select intentionally does NOT
+        // check on focus alone - only typing does (OnOtherTextChanged) - so the user can leave it unchecked.
+        private void OnOtherTextEnter(object sender, EventArgs e)
+        {
+            if (_building) return;
+            if (!_multi && _otherSelector != null && !IsChecked(_otherSelector))
+                SetChecked(_otherSelector, true);
+        }
+
+        // Multi-select: typing the first character auto-checks the Other box and deleting the last
+        // character auto-unchecks it (the empty<->non-empty transition only), while a manual toggle with
+        // text present is preserved. Single-select tracks emptiness for Submit validation only.
+        private void OnOtherTextChanged(object sender, EventArgs e)
+        {
+            if (_building) { UpdateSubmitEnabled(); return; }
+            bool nowEmpty = string.IsNullOrEmpty(_otherText.Text);
+            if (_multi && _otherSelector != null)
+            {
+                if (_otherWasEmpty && !nowEmpty && !IsChecked(_otherSelector))
+                    SetChecked(_otherSelector, true);
+                else if (!_otherWasEmpty && nowEmpty && IsChecked(_otherSelector))
+                    SetChecked(_otherSelector, false);
+            }
+            _otherWasEmpty = nowEmpty;
             UpdateSubmitEnabled();
         }
 
@@ -402,7 +466,17 @@ namespace GxPT
                     new Size(avail, int.MaxValue), TextFormatFlags.WordBreak);
                 _header.Height = Math.Max(20, hsz.Height + 4);
                 foreach (Label d in _descriptions)
-                    d.MaximumSize = new Size(Math.Max(80, avail - 24), 0);
+                    d.MaximumSize = new Size(Math.Max(80, avail - LabelIndent - 8), 0);
+
+                // The Other text box spans the full content width (minus its indent + a right gap), using
+                // the options area's client width when available so a vertical scrollbar is accounted for.
+                if (_otherText != null)
+                {
+                    int baseW = _options.ClientSize.Width > 10 ? _options.ClientSize.Width : avail;
+                    int otherW = baseW - LabelIndent - 8;
+                    if (otherW < 80) otherW = 80;
+                    if (_otherText.Width != otherW) _otherText.Width = otherW;
+                }
 
                 int optionsContent = _options.GetPreferredSize(new Size(avail, 0)).Height + 6;
                 int optionsH = Math.Max(MinOptionsHeight, Math.Min(MaxOptionsHeight, optionsContent));
@@ -429,6 +503,24 @@ namespace GxPT
             if (this.Visible) LayoutToContent();
         }
 
+        // Set this.Font to the user-chosen UI font size (settings.json font_size), the same clamp the
+        // rest of the UI uses (ThemeManager). Child controls without their own Font inherit it ambiently,
+        // so the whole panel renders at that size. No-op when the setting is unset (keeps the inherited
+        // page font).
+        private void ApplyUserFont()
+        {
+            try
+            {
+                double fs = AppSettings.GetDouble("font_size", 0);
+                if (fs <= 0) return;
+                float size = (float)Math.Max(6, Math.Min(48, fs));
+                if (this.Font == null || Math.Abs(this.Font.Size - size) > 0.01f)
+                    this.Font = new Font(this.Font != null ? this.Font.FontFamily : new Font("Tahoma", size).FontFamily,
+                                         size, this.Font != null ? this.Font.Style : FontStyle.Regular);
+            }
+            catch { }
+        }
+
         // If the panel is torn down (e.g. its tab is closed) while a question still awaits an answer,
         // resolve it as dismissed so the blocked tool-loop worker is released rather than left waiting
         // on the signal forever. Mirrors ToolApprovalPanel.Dispose.
@@ -443,6 +535,7 @@ namespace GxPT
                     try { cb(QuestionAnswer.DismissedAnswer()); }
                     catch { }
                 }
+                if (_headerFont != null) { try { _headerFont.Dispose(); } catch { } _headerFont = null; }
             }
             base.Dispose(disposing);
         }

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -16,6 +16,7 @@ namespace GxPT
     internal sealed class QuestionPanel : Panel
     {
         private readonly Label _header;            // the question (wraps)
+        private readonly Label _counter;           // "Question X of Y", pinned top-right (multi-question turns)
         private readonly FlowLayoutPanel _options; // option rows (radios/checks + descriptions + Other)
         private readonly FlowLayoutPanel _buttons;  // Submit / Skip
         private readonly TextBox _otherText;
@@ -69,6 +70,13 @@ namespace GxPT
             // _header.Font (bold) is built per show in ShowQuestion from the live UI font, so it tracks
             // the user-chosen font size; all other controls inherit this.Font ambiently.
 
+            // "Question X of Y" indicator, overlaid on the panel's top-right corner (not docked), shown
+            // only when the model asked several questions this turn. Mirrors ToolApprovalPanel's Explain
+            // button placement (PositionCounter / reserved header padding).
+            _counter = new Label();
+            _counter.AutoSize = true;
+            _counter.Visible = false;
+
             _options = new FlowLayoutPanel();
             _options.Dock = DockStyle.Fill;
             _options.FlowDirection = FlowDirection.TopDown;
@@ -112,6 +120,7 @@ namespace GxPT
             this.Controls.Add(_options);
             this.Controls.Add(_header);
             this.Controls.Add(_buttons);
+            this.Controls.Add(_counter); // overlay; brought to front when shown
 
             ApplyTheme();
         }
@@ -140,6 +149,7 @@ namespace GxPT
                 this.BackColor = tc.AssistantBubbleBack;
                 this.ForeColor = tc.UiForeground;
                 if (_header != null) { _header.BackColor = tc.AssistantBubbleBack; _header.ForeColor = tc.UiForeground; }
+                if (_counter != null) { _counter.BackColor = tc.AssistantBubbleBack; _counter.ForeColor = MutedFore(tc, dark); }
                 if (_options != null) _options.BackColor = tc.AssistantBubbleBack;
                 if (_buttons != null) _buttons.BackColor = tc.AssistantBubbleBack;
 
@@ -215,6 +225,7 @@ namespace GxPT
             _otherSelector = null;
 
             _header.Text = req != null ? req.Question : string.Empty;
+            UpdateCounter(req != null ? req.Position : 1, req != null ? req.Total : 1);
 
             if (req != null && req.Options != null)
             {
@@ -435,6 +446,40 @@ namespace GxPT
             }
         }
 
+        // Show/hide the top-right "Question X of Y" indicator (only when the model asked more than one
+        // question this turn) and reserve header space on the right so a long question doesn't draw under
+        // it. Mirrors ToolApprovalPanel.UpdateExplainButton.
+        private void UpdateCounter(int position, int total)
+        {
+            if (_counter == null) return;
+            bool show = total > 1 && position >= 1;
+            _counter.Visible = show;
+            if (show)
+            {
+                _counter.Text = "Question " + position + " of " + total;
+                int reserve = _counter.PreferredSize.Width + 8;
+                _header.Padding = new Padding(0, 0, reserve, 0);
+                PositionCounter();
+                _counter.BringToFront(); // paint over the docked header it overlaps
+            }
+            else
+            {
+                _header.Padding = Padding.Empty;
+            }
+        }
+
+        // Pin the counter to the panel's inner top-right corner, aligned with the header row. Re-run on
+        // resize. Positioning a hidden label is harmless (same rationale as PositionExplainButton).
+        private void PositionCounter()
+        {
+            if (_counter == null) return;
+            int w = _counter.PreferredSize.Width;
+            int x = this.ClientSize.Width - this.Padding.Right - w;
+            int y = this.Padding.Top;
+            if (x < this.Padding.Left) x = this.Padding.Left;
+            _counter.Location = new Point(x, y);
+        }
+
         private void SetPromptVisible(bool v)
         {
             if (_promptVisible == v) return;
@@ -478,7 +523,23 @@ namespace GxPT
                     if (_otherText.Width != otherW) _otherText.Width = otherW;
                 }
 
-                int optionsContent = _options.GetPreferredSize(new Size(avail, 0)).Height + 6;
+                // If any option is wider than the content area, the options panel shows a horizontal
+                // scrollbar. Reserve its height so the scrollbar doesn't eat into the content area and
+                // force a (redundant) vertical scrollbar too - grow the panel instead. Compared against
+                // the no-scrollbar content width (avail); descriptions wrap (MaximumSize) and the Other
+                // box is sized to fit, so only a long single-line option can overflow.
+                // Measure regardless of Control.Visible: this runs from ShowQuestion while the panel is
+                // still hidden (so children report Visible==false), and PreferredSize is valid anyway.
+                int widest = 0;
+                foreach (Control c in _options.Controls)
+                {
+                    if (c == null) continue;
+                    int w = c.PreferredSize.Width + c.Margin.Horizontal;
+                    if (w > widest) widest = w;
+                }
+                int hScroll = (widest > avail) ? SystemInformation.HorizontalScrollBarHeight : 0;
+
+                int optionsContent = _options.GetPreferredSize(new Size(avail, 0)).Height + 6 + hScroll;
                 int optionsH = Math.Max(MinOptionsHeight, Math.Min(MaxOptionsHeight, optionsContent));
 
                 int buttonsH = _buttons.GetPreferredSize(new Size(avail, 0)).Height;
@@ -501,6 +562,7 @@ namespace GxPT
         {
             base.OnSizeChanged(e);
             if (this.Visible) LayoutToContent();
+            PositionCounter(); // keep the counter anchored to the (now moved) right edge
         }
 
         // Set this.Font to the user-chosen UI font size (settings.json font_size), the same clamp the

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -1,0 +1,450 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // A native panel docked at the bottom of the chat area that puts a multiple-choice question from
+    // the model to the user (the ask_user host tool). Single-select renders radio buttons, multi-select
+    // renders checkboxes; a free-text "Other" row is always offered. The user confirms with Submit (so
+    // selection and confirmation are always distinct steps) or declines with Skip.
+    //
+    // Threading: the tool-loop worker calls IQuestionPrompt.Ask (blocking) via TranscriptQuestionPrompt,
+    // which marshals ShowQuestion onto the UI thread; Submit/Skip signals the chosen answer back. Mirrors
+    // ToolApprovalPanel's worker<->UI handoff (including the disposed/recycled-tab release in DenyPending).
+    internal sealed class QuestionPanel : Panel
+    {
+        private readonly Label _header;            // the question (wraps)
+        private readonly FlowLayoutPanel _options; // option rows (radios/checks + descriptions + Other)
+        private readonly FlowLayoutPanel _buttons;  // Submit / Skip
+        private readonly TextBox _otherText;
+        private readonly Button _submit;
+        private readonly Button _skip;
+        private readonly Font _descFont;   // shared by all description subtitles (created once)
+
+        // The option selectors in display order (RadioButton when single-select, CheckBox when multi);
+        // Tag carries the option label. _otherSelector is the always-present free-text row's selector.
+        private readonly List<ButtonBase> _selectors = new List<ButtonBase>();
+        private readonly List<Label> _descriptions = new List<Label>(); // width-managed on resize
+        private ButtonBase _otherSelector;
+
+        private Action<QuestionAnswer> _onAnswer;
+        private bool _multi;
+        private bool _inLayout;
+
+        // Mirrors ToolApprovalPanel: pause the status marquee / swap the Stop button for "awaiting
+        // user..." while a question is up. IsPromptVisible is the current state.
+        public event EventHandler PromptVisibleChanged;
+        private bool _promptVisible;
+        public bool IsPromptVisible { get { return _promptVisible; } }
+
+        private const int MinOptionsHeight = 48;
+        private const int MaxOptionsHeight = 260;
+
+        public QuestionPanel()
+        {
+            this.Dock = DockStyle.Bottom;
+            this.Visible = false;
+            this.AutoSize = false;
+            this.Height = 160;
+            this.Padding = new Padding(8);
+            this.BorderStyle = BorderStyle.FixedSingle;
+
+            _header = new Label();
+            _header.Dock = DockStyle.Top;
+            _header.AutoSize = false;
+            _header.Height = 20;
+            _header.Font = new Font(this.Font, FontStyle.Bold);
+            _descFont = new Font(this.Font.FontFamily, Math.Max(7f, this.Font.Size - 1f));
+
+            _options = new FlowLayoutPanel();
+            _options.Dock = DockStyle.Fill;
+            _options.FlowDirection = FlowDirection.TopDown;
+            _options.WrapContents = false;
+            _options.AutoScroll = true;
+
+            _otherText = new TextBox();
+            _otherText.Width = 240;
+            _otherText.Enabled = false; // enabled only while the Other row is selected
+            _otherText.TextChanged += delegate { UpdateSubmitEnabled(); };
+
+            _buttons = new FlowLayoutPanel();
+            _buttons.Dock = DockStyle.Bottom;
+            _buttons.FlowDirection = FlowDirection.RightToLeft; // Submit rightmost, Skip to its left
+            _buttons.WrapContents = true;
+            _buttons.AutoScroll = false;
+            _buttons.AutoSize = true;
+            _buttons.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _buttons.MinimumSize = new Size(0, 34);
+
+            _submit = new Button();
+            _submit.Text = "Submit";
+            _submit.AutoSize = true;
+            _submit.Margin = new Padding(4);
+            _submit.Click += OnSubmitClicked;
+
+            _skip = new Button();
+            _skip.Text = "Skip";
+            _skip.AutoSize = true;
+            _skip.Margin = new Padding(4);
+            _skip.Click += OnSkipClicked;
+
+            _buttons.Controls.Add(_submit);
+            _buttons.Controls.Add(_skip);
+
+            // Fill added before docked siblings (WinForms lays out docked controls by reverse z-order),
+            // matching ToolApprovalPanel's ordering so the options fill the area between header and buttons.
+            this.Controls.Add(_options);
+            this.Controls.Add(_header);
+            this.Controls.Add(_buttons);
+
+            ApplyTheme();
+        }
+
+        // True when the active theme is dark (same probe as ToolApprovalPanel).
+        private static bool IsDark()
+        {
+            try
+            {
+                string th = AppSettings.GetString("theme");
+                return !string.IsNullOrEmpty(th) && th.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        // Re-color the panel and its children for the active theme, using the same palette as the
+        // approval panel so the question prompt isn't stark white in dark mode. Safe to call repeatedly;
+        // the host calls it again on a live light<->dark switch.
+        public void ApplyTheme()
+        {
+            try
+            {
+                bool dark = IsDark();
+                ThemeColors tc = ThemeService.GetColors(dark);
+
+                this.BackColor = tc.AssistantBubbleBack;
+                this.ForeColor = tc.UiForeground;
+                if (_header != null) { _header.BackColor = tc.AssistantBubbleBack; _header.ForeColor = tc.UiForeground; }
+                if (_options != null) _options.BackColor = tc.AssistantBubbleBack;
+                if (_buttons != null) _buttons.BackColor = tc.AssistantBubbleBack;
+
+                foreach (ButtonBase b in _selectors)
+                {
+                    b.BackColor = tc.AssistantBubbleBack;
+                    b.ForeColor = tc.UiForeground;
+                }
+                // Description labels are dimmer than the option text (a subtitle), so derive a muted tone.
+                foreach (Label d in _descriptions)
+                {
+                    d.BackColor = tc.AssistantBubbleBack;
+                    d.ForeColor = MutedFore(tc, dark);
+                }
+                if (_otherText != null)
+                {
+                    _otherText.BackColor = tc.CodeBack;
+                    _otherText.ForeColor = tc.UiForeground;
+                }
+                if (_submit != null) ApplyButtonTheme(_submit, dark, tc);
+                if (_skip != null) ApplyButtonTheme(_skip, dark, tc);
+
+                Invalidate(true);
+            }
+            catch { }
+        }
+
+        private static Color MutedFore(ThemeColors tc, bool dark)
+        {
+            Color f = tc.UiForeground;
+            // Blend halfway toward the panel background for a subtitle look.
+            Color b = tc.AssistantBubbleBack;
+            return Color.FromArgb((f.R + b.R) / 2, (f.G + b.G) / 2, (f.B + b.B) / 2);
+        }
+
+        // Flat, theme-tinted buttons (a visual-styles button ignores BackColor), matching ToolApprovalPanel.
+        private static void ApplyButtonTheme(Button b, bool dark, ThemeColors tc)
+        {
+            b.FlatStyle = FlatStyle.Flat;
+            b.UseVisualStyleBackColor = false;
+            b.BackColor = tc.CodeBack;
+            b.ForeColor = tc.UiForeground;
+            try
+            {
+                b.FlatAppearance.BorderColor = tc.AssistantBubbleBorder;
+                b.FlatAppearance.MouseOverBackColor = tc.CopyHover;
+                b.FlatAppearance.MouseDownBackColor = tc.CopyPressed;
+            }
+            catch { }
+        }
+
+        // Populate + show for one question. answerCallback is invoked (on the UI thread) with the user's
+        // answer when they Submit, or a dismissed answer on Skip / teardown.
+        public void ShowQuestion(QuestionRequest req, Action<QuestionAnswer> answerCallback)
+        {
+            _onAnswer = answerCallback;
+            _multi = req != null && req.MultiSelect;
+
+            _options.Controls.Clear();
+            _selectors.Clear();
+            _descriptions.Clear();
+            _otherSelector = null;
+
+            _header.Text = req != null ? req.Question : string.Empty;
+
+            if (req != null && req.Options != null)
+            {
+                for (int i = 0; i < req.Options.Count; i++)
+                {
+                    QuestionOption opt = req.Options[i];
+                    if (opt == null || string.IsNullOrEmpty(opt.Label)) continue;
+                    ButtonBase sel = MakeSelector(opt.Label);
+                    sel.Tag = opt.Label;
+                    _selectors.Add(sel);
+                    _options.Controls.Add(sel);
+                    if (!string.IsNullOrEmpty(opt.Description))
+                    {
+                        Label d = MakeDescription(opt.Description);
+                        _descriptions.Add(d);
+                        _options.Controls.Add(d);
+                    }
+                }
+            }
+
+            // The always-present free-text "Other" row: selector + an inline text box.
+            _otherSelector = MakeSelector("Other:");
+            _otherSelector.Tag = null; // null Tag distinguishes the custom row from a preset option
+            _selectors.Add(_otherSelector);
+            _options.Controls.Add(_otherSelector);
+            _otherText.Enabled = false;
+            _otherText.Text = string.Empty;
+            _options.Controls.Add(_otherText);
+
+            UpdateSubmitEnabled();
+            ApplyTheme();
+            LayoutToContent();
+
+            this.Visible = true;
+            // Keep this Bottom-docked panel BEHIND the Fill transcript (same z-order rule as the approval
+            // panel) so the transcript shrinks above it rather than the panel overlaying it.
+            this.SendToBack();
+            SetPromptVisible(true);
+            FocusFirstSelector();
+        }
+
+        // Build a selector for the current mode: a RadioButton (single-select; auto-grouped because all
+        // selectors share _options as their immediate parent) or a CheckBox (multi-select).
+        private ButtonBase MakeSelector(string text)
+        {
+            ButtonBase b;
+            if (_multi)
+            {
+                CheckBox cb = new CheckBox();
+                cb.CheckedChanged += OnSelectionChanged;
+                b = cb;
+            }
+            else
+            {
+                RadioButton rb = new RadioButton();
+                rb.CheckedChanged += OnSelectionChanged;
+                b = rb;
+            }
+            b.Text = text;
+            b.AutoSize = true;
+            b.Margin = new Padding(2, 2, 2, 0);
+            return b;
+        }
+
+        private Label MakeDescription(string text)
+        {
+            Label d = new Label();
+            d.Text = text;
+            d.AutoSize = true;
+            d.Margin = new Padding(22, 0, 2, 4); // indented under the selector
+            d.Font = _descFont;
+            return d;
+        }
+
+        private bool IsChecked(ButtonBase b)
+        {
+            RadioButton rb = b as RadioButton;
+            if (rb != null) return rb.Checked;
+            CheckBox cb = b as CheckBox;
+            return cb != null && cb.Checked;
+        }
+
+        private void OnSelectionChanged(object sender, EventArgs e)
+        {
+            // Enable the Other text box only while its row is selected; clear it when deselected so a
+            // stale custom answer can't ride along.
+            if (_otherSelector != null)
+            {
+                bool otherOn = IsChecked(_otherSelector);
+                _otherText.Enabled = otherOn;
+                if (otherOn) { try { _otherText.Focus(); } catch { } }
+            }
+            UpdateSubmitEnabled();
+        }
+
+        // Submit is valid when the answer is well-formed: single-select needs exactly one selection (and
+        // non-empty text if it's Other); multi-select needs at least one preset checked, or Other checked
+        // with non-empty text. This is the guard that stops an empty "custom" answer reaching the model.
+        private void UpdateSubmitEnabled()
+        {
+            bool otherOn = _otherSelector != null && IsChecked(_otherSelector);
+            bool otherHasText = otherOn && _otherText.Text != null && _otherText.Text.Trim().Length > 0;
+            int presetChecked = 0;
+            for (int i = 0; i < _selectors.Count; i++)
+                if (!ReferenceEquals(_selectors[i], _otherSelector) && IsChecked(_selectors[i]))
+                    presetChecked++;
+
+            bool valid;
+            if (!_multi)
+                valid = otherOn ? otherHasText : (presetChecked == 1);
+            else
+                valid = (presetChecked > 0) || otherHasText;
+
+            _submit.Enabled = valid;
+        }
+
+        private void OnSubmitClicked(object sender, EventArgs e)
+        {
+            QuestionAnswer ans = new QuestionAnswer();
+            ans.Selected = new List<string>();
+            for (int i = 0; i < _selectors.Count; i++)
+            {
+                ButtonBase b = _selectors[i];
+                if (ReferenceEquals(b, _otherSelector)) continue;
+                if (IsChecked(b) && b.Tag is string) ans.Selected.Add((string)b.Tag);
+            }
+            if (_otherSelector != null && IsChecked(_otherSelector))
+            {
+                string t = _otherText.Text != null ? _otherText.Text.Trim() : string.Empty;
+                if (t.Length > 0) ans.CustomText = t; // empty custom is dropped (UpdateSubmitEnabled guards it)
+            }
+
+            Action<QuestionAnswer> cb = _onAnswer;
+            HidePanel();
+            if (cb != null) cb(ans);
+        }
+
+        private void OnSkipClicked(object sender, EventArgs e)
+        {
+            Action<QuestionAnswer> cb = _onAnswer;
+            HidePanel();
+            if (cb != null) cb(QuestionAnswer.DismissedAnswer());
+        }
+
+        public void HidePanel()
+        {
+            this.Visible = false;
+            _onAnswer = null;
+            SetPromptVisible(false);
+        }
+
+        // Resolve any pending question as dismissed, then hide. Used when the prompting turn detaches
+        // from this panel's tab (closed or recycled mid-prompt): the worker blocked in
+        // TranscriptQuestionPrompt must be released - HidePanel alone clears the callback WITHOUT
+        // invoking it, stranding that turn forever. Mirrors ToolApprovalPanel.DenyPending.
+        public void DenyPending()
+        {
+            Action<QuestionAnswer> cb = _onAnswer;
+            HidePanel();
+            if (cb != null) cb(QuestionAnswer.DismissedAnswer());
+        }
+
+        private void FocusFirstSelector()
+        {
+            ButtonBase first = _selectors.Count > 0 ? _selectors[0] : null;
+            if (first == null) return;
+            try
+            {
+                BeginInvoke((MethodInvoker)delegate
+                {
+                    try { if (first.IsHandleCreated && first.Visible) first.Focus(); }
+                    catch { }
+                });
+            }
+            catch
+            {
+                try { first.Focus(); }
+                catch { }
+            }
+        }
+
+        private void SetPromptVisible(bool v)
+        {
+            if (_promptVisible == v) return;
+            _promptVisible = v;
+            EventHandler h = PromptVisibleChanged;
+            if (h != null)
+            {
+                try { h(this, EventArgs.Empty); }
+                catch { }
+            }
+        }
+
+        // Rebuild the panel height so the options area fits its content between bounds (short questions
+        // collapse; long option lists cap and scroll), plus the wrapped header and the button strip.
+        // Capped so it can't bury the transcript above it. Recomputed on resize because both the header
+        // wrap and the description-label wrap depend on the current width.
+        private void LayoutToContent()
+        {
+            if (_inLayout) return;
+            _inLayout = true;
+            try
+            {
+                int avail = this.ClientSize.Width - this.Padding.Horizontal;
+                if (avail < 1) avail = (this.Parent != null ? this.Parent.ClientSize.Width : 400) - this.Padding.Horizontal;
+                if (avail < 1) avail = 400;
+
+                // Wrap the question text and the description subtitles at the live width.
+                Size hsz = TextRenderer.MeasureText(_header.Text ?? string.Empty, _header.Font,
+                    new Size(avail, int.MaxValue), TextFormatFlags.WordBreak);
+                _header.Height = Math.Max(20, hsz.Height + 4);
+                foreach (Label d in _descriptions)
+                    d.MaximumSize = new Size(Math.Max(80, avail - 24), 0);
+
+                int optionsContent = _options.GetPreferredSize(new Size(avail, 0)).Height + 6;
+                int optionsH = Math.Max(MinOptionsHeight, Math.Min(MaxOptionsHeight, optionsContent));
+
+                int buttonsH = _buttons.GetPreferredSize(new Size(avail, 0)).Height;
+                if (buttonsH < 28) buttonsH = 34;
+
+                const int border = 2; // FixedSingle: 1px top + 1px bottom
+                int target = this.Padding.Top + this.Padding.Bottom + _header.Height + optionsH + buttonsH + border;
+
+                if (this.Parent != null)
+                {
+                    int cap = this.Parent.ClientSize.Height - 64;
+                    if (cap > 120 && target > cap) target = cap;
+                }
+                if (this.Height != target) this.Height = target;
+            }
+            finally { _inLayout = false; }
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (this.Visible) LayoutToContent();
+        }
+
+        // If the panel is torn down (e.g. its tab is closed) while a question still awaits an answer,
+        // resolve it as dismissed so the blocked tool-loop worker is released rather than left waiting
+        // on the signal forever. Mirrors ToolApprovalPanel.Dispose.
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Action<QuestionAnswer> cb = _onAnswer;
+                _onAnswer = null;
+                if (cb != null)
+                {
+                    try { cb(QuestionAnswer.DismissedAnswer()); }
+                    catch { }
+                }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/GxPT/Controls/QuestionPanel.cs
+++ b/GxPT/Controls/QuestionPanel.cs
@@ -462,14 +462,19 @@ namespace GxPT
             }
         }
 
-        // Pin the counter to the panel's inner bottom-left corner (on the button row). Re-run on resize.
-        // Positioning a hidden label is harmless.
+        // Pin the counter to the panel's lower-left, vertically centered on the button strip so it lines
+        // up with Submit/Skip. Falls back to bottom-aligned if the strip isn't laid out yet. Re-run on
+        // resize; positioning a hidden label is harmless.
         private void PositionCounter()
         {
             if (_counter == null) return;
             int h = _counter.PreferredSize.Height;
             int x = this.Padding.Left;
-            int y = this.ClientSize.Height - this.Padding.Bottom - h;
+            int y;
+            if (_buttons != null && _buttons.Height > 0)
+                y = _buttons.Top + Math.Max(0, (_buttons.Height - h) / 2);
+            else
+                y = this.ClientSize.Height - this.Padding.Bottom - h;
             if (y < this.Padding.Top) y = this.Padding.Top;
             _counter.Location = new Point(x, y);
         }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4809,6 +4809,15 @@ namespace GxPT
 
             switch (name)
             {
+                case "ask_user":
+                {
+                    // "Asked" collapses to the question text (rendered as prose). The chosen answer isn't
+                    // shown here - like command__run, the record reflects the call (the question), not its
+                    // result. No question -> fall back to the generic marker.
+                    string q = Str(args, "question");
+                    if (q.Trim().Length == 0) return false;
+                    header = "Asked"; body = q; language = "markdown"; return true;
+                }
                 case "files__edit":
                 {
                     string path = Str(args, "path");

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -848,6 +848,7 @@ namespace GxPT
                 // Bottom approval panel. Add the docked siblings, then send the transcript to front.
                 ctx.Page.Controls.Add(strip);
                 AttachApprovalPanel(ctx);
+                AttachQuestionPanel(ctx);
                 AttachAgentActivityPanel(ctx);
                 if (ctx.Transcript != null) ctx.Transcript.BringToFront();
                 strip.SetWorkingDir(ctx.WorkingDir);
@@ -881,6 +882,22 @@ namespace GxPT
                 {
                     OpenCommandExplainTab(ctxRef, command, isPowerShell);
                 };
+                ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
+            }
+            catch { }
+        }
+
+        // Create this tab's ask_user question panel (docked at the bottom of its transcript area, hidden
+        // until the model asks a question). Per-tab like the approval panel, so a question appears on the
+        // conversation that asked it; while it's up, the status bar shows "awaiting user...".
+        internal void AttachQuestionPanel(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || ctx.Page == null) return;
+            try
+            {
+                var panel = new QuestionPanel();
+                ctx.QuestionPanel = panel;
+                panel.PromptVisibleChanged += delegate { SyncGenerationIndicatorFromActiveTab(); };
                 ctx.Page.Controls.Add(panel); // self-docks Bottom, starts hidden
             }
             catch { }
@@ -977,6 +994,8 @@ namespace GxPT
                     var ctx = kv.Value;
                     if (ctx != null && ctx.ApprovalPanel != null)
                         ctx.ApprovalPanel.ApplyTheme();
+                    if (ctx != null && ctx.QuestionPanel != null)
+                        ctx.QuestionPanel.ApplyTheme();
                 }
             }
             catch { }
@@ -1055,9 +1074,11 @@ namespace GxPT
             {
                 var act = _tabManager != null ? _tabManager.GetActiveContext() : null;
                 bool busy = act != null && act.IsSending && !act.SendDetached;
-                // The turn is paused at an approval/continuation gate when the active tab's prompt is
-                // up: pause the marquee and show "awaiting user..." in place of the Stop button.
-                bool awaiting = busy && act.ApprovalPanel != null && act.ApprovalPanel.IsPromptVisible;
+                // The turn is paused at an approval/continuation/question gate when the active tab's
+                // prompt is up: pause the marquee and show "awaiting user..." in place of the Stop button.
+                bool awaiting = busy
+                    && ((act.ApprovalPanel != null && act.ApprovalPanel.IsPromptVisible)
+                        || (act.QuestionPanel != null && act.QuestionPanel.IsPromptVisible));
                 // A dispatch_agent fan-out is running: keep the marquee going but show a passive
                 // "Sub-agents running..." label (cancel them from the panel). Approval takes priority.
                 bool agentsRunning = busy && act.AgentsFanOutActive && !awaiting;
@@ -1342,6 +1363,8 @@ namespace GxPT
             // released and the turn wraps up and saves. (Prompts the turn raises AFTER detaching are
             // auto-denied by the send path's panel gate.)
             try { if (ctx.ApprovalPanel != null) ctx.ApprovalPanel.DenyPending(); }
+            catch { }
+            try { if (ctx.QuestionPanel != null) ctx.QuestionPanel.DenyPending(); }
             catch { }
         }
 
@@ -3367,6 +3390,20 @@ namespace GxPT
                             return usable ? p : null;
                         });
                         orch.ContinuationDecider = delegate(int n) { return contPrompt.Ask(n); };
+                    }
+                    // ask_user: expose the question tool, routed to this tab's QuestionPanel. The panel
+                    // resolver uses the same recycled-tab guard as the approval prompt - it yields null
+                    // once the tab no longer hosts this turn's conversation (or the panel is gone), so a
+                    // detached turn's question resolves as dismissed instead of appearing on a blank tab.
+                    if (ctx.QuestionPanel != null)
+                    {
+                        orch.AskUser = new AskUserTool(new TranscriptQuestionPrompt(this, delegate
+                        {
+                            QuestionPanel qp = ctx.QuestionPanel;
+                            bool usable = ReferenceEquals(ctx.Conversation, convo)
+                                && qp != null && !qp.IsDisposed;
+                            return usable ? qp : null;
+                        }));
                     }
                     string modelForTransform = model; // capture for transform closure
                     bool zdrForTransform = zdr;       // capture ZDR for the transform closure

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -4816,7 +4816,7 @@ namespace GxPT
                     // result. No question -> fall back to the generic marker.
                     string q = Str(args, "question");
                     if (q.Trim().Length == 0) return false;
-                    header = "Asked"; body = q; language = "markdown"; return true;
+                    header = "Asked a question"; body = q; language = "markdown"; return true;
                 }
                 case "files__edit":
                 {

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -187,7 +187,13 @@
     <Compile Include="Services\Mcp\ApprovalStore.cs" />
     <Compile Include="Services\Mcp\TranscriptApprovalPrompt.cs" />
     <Compile Include="Services\Mcp\TranscriptContinuationPrompt.cs" />
+    <Compile Include="Services\Mcp\IQuestionPrompt.cs" />
+    <Compile Include="Services\Mcp\AskUserTool.cs" />
+    <Compile Include="Services\Mcp\TranscriptQuestionPrompt.cs" />
     <Compile Include="Controls\ToolApprovalPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Controls\QuestionPanel.cs">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Controls\AgentActivityPanel.cs">

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -66,6 +66,10 @@ namespace GxPT
             // The per-tab tool-approval panel docked at the bottom of this tab's transcript (set by
             // MainForm). A pending approval shows only on the conversation that requested it.
             public ToolApprovalPanel ApprovalPanel;
+            // The per-tab ask_user question panel docked at the bottom (set by MainForm). A pending
+            // question shows only on the conversation that asked it; released on teardown like the
+            // approval panel so a blocked turn isn't stranded.
+            public QuestionPanel QuestionPanel;
             // The per-tab sub-agents activity panel docked at the bottom (set by MainForm). Shown only
             // while a dispatch_agent fan-out runs on this tab's conversation.
             public AgentActivityPanel AgentActivityPanel;
@@ -503,6 +507,8 @@ namespace GxPT
                 // forever (it would never finalize or save). Resolve it as Deny/Stop first; the
                 // now-detached turn then wraps up on its own.
                 try { if (ctx != null && ctx.ApprovalPanel != null) ctx.ApprovalPanel.DenyPending(); }
+                catch { }
+                try { if (ctx != null && ctx.QuestionPanel != null) ctx.QuestionPanel.DenyPending(); }
                 catch { }
 
                 int desiredIndex = -1;

--- a/GxPT/Services/Mcp/AskUserTool.cs
+++ b/GxPT/Services/Mcp/AskUserTool.cs
@@ -107,18 +107,32 @@ namespace GxPT
             return def;
         }
 
+        // The 1-based position / total of the NEXT question among the ask_user calls the model issued
+        // this turn, set by the host just before dispatch and consumed by the next Ask. Kept here rather
+        // than threaded through the orchestrator's generic dispatch signature (which would carry these
+        // ask-specific values on every tool call). Defaults to a lone question (1 of 1).
+        private int _pendingPosition = 1;
+        private int _pendingTotal = 1;
+
+        // Locate the next question among the model's ask_user calls this turn (total > 1 drives the
+        // "Question X of Y" indicator). Set immediately before the matching Ask; consumed and reset there.
+        public void SetNextPosition(int position, int total)
+        {
+            _pendingPosition = position;
+            _pendingTotal = total;
+        }
+
         // Parse the call, show the question (blocking), and format the user's answer as the tool result.
         // isError is set for malformed arguments so the model can correct the call. A dismissed prompt
         // is NOT an error (the user deliberately declined) - it returns the dismissed sentinel.
         public string Ask(string argumentsJson, out bool isError)
         {
-            return Ask(argumentsJson, 1, 1, out isError);
-        }
+            // Consume the pending position atomically (reset to the single-question default) so a parse
+            // failure here, or a later call without SetNextPosition, cannot inherit stale values.
+            int position = _pendingPosition, total = _pendingTotal;
+            _pendingPosition = 1;
+            _pendingTotal = 1;
 
-        // position/total locate this question among the ask_user calls the model issued this turn
-        // (1-based; total > 1 drives the "Question X of Y" indicator). The orchestrator supplies them.
-        public string Ask(string argumentsJson, int position, int total, out bool isError)
-        {
             isError = false;
 
             string question;

--- a/GxPT/Services/Mcp/AskUserTool.cs
+++ b/GxPT/Services/Mcp/AskUserTool.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // The "ask the user" execution-surface meta-tool: ask_user. Host-synthesized and handled inside the
+    // orchestrator without an MCP round-trip - the question analogue of reveal_tools / open_skill /
+    // dispatch_agent. The model proposes a question and 2-4 options; the host shows a docked panel
+    // (radio buttons for single-select, checkboxes for multi-select), always offers a free-text "Other"
+    // choice, and feeds the user's answer back as the tool result so the model keeps reasoning with it
+    // in context. The Q&A persists in the transcript (assistant tool_call + tool result) like any tool.
+    //
+    // Threading: Ask runs on the tool-loop worker thread and blocks (via IQuestionPrompt) until the user
+    // submits - the turn pauses there, which is correct (the user is present), exactly as the approval
+    // gate does.
+    internal sealed class AskUserTool
+    {
+        public const string AskUserName = "ask_user";
+
+        // The most model-supplied options the panel renders; a 5th free-text "Other" row is always added
+        // by the UI on top of these. A model that sends more than this gets the first MaxOptions (a
+        // defensive cap, like AgentDispatcher.MaxAgentsPerCall) rather than an overflowing panel.
+        public const int MaxOptions = 4;
+
+        // Tool-result content when the user closes the question without choosing (or the tab was recycled
+        // away from this turn). A clear, model-readable sentinel so it stops and asks rather than guessing.
+        internal const string DismissedResultText = "[User dismissed the question without answering.]";
+
+        // Returned (as an isError result) when the model's arguments can't form a question - so it can
+        // correct the call rather than the host silently doing nothing.
+        internal const string InvalidArgsText =
+            "[ask_user error: provide a non-empty \"question\" and at least one option in \"options\".]";
+
+        private readonly IQuestionPrompt _prompt;
+
+        public AskUserTool(IQuestionPrompt prompt)
+        {
+            _prompt = prompt;
+        }
+
+        public bool IsAskUser(string functionName)
+        {
+            return functionName == AskUserName;
+        }
+
+        // The OpenAI-style function definition: ask_user({ question, options:[{label,description?}],
+        // multi_select? }). The description tells the model an "Other" free-text choice is always added
+        // for it, so it shouldn't include one, and steers toward genuine either/or decisions.
+        public JObject AskUserDef()
+        {
+            JObject labelP = new JObject(); labelP["type"] = "string";
+            JObject descP = new JObject(); descP["type"] = "string";
+            descP["description"] = "Optional short explanation of this option, shown under its label.";
+            JObject optionProps = new JObject();
+            optionProps["label"] = labelP;
+            optionProps["description"] = descP;
+            JObject optionSchema = new JObject();
+            optionSchema["type"] = "object";
+            optionSchema["properties"] = optionProps;
+            optionSchema["required"] = new JArray("label");
+
+            JObject optionsArr = new JObject();
+            optionsArr["type"] = "array";
+            optionsArr["items"] = optionSchema;
+            optionsArr["description"] = "Two to four options to offer. Do not add an \"Other\" or "
+                + "\"None\" option - a free-text \"Other\" choice is always added for the user.";
+
+            JObject questionP = new JObject();
+            questionP["type"] = "string";
+            questionP["description"] = "The question to put to the user.";
+
+            JObject multiP = new JObject();
+            multiP["type"] = "boolean";
+            multiP["description"] = "When true, the user may select more than one option; otherwise "
+                + "they pick exactly one. Defaults to false.";
+
+            JObject props = new JObject();
+            props["question"] = questionP;
+            props["options"] = optionsArr;
+            props["multi_select"] = multiP;
+
+            JObject schema = new JObject();
+            schema["type"] = "object";
+            schema["properties"] = props;
+            schema["required"] = new JArray("question", "options");
+
+            JObject fn = new JObject();
+            fn["name"] = AskUserName;
+            fn["description"] = "Ask the user a multiple-choice question and wait for their answer. Use "
+                + "this when you genuinely need the user to decide between options you cannot resolve "
+                + "yourself (e.g. which approach to take), not for information you can look up or infer. "
+                + "Provide 2-4 concise options; the user can also type their own answer. Their selection "
+                + "is returned to you. Prefer continuing on your own when the choice is clear.";
+            fn["parameters"] = schema;
+
+            JObject def = new JObject();
+            def["type"] = "function";
+            def["function"] = fn;
+            return def;
+        }
+
+        // Parse the call, show the question (blocking), and format the user's answer as the tool result.
+        // isError is set for malformed arguments so the model can correct the call. A dismissed prompt
+        // is NOT an error (the user deliberately declined) - it returns the dismissed sentinel.
+        public string Ask(string argumentsJson, out bool isError)
+        {
+            isError = false;
+
+            string question;
+            bool multiSelect;
+            List<QuestionOption> options = ParseArgs(argumentsJson, out question, out multiSelect);
+            if (string.IsNullOrEmpty(question) || options.Count == 0)
+            {
+                isError = true;
+                return InvalidArgsText;
+            }
+
+            QuestionAnswer answer = _prompt != null
+                ? _prompt.Ask(new QuestionRequest(question, options, multiSelect))
+                : QuestionAnswer.DismissedAnswer();
+            if (answer == null) answer = QuestionAnswer.DismissedAnswer();
+
+            return FormatAnswer(answer, multiSelect);
+        }
+
+        // Extracts question / options (capped to MaxOptions, blank labels dropped) / multi_select.
+        // Tolerant: anything missing or mistyped simply yields no question/options, which Ask reports
+        // as invalid arguments.
+        private static List<QuestionOption> ParseArgs(string argumentsJson, out string question,
+                                                      out bool multiSelect)
+        {
+            question = null;
+            multiSelect = false;
+            List<QuestionOption> options = new List<QuestionOption>();
+            if (string.IsNullOrEmpty(argumentsJson)) return options;
+
+            try
+            {
+                JObject o = JObject.Parse(argumentsJson);
+
+                JToken q = o["question"];
+                if (q != null && q.Type == JTokenType.String) question = ((string)q).Trim();
+
+                JToken ms = o["multi_select"];
+                if (ms != null && ms.Type == JTokenType.Boolean) multiSelect = (bool)ms;
+
+                JToken opts = o["options"];
+                if (opts != null && opts.Type == JTokenType.Array)
+                {
+                    foreach (JToken item in (JArray)opts)
+                    {
+                        if (options.Count >= MaxOptions) break; // defensive cap; UI also adds "Other"
+                        string label = null, desc = null;
+                        if (item != null && item.Type == JTokenType.Object)
+                        {
+                            JToken l = item["label"];
+                            if (l != null && l.Type == JTokenType.String) label = ((string)l).Trim();
+                            JToken d = item["description"];
+                            if (d != null && d.Type == JTokenType.String) desc = ((string)d).Trim();
+                        }
+                        else if (item != null && item.Type == JTokenType.String)
+                        {
+                            // Tolerate a bare string option ("A") as shorthand for { label: "A" }.
+                            label = ((string)item).Trim();
+                        }
+                        if (!string.IsNullOrEmpty(label))
+                            options.Add(new QuestionOption(label, string.IsNullOrEmpty(desc) ? null : desc));
+                    }
+                }
+            }
+            catch
+            {
+                // Malformed JSON -> empty/absent question+options; Ask reports invalid arguments.
+            }
+            return options;
+        }
+
+        // The chosen label(s) as the tool message content. Custom ("Other") text is included and marked
+        // so the model can tell it apart from a preset option. A dismissed or empty answer returns the
+        // dismissed sentinel rather than an empty string the model would have to guess at.
+        internal static string FormatAnswer(QuestionAnswer answer, bool multiSelect)
+        {
+            if (answer == null || answer.Dismissed) return DismissedResultText;
+
+            List<string> picks = new List<string>();
+            if (answer.Selected != null)
+            {
+                foreach (string s in answer.Selected)
+                    if (!string.IsNullOrEmpty(s)) picks.Add(s);
+            }
+            bool hasCustom = !string.IsNullOrEmpty(answer.CustomText);
+
+            if (picks.Count == 0 && !hasCustom) return DismissedResultText;
+
+            if (!multiSelect)
+            {
+                // Single-select: exactly one of a preset pick or custom text.
+                if (hasCustom && picks.Count == 0)
+                    return "Selected (custom): " + answer.CustomText.Trim();
+                return "Selected: " + picks[0];
+            }
+
+            // Multi-select: a labeled list, custom text as its own marked line.
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Selected:");
+            for (int i = 0; i < picks.Count; i++)
+                sb.Append("\n- ").Append(picks[i]);
+            if (hasCustom)
+                sb.Append("\n- (custom): ").Append(answer.CustomText.Trim());
+            return sb.ToString();
+        }
+    }
+}

--- a/GxPT/Services/Mcp/AskUserTool.cs
+++ b/GxPT/Services/Mcp/AskUserTool.cs
@@ -87,14 +87,17 @@ namespace GxPT
 
             JObject fn = new JObject();
             fn["name"] = AskUserName;
-            fn["description"] = "Ask the user a multiple-choice question and wait for their answer. Use "
-                + "it whenever the goal is to get the user's own choice - a decision you need before you "
-                + "can proceed (e.g. which approach to take), an option you want them to pick, or an answer "
-                + "you are deliberately soliciting from them. Set multi_select to let them choose more than "
-                + "one option; otherwise they pick exactly one. Provide 2-4 concise options; the user can "
-                + "also type their own answer. Their selection is returned to you to act on or respond to. "
-                + "Don't use it for routine steps you can handle yourself - just proceed - but when the "
-                + "user's choice genuinely matters, ask rather than guess.";
+            fn["description"] = "Ask the user a multiple-choice question and wait for their answer. "
+                + "Whenever you would offer the user a short set of options to pick from (roughly 2-4), "
+                + "present them through this tool rather than writing them out as text for the user to "
+                + "type back - the options render as clickable choices and the selection is returned to "
+                + "you. This applies whether it's a one-off decision you need before you can proceed, a "
+                + "question you return to repeatedly over a conversation, or a series of questions you "
+                + "want to put to the user. Set multi_select to let them choose more than one option; "
+                + "otherwise they pick exactly one. Keep options concise; the user can also type their "
+                + "own answer. Don't use it to offload work you can do yourself, to invent a choice that "
+                + "isn't there, or when you have more options than fit a short list. Otherwise, whenever "
+                + "you're genuinely presenting a few options, use this instead of plain text.";
             fn["parameters"] = schema;
 
             JObject def = new JObject();
@@ -108,6 +111,13 @@ namespace GxPT
         // is NOT an error (the user deliberately declined) - it returns the dismissed sentinel.
         public string Ask(string argumentsJson, out bool isError)
         {
+            return Ask(argumentsJson, 1, 1, out isError);
+        }
+
+        // position/total locate this question among the ask_user calls the model issued this turn
+        // (1-based; total > 1 drives the "Question X of Y" indicator). The orchestrator supplies them.
+        public string Ask(string argumentsJson, int position, int total, out bool isError)
+        {
             isError = false;
 
             string question;
@@ -120,7 +130,7 @@ namespace GxPT
             }
 
             QuestionAnswer answer = _prompt != null
-                ? _prompt.Ask(new QuestionRequest(question, options, multiSelect))
+                ? _prompt.Ask(new QuestionRequest(question, options, multiSelect, position, total))
                 : QuestionAnswer.DismissedAnswer();
             if (answer == null) answer = QuestionAnswer.DismissedAnswer();
 

--- a/GxPT/Services/Mcp/AskUserTool.cs
+++ b/GxPT/Services/Mcp/AskUserTool.cs
@@ -95,7 +95,8 @@ namespace GxPT
                 + "question you return to repeatedly over a conversation, or a series of questions you "
                 + "want to put to the user. Set multi_select to let them choose more than one option; "
                 + "otherwise they pick exactly one. Keep options concise; the user can also type their "
-                + "own answer. Don't use it to offload work you can do yourself, to invent a choice that "
+                + "own answer. Write the question, options, and descriptions as plain text - they aren't "
+                + "rendered as markdown. Don't use it to offload work you can do yourself, to invent a choice that "
                 + "isn't there, or when you have more options than fit a short list. Otherwise, whenever "
                 + "you're genuinely presenting a few options, use this instead of plain text.";
             fn["parameters"] = schema;

--- a/GxPT/Services/Mcp/AskUserTool.cs
+++ b/GxPT/Services/Mcp/AskUserTool.cs
@@ -88,10 +88,13 @@ namespace GxPT
             JObject fn = new JObject();
             fn["name"] = AskUserName;
             fn["description"] = "Ask the user a multiple-choice question and wait for their answer. Use "
-                + "this when you genuinely need the user to decide between options you cannot resolve "
-                + "yourself (e.g. which approach to take), not for information you can look up or infer. "
-                + "Provide 2-4 concise options; the user can also type their own answer. Their selection "
-                + "is returned to you. Prefer continuing on your own when the choice is clear.";
+                + "it whenever the goal is to get the user's own choice - a decision you need before you "
+                + "can proceed (e.g. which approach to take), an option you want them to pick, or an answer "
+                + "you are deliberately soliciting from them. Set multi_select to let them choose more than "
+                + "one option; otherwise they pick exactly one. Provide 2-4 concise options; the user can "
+                + "also type their own answer. Their selection is returned to you to act on or respond to. "
+                + "Don't use it for routine steps you can handle yourself - just proceed - but when the "
+                + "user's choice genuinely matters, ask rather than guess.";
             fn["parameters"] = schema;
 
             JObject def = new JObject();

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -14,8 +14,11 @@ namespace GxPT
 
         // A compact "using <tool>" marker, plain (not italic) for consistency with the collapsible
         // tool records. Display() turns the qualified name into "web: search" with no underscores.
+        // ask_user is a host tool that interacts with the user rather than "using" a service, so it
+        // reads "asking the user" instead.
         public static string Call(string functionName)
         {
+            if (functionName == AskUserTool.AskUserName) return "asking the user";
             return "using " + Display(functionName);
         }
 

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -14,11 +14,12 @@ namespace GxPT
 
         // A compact "using <tool>" marker, plain (not italic) for consistency with the collapsible
         // tool records. Display() turns the qualified name into "web: search" with no underscores.
-        // ask_user is a host tool that interacts with the user rather than "using" a service, so it
-        // reads "asking the user" instead.
+        // ask_user is a host tool that interacts with the user rather than "using" a service, so its
+        // in-progress placeholder reads "Asking a question" (replaced by the "Asked a question" record
+        // once answered).
         public static string Call(string functionName)
         {
-            if (functionName == AskUserTool.AskUserName) return "asking the user";
+            if (functionName == AskUserTool.AskUserName) return "Asking a question";
             return "using " + Display(functionName);
         }
 

--- a/GxPT/Services/Mcp/IQuestionPrompt.cs
+++ b/GxPT/Services/Mcp/IQuestionPrompt.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+
+namespace GxPT
+{
+    // The host's "ask the user a question" seam, called by AskUserTool on the tool-loop worker thread.
+    // The real implementation (TranscriptQuestionPrompt) marshals to a docked QuestionPanel and blocks
+    // the worker until the user submits; a test can supply a scripted stub. Kept UI-independent (no
+    // WinForms types) so it links into the net48 test project, the same split as IToolApprovalPolicy.
+    internal interface IQuestionPrompt
+    {
+        // Show the question and block until the user answers or dismisses it. Never returns null.
+        QuestionAnswer Ask(QuestionRequest request);
+    }
+
+    // One model-supplied choice. Description is optional (shown under the label when present).
+    internal sealed class QuestionOption
+    {
+        public readonly string Label;
+        public readonly string Description;
+
+        public QuestionOption(string label, string description)
+        {
+            Label = label;
+            Description = description;
+        }
+    }
+
+    // A question to put to the user. Options are already validated and capped (AskUserTool.MaxOptions)
+    // by the time this reaches the prompt; the always-on free-text "Other" choice is added by the UI,
+    // not carried here. MultiSelect chooses checkboxes (any number) over radio buttons (exactly one).
+    internal sealed class QuestionRequest
+    {
+        public readonly string Question;
+        public readonly IList<QuestionOption> Options;
+        public readonly bool MultiSelect;
+
+        public QuestionRequest(string question, IList<QuestionOption> options, bool multiSelect)
+        {
+            Question = question;
+            Options = options;
+            MultiSelect = multiSelect;
+        }
+    }
+
+    // The user's answer. Dismissed (closed without submitting, or the tab was recycled away) takes
+    // precedence: AskUserTool maps it to a sentinel result so the model knows no choice was made.
+    // Otherwise Selected holds the chosen option labels and CustomText holds the free-text "Other"
+    // entry when the user filled it in (null/empty when they didn't). The UI guarantees an empty
+    // custom entry is never returned as a selection, so CustomText is meaningful whenever non-empty.
+    internal sealed class QuestionAnswer
+    {
+        public bool Dismissed;
+        public IList<string> Selected;
+        public string CustomText;
+
+        public static QuestionAnswer DismissedAnswer()
+        {
+            return new QuestionAnswer { Dismissed = true, Selected = new List<string>() };
+        }
+    }
+}

--- a/GxPT/Services/Mcp/IQuestionPrompt.cs
+++ b/GxPT/Services/Mcp/IQuestionPrompt.cs
@@ -34,11 +34,26 @@ namespace GxPT
         public readonly IList<QuestionOption> Options;
         public readonly bool MultiSelect;
 
+        // 1-based position of this question among the ask_user calls the model issued in the current
+        // turn, and the total number of them. Total > 1 means the model asked several questions this
+        // turn (multiple ask_user tool calls in one assistant message); the UI shows "Question X of Y"
+        // so the back-to-back panels aren't a surprise. Defaults to 1 of 1 (a lone question).
+        public readonly int Position;
+        public readonly int Total;
+
         public QuestionRequest(string question, IList<QuestionOption> options, bool multiSelect)
+            : this(question, options, multiSelect, 1, 1)
+        {
+        }
+
+        public QuestionRequest(string question, IList<QuestionOption> options, bool multiSelect,
+                               int position, int total)
         {
             Question = question;
             Options = options;
             MultiSelect = multiSelect;
+            Position = position;
+            Total = total;
         }
     }
 

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -528,13 +528,13 @@ namespace GxPT
                 // immediately instead of leaving the user to reject each queued call (and instead of
                 // read-only calls quietly running after the user has signalled stop).
                 bool batchDenied = false;
-                // Count the ask_user calls in this batch so each question's panel can show "Question X
-                // of Y" (only meaningful when the model asked several in one turn). askOrdinal advances
-                // as each ask_user call is actually dispatched.
-                int askTotal = 0;
-                for (int a = 0; a < asm.Calls.Count; a++)
-                    if (AskUser != null && AskUser.IsAskUser(asm.Calls[a].Name)) askTotal++;
-                int askOrdinal = 0;
+                // Track the current contiguous run of ask_user calls so each question's panel can show
+                // "Question X of Y" with Y = the run length. A run is broken by any non-ask_user call,
+                // which is also the only call that can be denied (ask_user has no approval gate), so a
+                // denial halts the batch at a run boundary: every question in a run either all run or
+                // none do. That keeps the displayed count exact even when a denial cuts the batch short.
+                int runOrdinal = 0; // 1-based position within the current ask_user run (0 = not in a run)
+                int runTotal = 0;   // length of the current run
                 for (int c = 0; c < asm.Calls.Count; c++)
                 {
                     ToolCall call = asm.Calls[c];
@@ -555,11 +555,26 @@ namespace GxPT
                     }
                     else
                     {
-                        // Position for an ask_user panel's "Question X of Y" (0 for non-ask_user calls).
-                        int askPos = 0;
-                        if (AskUser != null && AskUser.IsAskUser(call.Name)) askPos = ++askOrdinal;
+                        // Maintain the ask_user run and stamp the next question's "X of Y" onto the tool
+                        // just before dispatch (consumed by AskUser.Ask), instead of threading it through
+                        // ExecuteCall's generic signature.
+                        if (AskUser != null && AskUser.IsAskUser(call.Name))
+                        {
+                            if (runOrdinal == 0)
+                            {
+                                runTotal = 0;
+                                for (int k = c; k < asm.Calls.Count
+                                        && AskUser.IsAskUser(asm.Calls[k].Name); k++) runTotal++;
+                            }
+                            runOrdinal++;
+                            AskUser.SetNextPosition(runOrdinal, runTotal);
+                        }
+                        else
+                        {
+                            runOrdinal = 0; // a non-ask_user call breaks the run
+                        }
                         bool denied;
-                        result = ExecuteCall(call, turnId, askPos, askTotal, out isError, out denied);
+                        result = ExecuteCall(call, turnId, out isError, out denied);
                         if (denied)
                         {
                             // The user denied this call at the approval gate. Halt the rest of the batch
@@ -854,8 +869,7 @@ namespace GxPT
         // loop can force the next model call to stop and ask, rather than work around the denial);
         // it stays false for every other isError outcome. reveal_tools is handled locally without an
         // MCP round-trip.
-        private string ExecuteCall(ToolCall call, string turnId, int askPosition, int askTotal,
-                                   out bool isError, out bool denied)
+        private string ExecuteCall(ToolCall call, string turnId, out bool isError, out bool denied)
         {
             isError = false;
             denied = false;
@@ -901,8 +915,8 @@ namespace GxPT
             // malformed arguments set isError so the model can correct the call.
             if (AskUser != null && AskUser.IsAskUser(call.Name))
             {
-                _log.Log("mcp", "[turn " + turnId + "] ask_user (" + askPosition + " of " + askTotal + ")");
-                string answer = AskUser.Ask(call.ArgumentsJson, askPosition, askTotal, out isError);
+                _log.Log("mcp", "[turn " + turnId + "] ask_user");
+                string answer = AskUser.Ask(call.ArgumentsJson, out isError);
                 return answer;
             }
 

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -189,6 +189,12 @@ namespace GxPT
         // A child never gets a dispatcher, so a sub-agent cannot dispatch (no nesting, A12).
         public AgentDispatcher AgentDispatcher { get; set; }
 
+        // Optional "ask the user" surface (ask_user). When set, ask_user is exposed in the tools array
+        // and handled locally without an MCP round-trip (the host shows a multiple-choice panel and the
+        // user's answer becomes the tool result), like reveal_tools. Blocks the turn while the user
+        // decides, the same as the approval gate.
+        public AskUserTool AskUser { get; set; }
+
         // Server-qualified MCP tool names to omit from this turn's context (names manifest + exposed
         // defs) and refuse to call. Used to gate the authoring tools on the meta-skills (ExtensionsToolGate).
         // Set per send (the orchestrator is built fresh each turn), so it's not shared/racy.
@@ -379,6 +385,11 @@ namespace GxPT
                 {
                     if (tools == null) tools = new List<JObject>();
                     tools.Add(AgentDispatcher.DispatchAgentDef());
+                }
+                if (AskUser != null)
+                {
+                    if (tools == null) tools = new List<JObject>();
+                    tools.Add(AskUser.AskUserDef());
                 }
                 // Hide owned-but-locked tools (e.g. skill-authoring tools when the meta-skill is off):
                 // drop them from the exposed defs and the names manifest so the model can't see or call them.
@@ -871,6 +882,17 @@ namespace GxPT
             {
                 _log.Log("mcp", "[turn " + turnId + "] dispatch_agent");
                 return AgentDispatcher.Dispatch(call.ArgumentsJson);
+            }
+
+            // ask_user is a host meta-tool too: show a multiple-choice panel and block until the user
+            // answers, returning their selection as the tool result. No MCP round-trip and no approval
+            // gate (the user is the one acting). A dismissed prompt is a non-error sentinel; only
+            // malformed arguments set isError so the model can correct the call.
+            if (AskUser != null && AskUser.IsAskUser(call.Name))
+            {
+                _log.Log("mcp", "[turn " + turnId + "] ask_user");
+                string answer = AskUser.Ask(call.ArgumentsJson, out isError);
+                return answer;
             }
 
             // A hidden (gated-off) tool must not be callable even if the model names it directly.

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -528,6 +528,13 @@ namespace GxPT
                 // immediately instead of leaving the user to reject each queued call (and instead of
                 // read-only calls quietly running after the user has signalled stop).
                 bool batchDenied = false;
+                // Count the ask_user calls in this batch so each question's panel can show "Question X
+                // of Y" (only meaningful when the model asked several in one turn). askOrdinal advances
+                // as each ask_user call is actually dispatched.
+                int askTotal = 0;
+                for (int a = 0; a < asm.Calls.Count; a++)
+                    if (AskUser != null && AskUser.IsAskUser(asm.Calls[a].Name)) askTotal++;
+                int askOrdinal = 0;
                 for (int c = 0; c < asm.Calls.Count; c++)
                 {
                     ToolCall call = asm.Calls[c];
@@ -548,8 +555,11 @@ namespace GxPT
                     }
                     else
                     {
+                        // Position for an ask_user panel's "Question X of Y" (0 for non-ask_user calls).
+                        int askPos = 0;
+                        if (AskUser != null && AskUser.IsAskUser(call.Name)) askPos = ++askOrdinal;
                         bool denied;
-                        result = ExecuteCall(call, turnId, out isError, out denied);
+                        result = ExecuteCall(call, turnId, askPos, askTotal, out isError, out denied);
                         if (denied)
                         {
                             // The user denied this call at the approval gate. Halt the rest of the batch
@@ -844,7 +854,8 @@ namespace GxPT
         // loop can force the next model call to stop and ask, rather than work around the denial);
         // it stays false for every other isError outcome. reveal_tools is handled locally without an
         // MCP round-trip.
-        private string ExecuteCall(ToolCall call, string turnId, out bool isError, out bool denied)
+        private string ExecuteCall(ToolCall call, string turnId, int askPosition, int askTotal,
+                                   out bool isError, out bool denied)
         {
             isError = false;
             denied = false;
@@ -890,8 +901,8 @@ namespace GxPT
             // malformed arguments set isError so the model can correct the call.
             if (AskUser != null && AskUser.IsAskUser(call.Name))
             {
-                _log.Log("mcp", "[turn " + turnId + "] ask_user");
-                string answer = AskUser.Ask(call.ArgumentsJson, out isError);
+                _log.Log("mcp", "[turn " + turnId + "] ask_user (" + askPosition + " of " + askTotal + ")");
+                string answer = AskUser.Ask(call.ArgumentsJson, askPosition, askTotal, out isError);
                 return answer;
             }
 

--- a/GxPT/Services/Mcp/TranscriptQuestionPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptQuestionPrompt.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace GxPT
+{
+    // Bridges the synchronous IQuestionPrompt (called on the tool-loop worker thread) to the docked
+    // QuestionPanel on the UI thread. Ask blocks the worker until the user submits or skips; the turn
+    // pauses there, which is correct - the user is present. A near-copy of TranscriptApprovalPrompt.
+    internal sealed class TranscriptQuestionPrompt : IQuestionPrompt
+    {
+        private readonly Control _uiMarshal;          // any control on the UI thread (the form)
+        private readonly Func<QuestionPanel> _getPanel;
+
+        public TranscriptQuestionPrompt(Control uiMarshal, Func<QuestionPanel> getPanel)
+        {
+            _uiMarshal = uiMarshal;
+            _getPanel = getPanel;
+        }
+
+        public QuestionAnswer Ask(QuestionRequest request)
+        {
+            if (_uiMarshal == null || _getPanel == null || request == null)
+                return QuestionAnswer.DismissedAnswer();
+
+            QuestionAnswer[] result = { null };
+            using (ManualResetEvent done = new ManualResetEvent(false))
+            {
+                try
+                {
+                    _uiMarshal.BeginInvoke((MethodInvoker)delegate
+                    {
+                        // Any UI failure (panel resolver, a disposed panel mid-show) must still signal the
+                        // waiting worker - an unset event strands the turn forever.
+                        try
+                        {
+                            QuestionPanel panel = _getPanel();
+                            if (panel == null) { done.Set(); return; }
+                            panel.ShowQuestion(request, delegate(QuestionAnswer answer)
+                            {
+                                result[0] = answer;
+                                done.Set();
+                            });
+                        }
+                        catch { done.Set(); }
+                    });
+                }
+                catch
+                {
+                    return QuestionAnswer.DismissedAnswer(); // UI gone (e.g. closing) -> safe default
+                }
+
+                done.WaitOne();
+            }
+            return result[0] != null ? result[0] : QuestionAnswer.DismissedAnswer();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the `ask_user` meta-tool, allowing Claude to present multiple-choice questions to users within the chat interface. The user selects from model-provided options or enters free-text, and their answer is fed back to the model as a tool result for continued reasoning.

## Key Changes

- **QuestionPanel** (`Controls/QuestionPanel.cs`): New docked UI panel that renders multiple-choice questions with:
  - Radio buttons for single-select, checkboxes for multi-select modes
  - Always-present free-text "Other" option
  - Submit/Skip buttons with validation (prevents empty custom answers)
  - Auto-selection behavior (focusing/typing the Other box selects it in single-select mode)
  - Theme support (dark/light mode) matching the approval panel
  - "Question X of Y" indicator for multi-question turns
  - Proper cleanup and disposal of selector/description controls on reuse

- **AskUserTool** (`Services/Mcp/AskUserTool.cs`): Tool implementation that:
  - Parses model arguments (question, options with optional descriptions, multi_select flag)
  - Caps options to `MaxOptions` (4) with defensive overflow handling
  - Formats user answers as tool results (single-select: "Selected: X", multi-select: bulleted list)
  - Returns a dismissed sentinel when the user declines or the tab closes
  - Validates arguments and returns error messages for malformed calls

- **IQuestionPrompt** (`Services/Mcp/IQuestionPrompt.cs`): Interface and supporting types:
  - `QuestionRequest`: Carries question, options, multi-select flag, and position/total for batch questions
  - `QuestionAnswer`: Holds selected preset options and optional custom text
  - `QuestionOption`: Model-supplied choice with label and optional description

- **TranscriptQuestionPrompt** (`Services/Mcp/TranscriptQuestionPrompt.cs`): Worker-to-UI marshaling:
  - Bridges the blocking `IQuestionPrompt.Ask()` call (on tool-loop worker thread) to the UI thread
  - Uses `ManualResetEvent` to block the worker until the user submits/skips
  - Handles disposal and recycled-tab scenarios (calls `DenyPending()` to release stranded workers)

- **McpChatOrchestrator** integration:
  - Added `AskUser` property to expose the tool in the tools array
  - Dispatches `ask_user` calls locally without MCP round-trip (like `reveal_tools`)
  - Threads position/total through `SetNextPosition()` for multi-question turns

- **MainForm** integration:
  - New `AttachQuestionPanel()` method creates per-tab question panels
  - Syncs generation indicator when prompt visibility changes (mirrors approval panel behavior)

- **TabManager**: Added `QuestionPanel` field to `ChatTabContext` for per-conversation question state

## Notable Implementation Details

- **Threading model**: Mirrors `ToolApprovalPanel`—the worker blocks in `TranscriptQuestionPrompt.Ask()` while the UI thread handles user interaction, pausing the turn until the user decides.
- **Multi-question batches**: When the model issues multiple `ask_user` calls in one turn, the orchestrator counts them and the UI displays "Question X of Y" so the back-to-back panels aren't surprising.
- **Validation**: The panel enforces answer validity (non-empty custom text if Other is selected, at least one preset or custom in multi-select) before enabling Submit, preventing empty answers from reaching the model.
- **Resource cleanup**: Selector and description controls are explicitly disposed on panel reuse to prevent window handle leaks.
- **Theme consistency**: Uses the same color palette as the approval panel so the question prompt integrates seamlessly in dark mode.

https://claude.ai/code/session_01GuPwVEi2RqAswxjRMwgMnr