### PR TITLE
Implement read truncation with continuation tokens for large files

### DIFF
--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -1205,8 +1205,9 @@ namespace GxPT
         }
 
         // CallToolResult.content[] → a single string for the tool message. Text blocks are
-        // concatenated; non-text blocks become a short placeholder; structuredContent (if any) is
-        // appended as compact JSON. isError content is still returned verbatim (the model sees it).
+        // concatenated; non-text blocks become a short placeholder; structuredContent is appended as
+        // compact JSON only when there were no text blocks (it is otherwise already mirrored into
+        // content). isError content is still returned verbatim (the model sees it).
         private static string FormatResult(CallToolResult res)
         {
             if (res == null) return string.Empty;
@@ -1226,11 +1227,13 @@ namespace GxPT
                 }
             }
 
-            if (res.StructuredContent != null)
-            {
-                if (sb.Length > 0) sb.Append("\n");
+            // ToolResults.Json already mirrors structuredContent into a text content block (appended
+            // above), and per the MCP spec structured/unstructured content are functionally
+            // equivalent — so only emit the JSON here when there were no text blocks. Otherwise the
+            // same payload is sent to the model twice, which on a truncated read doubles a large
+            // content blob and can confuse the paging loop.
+            if (res.StructuredContent != null && sb.Length == 0)
                 sb.Append(res.StructuredContent.ToString(Formatting.None));
-            }
             return sb.ToString();
         }
 

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -75,7 +75,7 @@ Tools map to the approval table: `read`/`list`/`search` ReadOnly,
 
 | Tool | Schema (required *) | Behavior |
 |------|---------------------|----------|
-| `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. |
+| `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?`, `offset?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. Over-cap reads **truncate** (not error), returning `{content, truncated, next_start_line \| next_offset}`; `offset` resumes a byte window. |
 | `list` | `path*`, `recursive?` | Directory entries: `{name,type,size}`; capped count. |
 | `search` | `query*`, `path?`, `regex?`, `ignore_case?`, `glob?`, `max_results?` | Grep file contents under root → `{path,line,text}`; recursive, **streamed (any file size)**, skips binary. |
 | `write` | `path*`, `content*`, `create_dirs?` | Atomic create/overwrite under root. |
@@ -86,11 +86,13 @@ The **agentic** additions — `search`, `edit`, and `read`'s line-range/numberin
 options — exist so the model can locate and surgically modify code without
 rewriting whole files (fewer tokens, fewer clobbers). All share the sandbox and
 binary sniff; `edit` reuses `write`'s atomic temp-then-move. The 1 MiB cap is a
-**context** guard, so it applies only to operations that emit a whole file into
-the model: a *whole-file* `read`. Everything else **streams**, bounding output (or
-memory) rather than file size: `search` and a *ranged* `read` by line, `edit` by a
-chunk + carry buffer. So large files remain searchable, a slice is always readable,
-and any file is editable — only a whole-file `read` is capped.
+**context** guard on what a `read` emits into the model — but it never blocks: an
+over-cap `read` **truncates and hands back a continuation token** (`next_start_line`,
+or `next_offset` for a single line longer than the cap) so the model pages through
+the rest. Everything streams, bounding output (or memory) rather than file size:
+`search` and `read` (by line, falling to a byte window for a lone over-cap line),
+`edit` by a chunk + carry buffer. So large files remain searchable, any file is
+readable in full via pagination, and any file is editable.
 
 **Sandbox — the one rule that matters here:** every `path` is resolved against
 the root and must stay inside it.
