### PR TITLE
Add support for git worktree operations

### DIFF
--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -1241,6 +1241,22 @@ namespace GxPT
                 }
                 case "git__rm":
                     sb.Append("rm"); if (Bv(a, "cached")) sb.Append(" --cached"); if (Bv(a, "recursive")) sb.Append(" -r"); Append(sb, PathsOf(a, "paths")); break;
+                case "git__worktree":
+                {
+                    string act = Sv(a, "action"); if (act.Length == 0) act = "list";
+                    sb.Append("worktree ").Append(act.ToLowerInvariant());
+                    switch (act.ToLowerInvariant())
+                    {
+                        case "add":
+                            if (Bv(a, "force")) sb.Append(" --force");
+                            if (Sv(a, "branch").Length > 0) sb.Append(" -b ").Append(Sv(a, "branch"));
+                            Append(sb, Sv(a, "path")); Append(sb, Sv(a, "ref")); break;
+                        case "remove":
+                            if (Bv(a, "force")) sb.Append(" --force");
+                            Append(sb, Sv(a, "path")); break;
+                    }
+                    break;
+                }
                 case "git__stash":
                 {
                     string act = Sv(a, "action"); if (act.Length == 0) act = "push";

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5164,6 +5164,28 @@ namespace GxPT
                     }
                     return true;
                 }
+                case "git__worktree":
+                {
+                    string action = Str(args, "action"); if (action.Length == 0) action = "list";
+                    string path = Str(args, "path");
+                    switch (action.ToLowerInvariant())
+                    {
+                        case "add":
+                        {
+                            // The new branch (if any) is the most useful detail; otherwise name the dir.
+                            string branch = Str(args, "branch");
+                            string at = path.Length > 0 ? " at " + path : "";
+                            header = branch.Length > 0
+                                ? ("Added worktree" + at + " on new branch " + branch)
+                                : ("Added worktree" + at);
+                            break;
+                        }
+                        case "remove": header = path.Length > 0 ? ("Removed worktree " + path) : "Removed worktree"; break;
+                        case "prune": header = "Pruned worktrees"; break;
+                        default: header = "Listed worktrees"; break;
+                    }
+                    return true;
+                }
                 case "reveal_tools": header = "Checked available tools"; return true;
                 case "cd":
                 {


### PR DESCRIPTION
## Summary
Added support for git worktree operations (add, remove, prune, list) to the tool execution and approval system.

## Key Changes
- **MainForm.cs**: Added a new `git__worktree` case in `TryBuildToolRecord()` to handle worktree operations and generate appropriate user-facing messages for each action type
  - "add" action: Displays the new branch name if provided, otherwise shows the worktree path
  - "remove" action: Shows the removed worktree path
  - "prune" action: Generic pruning confirmation message
  - "list" action (default): Generic listing confirmation message

- **ToolApprovalPanel.cs**: Added a new `git__worktree` case in `GitOpSummary()` to generate command summaries for approval requests
  - Constructs the full `git worktree` command with appropriate flags and arguments
  - "add" action: Supports `--force`, `-b` (branch), path, and ref arguments
  - "remove" action: Supports `--force` and path arguments
  - Other actions (list, prune): Display the action without additional arguments

## Implementation Details
- Both implementations follow the existing pattern used for other git operations
- The action parameter defaults to "list" if not specified
- User-facing messages in MainForm are human-readable and context-aware
- Command summaries in ToolApprovalPanel accurately reflect the git command that will be executed

https://claude.ai/code/session_01KaP3ohefhz9JJcKPXSfnkV