### PR TITLE
Move memory store to .gxpt/memory subfolder

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3425,7 +3425,7 @@ namespace GxPT
                     // across the turn's loop iterations; an edit takes effect on the next turn.
                     orch.ProjectInstructions = AgentsFileInjection.Build(ctx.WorkingDir);
 
-                    // Inject the workspace's persistent memory index (rebuilt from .gxpt/memory.md each
+                    // Inject the workspace's persistent memory index (rebuilt from .gxpt/memory/memory.md each
                     // request) only when memory is enabled and this conversation has a workspace.
                     if (AppSettings.GetBool("mcp_memory_enabled") && !string.IsNullOrEmpty(ctx.WorkingDir))
                     {

--- a/GxPT/Services/Mcp/McpConfig.cs
+++ b/GxPT/Services/Mcp/McpConfig.cs
@@ -142,7 +142,7 @@ namespace GxPT
             // No extra env beyond the working directory: engines are discovered, not configured.
             list.Add(NewBuiltIn(MsBuildName, "MSBuildMcpServer.exe", o.ServerDir, true, o.MsBuildEnabled));
 
-            // memory - persistent project memory under GXPT_WORKDIR/.gxpt; workdir-scoped (each
+            // memory - persistent project memory under GXPT_WORKDIR/.gxpt/memory; workdir-scoped (each
             // folder has its own store). The soft index line cap is injected so the server's
             // over-cap nudge matches the user's configured value.
             McpServerSpec mem = NewBuiltIn(MemoryName, "MemoryMcpServer.exe", o.ServerDir, true, o.MemoryEnabled);

--- a/GxPT/Services/Mcp/MemoryInjection.cs
+++ b/GxPT/Services/Mcp/MemoryInjection.cs
@@ -5,13 +5,16 @@ using System.Text;
 namespace GxPT
 {
     // Host side of the memory feature: reads the workspace's primary memory index
-    // (<workdir>/.gxpt/memory.md) and wraps it with framing for injection as an ephemeral system
-    // message (McpChatOrchestrator.MemorySystemMessageProvider). The MemoryMcpServer is the only
-    // writer; this is read-only. All memory framing lives here so a disabled memory system leaves
-    // no trace in context (design M5/M6, sec.5).
+    // (<workdir>/.gxpt/memory/memory.md) and wraps it with framing for injection as an ephemeral
+    // system message (McpChatOrchestrator.MemorySystemMessageProvider). The MemoryMcpServer is the
+    // only writer; this is read-only. All memory framing lives here so a disabled memory system
+    // leaves no trace in context (design M5/M6, sec.5).
     internal static class MemoryInjection
     {
+        // The shared .gxpt project home (reused by skills/ and agents/); memory lives in its own
+        // "memory" subfolder beneath it, kept in sync with MemoryMcpServer's MemoryConfig.
         public const string MemoryDirName = ".gxpt";
+        public const string MemorySubDirName = "memory";
         public const string IndexFileName = "memory.md";
 
         // Cap the read so a hand-edited or runaway index can't bloat the prompt; the store keeps it
@@ -58,7 +61,9 @@ namespace GxPT
         {
             try
             {
-                string path = Path.Combine(Path.Combine(workingDir, MemoryDirName), IndexFileName);
+                string path = Path.Combine(
+                    Path.Combine(Path.Combine(workingDir, MemoryDirName), MemorySubDirName),
+                    IndexFileName);
                 if (!File.Exists(path)) return null;
                 string text = File.ReadAllText(path, Encoding.UTF8);
                 if (string.IsNullOrEmpty(text)) return null;

--- a/docs/memory-system-design.md
+++ b/docs/memory-system-design.md
@@ -41,14 +41,17 @@ MCP server for the tool surface, plus host-side injection of a light index.
 
 ---
 
-## 3. On-disk layout (`<workdir>/.gxpt/`)
+## 3. On-disk layout (`<workdir>/.gxpt/memory/`)
 
 ```
-.gxpt/
+.gxpt/memory/
   memory.md        # primary index: light, injected every request
   <slug>.md        # detail files, read on demand
   .gitignore       # seeded automatically ("*") — personal memory not committed unless opted in
 ```
+
+Memory lives in its own `memory/` subfolder of the shared `.gxpt/` project home,
+alongside the `skills/` and `agents/` subfolders.
 
 `memory.md` is a flat list of entries:
 
@@ -96,7 +99,7 @@ overwrites when it means to add or vice versa.
 Because `memory.md` is in context every turn, the names are always in front of
 the model — it addresses entries by reading the name beside the summary it
 recognizes. Writes are atomic (temp file + rename). The server is sandboxed to
-`.gxpt/` (reuse `PathSandbox`).
+`.gxpt/memory/` (reuse `PathSandbox`).
 
 ---
 
@@ -181,7 +184,7 @@ memories as standalone entries.
   soft cap; it never compacts on its own.
 - **Soft cap defaults to 40 lines**, exposed as a user-configurable setting
   (alongside the `MemoryEnabled` toggle in the main settings tab).
-- **`.gxpt/.gitignore` is seeded automatically** (`*`) on first write.
+- **`.gxpt/memory/.gitignore` is seeded automatically** (`*`) on first write.
 - **Names are normalized to kebab-case** (lowercase, hyphen-joined; camelCase/underscore/
   whitespace boundaries); the slug is the index handle and the `<slug>.md` filename, so
   no name→file map is needed.

--- a/servers/MemoryMcpServer/MemoryConfig.cs
+++ b/servers/MemoryMcpServer/MemoryConfig.cs
@@ -6,14 +6,14 @@ namespace MemoryMcpServer
 {
     /// <summary>
     /// Startup config, read once from the environment (servers-spec sec.1). Memory's inputs are its
-    /// store root - <c>GXPT_WORKDIR</c>/.gxpt (default: the process current dir) - and the soft
+    /// store root - <c>GXPT_WORKDIR</c>/.gxpt/memory (default: the process current dir) - and the soft
     /// line cap for the index, <c>GXPT_MEMORY_MAX_LINES</c> (default 40).
     /// </summary>
     internal sealed class MemoryConfig
     {
         public const int DefaultMaxLines = 40;
 
-        public readonly string MemoryRoot;   // <workdir>/.gxpt
+        public readonly string MemoryRoot;   // <workdir>/.gxpt/memory
         public readonly int MaxLines;
 
         private MemoryConfig(string memoryRoot, int maxLines)
@@ -27,7 +27,9 @@ namespace MemoryMcpServer
             string workDir = Environment.GetEnvironmentVariable("GXPT_WORKDIR");
             if (string.IsNullOrEmpty(workDir))
                 workDir = Directory.GetCurrentDirectory();
-            string root = Path.Combine(workDir, ".gxpt");
+            // Memory lives under the .gxpt project home in its own "memory" subfolder, alongside the
+            // skills/ and agents/ subfolders that share that home.
+            string root = Path.Combine(Path.Combine(workDir, ".gxpt"), "memory");
 
             int maxLines = DefaultMaxLines;
             string capRaw = Environment.GetEnvironmentVariable("GXPT_MEMORY_MAX_LINES");

--- a/servers/MemoryMcpServer/MemoryStore.cs
+++ b/servers/MemoryMcpServer/MemoryStore.cs
@@ -22,7 +22,7 @@ namespace MemoryMcpServer
     }
 
     /// <summary>
-    /// Reads and writes the .gxpt memory store. The server is the <b>only</b> writer, so
+    /// Reads and writes the .gxpt/memory store. The server is the <b>only</b> writer, so
     /// <c>memory.md</c> is rewritten canonically on every change - a flat list of
     /// "<c>- slug: summary</c>" lines (one entry per line, with a "<c> -> slug.md</c>" marker when a
     /// detail file exists). Detail lives in <c>&lt;slug&gt;.md</c>, read on demand. All writes are
@@ -266,7 +266,7 @@ namespace MemoryMcpServer
 
         // ---- store setup ----
 
-        // Create .gxpt and seed a gitignore so personal memory isn't committed unless opted in.
+        // Create .gxpt/memory and seed a gitignore so personal memory isn't committed unless opted in.
         private void EnsureStore()
         {
             Directory.CreateDirectory(_root);

--- a/servers/MemoryMcpServer/Program.cs
+++ b/servers/MemoryMcpServer/Program.cs
@@ -4,7 +4,7 @@ using Mcp35.Server;
 namespace MemoryMcpServer
 {
     /// <summary>
-    /// First-party Memory MCP server: persistent, project-scoped memory under GXPT_WORKDIR/.gxpt.
+    /// First-party Memory MCP server: persistent, project-scoped memory under GXPT_WORKDIR/.gxpt/memory.
     /// The same five lines as every first-party server (servers-spec sec.1), around the Memory tool set.
     /// </summary>
     internal static class Program

--- a/servers/MemoryMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/MemoryMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("79603c90-d8d9-4bbd-88cf-3444fd4cd81a")]
 
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.2.0")]
+[assembly: AssemblyFileVersion("0.1.2.0")]

--- a/servers/MemoryMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/MemoryMcpServer/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("MemoryMcpServer")]
-[assembly: AssemblyDescription("First-party MCP server: persistent, project-scoped memory under <workdir>/.gxpt.")]
+[assembly: AssemblyDescription("First-party MCP server: persistent, project-scoped memory under <workdir>/.gxpt/memory.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Mcp35")]


### PR DESCRIPTION
## Summary

Moves the persistent memory store from `<workdir>/.gxpt` into its own `<workdir>/.gxpt/memory` subfolder, so it sits alongside the `skills/` and `agents/` subfolders that already share the `.gxpt` project home.

## Changes

- **`MemoryConfig.cs`** — store root is now `<workdir>/.gxpt/memory` (drives `memory.md`, the `<slug>.md` detail files, and the auto-seeded `.gitignore`).
- **`MemoryInjection.cs`** — host now reads `<workdir>/.gxpt/memory/memory.md` for context injection. The shared `.gxpt` project-home constant (`MemoryDirName`) is kept intact since `SkillRoots`/`AgentRoots` depend on it; a separate `MemorySubDirName = "memory"` was added instead of repurposing it.
- Bumped `MemoryMcpServer` assembly version `0.1.1.0` → `0.1.2.0`.
- Updated doc-comments and the on-disk-layout section of `docs/memory-system-design.md`.

## Notes

- **No migration** is included — this feature hasn't been used in the wild, so existing workspaces simply start a fresh empty store at the new path.
- Not compile-checked locally: this is a .NET Framework (net48/net35) solution and the dev environment is Linux with no .NET toolchain. The edits are mechanical path changes; no existing tests assert the memory path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AafUSyoMr2z8sYnUeDxS2w)_