@@ -106,16 +108,27 @@ string Resolve(string root, string rel) {
 // NOT a bare StartsWith — so "/root" does not match "/root-evil".
 ```
 
-- `read`: a **whole-file** read enforces the **1 MiB** cap (over → `Error`,
-  pointing the model at a line range) and detects binary (NUL byte in a head
-  sample) → `Error("not a text file")`. A **ranged** read (`start_line`/`end_line`,
-  1-based inclusive) **streams** instead: it works on files past the cap, but its
-  **rendered output** is held to the same 1 MiB — counted as exact UTF-8 bytes (line
-  content + `\n` separators + the line-number prefix when numbering), so a slice that
-  would render over 1 MiB → `Error`. A `start_line` past EOF → `Error`, an `end_line`
-  past EOF just stops at the last line. `line_numbers` prefixes each
-  returned line with a right-aligned number + tab. With no range and no numbering,
-  content is returned **verbatim** (exact bytes preserved).
+- `read`: a **whole-file** read that fits the **1 MiB** cap is returned in full
+  (**verbatim** — exact bytes preserved — unless numbering is requested) and detects
+  binary (NUL byte in a head sample) → `Error("not a text file")`. Over the cap it
+  **truncates instead of erroring**: the rendered output (exact UTF-8 bytes — line
+  content + `\n` separators + the line-number prefix when numbering) is held to 1 MiB
+  and the result becomes a JSON envelope `{content, truncated:true, next_start_line |
+  next_offset}`. The continuation coordinate is set by **where the cut lands**: at a
+  line boundary (≥1 whole line emitted) → **`next_start_line`** (resume via
+  `start_line`); inside a **single line longer than the cap** (the minified-file case,
+  where line ranges can't subdivide) → **`next_offset`**, a byte offset to resume via
+  the **`offset`** parameter. `offset` reads a raw byte window with an O(1) seek
+  (ignoring `start_line`/`end_line`), backing each cut up to a UTF-8 boundary so a
+  codepoint is never split; it keeps reporting `next_offset` until the tail fits and
+  comes back as plain text. So the model pages through a file of any shape — multi-line
+  or single-line — until a read is no longer truncated. The reader streams fixed char
+  chunks (never buffering a whole over-cap line), so memory stays bounded. A
+  `start_line`/`offset` past EOF → `Error`; an `end_line` past EOF stops at the last
+  line. **Limitations:** truncated output is line-normalized (the verbatim guarantee is
+  for the untruncated whole-file read only); the streaming path treats `\n` as the
+  separator (CRLF handled, a lone CR is not a break); `line_numbers` is dropped once a
+  read cuts into a single line.
 - `list`: cap entries (e.g. 1000) and note truncation; `recursive` bounded depth.
 - `search`: walk the tree under `path` (default root) bounded by the same depth
   cap as `list`, **streaming** each file line-by-line (no per-file size cap);
@@ -335,8 +348,10 @@ Per server, over the scripted-stream harness:
 1. **Listing** — `tools/list` returns exactly the documented tools with intact
    `inputSchema`.
 2. **Files sandbox** — `..`, absolute paths, and `/root` vs `/root-evil` boundary
-   tricks are all rejected; in-root read/list/write/delete round-trip; oversize
-   and binary reads → `Error`; write is atomic; delete refuses non-empty dirs.
+   tricks are all rejected; in-root read/list/write/delete round-trip; binary
+   reads → `Error`; an over-cap read **truncates** with a `next_start_line` /
+   `next_offset` continuation (single-line/minified files page via `offset`);
+   write is atomic; delete refuses non-empty dirs.
 3. **Web** — happy path parses `results[]` into structured+text (curl stubbed
    via injected `GXPT_CURL_PATH` pointing at a fake); missing key, curl failure,
    non-200, bad JSON → `Error`; key never leaks into output.

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -85,8 +85,8 @@ Tools map to the approval table: `read`/`list`/`search` ReadOnly,
 The **agentic** additions — `search`, `edit`, and `read`'s line-range/numbering
 options — exist so the model can locate and surgically modify code without
 rewriting whole files (fewer tokens, fewer clobbers). All share the sandbox and
-binary sniff; `edit` reuses `write`'s atomic temp-then-move. The **128 KiB** read
-cap (~32K tokens; 1 MiB would be ~250K+) is a **context** guard on what a `read`
+binary sniff; `edit` reuses `write`'s atomic temp-then-move. The **32 KiB** read
+cap (~8K tokens; 1 MiB would be ~250K+) is a **context** guard on what a `read`
 emits into the model — but it never blocks: an over-cap `read` **truncates and hands
 back a continuation token** (`next_start_line`+`next_offset`, or `next_offset` alone
 for a single line longer than the cap) so the model pages through the rest.
@@ -110,7 +110,7 @@ string Resolve(string root, string rel) {
 // NOT a bare StartsWith — so "/root" does not match "/root-evil".
 ```
 
-- `read`: a **whole-file** read that fits the **128 KiB** cap is returned in full
+- `read`: a **whole-file** read that fits the **32 KiB** cap is returned in full
   (**verbatim** — exact bytes preserved — unless numbering is requested) and detects
   binary (NUL byte in a head sample) → `Error("not a text file")`. Over the cap it
   **truncates instead of erroring**: the rendered output (exact UTF-8 bytes — line

--- a/docs/mcp35-servers-spec.md
+++ b/docs/mcp35-servers-spec.md
@@ -75,7 +75,7 @@ Tools map to the approval table: `read`/`list`/`search` ReadOnly,
 
 | Tool | Schema (required *) | Behavior |
 |------|---------------------|----------|
-| `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?`, `offset?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. Over-cap reads **truncate** (not error), returning `{content, truncated, next_start_line \| next_offset}`; `offset` resumes a byte window. |
+| `read` | `path*`, `start_line?`, `end_line?`, `line_numbers?`, `offset?` | UTF-8 (BOM-aware) text of a file under root; optional 1-based inclusive line range and/or per-line numbering. Over-cap reads **truncate** (not error), returning `{content, truncated, next_start_line?, next_offset}`; resume by passing `start_line`+`offset` (line-aware, O(1) seek) or `offset` alone (raw byte window for a single over-cap line). |
 | `list` | `path*`, `recursive?` | Directory entries: `{name,type,size}`; capped count. |
 | `search` | `query*`, `path?`, `regex?`, `ignore_case?`, `glob?`, `max_results?` | Grep file contents under root → `{path,line,text}`; recursive, **streamed (any file size)**, skips binary. |
 | `write` | `path*`, `content*`, `create_dirs?` | Atomic create/overwrite under root. |
@@ -85,14 +85,16 @@ Tools map to the approval table: `read`/`list`/`search` ReadOnly,
 The **agentic** additions — `search`, `edit`, and `read`'s line-range/numbering
 options — exist so the model can locate and surgically modify code without
 rewriting whole files (fewer tokens, fewer clobbers). All share the sandbox and
-binary sniff; `edit` reuses `write`'s atomic temp-then-move. The 1 MiB cap is a
-**context** guard on what a `read` emits into the model — but it never blocks: an
-over-cap `read` **truncates and hands back a continuation token** (`next_start_line`,
-or `next_offset` for a single line longer than the cap) so the model pages through
-the rest. Everything streams, bounding output (or memory) rather than file size:
-`search` and `read` (by line, falling to a byte window for a lone over-cap line),
-`edit` by a chunk + carry buffer. So large files remain searchable, any file is
-readable in full via pagination, and any file is editable.
+binary sniff; `edit` reuses `write`'s atomic temp-then-move. The **128 KiB** read
+cap (~32K tokens; 1 MiB would be ~250K+) is a **context** guard on what a `read`
+emits into the model — but it never blocks: an over-cap `read` **truncates and hands
+back a continuation token** (`next_start_line`+`next_offset`, or `next_offset` alone
+for a single line longer than the cap) so the model pages through the rest.
+Everything streams, bounding output (or memory) rather than file size: `search` and
+`read` (by line, falling to a byte window for a lone over-cap line), `edit` by a
+chunk + carry buffer. So large files remain searchable, any file is readable in full
+via pagination, and any file is editable. (Multiline `search` is the one exception —
+it reads a whole file into memory, so it keeps a separate 1 MiB file-size limit.)
 
 **Sandbox — the one rule that matters here:** every `path` is resolved against
 the root and must stay inside it.
@@ -108,27 +110,28 @@ string Resolve(string root, string rel) {
 // NOT a bare StartsWith — so "/root" does not match "/root-evil".
 ```
 
-- `read`: a **whole-file** read that fits the **1 MiB** cap is returned in full
+- `read`: a **whole-file** read that fits the **128 KiB** cap is returned in full
   (**verbatim** — exact bytes preserved — unless numbering is requested) and detects
   binary (NUL byte in a head sample) → `Error("not a text file")`. Over the cap it
   **truncates instead of erroring**: the rendered output (exact UTF-8 bytes — line
-  content + `\n` separators + the line-number prefix when numbering) is held to 1 MiB
-  and the result becomes a JSON envelope `{content, truncated:true, next_start_line |
-  next_offset}`. The continuation coordinate is set by **where the cut lands**: at a
-  line boundary (≥1 whole line emitted) → **`next_start_line`** (resume via
-  `start_line`); inside a **single line longer than the cap** (the minified-file case,
-  where line ranges can't subdivide) → **`next_offset`**, a byte offset to resume via
-  the **`offset`** parameter. `offset` reads a raw byte window with an O(1) seek
-  (ignoring `start_line`/`end_line`), backing each cut up to a UTF-8 boundary so a
-  codepoint is never split; it keeps reporting `next_offset` until the tail fits and
-  comes back as plain text. So the model pages through a file of any shape — multi-line
-  or single-line — until a read is no longer truncated. The reader streams fixed char
-  chunks (never buffering a whole over-cap line), so memory stays bounded. A
-  `start_line`/`offset` past EOF → `Error`; an `end_line` past EOF stops at the last
-  line. **Limitations:** truncated output is line-normalized (the verbatim guarantee is
-  for the untruncated whole-file read only); the streaming path treats `\n` as the
-  separator (CRLF handled, a lone CR is not a break); `line_numbers` is dropped once a
-  read cuts into a single line.
+  content + `\n` separators + the line-number prefix when numbering) is held to the cap
+  and the result becomes a JSON envelope `{content, truncated:true, next_start_line?,
+  next_offset}`. The continuation is set by **where the cut lands**: at a line boundary
+  (≥1 whole line emitted) → **`next_start_line`** *and* **`next_offset`** (the byte that
+  line begins at); inside a **single line longer than the cap** (the minified-file case,
+  where line ranges can't subdivide) → **`next_offset`** only. To resume, pass back
+  **both** `start_line` and `offset` (a line-aware **O(1) seek** — no rescan from the
+  top — that continues numbering), or `offset` alone for a raw byte window of the over-cap
+  line. A byte window backs each cut up to a UTF-8 boundary so a codepoint is never
+  split, and keeps reporting `next_offset` until the tail fits and comes back as plain
+  text. So the model pages through a file of any shape — multi-line or single-line —
+  until a read is no longer truncated. The reader streams fixed char chunks (never
+  buffering a whole over-cap line), so memory stays bounded. A `start_line`/`offset`
+  past EOF → `Error` (a malformed/negative `offset` → `Error`); an `end_line` past EOF
+  stops at the last line. Line endings are split like the rest of the read path (LF,
+  CRLF, and lone CR). **Limitations:** truncated output is line-normalized (the verbatim
+  guarantee is for the untruncated whole-file read only); `line_numbers` is dropped once
+  a read cuts into a single line (byte-window mode).
 - `list`: cap entries (e.g. 1000) and note truncation; `recursive` bounded depth.
 - `search`: walk the tree under `path` (default root) bounded by the same depth
   cap as `list`, **streaming** each file line-by-line (no per-file size cap);

--- a/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
+++ b/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
@@ -1,0 +1,135 @@
+# files__read Truncation & Chunked Reads — Implementation Spec
+
+**Goal:** Make `files__read` (FilesMcpServer's `read` tool) handle files larger than the
+1 MiB output cap by **truncating with a continuation token** instead of erroring, and make
+**minified / zero-newline files readable** by paginating with a byte offset when a single line
+is itself larger than the cap.
+
+**Tech stack / constraints:** `servers/FilesMcpServer/FilesTools.cs` compiles under **C# 3 /
+.NET 3.5** (VS2008 toolchain) — no `StringBuilder.Clear()` (use `.Length = 0`), no
+`string.IsNullOrWhiteSpace`, match the file's explicit-type / `delegate(...)` style. Tests are
+xUnit on `net48` in `tests/FilesMcpServer.Tests/` driven through the scripted-stream `Harness`.
+
+---
+
+## Background — current behavior (the dead end)
+
+The 1 MiB cap (`MaxReadBytes`) is a **context** guard. Today it is enforced by **erroring**:
+
+- Whole-file read over cap → `Error("file too large … read a line range instead")`.
+- Ranged read whose rendered output exceeds the cap → `Error("requested range is too large …")`.
+
+For a **minified file** (a multi-MiB JSON/JS with zero newlines) *every* path fails with no
+content: the whole file is one line, so a line range can't subdivide it, and `start_line=1`
+just re-hits the cap. The file is unreadable.
+
+## Design
+
+### 1. Two continuation coordinates (Option A — explicit dual fields)
+
+Line ranges stay the ergonomic front door. The continuation token's **type is decided by where
+the read stops**:
+
+- Stop on a **line boundary** (≥1 complete line emitted, next line won't fit) → report
+  **`next_start_line`**. Resume in line-world.
+- Stop **inside a single line** that alone exceeds the cap (zero complete lines emitted) →
+  report **`next_offset`** (an absolute **byte** offset). Resume in byte-world.
+
+`next_offset` is byte-only; `next_start_line` is line-only. We never overload one field to mean
+both — the model must know which `read` parameter to feed it back into.
+
+**Per-call rule:** *Did at least one complete line fit before the cap?* Yes → boundary cut
+(`next_start_line` = the line we stopped before). No → byte cut (emit a byte-bounded prefix of
+that line, `next_offset` = byte position where we stopped). A line is only ever split when it
+alone can't fit — exactly the minified case.
+
+### 2. Result shape
+
+- **Not truncated** → bare text, exactly as today (whole-file verbatim when no range/numbering;
+  line-joined for ranged/numbered). The verbatim, byte-exact guarantee is preserved for the
+  untruncated whole-file read.
+- **Truncated** → `ToolResults.Json` envelope (sets `structuredContent`), built as a `JObject`
+  like `list`/`search`:
+  ```json
+  { "content": "…", "truncated": true, "next_start_line": 343, "hint": "…" }
+  // or, for a single over-cap line:
+  { "content": "…", "truncated": true, "next_offset": 1048576, "hint": "…" }
+  ```
+  The model loops while it keeps getting `truncated: true`, feeding `next_start_line` →
+  `start_line` or `next_offset` → `offset`, until a read comes back not truncated (bare text).
+
+### 3. New `read` parameter: `offset`
+
+`offset` (integer, byte, 0-based). When present, the read is a **byte window**: O(1) seek to the
+offset, read up to the cap, return the slice. Ignores `start_line`/`end_line`/`line_numbers`
+(byte-window reads are raw — there is no whole line to number). Truncates with `next_offset`;
+reaches EOF within the cap → not truncated (bare text), which terminates the loop.
+
+### 4. Mode transition (one-way, deliberately)
+
+`line-mode → byte-mode` happens within a line-mode call when the first line overflows. A
+**byte-mode read stays in byte-mode** (continues reporting `next_offset`) until it completes,
+because recovering line numbers after an O(1) byte seek would require an O(n) rescan from the
+start — not worth it. The model still receives every byte; only the trailing chunks of a file
+that contained an over-cap line come back unnumbered. (A no-arg whole-file over-cap read starts
+in **line-mode from line 1**, so ordinary multi-line files truncate with `next_start_line` and
+only genuinely single-line files fall to `next_offset`.)
+
+### 5. Streaming & memory (why not `ReadLine()`)
+
+`StreamReader.ReadLine()` buffers an entire line, so a 5 MiB single line materializes fully —
+blowing the budget we're enforcing. The line-mode reader therefore reads **fixed char chunks**
+(like `Edit`'s 64K loop) and scans for `\n` itself, tracking:
+
+- the running line number,
+- the absolute **byte** offset (incremental UTF-8 byte count of consumed chars; `\r` of a CRLF
+  is counted in the line content, only the `\n` is added as the terminator; BOM adds 3),
+- emitted content, capped at the budget.
+
+An **overflow guard** runs per emitted char: when the tentative rendered total (content bytes +
+`\n` separators + line-number prefixes, same exact-UTF-8-byte accounting as today) exceeds the
+cap, it cuts immediately — boundary cut if any line was already emitted, else byte cut — so it
+never finishes reading an over-cap line. Memory stays ≈ one chunk + ≤ budget.
+
+Byte-mode reads raw bytes with an O(1) seek and, when truncating, **backs the cut up to a UTF-8
+lead-byte boundary** so a multi-byte codepoint is never split (line-mode cuts on char
+boundaries, so it's inherently safe). A leading UTF-8 BOM is stripped only when `offset == 0`.
+
+### 6. Documented limitations
+
+- Truncated reads are **line-normalized** (CRLF/CR rendered as the read tools already do); the
+  byte-exact guarantee holds only for the untruncated whole-file read.
+- The streaming line scanner treats **`\n`** as the separator (CRLF handled); a **lone CR**
+  (classic-Mac) is not a line break on the truncation path. Rare, and the small-file fast paths
+  are unchanged.
+- `line_numbers` is ignored once a read cuts into a single line (byte cut) — there is no whole
+  line to number, and this only happens for single-line files where numbering is meaningless.
+
+---
+
+## Implementation tasks
+
+### Task 1 — `read` schema + handler (`FilesTools.cs`)
+
+- [ ] Add `.Int("offset", false, "Byte offset to resume a truncated read from (for a single line longer than the cap)")` to the `read` schema; update the tool description to explain truncation, `next_start_line` / `next_offset`, and `offset`.
+- [ ] Rewrite `Read`: keep the untruncated whole-file fast path (verbatim / numbered) for files ≤ cap; route `offset` → `ReadByteWindow`; route `start_line`/`end_line` and the **over-cap whole-file** case → `ReadLineWindow`. Replace the two over-cap `Error`s with truncation.
+- [ ] Add `RenderRead(ReadResult)`: `Error` → `ToolResults.Error`; not truncated → `ToolResults.Text`; truncated → `JObject` envelope → `ToolResults.Json`.
+
+### Task 2 — streaming readers (`FilesTools.cs`)
+
+- [ ] `ReadLineWindow(full, startLine, endLine, lineNumbers, budget)` — chunked char scanner with the overflow guard producing boundary cut (`next_start_line`) or byte cut (`next_offset`); `start_line` past EOF → `Error`.
+- [ ] `ReadByteWindow(full, offset, budget)` — binary sniff, O(1) seek, UTF-8-safe cut, BOM strip at offset 0, `next_offset` on truncation; `offset > length` → `Error`, `offset == length` → empty/not truncated.
+- [ ] Helpers: `LongArg`, `Utf8ByteCount`, `HasUtf8Bom`, `Utf8SafeCut`, `IsUtf8Continuation`, `ReadFull`, and a private `ReadResult` holder. Remove the old `ReadRange`.
+
+### Task 3 — tests (`tests/FilesMcpServer.Tests/FilesToolsTests.cs`)
+
+- [ ] **Update** the now-truncating cases: `Oversize_read_is_error` (single 2 MiB line → `next_offset`), `Read_range_rejects_an_oversize_selection` (→ `next_start_line`), `Read_range_cap_counts_utf8_bytes_not_chars` (→ truncated), the "just over" half of `Read_range_at_cap_boundary…` (→ `next_start_line=61682`, same content length), and part 2 of `Read_range_works_on_oversize_file…` (whole-file over cap → `next_start_line`).
+- [ ] **Add:** resume-via-`next_offset`-until-complete on a minified single-line file (reassembles to original); UTF-8 byte cut never splits a codepoint (all-`€` line); short-line-then-giant-line yields `next_start_line` then `next_offset`; `offset` past EOF → error; `offset == length` → empty, not truncated.
+
+### Task 4 — spec doc
+
+- [ ] Update `docs/mcp35-servers-spec.md` `read` row + bullet to describe truncation, `offset`, and the two continuation coordinates.
+
+### Verification
+
+- [ ] `dotnet test tests/FilesMcpServer.Tests` green; whole-file verbatim / numbering / BOM / binary / sandbox tests still pass unchanged.

--- a/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
+++ b/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
@@ -1,7 +1,15 @@
 # files__read Truncation & Chunked Reads — Implementation Spec
 
+> **Addendum (post-review).** A code review revised several details after this plan was written;
+> `docs/mcp35-servers-spec.md` is authoritative. Deltas: the output cap is **128 KiB** (~32K
+> tokens), not 1 MiB; a **boundary cut returns `next_start_line` AND `next_offset`** so a resume
+> passing both seeks **O(1)** (no rescan from the top) while continuing line numbering — `offset`
+> alone is still the raw byte window for a single over-cap line; the line scanner is **lone-CR
+> aware** (matches `SplitLines`); a **malformed/negative `offset` errors**; and the host's
+> `FormatResult` was fixed so a `ToolResults.Json` envelope is no longer sent to the model twice.
+
 **Goal:** Make `files__read` (FilesMcpServer's `read` tool) handle files larger than the
-1 MiB output cap by **truncating with a continuation token** instead of erroring, and make
+output cap by **truncating with a continuation token** instead of erroring, and make
 **minified / zero-newline files readable** by paginating with a byte offset when a single line
 is itself larger than the cap.
 

--- a/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
+++ b/docs/superpowers/plans/2026-06-26-read-truncation-chunked.md
@@ -1,7 +1,7 @@
 # files__read Truncation & Chunked Reads — Implementation Spec
 
 > **Addendum (post-review).** A code review revised several details after this plan was written;
-> `docs/mcp35-servers-spec.md` is authoritative. Deltas: the output cap is **128 KiB** (~32K
+> `docs/mcp35-servers-spec.md` is authoritative. Deltas: the output cap is **32 KiB** (~8K
 > tokens), not 1 MiB; a **boundary cut returns `next_start_line` AND `next_offset`** so a resume
 > passing both seeks **O(1)** (no rescan from the top) while continuing line numbering — `offset`
 > alone is still the raw byte window for a single over-cap line; the line scanner is **lone-CR

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -14,7 +14,10 @@ namespace FilesMcpServer
     /// The Files server's tools, all confined to the sandbox root. read/list/search are ReadOnly,
     /// write/edit are Write(path-scoped), delete is Destructive(path-scoped) — host-gated; the
     /// server's job is safe construction (servers-spec §2). edit/search and read's line-range/
-    /// numbering options are the agentic enhancements (range reads were flagged as a later add).
+    /// numbering options are the agentic enhancements. An over-cap read truncates rather than
+    /// failing, returning a continuation token (next_start_line, or next_offset for a single line
+    /// longer than the cap) so the model can page through a file of any shape — including minified
+    /// (zero-newline) files, where line ranges can't subdivide the one giant line.
     /// </summary>
     internal static class FilesTools
     {
@@ -35,12 +38,19 @@ namespace FilesMcpServer
             PathSandbox sandbox = new PathSandbox(config.WorkDir, "workspace root");
 
             server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root. "
-                + "Optionally read a line range (1-based, inclusive) and/or prefix each line with its number.",
+                + "Optionally read a line range (1-based, inclusive) and/or prefix each line with its number. "
+                + "Reads larger than the size cap are TRUNCATED rather than failing: the result is then a JSON "
+                + "object {content, truncated:true, next_start_line | next_offset}. Continue by passing "
+                + "next_start_line to the next read's start_line; for a single line longer than the cap you "
+                + "instead get next_offset (a byte offset) — pass it as offset to read the next chunk. Loop "
+                + "until a read comes back as plain (non-truncated) text.",
                 SchemaBuilder.Object()
                     .Str("path", true, "Path relative to the workspace root")
                     .Int("start_line", false, "First line to return (1-based, inclusive)")
                     .Int("end_line", false, "Last line to return (1-based, inclusive)")
                     .Bool("line_numbers", false, "Prefix each returned line with its 1-based line number")
+                    .Int("offset", false, "Byte offset to resume a truncated read from (used with next_offset "
+                        + "to page through a single line longer than the cap); ignores start_line/end_line")
                     .Build(),
                 ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Read(sandbox, ctx); });
@@ -101,6 +111,24 @@ namespace FilesMcpServer
 
         // ---- read ----
 
+        // Chunk size for the streaming line scanner — matches Edit's reader so a single over-cap
+        // line is never materialized whole (ReadLine would buffer it, blowing the size budget).
+        private const int ReadChunkChars = 64 * 1024;
+
+        // The outcome of a streaming read: emitted text plus how (if at all) to continue. Exactly
+        // one of Error / a plain (untruncated) Content / a truncated Content + continuation holds.
+        private sealed class ReadResult
+        {
+            public string Error;          // non-null => return ToolResults.Error
+            public string Content;        // emitted text
+            public bool Truncated;
+            public bool HasNextLine;      // true => NextStartLine, false => NextOffset
+            public int NextStartLine;     // resume at this 1-based line (boundary cut)
+            public long NextOffset;       // resume at this byte offset (byte cut / byte-window)
+
+            public static ReadResult Err(string m) { ReadResult r = new ReadResult(); r.Error = m; return r; }
+        }
+
         private static CallToolResult Read(PathSandbox sandbox, ToolCallContext ctx)
         {
             string full;
@@ -109,101 +137,318 @@ namespace FilesMcpServer
 
             if (!File.Exists(full)) return ToolResults.Error("file not found");
 
-            bool hasStart = HasArg(ctx, "start_line");
-            bool hasEnd = HasArg(ctx, "end_line");
             bool lineNumbers = BoolArg(ctx, "line_numbers", false);
 
-            // A line range streams, so a slice of a large file is readable even past the whole-file
-            // cap (the output is bounded by the range, not the file size).
-            if (hasStart || hasEnd)
-                return ReadRange(full, ctx, hasStart, hasEnd, lineNumbers);
-
-            // Whole-file read: bounded by the size cap (it all lands in the model context).
-            FileInfo fi = new FileInfo(full);
-            if (fi.Length > MaxReadBytes)
-                return ToolResults.Error("file too large (" + fi.Length + " bytes; max " + MaxReadBytes
-                    + ") — read a line range instead");
-
-            byte[] bytes = File.ReadAllBytes(full);
-            if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
-            string text = DecodeUtf8(bytes);
-
-            // Fast path: whole file, no numbering -> return content verbatim (preserves exact bytes).
-            if (!lineNumbers)
-                return ToolResults.Text(text);
-
-            string[] lines = SplitLines(text);
-            int width = lines.Length.ToString().Length;
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < lines.Length; i++)
+            // Resuming a truncated single-line read: a byte window (O(1) seek), no line semantics.
+            if (HasArg(ctx, "offset"))
             {
-                sb.Append((i + 1).ToString().PadLeft(width));
-                sb.Append('\t');
-                sb.Append(lines[i]);
-                if (i < lines.Length - 1) sb.Append('\n');
+                long offset = LongArg(ctx, "offset", 0, 0, long.MaxValue);
+                return RenderRead(ReadByteWindow(full, offset, MaxReadBytes));
             }
-            return ToolResults.Text(sb.ToString());
+
+            // A line range streams and is now truncated (not rejected) when its rendered output would
+            // exceed the cap: ordinary ranges resume by line, a single over-cap line by byte offset.
+            bool hasStart = HasArg(ctx, "start_line");
+            bool hasEnd = HasArg(ctx, "end_line");
+            if (hasStart || hasEnd)
+            {
+                int start = hasStart ? IntArg(ctx, "start_line", 1, 1, int.MaxValue) : 1;
+                int end = hasEnd ? IntArg(ctx, "end_line", int.MaxValue, 1, int.MaxValue) : int.MaxValue;
+                if (end < start)
+                    return ToolResults.Error("end_line (" + end + ") is before start_line (" + start + ")");
+                return RenderRead(ReadLineWindow(full, start, end, lineNumbers, MaxReadBytes));
+            }
+
+            // Whole-file read. If it fits the cap, return it in full (verbatim when no numbering, so
+            // exact bytes are preserved). If it is over the cap, truncate from line 1 instead of
+            // failing — the model pages onward via next_start_line (or next_offset for a lone line).
+            FileInfo fi = new FileInfo(full);
+            if (fi.Length <= MaxReadBytes)
+            {
+                byte[] bytes = File.ReadAllBytes(full);
+                if (LooksBinary(bytes)) return ToolResults.Error("not a text file");
+                string text = DecodeUtf8(bytes);
+
+                if (!lineNumbers)
+                    return ToolResults.Text(text);
+
+                string[] lines = SplitLines(text);
+                int width = lines.Length.ToString().Length;
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    sb.Append((i + 1).ToString().PadLeft(width));
+                    sb.Append('\t');
+                    sb.Append(lines[i]);
+                    if (i < lines.Length - 1) sb.Append('\n');
+                }
+                return ToolResults.Text(sb.ToString());
+            }
+
+            return RenderRead(ReadLineWindow(full, 1, int.MaxValue, lineNumbers, MaxReadBytes));
         }
 
-        // Stream a 1-based inclusive line range; output bytes are capped (not the file size), so a
-        // slice of an arbitrarily large file is readable. start/end default to file bounds.
-        private static CallToolResult ReadRange(string full, ToolCallContext ctx, bool hasStart, bool hasEnd, bool lineNumbers)
+        // Turn a streaming ReadResult into a tool result: error, plain text (not truncated), or a
+        // JSON envelope carrying the continuation token (mirrors list/search's structured shape).
+        private static CallToolResult RenderRead(ReadResult rr)
         {
-            int start = hasStart ? IntArg(ctx, "start_line", 1, 1, int.MaxValue) : 1;
-            int end = hasEnd ? IntArg(ctx, "end_line", int.MaxValue, 1, int.MaxValue) : int.MaxValue;
-            if (end < start)
-                return ToolResults.Error("end_line (" + end + ") is before start_line (" + start + ")");
+            if (rr.Error != null) return ToolResults.Error(rr.Error);
+            if (!rr.Truncated) return ToolResults.Text(rr.Content);
 
+            JObject o = new JObject();
+            o["content"] = rr.Content;
+            o["truncated"] = true;
+            if (rr.HasNextLine)
+            {
+                o["next_start_line"] = rr.NextStartLine;
+                o["hint"] = "Output truncated at the size cap. Continue with start_line=" + rr.NextStartLine + ".";
+            }
+            else
+            {
+                o["next_offset"] = rr.NextOffset;
+                o["hint"] = "Output truncated inside a single long line. Continue with offset=" + rr.NextOffset + ".";
+            }
+            return ToolResults.Json(o);
+        }
+
+        // Stream a 1-based inclusive line range, emitting whole lines until the rendered output would
+        // exceed `budget`. When it would: if at least one line was emitted, stop on that boundary and
+        // resume by line (next_start_line); if the very first line alone is over budget, emit a
+        // byte-bounded prefix of it and resume by byte (next_offset). Reads fixed char chunks and
+        // scans for '\n' itself so a single huge line is never buffered whole. Byte positions are
+        // tracked exactly (a CRLF's '\r' counts as line content; only the '\n' is the +1 terminator;
+        // a UTF-8 BOM adds 3) so next_offset lands on a real boundary.
+        private static ReadResult ReadLineWindow(string full, int startLine, int endLine, bool lineNumbers, long budget)
+        {
             StreamReader sr;
             try { sr = OpenTextReaderOrNull(full); }
-            catch { return ToolResults.Error("file not found"); }
-            if (sr == null) return ToolResults.Error("not a text file");
+            catch { return ReadResult.Err("file not found"); }
+            if (sr == null) return ReadResult.Err("not a text file");
 
-            UTF8Encoding utf8NoBom = new UTF8Encoding(false);
-            List<string> picked = new List<string>();
-            int lineNo = 0;
-            long contentBytes = 0;
+            long bomLen = HasUtf8Bom(full) ? 3 : 0;   // OpenTextReaderOrNull strips the BOM from the chars
+
+            List<string> emitted = new List<string>();  // content of emitted lines (bounded by budget)
+            long contentBytes = 0;                       // UTF-8 bytes of emitted contents (no separators)
+            int lastEmittedLineNo = 0;
+
             using (sr)
             {
-                string line;
-                while ((line = sr.ReadLine()) != null)
-                {
-                    lineNo++;
-                    if (lineNo < start) continue;
-                    if (lineNo > end) break;
-                    picked.Add(line);
-                    contentBytes += utf8NoBom.GetByteCount(line);
+                char[] buf = new char[ReadChunkChars];
+                StringBuilder cur = new StringBuilder();   // chars of the in-progress line (incl. a CRLF '\r')
+                long curContentBytes = 0;                  // UTF-8 bytes of every char consumed for this line
+                long curStartByte = bomLen;                // byte offset where the in-progress line begins
+                int curLineNo = 1;
+                bool highPending = false;                  // surrogate-pair state for incremental byte counting
 
-                    // Cap the exact rendered UTF-8 size, not the char count. The rendered output is:
-                    // the line bytes, '\n' separators (count - 1), and — when numbering — a prefix on
-                    // every line of `width` digits + a '\t', where width is the digit count of the
-                    // LAST line number (right-aligned PadLeft). `lineNo` is that last number so far, so
-                    // applying its width to all picked lines makes this total exact at the final line.
-                    long total = contentBytes + (picked.Count - 1);
-                    if (lineNumbers) total += (long)picked.Count * (DigitCount(lineNo) + 1);
-                    if (total > MaxReadBytes)
-                        return ToolResults.Error("requested range is too large (over " + MaxReadBytes
-                            + " bytes of rendered output) — narrow start_line/end_line");
+                int read;
+                while ((read = sr.Read(buf, 0, buf.Length)) > 0)
+                {
+                    for (int i = 0; i < read; i++)
+                    {
+                        char c = buf[i];
+
+                        if (c == '\n')
+                        {
+                            string raw = cur.ToString();
+                            bool crlf = raw.Length > 0 && raw[raw.Length - 1] == '\r';
+                            string content = crlf ? raw.Substring(0, raw.Length - 1) : raw;
+
+                            if (curLineNo >= startLine && curLineNo <= endLine)
+                            {
+                                // The overflow guard below guarantees this completed line fits.
+                                emitted.Add(content);
+                                contentBytes += Utf8ByteCount(content);
+                                lastEmittedLineNo = curLineNo;
+                            }
+
+                            // Advance past the line + its '\n' ('\r' is already inside curContentBytes).
+                            curStartByte = curStartByte + curContentBytes + 1;
+                            cur.Length = 0;                // .NET 3.5: StringBuilder has no Clear()
+                            curContentBytes = 0;
+                            highPending = false;
+                            curLineNo++;
+
+                            if (curLineNo > endLine)
+                                return Complete(emitted, lineNumbers, lastEmittedLineNo);
+                            continue;
+                        }
+
+                        // Incremental UTF-8 byte count of this char (correct across surrogate pairs).
+                        int cb;
+                        if (char.IsHighSurrogate(c)) { highPending = true; cb = 0; }
+                        else if (highPending) { highPending = false; cb = 4; }
+                        else if (c < 0x80) cb = 1;
+                        else if (c < 0x800) cb = 2;
+                        else cb = 3;
+                        curContentBytes += cb;
+
+                        bool emitting = curLineNo >= startLine && curLineNo <= endLine;
+                        if (!emitting) continue;   // skipped line: count bytes only, never store content
+
+                        cur.Append(c);
+
+                        // Would this line, completed now, push the rendered output past the budget?
+                        long total = TentativeTotal(contentBytes, emitted.Count, curContentBytes, curLineNo, lineNumbers);
+                        if (total > budget)
+                        {
+                            if (emitted.Count > 0)
+                                return BoundaryCut(emitted, lineNumbers, lastEmittedLineNo, curLineNo);
+                            return ByteCut(cur, curStartByte, budget);
+                        }
+                    }
                 }
+
+                // EOF — finalize a trailing line that had no terminating '\n'.
+                string lastRaw = cur.ToString();
+                if (lastRaw.Length > 0)
+                {
+                    bool crlf = lastRaw[lastRaw.Length - 1] == '\r';
+                    string content = crlf ? lastRaw.Substring(0, lastRaw.Length - 1) : lastRaw;
+                    if (curLineNo >= startLine && curLineNo <= endLine)
+                    {
+                        emitted.Add(content);
+                        lastEmittedLineNo = curLineNo;
+                    }
+                }
+
+                if (emitted.Count == 0)
+                {
+                    int totalLines = lastRaw.Length > 0 ? curLineNo : curLineNo - 1;
+                    return ReadResult.Err("start_line " + startLine + " exceeds file length (" + totalLines + " lines)");
+                }
+                return Complete(emitted, lineNumbers, lastEmittedLineNo);
+            }
+        }
+
+        // Rendered size if the candidate line (candidateBytes of content) were emitted now: existing
+        // content + this line + '\n' separators (one before each line after the first) + the
+        // right-aligned number prefix on every line when numbering (width = the last line's digits).
+        private static long TentativeTotal(long contentBytes, int emittedCount, long candidateBytes, int candidateLineNo, bool lineNumbers)
+        {
+            long total = contentBytes + candidateBytes + emittedCount;
+            if (lineNumbers) total += (long)(emittedCount + 1) * (DigitCount(candidateLineNo) + 1);
+            return total;
+        }
+
+        private static ReadResult Complete(List<string> emitted, bool lineNumbers, int lastLineNo)
+        {
+            ReadResult r = new ReadResult();
+            r.Content = JoinEmitted(emitted, lineNumbers, lastLineNo);
+            r.Truncated = false;
+            return r;
+        }
+
+        private static ReadResult BoundaryCut(List<string> emitted, bool lineNumbers, int lastLineNo, int nextStartLine)
+        {
+            ReadResult r = new ReadResult();
+            r.Content = JoinEmitted(emitted, lineNumbers, lastLineNo);
+            r.Truncated = true;
+            r.HasNextLine = true;
+            r.NextStartLine = nextStartLine;
+            return r;
+        }
+
+        // The first emitted line alone exceeds the budget: emit the largest char prefix whose UTF-8
+        // size fits and resume by byte. Cutting on a char boundary keeps both halves valid UTF-8;
+        // numbering is dropped because we are mid-line. next_offset is the file byte after the prefix.
+        private static ReadResult ByteCut(StringBuilder cur, long lineStartByte, long budget)
+        {
+            long bytes = 0;
+            int cut = 0;
+            for (int i = 0; i < cur.Length; i++)
+            {
+                char c = cur[i];
+                int cb;
+                bool pair = false;
+                if (char.IsHighSurrogate(c) && i + 1 < cur.Length && char.IsLowSurrogate(cur[i + 1]))
+                { cb = 4; pair = true; }
+                else if (c < 0x80) cb = 1;
+                else if (c < 0x800) cb = 2;
+                else cb = 3;
+
+                if (bytes + cb > budget) break;
+                bytes += cb;
+                cut = pair ? i + 2 : i + 1;
+                if (pair) i++;
             }
 
-            if (picked.Count == 0)
-                return ToolResults.Error("start_line " + start + " exceeds file length (" + lineNo + " lines)");
+            ReadResult r = new ReadResult();
+            r.Content = cur.ToString(0, cut);
+            r.Truncated = true;
+            r.HasNextLine = false;
+            r.NextOffset = lineStartByte + bytes;
+            return r;
+        }
 
-            int lastLineNo = start + picked.Count - 1;
+        private static string JoinEmitted(List<string> emitted, bool lineNumbers, int lastLineNo)
+        {
+            if (emitted.Count == 0) return string.Empty;
             int width = lastLineNo.ToString().Length;
+            int firstNo = lastLineNo - emitted.Count + 1;
             StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < picked.Count; i++)
+            for (int i = 0; i < emitted.Count; i++)
             {
                 if (lineNumbers)
                 {
-                    sb.Append((start + i).ToString().PadLeft(width));
+                    sb.Append((firstNo + i).ToString().PadLeft(width));
                     sb.Append('\t');
                 }
-                sb.Append(picked[i]);
-                if (i < picked.Count - 1) sb.Append('\n');
+                sb.Append(emitted[i]);
+                if (i < emitted.Count - 1) sb.Append('\n');
             }
-            return ToolResults.Text(sb.ToString());
+            return sb.ToString();
+        }
+
+        // Read a raw byte window at an O(1) seek. Returns up to `budget` bytes; when more remains,
+        // backs the cut up to a UTF-8 lead byte so a codepoint is never split, and reports the byte
+        // offset to resume from. A leading BOM is stripped only at offset 0. Skips binary files.
+        private static ReadResult ReadByteWindow(string full, long offset, long budget)
+        {
+            FileStream fs;
+            try { fs = new FileStream(full, FileMode.Open, FileAccess.Read, FileShare.ReadWrite); }
+            catch { return ReadResult.Err("file not found"); }
+
+            using (fs)
+            {
+                byte[] head = new byte[BinarySniffBytes];
+                int hn = fs.Read(head, 0, head.Length);
+                if (LooksBinary(head, hn)) return ReadResult.Err("not a text file");
+
+                long len = fs.Length;
+                if (offset > len)
+                    return ReadResult.Err("offset " + offset + " exceeds file length (" + len + " bytes)");
+                if (offset == len)
+                {
+                    ReadResult empty = new ReadResult();
+                    empty.Content = string.Empty;
+                    empty.Truncated = false;
+                    return empty;
+                }
+
+                fs.Position = offset;
+                int cap = (int)Math.Min(budget, (long)int.MaxValue);
+                byte[] data = new byte[cap];
+                int got = ReadFull(fs, data, cap);
+                bool more = offset + got < len;
+
+                int consumed = more ? Utf8SafeCut(data, got) : got;
+
+                int start = 0;
+                if (offset == 0 && consumed >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
+                    start = 3;
+                string content = new UTF8Encoding(false, false).GetString(data, start, consumed - start);
+
+                ReadResult r = new ReadResult();
+                r.Content = content;
+                if (more)
+                {
+                    r.Truncated = true;
+                    r.HasNextLine = false;
+                    r.NextOffset = offset + consumed;
+                }
+                else r.Truncated = false;
+                return r;
+            }
         }
 
         // ---- list ----
@@ -704,6 +949,81 @@ namespace FilesMcpServer
             if (n < min) return min;
             if (n > max) return max;
             return n;
+        }
+
+        private static long LongArg(ToolCallContext ctx, string name, long fallback, long min, long max)
+        {
+            JToken t = ctx.Arguments[name];
+            if (t == null || t.Type == JTokenType.Null) return fallback;
+            long n;
+            try { n = t.Value<long>(); }
+            catch { return fallback; }
+            if (n < min) return min;
+            if (n > max) return max;
+            return n;
+        }
+
+        private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false, false);
+
+        private static long Utf8ByteCount(string s)
+        {
+            return s.Length == 0 ? 0 : Utf8NoBom.GetByteCount(s);
+        }
+
+        // True if the file begins with a UTF-8 BOM (which the streaming reader strips from the chars,
+        // so its 3 bytes must be added back when computing absolute file byte offsets).
+        private static bool HasUtf8Bom(string full)
+        {
+            try
+            {
+                using (FileStream fs = new FileStream(full, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    byte[] b = new byte[3];
+                    int n = fs.Read(b, 0, 3);
+                    return n == 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF;
+                }
+            }
+            catch { return false; }
+        }
+
+        private static bool IsUtf8Continuation(byte b)
+        {
+            return (b & 0xC0) == 0x80;   // 10xxxxxx
+        }
+
+        // Largest count <= n that ends on a complete UTF-8 sequence: walk back over trailing
+        // continuation bytes to their lead byte; if that sequence is cut short, drop it too.
+        private static int Utf8SafeCut(byte[] data, int n)
+        {
+            if (n == 0) return 0;
+            int i = n - 1;
+            int cont = 0;
+            while (i >= 0 && IsUtf8Continuation(data[i])) { i--; cont++; }
+            if (i < 0) return n;   // all continuation bytes (invalid) — leave as-is
+
+            byte lead = data[i];
+            int seqLen;
+            if ((lead & 0x80) == 0) seqLen = 1;
+            else if ((lead & 0xE0) == 0xC0) seqLen = 2;
+            else if ((lead & 0xF0) == 0xE0) seqLen = 3;
+            else if ((lead & 0xF8) == 0xF0) seqLen = 4;
+            else seqLen = 1;       // invalid lead — treat as a single byte
+
+            int have = cont + 1;   // lead + its trailing continuation bytes present in the buffer
+            return have >= seqLen ? n : i;   // complete -> keep all; truncated -> cut before the lead
+        }
+
+        // FileStream.Read may return short; loop until `count` bytes or EOF. Returns bytes read.
+        private static int ReadFull(FileStream fs, byte[] buf, int count)
+        {
+            int total = 0;
+            while (total < count)
+            {
+                int n = fs.Read(buf, total, count - total);
+                if (n <= 0) break;
+                total += n;
+            }
+            return total;
         }
 
         // Split into lines on \n, \r\n, or \r, dropping the separators. A trailing newline does

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -23,10 +23,10 @@ namespace FilesMcpServer
     {
         // Caps (servers-spec §2).
         // Read OUTPUT cap: the rendered text of a single read lands in the model context, so this is
-        // a token guard. 128 KiB is ~32K tokens (1 MiB would be ~250K+ — larger than most context
+        // a token guard. 32 KiB is ~8K tokens (1 MiB would be ~250K+ — larger than most context
         // windows). Over-cap reads truncate with a continuation token rather than failing.
         // (internal so the tests can size fixtures off it instead of hard-coding the value.)
-        internal const long MaxReadBytes = 128 * 1024;       // 128 KiB
+        internal const long MaxReadBytes = 32 * 1024;        // 32 KiB
         // Multiline search reads a whole file into memory to match across lines; this bounds that
         // memory (not model context), so it stays at 1 MiB independent of the read output cap.
         private const long MaxMultilineFileBytes = 1024 * 1024;   // 1 MiB

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -22,7 +22,14 @@ namespace FilesMcpServer
     internal static class FilesTools
     {
         // Caps (servers-spec §2).
-        private const long MaxReadBytes = 1024 * 1024;       // 1 MiB
+        // Read OUTPUT cap: the rendered text of a single read lands in the model context, so this is
+        // a token guard. 128 KiB is ~32K tokens (1 MiB would be ~250K+ — larger than most context
+        // windows). Over-cap reads truncate with a continuation token rather than failing.
+        // (internal so the tests can size fixtures off it instead of hard-coding the value.)
+        internal const long MaxReadBytes = 128 * 1024;       // 128 KiB
+        // Multiline search reads a whole file into memory to match across lines; this bounds that
+        // memory (not model context), so it stays at 1 MiB independent of the read output cap.
+        private const long MaxMultilineFileBytes = 1024 * 1024;   // 1 MiB
         private const int MaxListEntries = 1000;
         private const int MaxRecursiveDepth = 16;
         private const int BinarySniffBytes = 8000;
@@ -40,17 +47,18 @@ namespace FilesMcpServer
             server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root. "
                 + "Optionally read a line range (1-based, inclusive) and/or prefix each line with its number. "
                 + "Reads larger than the size cap are TRUNCATED rather than failing: the result is then a JSON "
-                + "object {content, truncated:true, next_start_line | next_offset}. Continue by passing "
-                + "next_start_line to the next read's start_line; for a single line longer than the cap you "
-                + "instead get next_offset (a byte offset) — pass it as offset to read the next chunk. Loop "
+                + "object {content, truncated:true, next_start_line?, next_offset}. To continue a truncated "
+                + "read, pass the returned next_start_line AND next_offset back as start_line and offset; if "
+                + "only next_offset is returned (a single line longer than the cap), pass just offset. Loop "
                 + "until a read comes back as plain (non-truncated) text.",
                 SchemaBuilder.Object()
                     .Str("path", true, "Path relative to the workspace root")
                     .Int("start_line", false, "First line to return (1-based, inclusive)")
                     .Int("end_line", false, "Last line to return (1-based, inclusive)")
                     .Bool("line_numbers", false, "Prefix each returned line with its 1-based line number")
-                    .Int("offset", false, "Byte offset to resume a truncated read from (used with next_offset "
-                        + "to page through a single line longer than the cap); ignores start_line/end_line")
+                    .Int("offset", false, "Byte offset to resume a truncated read from. Combine with start_line "
+                        + "(both come back together as next_offset/next_start_line) to continue by line; pass "
+                        + "offset alone to read a raw byte window of a single over-cap line")
                     .Build(),
                 ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Read(sandbox, ctx); });
@@ -102,8 +110,8 @@ namespace FilesMcpServer
                     .Int("max_results", false, "Maximum matches to return (default 100, max 1000)")
                     .Bool("multiline", false, "Match against whole-file text with line endings intact, so the "
                         + "query/pattern may contain or span newlines (grep -U). In regex mode ^/$ become line "
-                        + "anchors. 'line' is where each match starts. Bounded by the read cap; line-mode streams "
-                        + "files of any size, multiline skips files over the cap.")
+                        + "anchors. 'line' is where each match starts. line-mode streams files of any size; "
+                        + "multiline reads the whole file into memory and skips files over 1 MiB.")
                     .Build(),
                 ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return Search(sandbox, ctx); });
@@ -139,15 +147,17 @@ namespace FilesMcpServer
 
             bool lineNumbers = BoolArg(ctx, "line_numbers", false);
 
-            // Resuming a truncated single-line read: a byte window (O(1) seek), no line semantics.
-            if (HasArg(ctx, "offset"))
-            {
-                long offset = LongArg(ctx, "offset", 0, 0, long.MaxValue);
-                return RenderRead(ReadByteWindow(full, offset, MaxReadBytes));
-            }
+            // offset is a byte position (int64) used to resume a truncated read. Reject a present-but-
+            // malformed value rather than silently restarting at 0 (which would re-read the head).
+            bool hasOffset = HasArg(ctx, "offset");
+            long offset = 0;
+            if (hasOffset && (!TryLongArg(ctx, "offset", out offset) || offset < 0))
+                return ToolResults.Error("offset must be a non-negative integer");
 
-            // A line range streams and is now truncated (not rejected) when its rendered output would
-            // exceed the cap: ordinary ranges resume by line, a single over-cap line by byte offset.
+            // A line range streams and is truncated (not rejected) when its rendered output would
+            // exceed the cap. When `offset` is also supplied it is the byte where `start` begins, so
+            // we seek there directly (O(1)) instead of rescanning from the top — the continuation a
+            // prior boundary-cut handed back. (offset alone, below, is a raw byte window.)
             bool hasStart = HasArg(ctx, "start_line");
             bool hasEnd = HasArg(ctx, "end_line");
             if (hasStart || hasEnd)
@@ -156,8 +166,18 @@ namespace FilesMcpServer
                 int end = hasEnd ? IntArg(ctx, "end_line", int.MaxValue, 1, int.MaxValue) : int.MaxValue;
                 if (end < start)
                     return ToolResults.Error("end_line (" + end + ") is before start_line (" + start + ")");
-                return RenderRead(ReadLineWindow(full, start, end, lineNumbers, MaxReadBytes));
+                if (hasOffset)
+                {
+                    long len = new FileInfo(full).Length;
+                    if (offset > len)
+                        return ToolResults.Error("offset " + offset + " exceeds file length (" + len + " bytes)");
+                }
+                return RenderRead(ReadLineWindow(full, start, end, lineNumbers, MaxReadBytes, hasOffset ? offset : 0));
             }
+
+            // offset alone: a raw byte window (resuming a single over-cap line), no line semantics.
+            if (hasOffset)
+                return RenderRead(ReadByteWindow(full, offset, MaxReadBytes));
 
             // Whole-file read. If it fits the cap, return it in full (verbatim when no numbering, so
             // exact bytes are preserved). If it is over the cap, truncate from line 1 instead of
@@ -185,7 +205,7 @@ namespace FilesMcpServer
                 return ToolResults.Text(sb.ToString());
             }
 
-            return RenderRead(ReadLineWindow(full, 1, int.MaxValue, lineNumbers, MaxReadBytes));
+            return RenderRead(ReadLineWindow(full, 1, int.MaxValue, lineNumbers, MaxReadBytes, 0));
         }
 
         // Turn a streaming ReadResult into a tool result: error, plain text (not truncated), or a
