### PR TITLE
Add past-tense "Used" marker for completed tool calls

### DIFF
--- a/GxPT/Forms/AgentTranscriptViewerForm.cs
+++ b/GxPT/Forms/AgentTranscriptViewerForm.cs
@@ -112,7 +112,7 @@ namespace GxPT
             Ui(delegate { _liveAssistantOpen = false; _toolBlockOpen = false; });
         }
 
-        // Append a tool marker (a collapsible-record sentinel or a "using <tool>" line) the way the main
+        // Append a tool marker (a collapsible-record sentinel or a "Used <tool>" line) the way the main
         // chat does: consecutive tool calls accumulate into one chrome-less block; assistant text breaks it.
         private void AddToolMarker(string marker)
         {

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3545,7 +3545,7 @@ namespace GxPT
                             cur.Text.Append(t);
                         }
                     };
-                    // Tool activity renders in two beats: an immediate "using <tool>" placeholder on the
+                    // Tool activity renders in two beats: an immediate "Using <tool>" placeholder on the
                     // call (live feedback while it runs / the approval gate waits), replaced by the
                     // outcome marker on the result. So a denied call ends as "denied: <tool>" and an
                     // approved edit ends as its collapsible record — never an unapproved diff. The
@@ -4739,10 +4739,10 @@ namespace GxPT
         // Role marker for the chrome-less tool-activity blocks used on reload.
         private const string ToolActivityRole = "toolactivity";
 
-        // Activity marker for a tool call. If the tool maps to a collapsible/labelled record, register
-        // it with the transcript under a stable key and return its sentinel; otherwise (or on any
-        // failure) return the generic "using <tool>" marker. internal so the agent transcript viewer can
-        // render a child's tool calls identically to the main chat.
+        // Activity marker for a *completed* tool call. If the tool maps to a collapsible/labelled record,
+        // register it with the transcript under a stable key and return its sentinel; otherwise (or on any
+        // failure) return the generic past-tense "Used <tool>" marker. internal so the agent transcript
+        // viewer can render a child's tool calls identically to the main chat.
         internal static string EditDiffMarkerOrCall(ChatTranscriptControl transcript, string name, string argsJson, string key)
         {
             if (transcript != null && !string.IsNullOrEmpty(key))
@@ -4759,7 +4759,7 @@ namespace GxPT
                 }
                 catch { /* fall through to the generic marker */ }
             }
-            return McpMarkers.Call(name);
+            return McpMarkers.Used(name);
         }
 
         // Surface a streaming/transport failure as a chrome-less red notice in the transcript, so a

--- a/GxPT/Services/Mcp/DelegateToolLoopUi.cs
+++ b/GxPT/Services/Mcp/DelegateToolLoopUi.cs
@@ -12,15 +12,27 @@ namespace GxPT
             return string.IsNullOrEmpty(functionName) ? string.Empty : functionName.Replace("__", ": ");
         }
 
-        // A compact "using <tool>" marker, plain (not italic) for consistency with the collapsible
-        // tool records. Display() turns the qualified name into "web: search" with no underscores.
-        // ask_user is a host tool that interacts with the user rather than "using" a service, so its
-        // in-progress placeholder reads "Asking a question" (replaced by the "Asked a question" record
-        // once answered).
+        // The in-progress "Using <tool>" placeholder shown while a call runs (and the approval gate
+        // waits), plain (not italic) for consistency with the collapsible tool records. Display() turns
+        // the qualified name into "web: search" with no underscores. ask_user is a host tool that
+        // interacts with the user rather than "using" a service, so its in-progress placeholder reads
+        // "Asking a question" (replaced by the "Asked a question" record once answered). Once the call
+        // completes, this is replaced by the matching past-tense marker (Used / a collapsible record).
         public static string Call(string functionName)
         {
             if (functionName == AskUserTool.AskUserName) return "Asking a question";
-            return "using " + Display(functionName);
+            return "Using " + Display(functionName);
+        }
+
+        // The catch-all past-tense marker for a *completed* call whose tool has no specific record
+        // (files__edit, command__run, ask_user, ...). The in-progress "Using <tool>" placeholder is
+        // replaced by this "Used <tool>" once the call finishes, and reloaded/agent-viewer transcripts
+        // render finished calls with it directly — keeping it consistent with the past-tense records
+        // ("Edited", "Ran a command", "Asked a question").
+        public static string Used(string functionName)
+        {
+            if (functionName == AskUserTool.AskUserName) return "Asked a question";
+            return "Used " + Display(functionName);
         }
 
         // For files__edit / command__run, the generic "using" marker is replaced by a collapsible
@@ -50,7 +62,7 @@ namespace GxPT
     // turn as a chrome-less "tool activity" message plus a separate answer bubble: model text ->
     // appendText, tool calls -> onToolCall/onToolResult, Complete/OnError finalize.
     //
-    // Tool activity renders in two beats: OnToolCall shows an immediate "using <tool>" placeholder so
+    // Tool activity renders in two beats: OnToolCall shows an immediate "Using <tool>" placeholder so
     // there's live feedback while the call runs (and the approval gate waits); OnToolResult replaces
     // that placeholder once the outcome is known, so the transcript reflects what actually happened
     // (applied record / denied / errored) rather than the unapproved request. Arguments are stashed at


### PR DESCRIPTION
## Summary
This PR introduces a new `Used()` method to the `McpMarkers` class to provide a proper past-tense marker for completed tool calls, replacing the previous use of the in-progress `Call()` method for finished operations.

## Key Changes
- **New `McpMarkers.Used()` method**: Added a dedicated method that returns past-tense markers for completed tool calls ("Used <tool>" or "Asked a question" for ask_user)
- **Updated `EditDiffMarkerOrCall()`**: Changed to use `McpMarkers.Used()` instead of `McpMarkers.Call()` when rendering completed tool calls in transcripts
- **Capitalization fix**: Changed "using" to "Using" in the `Call()` method for consistency with UI conventions
- **Documentation updates**: Enhanced comments throughout to clarify the distinction between in-progress placeholders ("Using <tool>") and completed call markers ("Used <tool>")

## Implementation Details
The change maintains consistency in how tool activity is displayed across the application:
- **In-progress**: "Using <tool>" placeholder shown while a call runs and approval gates wait
- **Completed**: "Used <tool>" marker shown once the call finishes, or specific record markers (e.g., "Edited", "Ran a command") for tools with collapsible records
- Special handling for `ask_user` tool: "Asking a question" → "Asked a question"

This ensures transcripts accurately reflect what actually happened rather than showing unapproved requests, and provides consistency with past-tense record labels.

https://claude.ai/code/session_01EZVz7yWUaMwg3o4g1We3cv