### PR TITLE
Bump Mcp35.Client assembly version to 0.1.2.0

### DIFF
--- a/src/Mcp35.Client/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Client/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a043f034-fff5-44ce-9605-b40ff0016262")]
 
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.2.0")]
+[assembly: AssemblyFileVersion("0.1.2.0")]


### PR DESCRIPTION
## Problem

Launching an upgraded install of GxPT and issuing any tool call crashes with:

```
MissingMethodException: Method not found:
'Mcp35.Core.Protocol.CallToolResult Mcp35.Client.McpServerConnection.CallTool(
   System.String, Newtonsoft.Json.Linq.JObject, Newtonsoft.Json.Linq.JObject, Int32)'
   at GxPT.McpChatOrchestrator.ExecuteCall(...)
```

The source is consistent — the 4-arg `CallTool(name, args, meta, timeoutMs)` overload exists (`src/Mcp35.Client/McpServerConnection.cs`) and is called correctly (`GxPT/Services/Mcp/McpChatOrchestrator.cs`). The crash is a **stale `Mcp35.Client.dll` on disk**: a freshly built `GxPT.exe` bound against an older client DLL that lacks the overload.

## Root cause

`Mcp35.Client`'s `AssemblyVersion`/`AssemblyFileVersion` were never bumped past `0.1.1.0` when the `meta` overload was introduced (commit `76742aa`). Windows Installer keys file replacement off the Win32 file version (sourced from `AssemblyFileVersion`), and the Visual Studio setup project schedules `RemoveExistingProducts` after `InstallFinalize` — so on upgrade, file-version rules apply and a **same-version file is skipped, leaving the old copy in place**.

The asymmetry confirms it: `GxPT.exe` (version bumped each release) and `Mcp35.Core.dll` (already at `0.1.2.0`) get replaced on upgrade, but `Mcp35.Client.dll` (pinned at `0.1.1.0`) does not — and the missing method lives in `Mcp35.Client`.

## Change

Bump `Mcp35.Client` to `0.1.2.0` (matching `Mcp35.Core`'s cadence) so the installer detects the assembly as changed and overwrites the stale copy on upgrade.

## Notes / follow-ups (not in this PR)

- Affected machines already carrying the stale DLL need a **clean uninstall + install** (or this new version) to clear it.
- Longer term, consider tying all first-party (`Mcp35.*` and server) assembly file versions to the product version each release so a forgotten bump can't cause this again, and/or de-duplicating the bundled first-party DLLs in the setup payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NqGm4ok38B8B3Peg22Arw

---
_Generated by [Claude Code](https://claude.ai/code/session_011NqGm4ok38B8B3Peg22Arw)_