@@ -200,11 +220,16 @@ namespace FilesMcpServer
             o["truncated"] = true;
             if (rr.HasNextLine)
             {
+                // Boundary cut: resume by line. next_offset is the byte that line starts at, so a
+                // resume passing BOTH start_line and offset seeks O(1) instead of rescanning the head.
                 o["next_start_line"] = rr.NextStartLine;
-                o["hint"] = "Output truncated at the size cap. Continue with start_line=" + rr.NextStartLine + ".";
+                o["next_offset"] = rr.NextOffset;
+                o["hint"] = "Output truncated at the size cap. Continue with start_line="
+                    + rr.NextStartLine + " and offset=" + rr.NextOffset + ".";
             }
             else
             {
+                // Byte cut inside a single over-cap line: resume by raw (unnumbered) byte window.
                 o["next_offset"] = rr.NextOffset;
                 o["hint"] = "Output truncated inside a single long line. Continue with offset=" + rr.NextOffset + ".";
             }
@@ -212,20 +237,22 @@ namespace FilesMcpServer
         }
 
         // Stream a 1-based inclusive line range, emitting whole lines until the rendered output would
-        // exceed `budget`. When it would: if at least one line was emitted, stop on that boundary and
-        // resume by line (next_start_line); if the very first line alone is over budget, emit a
-        // byte-bounded prefix of it and resume by byte (next_offset). Reads fixed char chunks and
-        // scans for '\n' itself so a single huge line is never buffered whole. Byte positions are
-        // tracked exactly (a CRLF's '\r' counts as line content; only the '\n' is the +1 terminator;
-        // a UTF-8 BOM adds 3) so next_offset lands on a real boundary.
-        private static ReadResult ReadLineWindow(string full, int startLine, int endLine, bool lineNumbers, long budget)
+        // exceed `budget`. If at least one line was emitted, stop on the boundary and resume by line
+        // (next_start_line, plus next_offset = the byte that line starts at, for an O(1) resume); if
+        // the first line alone is over budget, emit a byte-bounded prefix and resume by byte
+        // (next_offset). Reads fixed char chunks and scans line endings itself — LF, CRLF, and a lone
+        // CR (matching SplitLines) — so a single huge line is never buffered whole. `startByte` > 0
+        // seeks there directly and treats it as the start of line `startLine` (the O(1) resume path);
+        // otherwise it streams from the top, skipping lines before `startLine`. Byte offsets are
+        // tracked exactly (a line ending is 1 byte for LF/lone-CR, 2 for CRLF; a BOM adds 3) so
+        // next_offset lands on a real boundary.
+        private static ReadResult ReadLineWindow(string full, int startLine, int endLine, bool lineNumbers, long budget, long startByte)
         {
+            long bomLen;
             StreamReader sr;
-            try { sr = OpenTextReaderOrNull(full); }
+            try { sr = OpenTextReaderAt(full, startByte, out bomLen); }
             catch { return ReadResult.Err("file not found"); }
             if (sr == null) return ReadResult.Err("not a text file");
-
-            long bomLen = HasUtf8Bom(full) ? 3 : 0;   // OpenTextReaderOrNull strips the BOM from the chars
 
             List<string> emitted = new List<string>();  // content of emitted lines (bounded by budget)
             long contentBytes = 0;                       // UTF-8 bytes of emitted contents (no separators)
@@ -234,11 +261,13 @@ namespace FilesMcpServer
             using (sr)
             {
                 char[] buf = new char[ReadChunkChars];
-                StringBuilder cur = new StringBuilder();   // chars of the in-progress line (incl. a CRLF '\r')
-                long curContentBytes = 0;                  // UTF-8 bytes of every char consumed for this line
-                long curStartByte = bomLen;                // byte offset where the in-progress line begins
-                int curLineNo = 1;
-                bool highPending = false;                  // surrogate-pair state for incremental byte counting
+                StringBuilder cur = new StringBuilder();   // content chars of the in-progress line (no terminator)
+                long curContentBytes = 0;                  // UTF-8 bytes of cur (content only; terminators excluded)
+                long curStartByte = startByte > 0 ? startByte : bomLen;   // byte offset where this line begins
+                int curLineNo = startByte > 0 ? startLine : 1;
+                bool highPending = false;                  // surrogate-pair state for the byte counter
+                bool pendingCR = false;                    // a '\r' was seen; CRLF vs lone-CR still pending
+                long lineBaseTotal = LineBase(contentBytes, emitted.Count, curLineNo, lineNumbers);
 
                 int read;
                 while ((read = sr.Read(buf, 0, buf.Length)) > 0)
@@ -246,86 +275,87 @@ namespace FilesMcpServer
                     for (int i = 0; i < read; i++)
                     {
                         char c = buf[i];
+                        int terminatorBytes = -1;          // >= 0 once this char completes a line
 
-                        if (c == '\n')
+                        if (pendingCR)
                         {
-                            string raw = cur.ToString();
-                            bool crlf = raw.Length > 0 && raw[raw.Length - 1] == '\r';
-                            string content = crlf ? raw.Substring(0, raw.Length - 1) : raw;
+                            pendingCR = false;
+                            terminatorBytes = (c == '\n') ? 2 : 1;   // CRLF, else lone CR
+                        }
+                        else if (c == '\r') { pendingCR = true; continue; }   // defer: CRLF or lone CR
+                        else if (c == '\n') terminatorBytes = 1;              // bare LF
 
+                        if (terminatorBytes >= 0)
+                        {
                             if (curLineNo >= startLine && curLineNo <= endLine)
                             {
-                                // The overflow guard below guarantees this completed line fits.
-                                emitted.Add(content);
-                                contentBytes += Utf8ByteCount(content);
+                                // The overflow guard below guarantees a completed line fits.
+                                emitted.Add(cur.ToString());   // '\r'/'\n' were never appended to cur
+                                contentBytes += curContentBytes;
                                 lastEmittedLineNo = curLineNo;
                             }
-
-                            // Advance past the line + its '\n' ('\r' is already inside curContentBytes).
-                            curStartByte = curStartByte + curContentBytes + 1;
+                            curStartByte = curStartByte + curContentBytes + terminatorBytes;
                             cur.Length = 0;                // .NET 3.5: StringBuilder has no Clear()
                             curContentBytes = 0;
                             highPending = false;
                             curLineNo++;
+                            lineBaseTotal = LineBase(contentBytes, emitted.Count, curLineNo, lineNumbers);
 
                             if (curLineNo > endLine)
                                 return Complete(emitted, lineNumbers, lastEmittedLineNo);
-                            continue;
+
+                            if (c == '\n') continue;                       // CRLF / bare LF: '\n' consumed
+                            if (c == '\r') { pendingCR = true; continue; } // lone CR followed by another CR
+                            // otherwise c is the first content char of the next line — fall through
                         }
 
-                        // Incremental UTF-8 byte count of this char (correct across surrogate pairs).
+                        // Content char (also reached when a lone CR's following char starts a new line).
                         int cb;
                         if (char.IsHighSurrogate(c)) { highPending = true; cb = 0; }
                         else if (highPending) { highPending = false; cb = 4; }
-                        else if (c < 0x80) cb = 1;
-                        else if (c < 0x800) cb = 2;
-                        else cb = 3;
+                        else cb = Utf8WidthBmp(c);
                         curContentBytes += cb;
 
-                        bool emitting = curLineNo >= startLine && curLineNo <= endLine;
-                        if (!emitting) continue;   // skipped line: count bytes only, never store content
+                        if (curLineNo < startLine || curLineNo > endLine) continue;   // skipped: count bytes only
 
                         cur.Append(c);
 
                         // Would this line, completed now, push the rendered output past the budget?
-                        long total = TentativeTotal(contentBytes, emitted.Count, curContentBytes, curLineNo, lineNumbers);
-                        if (total > budget)
+                        if (lineBaseTotal + curContentBytes > budget)
                         {
                             if (emitted.Count > 0)
-                                return BoundaryCut(emitted, lineNumbers, lastEmittedLineNo, curLineNo);
+                                return BoundaryCut(emitted, lineNumbers, lastEmittedLineNo, curLineNo, curStartByte);
                             return ByteCut(cur, curStartByte, budget);
                         }
                     }
                 }
 
-                // EOF — finalize a trailing line that had no terminating '\n'.
-                string lastRaw = cur.ToString();
-                if (lastRaw.Length > 0)
+                // EOF — finalize a trailing line ended by a lone CR (pendingCR), or a final line with
+                // no terminator at all. curContentBytes > 0 catches a trailing line that was skipped
+                // (before startLine), so it still counts toward the line total in the error below.
+                if (pendingCR || cur.Length > 0 || curContentBytes > 0)
                 {
-                    bool crlf = lastRaw[lastRaw.Length - 1] == '\r';
-                    string content = crlf ? lastRaw.Substring(0, lastRaw.Length - 1) : lastRaw;
                     if (curLineNo >= startLine && curLineNo <= endLine)
                     {
-                        emitted.Add(content);
+                        emitted.Add(cur.ToString());
                         lastEmittedLineNo = curLineNo;
                     }
+                    curLineNo++;
                 }
 
                 if (emitted.Count == 0)
-                {
-                    int totalLines = lastRaw.Length > 0 ? curLineNo : curLineNo - 1;
-                    return ReadResult.Err("start_line " + startLine + " exceeds file length (" + totalLines + " lines)");
-                }
+                    return ReadResult.Err("start_line " + startLine + " exceeds file length (" + (curLineNo - 1) + " lines)");
                 return Complete(emitted, lineNumbers, lastEmittedLineNo);
             }
         }
 
-        // Rendered size if the candidate line (candidateBytes of content) were emitted now: existing
-        // content + this line + '\n' separators (one before each line after the first) + the
-        // right-aligned number prefix on every line when numbering (width = the last line's digits).
-        private static long TentativeTotal(long contentBytes, int emittedCount, long candidateBytes, int candidateLineNo, bool lineNumbers)
+        // Rendered size of the already-emitted lines plus one more line's content (added by the caller
+        // as curContentBytes): emitted content + '\n' separators (one before each line after the
+        // first) + the right-aligned number prefix on every line when numbering (width = the
+        // candidate line's digit count). Recomputed once per line, not per character.
+        private static long LineBase(long contentBytes, int emittedCount, int candidateLineNo, bool lineNumbers)
         {
-            long total = contentBytes + candidateBytes + emittedCount;
+            long total = contentBytes + emittedCount;
             if (lineNumbers) total += (long)(emittedCount + 1) * (DigitCount(candidateLineNo) + 1);
             return total;
         }
@@ -338,13 +368,14 @@ namespace FilesMcpServer
             return r;
         }
 
-        private static ReadResult BoundaryCut(List<string> emitted, bool lineNumbers, int lastLineNo, int nextStartLine)
+        private static ReadResult BoundaryCut(List<string> emitted, bool lineNumbers, int lastLineNo, int nextStartLine, long nextOffset)
         {
             ReadResult r = new ReadResult();
             r.Content = JoinEmitted(emitted, lineNumbers, lastLineNo);
             r.Truncated = true;
             r.HasNextLine = true;
             r.NextStartLine = nextStartLine;
+            r.NextOffset = nextOffset;
             return r;
         }
 
@@ -362,9 +393,7 @@ namespace FilesMcpServer
                 bool pair = false;
                 if (char.IsHighSurrogate(c) && i + 1 < cur.Length && char.IsLowSurrogate(cur[i + 1]))
                 { cb = 4; pair = true; }
-                else if (c < 0x80) cb = 1;
-                else if (c < 0x800) cb = 2;
-                else cb = 3;
+                else cb = Utf8WidthBmp(c);
 
                 if (bytes + cb > budget) break;
                 bytes += cb;
@@ -436,7 +465,7 @@ namespace FilesMcpServer
                 int start = 0;
                 if (offset == 0 && consumed >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
                     start = 3;
-                string content = new UTF8Encoding(false, false).GetString(data, start, consumed - start);
+                string content = Utf8NoBom.GetString(data, start, consumed - start);
 
                 ReadResult r = new ReadResult();
                 r.Content = content;
@@ -831,7 +860,7 @@ namespace FilesMcpServer
         private static bool SearchFileMultiline(PathSandbox sandbox, string file, Regex rx, string query,
             StringComparison cmp, int maxResults, List<JObject> matches)
         {
-            try { if (new FileInfo(file).Length > MaxReadBytes) return false; }
+            try { if (new FileInfo(file).Length > MaxMultilineFileBytes) return false; }
             catch { return false; }
 
             StreamReader sr;
@@ -951,39 +980,24 @@ namespace FilesMcpServer
             return n;
         }
 
-        private static long LongArg(ToolCallContext ctx, string name, long fallback, long min, long max)
+        // Read a strictly-integer argument. Returns false when the value is absent or not a JSON
+        // integer (so a malformed `offset` is reported, not silently treated as 0).
+        private static bool TryLongArg(ToolCallContext ctx, string name, out long value)
         {
+            value = 0;
             JToken t = ctx.Arguments[name];
-            if (t == null || t.Type == JTokenType.Null) return fallback;
-            long n;
-            try { n = t.Value<long>(); }
-            catch { return fallback; }
-            if (n < min) return min;
-            if (n > max) return max;
-            return n;
+            if (t == null || t.Type != JTokenType.Integer) return false;
+            try { value = t.Value<long>(); return true; }
+            catch { return false; }
         }
 
         private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(false, false);
 
-        private static long Utf8ByteCount(string s)
+        // UTF-8 byte width of a single BMP char (not part of a surrogate pair). Astral codepoints are
+        // a surrogate pair = 4 bytes, handled by the callers that track pairing.
+        private static int Utf8WidthBmp(char c)
         {
-            return s.Length == 0 ? 0 : Utf8NoBom.GetByteCount(s);
-        }
-
-        // True if the file begins with a UTF-8 BOM (which the streaming reader strips from the chars,
-        // so its 3 bytes must be added back when computing absolute file byte offsets).
-        private static bool HasUtf8Bom(string full)
-        {
-            try
-            {
-                using (FileStream fs = new FileStream(full, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                    byte[] b = new byte[3];
-                    int n = fs.Read(b, 0, 3);
-                    return n == 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF;
-                }
-            }
-            catch { return false; }
+            return c < 0x80 ? 1 : (c < 0x800 ? 2 : 3);
         }
 
         private static bool IsUtf8Continuation(byte b)
@@ -1105,21 +1119,44 @@ namespace FilesMcpServer
         }
 
         /// <summary>
-        /// Open a file as BOM-aware UTF-8 text lines after sniffing its head for a NUL byte. Returns
-        /// <c>null</c> (stream disposed) if the file looks binary. Streaming lets search and ranged
-        /// read work on files larger than the whole-file cap — output is bounded by matches / range,
-        /// not file size. Caller owns the returned reader (wrap in <c>using</c>).
+        /// Open a file as BOM-aware UTF-8 text lines from the start after sniffing its head for a NUL
+        /// byte. Returns <c>null</c> (stream disposed) if the file looks binary. Caller owns the
+        /// returned reader (wrap in <c>using</c>).
         /// </summary>
         private static StreamReader OpenTextReaderOrNull(string file)
         {
+            long bomLen;
+            return OpenTextReaderAt(file, 0, out bomLen);
+        }
+
+        /// <summary>
+        /// Like <see cref="OpenTextReaderOrNull"/> but positioned at <paramref name="byteOffset"/>
+        /// (an O(1) seek for resuming a truncated read). Sniffs the head for binary in one open, and
+        /// reports the leading BOM length via <paramref name="bomLen"/> (only meaningful at offset 0;
+        /// past it there is no BOM). Returns <c>null</c> (disposed) for a binary file or an offset
+        /// beyond the file length.
+        /// </summary>
+        private static StreamReader OpenTextReaderAt(string file, long byteOffset, out long bomLen)
+        {
+            bomLen = 0;
             FileStream fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             try
             {
                 byte[] head = new byte[BinarySniffBytes];
                 int n = fs.Read(head, 0, head.Length);
                 if (LooksBinary(head, n)) { fs.Dispose(); return null; }
+
+                if (byteOffset > 0)
+                {
+                    if (byteOffset > fs.Length) { fs.Dispose(); return null; }
+                    fs.Position = byteOffset;
+                    // detect=false: there is no BOM mid-file, and one must not be stripped here.
+                    return new StreamReader(fs, Utf8NoBom, false);
+                }
+
+                bomLen = (n >= 3 && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF) ? 3 : 0;
                 fs.Position = 0;
-                return new StreamReader(fs, new UTF8Encoding(false, false), true);
+                return new StreamReader(fs, Utf8NoBom, true);   // detect=true strips a leading BOM
             }
             catch
             {

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -25,6 +25,9 @@ namespace FilesMcpServer.Tests
 
         private string Abs(string rel) { return Path.Combine(_root, rel); }
 
+        // The read output cap, sourced from production so fixtures stay correct if the value changes.
+        private static readonly int Cap = (int)FilesMcpServer.FilesTools.MaxReadBytes;
+
         // ---- Criterion 1: listing ----
 
         [Fact]
@@ -123,16 +126,16 @@ namespace FilesMcpServer.Tests
         [Fact]
         public void Oversize_single_line_read_truncates_with_next_offset()
         {
-            // A 2 MiB file with no newlines is one giant line: it can't be subdivided by line, so the
-            // read truncates mid-line and hands back a byte offset to continue from (not an error).
-            File.WriteAllText(Abs("big.txt"), new string('a', 2 * 1024 * 1024)); // 2 MiB > 1 MiB cap
+            // A file with no newlines twice the cap is one giant line: it can't be subdivided by line,
+            // so the read truncates mid-line and hands back a byte offset to continue from (not error).
+            File.WriteAllText(Abs("big.txt"), new string('a', 2 * Cap));
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
             Assert.False(Harness.IsError(msgs[0]));
             JToken sc = msgs[0]["result"]["structuredContent"];
             Assert.True((bool)sc["truncated"]);
-            Assert.Equal(1024 * 1024, (long)sc["next_offset"]);       // cut at the 1 MiB cap
-            Assert.Equal(1024 * 1024, ((string)sc["content"]).Length);
+            Assert.Equal((long)Cap, (long)sc["next_offset"]);        // cut at the cap
+            Assert.Equal(Cap, ((string)sc["content"]).Length);
             Assert.Null(sc["next_start_line"]);                       // byte cut, not a line boundary
         }
 
@@ -613,14 +616,15 @@ namespace FilesMcpServer.Tests
             Assert.False(Harness.IsError(r[0]));
             Assert.Equal("first line", Harness.Text(r[0]));
 
-            // Whole-file read now truncates at a line boundary instead of failing.
+            // Whole-file read now truncates at a line boundary instead of failing. A boundary cut
+            // carries next_start_line AND next_offset (the byte that line starts at, for O(1) resume).
             var w = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
             Assert.False(Harness.IsError(w[0]));
             JToken sc = w[0]["result"]["structuredContent"];
             Assert.True((bool)sc["truncated"]);
             Assert.True((int)sc["next_start_line"] > 1);   // resume by line (multi-line file)
-            Assert.Null(sc["next_offset"]);
+            Assert.True((long)sc["next_offset"] > 0);
         }
 
         [Fact]
@@ -642,14 +646,14 @@ namespace FilesMcpServer.Tests
         [Fact]
         public void Read_range_cap_counts_utf8_bytes_not_chars()
         {
-            // 2000 lines × 250 '€' (3 bytes each) ≈ 1.5 MiB of UTF-8, but only ~0.5M chars — under a
-            // char-based cap, over the byte cap. The read truncates on real byte size: a char-based
-            // cap would never trip (500K chars < 1 MiB), so truncation here proves byte counting.
+            // '€' is 3 UTF-8 bytes. Size the file so its char count is under the cap but its byte
+            // count is over: a char-based cap would never trip, so truncation here proves byte
+            // counting. 500 lines × 100 '€' ≈ 50K chars (< cap) but ~150K bytes (> cap=128 KiB).
             var sb = new StringBuilder();
-            for (int i = 0; i < 2000; i++) sb.Append(new string('€', 250)).Append('\n');
+            for (int i = 0; i < 500; i++) sb.Append(new string('€', 100)).Append('\n');
             File.WriteAllText(Abs("uni.txt"), sb.ToString(), new UTF8Encoding(false));
-            Assert.True(sb.Length < 1024 * 1024);                                  // char count under cap
-            Assert.True(new FileInfo(Abs("uni.txt")).Length > 1024 * 1024);        // byte count over cap
+            Assert.True(sb.Length < Cap);                                  // char count under cap
+            Assert.True(new FileInfo(Abs("uni.txt")).Length > Cap);        // byte count over cap
 
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "uni.txt", "start_line", 1)));
@@ -657,32 +661,36 @@ namespace FilesMcpServer.Tests
             JToken sc = msgs[0]["result"]["structuredContent"];
             Assert.True((bool)sc["truncated"]);
             int next = (int)sc["next_start_line"];
-            Assert.True(next > 1 && next < 2000);    // cut partway through on byte size, not at line 2000
+            Assert.True(next > 1 && next < 500);    // cut partway through on byte size, not at the last line
         }
 
         [Fact]
         public void Read_range_at_cap_boundary_returns_just_under_and_truncates_just_over()
         {
-            // 16-byte ASCII lines; joined by '\n' that is 17 bytes/line. Output for N lines = 17N-1.
-            // 17×61681-1 = 1,048,576 = the 1 MiB cap exactly (fits, since the check is strictly >);
-            // line 61682 tips it over and is left for the next read.
-            string row = new string('x', 16);
+            // 15-char ASCII rows; rendered = 16 bytes/line (content + one '\n' separator). N lines
+            // render to N*16 - 1 bytes. `fit` is the largest N that fits the cap exactly (the check is
+            // strictly >); line fit+1 tips it over and is left for the next read. Derived from the cap
+            // so it stays correct if the cap changes.
+            const int rendered = 16;
+            int fit = (Cap + 1) / rendered;
+            int okLen = fit * rendered - 1;
+            string row = new string('x', rendered - 1);
             var sb = new StringBuilder();
-            for (int i = 0; i < 70000; i++) sb.Append(row).Append('\n');
+            for (int i = 0; i < fit + 100; i++) sb.Append(row).Append('\n');
             File.WriteAllText(Abs("rows.txt"), sb.ToString(), new UTF8Encoding(false));
 
             var ok = Harness.Exchange(Harness.NewFilesServer(_root),
-                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", 61681)));
+                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", fit)));
             Assert.False(Harness.IsError(ok[0]));
-            Assert.Equal(61681 * 17 - 1, Harness.Text(ok[0]).Length); // 61681 rows joined by 61680 '\n'
+            Assert.Equal(okLen, Harness.Text(ok[0]).Length);
 
             var over = Harness.Exchange(Harness.NewFilesServer(_root),
-                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", 61682)));
+                Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", fit + 1)));
             Assert.False(Harness.IsError(over[0]));
             JToken sc = over[0]["result"]["structuredContent"];
             Assert.True((bool)sc["truncated"]);
-            Assert.Equal(61682, (int)sc["next_start_line"]);                  // resume at the line that didn't fit
-            Assert.Equal(61681 * 17 - 1, ((string)sc["content"]).Length);     // same content as the just-under read
+            Assert.Equal(fit + 1, (int)sc["next_start_line"]);            // resume at the line that didn't fit
+            Assert.Equal(okLen, ((string)sc["content"]).Length);         // same content as the just-under read
         }
 
         // ---- read: truncation continuation (chunked / minified files) ----
@@ -727,10 +735,13 @@ namespace FilesMcpServer.Tests
         [Fact]
         public void Read_byte_cut_keeps_utf8_codepoints_intact()
         {
-            // One line of many 3-byte '€', over the cap. The mid-line cut must land on a char
+            // One line of 3-byte '€' chars totalling 1.5× the cap in bytes (Cap/2 chars × 3), so it
+            // is over the cap but pages in exactly two reads. The mid-line cut must land on a char
             // boundary (no replacement chars), and the two pieces must reassemble to the original.
-            string original = new string('€', 450000); // 450000×3 = ~1.35 MiB > cap
+            string original = new string('€', Cap / 2);
             File.WriteAllText(Abs("euro.txt"), original, new UTF8Encoding(false));
+            Assert.True(new FileInfo(Abs("euro.txt")).Length > Cap);
+            Assert.True(new FileInfo(Abs("euro.txt")).Length < 2L * Cap);
 
             var r1 = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "euro.txt")));
@@ -739,7 +750,7 @@ namespace FilesMcpServer.Tests
             string part1 = (string)sc["content"];
             Assert.True(part1.IndexOf('�') < 0); // no replacement char => clean codepoint cut
             long offset = (long)sc["next_offset"];
-            Assert.Equal(0, offset % 3);                  // boundary aligned to the 3-byte char
+            Assert.Equal(0L, offset % 3);                 // boundary aligned to the 3-byte char
 
             var r2 = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "euro.txt", "offset", offset)));
@@ -751,8 +762,9 @@ namespace FilesMcpServer.Tests
         public void Read_short_line_then_giant_line_switches_from_line_to_offset()
         {
             // Line 1 is short, line 2 is a single over-cap line. The first read stops at the boundary
-            // (next_start_line=2); resuming at line 2 then falls to a byte offset.
-            string giant = new string('z', 2 * 1024 * 1024);
+            // (next_start_line=2, next_offset=byte 6 where line 2 begins); resuming there (passing
+            // both, the O(1) line-aware path) then falls to a byte offset on the giant line.
+            string giant = new string('z', 2 * Cap);
             File.WriteAllText(Abs("mix.txt"), "short\n" + giant, new UTF8Encoding(false));
 
             var r1 = Harness.Exchange(Harness.NewFilesServer(_root),
@@ -760,14 +772,17 @@ namespace FilesMcpServer.Tests
             JToken sc1 = r1[0]["result"]["structuredContent"];
             Assert.True((bool)sc1["truncated"]);
             Assert.Equal(2, (int)sc1["next_start_line"]);
+            Assert.Equal(6L, (long)sc1["next_offset"]);   // "short\n" is 6 bytes
             Assert.Equal("short", (string)sc1["content"]);
 
             var r2 = Harness.Exchange(Harness.NewFilesServer(_root),
-                Harness.ToolsCall(1, "read", Harness.Args("path", "mix.txt", "start_line", 2)));
+                Harness.ToolsCall(1, "read", Harness.Args("path", "mix.txt",
+                    "start_line", (int)sc1["next_start_line"], "offset", (long)sc1["next_offset"])));
             JToken sc2 = r2[0]["result"]["structuredContent"];
             Assert.True((bool)sc2["truncated"]);
+            Assert.Null(sc2["next_start_line"]);          // a single over-cap line -> byte cut
             Assert.NotNull(sc2["next_offset"]);
-            Assert.Equal(1024 * 1024, ((string)sc2["content"]).Length);
+            Assert.Equal(Cap, ((string)sc2["content"]).Length);
         }
 
         [Fact]
@@ -788,6 +803,78 @@ namespace FilesMcpServer.Tests
                 Harness.ToolsCall(1, "read", Harness.Args("path", "s.txt", "offset", 5)));
             Assert.False(Harness.IsError(msgs[0]));
             Assert.Equal("", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_malformed_offset_is_error()
+        {
+            File.WriteAllText(Abs("s.txt"), "hello world");
+
+            var bad = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "s.txt", "offset", "notanumber")));
+            Assert.True(Harness.IsError(bad[0]));
+            Assert.Contains("offset must be", Harness.Text(bad[0]));
+
+            var neg = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "s.txt", "offset", -5)));
+            Assert.True(Harness.IsError(neg[0]));
+            Assert.Contains("offset must be", Harness.Text(neg[0]));
+        }
+
+        [Fact]
+        public void Read_range_splits_on_lone_cr_line_endings()
+        {
+            // Classic-Mac lone-CR endings: the streaming reader must split on '\r' the way SplitLines
+            // does, so the same line targets work as for an LF file (output is LF-joined).
+            File.WriteAllText(Abs("cr.txt"), "a\rb\rc\rd\re", new UTF8Encoding(false));
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "cr.txt", "start_line", 2, "end_line", 3)));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("b\nc", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_pages_whole_multiline_file_via_line_aware_resume()
+        {
+            // Page an over-cap multi-line file using the O(1) line-aware continuation (start_line +
+            // offset together) and reassemble; the result must equal the original. No trailing newline
+            // so the page contents (whole lines, '\n'-joined, no trailing) rejoin exactly.
+            var sb = new StringBuilder();
+            for (int i = 0; i < 60000; i++)
+            {
+                if (i > 0) sb.Append('\n');
+                sb.Append("line ").Append(i).Append(" of some content");
+            }
+            string original = sb.ToString();
+            File.WriteAllText(Abs("big.txt"), original, new UTF8Encoding(false));
+            Assert.True(original.Length > 3 * Cap);   // forces several pages
+
+            var assembled = new StringBuilder();
+            JObject call = Harness.Args("path", "big.txt");
+            int pages = 0;
+            int guard = 0;
+            while (guard++ < 1000)
+            {
+                var msgs = Harness.Exchange(Harness.NewFilesServer(_root), Harness.ToolsCall(1, "read", call));
+                Assert.False(Harness.IsError(msgs[0]));
+                JToken sc = msgs[0]["result"]["structuredContent"];
+                if (sc != null && sc["truncated"] != null && (bool)sc["truncated"])
+                {
+                    if (assembled.Length > 0) assembled.Append('\n');   // the line boundary between pages
+                    assembled.Append((string)sc["content"]);
+                    call = Harness.Args("path", "big.txt",
+                        "start_line", (int)sc["next_start_line"], "offset", (long)sc["next_offset"]);
+                    pages++;
+                }
+                else
+                {
+                    if (assembled.Length > 0) assembled.Append('\n');
+                    assembled.Append(Harness.Text(msgs[0]));
+                    break;
+                }
+            }
+            Assert.True(pages >= 2);                       // actually paged
+            Assert.Equal(original, assembled.ToString());
         }
 
         // ---- Criterion 6: lifecycle ----

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -121,13 +121,19 @@ namespace FilesMcpServer.Tests
         }
 
         [Fact]
-        public void Oversize_read_is_error()
+        public void Oversize_single_line_read_truncates_with_next_offset()
         {
+            // A 2 MiB file with no newlines is one giant line: it can't be subdivided by line, so the
+            // read truncates mid-line and hands back a byte offset to continue from (not an error).
             File.WriteAllText(Abs("big.txt"), new string('a', 2 * 1024 * 1024)); // 2 MiB > 1 MiB cap
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
-            Assert.True(Harness.IsError(msgs[0]));
-            Assert.Contains("too large", Harness.Text(msgs[0]));
+            Assert.False(Harness.IsError(msgs[0]));
+            JToken sc = msgs[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            Assert.Equal(1024 * 1024, (long)sc["next_offset"]);       // cut at the 1 MiB cap
+            Assert.Equal(1024 * 1024, ((string)sc["content"]).Length);
+            Assert.Null(sc["next_start_line"]);                       // byte cut, not a line boundary
         }
 
         [Fact]
@@ -593,7 +599,7 @@ namespace FilesMcpServer.Tests
         }
 
         [Fact]
-        public void Read_range_works_on_oversize_file_while_whole_file_is_capped()
+        public void Read_range_works_on_oversize_file_and_whole_file_truncates()
         {
             var sb = new StringBuilder();
             sb.Append("first line\n");
@@ -607,32 +613,38 @@ namespace FilesMcpServer.Tests
             Assert.False(Harness.IsError(r[0]));
             Assert.Equal("first line", Harness.Text(r[0]));
 
-            // Whole-file read is still capped.
+            // Whole-file read now truncates at a line boundary instead of failing.
             var w = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt")));
-            Assert.True(Harness.IsError(w[0]));
-            Assert.Contains("too large", Harness.Text(w[0]));
+            Assert.False(Harness.IsError(w[0]));
+            JToken sc = w[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            Assert.True((int)sc["next_start_line"] > 1);   // resume by line (multi-line file)
+            Assert.Null(sc["next_offset"]);
         }
 
         [Fact]
-        public void Read_range_rejects_an_oversize_selection()
+        public void Read_range_oversize_selection_truncates_at_line_boundary()
         {
             var sb = new StringBuilder();
             for (int i = 0; i < 120000; i++) sb.Append("padding padding padding\n"); // ~2.8 MiB
             File.WriteAllText(Abs("big.txt"), sb.ToString());
 
-            // Asking for the whole thing via an open-ended range hits the output cap.
+            // An open-ended range over the cap truncates and points at the next line.
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "big.txt", "start_line", 1)));
-            Assert.True(Harness.IsError(msgs[0]));
-            Assert.Contains("too large", Harness.Text(msgs[0]));
+            Assert.False(Harness.IsError(msgs[0]));
+            JToken sc = msgs[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            Assert.True((int)sc["next_start_line"] > 1);
         }
 
         [Fact]
         public void Read_range_cap_counts_utf8_bytes_not_chars()
         {
             // 2000 lines × 250 '€' (3 bytes each) ≈ 1.5 MiB of UTF-8, but only ~0.5M chars — under a
-            // char-based cap, over the byte cap. The range read must reject it on real byte size.
+            // char-based cap, over the byte cap. The read truncates on real byte size: a char-based
+            // cap would never trip (500K chars < 1 MiB), so truncation here proves byte counting.
             var sb = new StringBuilder();
             for (int i = 0; i < 2000; i++) sb.Append(new string('€', 250)).Append('\n');
             File.WriteAllText(Abs("uni.txt"), sb.ToString(), new UTF8Encoding(false));
@@ -641,16 +653,19 @@ namespace FilesMcpServer.Tests
 
             var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "uni.txt", "start_line", 1)));
-            Assert.True(Harness.IsError(msgs[0]));
-            Assert.Contains("too large", Harness.Text(msgs[0]));
+            Assert.False(Harness.IsError(msgs[0]));
+            JToken sc = msgs[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            int next = (int)sc["next_start_line"];
+            Assert.True(next > 1 && next < 2000);    // cut partway through on byte size, not at line 2000
         }
 
         [Fact]
-        public void Read_range_at_cap_boundary_returns_just_under_and_rejects_just_over()
+        public void Read_range_at_cap_boundary_returns_just_under_and_truncates_just_over()
         {
             // 16-byte ASCII lines; joined by '\n' that is 17 bytes/line. Output for N lines = 17N-1.
             // 17×61681-1 = 1,048,576 = the 1 MiB cap exactly (fits, since the check is strictly >);
-            // 61682 lines = 1,048,593 bytes, just over.
+            // line 61682 tips it over and is left for the next read.
             string row = new string('x', 16);
             var sb = new StringBuilder();
             for (int i = 0; i < 70000; i++) sb.Append(row).Append('\n');
@@ -663,8 +678,116 @@ namespace FilesMcpServer.Tests
 
             var over = Harness.Exchange(Harness.NewFilesServer(_root),
                 Harness.ToolsCall(1, "read", Harness.Args("path", "rows.txt", "start_line", 1, "end_line", 61682)));
-            Assert.True(Harness.IsError(over[0]));
-            Assert.Contains("too large", Harness.Text(over[0]));
+            Assert.False(Harness.IsError(over[0]));
+            JToken sc = over[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            Assert.Equal(61682, (int)sc["next_start_line"]);                  // resume at the line that didn't fit
+            Assert.Equal(61681 * 17 - 1, ((string)sc["content"]).Length);     // same content as the just-under read
+        }
+
+        // ---- read: truncation continuation (chunked / minified files) ----
+
+        [Fact]
+        public void Read_minified_file_pages_via_next_offset_until_complete()
+        {
+            // ~2.5 MiB single line of varied bytes: page through it with offset and reassemble.
+            var sb = new StringBuilder();
+            for (int i = 0; i < 2500000; i++) sb.Append((char)('0' + (i % 10)));
+            string original = sb.ToString();
+            File.WriteAllText(Abs("min.json"), original, new UTF8Encoding(false));
+
+            var assembled = new StringBuilder();
+            long offset = 0;
+            bool first = true;
+            int guard = 0;
+            while (guard++ < 100)
+            {
+                JObject call = first
+                    ? Harness.Args("path", "min.json")
+                    : Harness.Args("path", "min.json", "offset", offset);
+                first = false;
+                var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                    Harness.ToolsCall(1, "read", call));
+                Assert.False(Harness.IsError(msgs[0]));
+                JToken sc = msgs[0]["result"]["structuredContent"];
+                if (sc != null && sc["truncated"] != null && (bool)sc["truncated"])
+                {
+                    assembled.Append((string)sc["content"]);
+                    offset = (long)sc["next_offset"];
+                }
+                else
+                {
+                    assembled.Append(Harness.Text(msgs[0])); // final chunk: plain text
+                    break;
+                }
+            }
+            Assert.Equal(original, assembled.ToString());
+        }
+
+        [Fact]
+        public void Read_byte_cut_keeps_utf8_codepoints_intact()
+        {
+            // One line of many 3-byte '€', over the cap. The mid-line cut must land on a char
+            // boundary (no replacement chars), and the two pieces must reassemble to the original.
+            string original = new string('€', 450000); // 450000×3 = ~1.35 MiB > cap
+            File.WriteAllText(Abs("euro.txt"), original, new UTF8Encoding(false));
+
+            var r1 = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "euro.txt")));
+            JToken sc = r1[0]["result"]["structuredContent"];
+            Assert.True((bool)sc["truncated"]);
+            string part1 = (string)sc["content"];
+            Assert.True(part1.IndexOf('�') < 0); // no replacement char => clean codepoint cut
+            long offset = (long)sc["next_offset"];
+            Assert.Equal(0, offset % 3);                  // boundary aligned to the 3-byte char
+
+            var r2 = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "euro.txt", "offset", offset)));
+            string part2 = Harness.Text(r2[0]);           // remainder fits under the cap => plain text
+            Assert.Equal(original, part1 + part2);
+        }
+
+        [Fact]
+        public void Read_short_line_then_giant_line_switches_from_line_to_offset()
+        {
+            // Line 1 is short, line 2 is a single over-cap line. The first read stops at the boundary
+            // (next_start_line=2); resuming at line 2 then falls to a byte offset.
+            string giant = new string('z', 2 * 1024 * 1024);
+            File.WriteAllText(Abs("mix.txt"), "short\n" + giant, new UTF8Encoding(false));
+
+            var r1 = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "mix.txt")));
+            JToken sc1 = r1[0]["result"]["structuredContent"];
+            Assert.True((bool)sc1["truncated"]);
+            Assert.Equal(2, (int)sc1["next_start_line"]);
+            Assert.Equal("short", (string)sc1["content"]);
+
+            var r2 = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "mix.txt", "start_line", 2)));
+            JToken sc2 = r2[0]["result"]["structuredContent"];
+            Assert.True((bool)sc2["truncated"]);
+            Assert.NotNull(sc2["next_offset"]);
+            Assert.Equal(1024 * 1024, ((string)sc2["content"]).Length);
+        }
+
+        [Fact]
+        public void Read_offset_past_eof_is_error()
+        {
+            File.WriteAllText(Abs("s.txt"), "hello");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "s.txt", "offset", 99)));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains("exceeds file length", Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Read_offset_at_eof_returns_empty_not_truncated()
+        {
+            File.WriteAllText(Abs("s.txt"), "hello");
+            var msgs = Harness.Exchange(Harness.NewFilesServer(_root),
+                Harness.ToolsCall(1, "read", Harness.Args("path", "s.txt", "offset", 5)));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.Equal("", Harness.Text(msgs[0]));
         }
 
         // ---- Criterion 6: lifecycle ----

--- a/tests/FilesMcpServer.Tests/FilesToolsTests.cs
+++ b/tests/FilesMcpServer.Tests/FilesToolsTests.cs
@@ -646,11 +646,13 @@ namespace FilesMcpServer.Tests
         [Fact]
         public void Read_range_cap_counts_utf8_bytes_not_chars()
         {
-            // '€' is 3 UTF-8 bytes. Size the file so its char count is under the cap but its byte
-            // count is over: a char-based cap would never trip, so truncation here proves byte
-            // counting. 500 lines × 100 '€' ≈ 50K chars (< cap) but ~150K bytes (> cap=128 KiB).
+            // '€' is 3 UTF-8 bytes. Size the file (relative to the cap) so its char count is under the
+            // cap but its byte count is over: a char-based cap would never trip, so truncation here
+            // proves byte counting. ~Cap/2 chars of '€' is ~1.5× Cap bytes.
+            const int charsPerLine = 200;
+            int numLines = (Cap / 2) / charsPerLine;
             var sb = new StringBuilder();
-            for (int i = 0; i < 500; i++) sb.Append(new string('€', 100)).Append('\n');
+            for (int i = 0; i < numLines; i++) sb.Append(new string('€', charsPerLine)).Append('\n');
             File.WriteAllText(Abs("uni.txt"), sb.ToString(), new UTF8Encoding(false));
             Assert.True(sb.Length < Cap);                                  // char count under cap
             Assert.True(new FileInfo(Abs("uni.txt")).Length > Cap);        // byte count over cap
@@ -661,7 +663,7 @@ namespace FilesMcpServer.Tests
             JToken sc = msgs[0]["result"]["structuredContent"];
             Assert.True((bool)sc["truncated"]);
             int next = (int)sc["next_start_line"];
-            Assert.True(next > 1 && next < 500);    // cut partway through on byte size, not at the last line
+            Assert.True(next > 1 && next < numLines);    // cut partway through on byte size, not at the last line
         }
 
         [Fact]
@@ -698,9 +700,9 @@ namespace FilesMcpServer.Tests
         [Fact]
         public void Read_minified_file_pages_via_next_offset_until_complete()
         {
-            // ~2.5 MiB single line of varied bytes: page through it with offset and reassemble.
+            // A single line of varied bytes ~10× the cap: page through it with offset and reassemble.
             var sb = new StringBuilder();
-            for (int i = 0; i < 2500000; i++) sb.Append((char)('0' + (i % 10)));
+            for (int i = 0; i < 10 * Cap; i++) sb.Append((char)('0' + (i % 10)));
             string original = sb.ToString();
             File.WriteAllText(Abs("min.json"), original, new UTF8Encoding(false));
 


### PR DESCRIPTION
## Summary

Redesign the `files__read` tool to handle files larger than the output cap by truncating with continuation tokens instead of failing. This enables pagination through arbitrarily large files, including minified (single-line) files that cannot be subdivided by line ranges.

## Key Changes

- **Reduced output cap from 1 MiB to 32 KiB** (~8K tokens) to better fit typical model context windows
- **Truncation instead of errors**: Over-cap reads now return a structured JSON response with `{content, truncated: true, next_start_line?, next_offset}` instead of failing
- **Dual continuation coordinates**:
  - `next_start_line` + `next_offset`: Returned when stopping at a line boundary (multi-line files); enables O(1) resume by seeking to the byte offset
  - `next_offset` alone: Returned when a single line exceeds the cap (minified files); enables raw byte-window reads
- **New `offset` parameter**: Allows resuming a truncated read at a specific byte position, supporting both line-aware seeks (when combined with `start_line`) and raw byte windows
- **Streaming line scanner**: Replaced `ReadLine()` with fixed-chunk reading (64K chars) to avoid buffering entire over-cap lines in memory; tracks line numbers, byte offsets, and UTF-8 width precisely
- **UTF-8 safety**: Byte cuts are aligned to UTF-8 codepoint boundaries; surrogate pairs and multi-byte characters are never split
- **Separate multiline search cap**: Multiline `search` retains the 1 MiB cap (memory bound, not context bound) independent of the read output cap

## Implementation Details

- `ReadResult` class encapsulates the outcome: error, plain content (untruncated), or truncated content with continuation info
- `ReadLineWindow()` streams a line range with precise UTF-8 byte accounting, supporting:
  - Line-based pagination (boundary cuts)
  - Byte-based pagination (cuts inside a single line)
  - O(1) resume via `startByte` parameter when both `start_line` and `offset` are provided
  - Lone CR handling (matches `SplitLines` behavior)
- `ReadByteWindow()` and `ByteCut()` handle raw byte-window reads for over-cap single lines
- `RenderRead()` converts `ReadResult` to appropriate tool output (error, plain text, or JSON envelope)
- Tests updated to verify truncation behavior, continuation token accuracy, UTF-8 integrity, and minified file pagination
- Documentation updated in `mcp35-servers-spec.md` and implementation spec added

## Backward Compatibility

- Untruncated reads return plain text as before (byte-exact for whole-file reads without numbering)
- Existing `start_line`, `end_line`, `line_numbers` parameters unchanged
- New `offset` parameter is optional and only used for resuming truncated reads

https://claude.ai/code/session_01VA7icMa6V5nqx6cPE8AnSW