### PR TITLE
Add per-call model override support to dispatch_agent

### DIFF
--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -152,8 +152,90 @@ namespace GxPT.Tests
             Assert.Equal("function", (string)def["type"]);
             Assert.Equal("dispatch_agent", (string)def["function"]["name"]);
             Assert.NotNull(def["function"]["parameters"]["properties"]["agents"]);
+            // Each agent entry exposes an optional model override alongside name/task.
+            JToken entryProps = def["function"]["parameters"]["properties"]["agents"]["items"]["properties"];
+            Assert.NotNull(entryProps["name"]);
+            Assert.NotNull(entryProps["task"]);
+            Assert.NotNull(entryProps["model"]);
+            // model is not required: only name and task are.
+            JArray required = (JArray)def["function"]["parameters"]["properties"]["agents"]["items"]["required"];
+            Assert.Contains("name", required.Values<string>());
+            Assert.Contains("task", required.Values<string>());
+            Assert.DoesNotContain("model", required.Values<string>());
             Assert.True(d.IsDispatchAgent("dispatch_agent"));
             Assert.False(d.IsDispatchAgent("files__read"));
+        }
+
+        // ---- per-call model override ----
+
+        // Writes an agent whose frontmatter pins a model, so override precedence can be exercised.
+        private Agent WriteAgentWithModel(string slug, string model)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file,
+                "---\nname: " + slug + "\ndescription: d\nmodel: " + model + "\n---\nbody\n",
+                new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        [Fact]
+        public void ModelOverride_RunsChildWithOverride_NotFrontmatterOrParent()
+        {
+            Agent a = WriteAgentWithModel("explorer", "frontmatter-model");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, a)
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\",\"model\":\"override-model\"}]}");
+
+            Assert.True(streamer.SeenModels.Count > 0);
+            Assert.Equal("override-model", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void NoModelOverride_FallsBackToFrontmatterModel()
+        {
+            Agent a = WriteAgentWithModel("explorer", "frontmatter-model");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, a)
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.True(streamer.SeenModels.Count > 0);
+            Assert.Equal("frontmatter-model", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void NoModelAnywhere_FallsBackToParentModel()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");   // no frontmatter model
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, a)   // parent model is "parent-model"
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.True(streamer.SeenModels.Count > 0);
+            Assert.Equal("parent-model", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void ModelOverride_IsReportedToActivityUiModelList()
+        {
+            Agent a = WriteAgentWithModel("explorer", "frontmatter-model");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            var ui = new FakeActivityUi();
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.ActivityUi = ui;
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\",\"model\":\"override-model\"}]}");
+
+            Assert.Equal("override-model", ui.LastFanOutFirstModel);
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
+++ b/GxPT.Tests/Mcp/OrchestratorTestSupport.cs
@@ -74,6 +74,7 @@ namespace GxPT.Tests.Mcp
         public readonly List<IList<ChatMessage>> SeenMessages = new List<IList<ChatMessage>>();
         public readonly List<IList<JObject>> SeenTools = new List<IList<JObject>>();
         public readonly List<ClientProperties> SeenProps = new List<ClientProperties>();
+        public readonly List<string> SeenModels = new List<string>();
 
         public void StreamChat(string model, IList<ChatMessage> messages, IList<JObject> tools,
                                ClientProperties props, Action<ChatCompletionChunk> onChunk, Action<string> onError,
@@ -83,6 +84,7 @@ namespace GxPT.Tests.Mcp
             SeenMessages.Add(messages);
             SeenTools.Add(tools);
             SeenProps.Add(props);
+            SeenModels.Add(model);
 
             // Test hook fired with this call's index, e.g. to simulate the user pressing Stop
             // mid-turn (cancel.Cancel()) after a particular streamed response.

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -119,7 +119,8 @@ namespace GxPT
             JObject taskP = new JObject(); taskP["type"] = "string";
             JObject modelP = new JObject();
             modelP["type"] = "string";
-            modelP["description"] = "Optional model id to run this agent with. Overrides the agent's "
+            modelP["description"] = "Optional model id to run this agent with, in OpenRouter format "
+                + "\"model-author/model-name\" (e.g. \"z-ai/glm-5.2\"). Overrides the agent's "
                 + "frontmatter model (and the default parent model) for this dispatch only. Omit to use "
                 + "the agent's own model.";
             JObject entryProps = new JObject();

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -119,9 +119,12 @@ namespace GxPT
             JObject taskP = new JObject(); taskP["type"] = "string";
             JObject modelP = new JObject();
             modelP["type"] = "string";
-            modelP["description"] = "Optional model id to run this agent with. Overrides the agent's "
-                + "frontmatter model (and the default parent model) for this dispatch only. Omit to use "
-                + "the agent's own model.";
+            modelP["description"] = "Optional, and almost always omit it. Each agent already declares the "
+                + "right model for its job, so leaving this unset (the default) is correct for nearly every "
+                + "dispatch - you do not need to pick a model. Only set it when there is a specific reason to "
+                + "override the agent's usual model (e.g. the user explicitly asked, or the task plainly needs "
+                + "a more or less capable model than the agent's default). When set, it overrides the agent's "
+                + "frontmatter model (and the default parent model) for this dispatch only.";
             JObject entryProps = new JObject();
             entryProps["name"] = nameP;
             entryProps["task"] = taskP;

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -119,12 +119,9 @@ namespace GxPT
             JObject taskP = new JObject(); taskP["type"] = "string";
             JObject modelP = new JObject();
             modelP["type"] = "string";
-            modelP["description"] = "Optional, and almost always omit it. Each agent already declares the "
-                + "right model for its job, so leaving this unset (the default) is correct for nearly every "
-                + "dispatch - you do not need to pick a model. Only set it when there is a specific reason to "
-                + "override the agent's usual model (e.g. the user explicitly asked, or the task plainly needs "
-                + "a more or less capable model than the agent's default). When set, it overrides the agent's "
-                + "frontmatter model (and the default parent model) for this dispatch only.";
+            modelP["description"] = "Optional model id to run this agent with. Overrides the agent's "
+                + "frontmatter model (and the default parent model) for this dispatch only. Omit to use "
+                + "the agent's own model.";
             JObject entryProps = new JObject();
             entryProps["name"] = nameP;
             entryProps["task"] = taskP;

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -112,14 +112,20 @@ namespace GxPT
 
         public bool IsDispatchAgent(string functionName) { return functionName == DispatchAgentName; }
 
-        // The OpenAI-style function definition: dispatch_agent({ agents: [{ name, task }] }).
+        // The OpenAI-style function definition: dispatch_agent({ agents: [{ name, task, model? }] }).
         public JObject DispatchAgentDef()
         {
             JObject nameP = new JObject(); nameP["type"] = "string";
             JObject taskP = new JObject(); taskP["type"] = "string";
+            JObject modelP = new JObject();
+            modelP["type"] = "string";
+            modelP["description"] = "Optional model id to run this agent with. Overrides the agent's "
+                + "frontmatter model (and the default parent model) for this dispatch only. Omit to use "
+                + "the agent's own model.";
             JObject entryProps = new JObject();
             entryProps["name"] = nameP;
             entryProps["task"] = taskP;
+            entryProps["model"] = modelP;
             JObject entrySchema = new JObject();
             entrySchema["type"] = "object";
             entrySchema["properties"] = entryProps;
@@ -155,7 +161,7 @@ namespace GxPT
         // batch still returns the rest (the open_skill tolerance). Never throws to the caller.
         public string Dispatch(string argumentsJson)
         {
-            List<string[]> entries = ParseEntries(argumentsJson);   // each = { name, task }
+            List<string[]> entries = ParseEntries(argumentsJson);   // each = { name, task, model }
             if (entries.Count == 0) return "No agents specified to dispatch.";
 
             int n = entries.Count;
@@ -167,6 +173,9 @@ namespace GxPT
             string[] names = new string[n];
             Agent[] agents = new Agent[n];
             string[] tasks = new string[n];
+            // Optional per-call model override (the dispatch_agent `model` arg). Null => fall back to the
+            // agent's frontmatter model, then the parent model.
+            string[] modelOverrides = new string[n];
             string[] results = new string[n];
             // Per-slot child transcripts (tier 3): slot i is null until/unless that agent runs a child.
             // Exposed via LastTranscripts so the host can cache them under the dispatch record's key and
@@ -177,6 +186,7 @@ namespace GxPT
             {
                 names[i] = entries[i][0];
                 tasks[i] = entries[i][1];
+                modelOverrides[i] = entries[i][2];
                 Agent agent;
                 if (names[i] == null || !_bySlug.TryGetValue(names[i], out agent))
                     results[i] = "Unknown agent: " + (names[i] != null ? names[i] : "(null)");
@@ -195,10 +205,11 @@ namespace GxPT
                 List<string> modelList = new List<string>(runnable.Count);
                 for (int k = 0; k < runnable.Count; k++)
                 {
-                    Agent a = agents[runnable[k]];
+                    int slot = runnable[k];
+                    Agent a = agents[slot];
                     slugs.Add(a.Slug);
-                    taskList.Add(tasks[runnable[k]]);
-                    modelList.Add(!string.IsNullOrEmpty(a.Model) ? a.Model : _parentModel);
+                    taskList.Add(tasks[slot]);
+                    modelList.Add(ResolveModel(modelOverrides[slot], a));
                 }
                 ui.OnFanOutStart(slugs, taskList, modelList);
             }
@@ -212,12 +223,12 @@ namespace GxPT
                 // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
                 // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
                 if (RunsInParallel(agents, runnable))
-                    RunParallel(agents, tasks, runnable, results, transcripts);
+                    RunParallel(agents, tasks, modelOverrides, runnable, results, transcripts);
                 else
                     for (int k = 0; k < runnable.Count; k++)
                     {
                         int i = runnable[k];
-                        results[i] = RunChildReported(k, i, agents[i], tasks[i], transcripts);
+                        results[i] = RunChildReported(k, i, agents[i], tasks[i], modelOverrides[i], transcripts);
                     }
             }
             finally
@@ -275,8 +286,8 @@ namespace GxPT
         // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
         // is valid here; no lock is held across the join, so the fan-out cannot deadlock. At most
         // MaxParallelAgents worker handles are joined, well under WaitAll's 64-handle limit.
-        private void RunParallel(Agent[] agents, string[] tasks, List<int> runnable, string[] results,
-                                 AgentTranscript[] transcripts)
+        private void RunParallel(Agent[] agents, string[] tasks, string[] modelOverrides, List<int> runnable,
+                                 string[] results, AgentTranscript[] transcripts)
         {
             int count = runnable.Count;
             int workerCount = Math.Min(MaxParallelAgents, count);
@@ -300,7 +311,8 @@ namespace GxPT
                                 int slot = runnable[row];   // entry slot (position in the agents/tasks arrays)
                                 Agent agent = agents[slot];
                                 string task = tasks[slot];
-                                try { results[slot] = RunChildReported(row, slot, agent, task, transcripts); }
+                                string modelOverride = modelOverrides[slot];
+                                try { results[slot] = RunChildReported(row, slot, agent, task, modelOverride, transcripts); }
                                 catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
                             }
                         }
@@ -321,7 +333,7 @@ namespace GxPT
         // entry index (used for the result/transcript arrays). A per-child forwarding UI reports the
         // child's tool calls as the row's live activity line (tier 2); the run's full message list is
         // captured into transcripts[slot] for the tier-3 viewer (even on error - the partial history).
-        private string RunChildReported(int row, int slot, Agent agent, string task,
+        private string RunChildReported(int row, int slot, Agent agent, string task, string modelOverride,
                                         AgentTranscript[] transcripts)
         {
             IAgentActivityUi ui = ActivityUi;
@@ -342,7 +354,7 @@ namespace GxPT
             try
             {
                 IList<ChatMessage> history;
-                string answer = RunChild(agent, task, childUi, out history);
+                string answer = RunChild(agent, task, modelOverride, childUi, out history);
                 if (transcripts != null) transcripts[slot] = new AgentTranscript(agent.Slug, task, history);
                 return answer;
             }
@@ -356,9 +368,10 @@ namespace GxPT
         // Builds and runs one child orchestrator to completion, returning its final answer. `history` is set
         // (before the run) to the child's message list so the caller gets the full transcript even if the
         // turn throws. `childUi` receives the child's tool activity (forwarded to the row's activity line).
-        private string RunChild(Agent agent, string task, IToolLoopUi childUi, out IList<ChatMessage> history)
+        private string RunChild(Agent agent, string task, string modelOverride, IToolLoopUi childUi,
+                                out IList<ChatMessage> history)
         {
-            string model = !string.IsNullOrEmpty(agent.Model) ? agent.Model : _parentModel;
+            string model = ResolveModel(modelOverride, agent);
             int maxIter = agent.MaxTurns > 0 ? agent.MaxTurns : _defaultMaxIterations;
 
             McpChatOrchestrator child = new McpChatOrchestrator(_streamer, _registry, _approval, model,
@@ -414,6 +427,16 @@ namespace GxPT
             return ExtractFinalAnswer(msgs);
         }
 
+        // Resolves the model a child runs under, in decreasing precedence: the per-call `model` override
+        // (the dispatch_agent arg), then the agent's frontmatter model, then the parent turn's model. So a
+        // caller can steer a single dispatch onto a different model without editing the agent file.
+        private string ResolveModel(string modelOverride, Agent agent)
+        {
+            if (!string.IsNullOrEmpty(modelOverride)) return modelOverride;
+            if (agent != null && !string.IsNullOrEmpty(agent.Model)) return agent.Model;
+            return _parentModel;
+        }
+
         // The child's final answer is the last assistant message its turn appended to history. Only the
         // final answer crosses back to the parent (context firewall, A3/A7); intermediate tool chatter
         // stays in the child's own message list.
@@ -445,8 +468,9 @@ namespace GxPT
             }
         }
 
-        // Parses { agents: [ { name, task }, ... ] } into a list of {name, task} pairs. Malformed input
-        // yields an empty list (the tool then reports "no agents"), never an exception.
+        // Parses { agents: [ { name, task, model? }, ... ] } into a list of {name, task, model} triples
+        // (model null when omitted). Malformed input yields an empty list (the tool then reports "no
+        // agents"), never an exception.
         private static List<string[]> ParseEntries(string argumentsJson)
         {
             List<string[]> list = new List<string[]>();
@@ -461,7 +485,7 @@ namespace GxPT
                     {
                         if (t == null || t.Type != JTokenType.Object) continue;
                         JObject e = (JObject)t;
-                        list.Add(new string[] { AsString(e["name"]), AsString(e["task"]) });
+                        list.Add(new string[] { AsString(e["name"]), AsString(e["task"]), AsString(e["model"]) });
                     }
                 }
             }

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -232,8 +232,11 @@ resolution (like `IsOpenSkill`), so it never hits a server.
 ### `dispatch_agent` — the meta-tool
 
 ```
-dispatch_agent(agents: [ { name: string, task: string }, … ])   // batch (A9)
+dispatch_agent(agents: [ { name: string, task: string, model?: string }, … ])   // batch (A9)
 ```
+The optional per-entry `model` overrides that agent's frontmatter model (and the
+default parent model) for this dispatch only — precedence is
+`model` arg → frontmatter `model` → parent turn's model.
 Definition shape mirrors `open_skill`/`reveal_tools` so the model treats it the
 same way. Description: *"Delegate one or more self-contained sub-tasks to specialist
 agents that work in isolation and report back. Pass each agent's slug (from the


### PR DESCRIPTION
## Summary
This PR adds support for per-call model overrides when dispatching child agents. The `dispatch_agent` meta-tool now accepts an optional `model` parameter for each agent entry, allowing callers to override which model a child agent runs under without modifying the agent's frontmatter.

## Key Changes

- **Updated `dispatch_agent` function signature**: Added optional `model` parameter to agent entries in the dispatch payload: `{ name, task, model? }`
  - The `model` parameter is optional; only `name` and `task` are required
  - Includes detailed description of the parameter format and override behavior

- **Implemented model resolution precedence**: Created `ResolveModel()` method that determines which model to use in this order:
  1. Per-call `model` override (dispatch_agent argument)
  2. Agent's frontmatter `model` field
  3. Parent turn's default model

- **Updated dispatch pipeline**: Modified `Dispatch()`, `RunParallel()`, and `RunChild()` methods to:
  - Parse and track model overrides from the dispatch arguments
  - Pass model overrides through the parallel and sequential execution paths
  - Apply the resolved model when creating child orchestrators

- **Updated activity UI reporting**: Modified fan-out reporting to use the resolved model (including overrides) so the UI accurately reflects which model each child agent runs under

- **Added comprehensive test coverage**: Four new test cases verify:
  - Override takes precedence over frontmatter and parent models
  - Fallback to frontmatter model when no override provided
  - Fallback to parent model when neither override nor frontmatter model exists
  - Override is correctly reported to the activity UI

- **Updated documentation**: Modified design doc to reflect the new optional `model` parameter and its precedence rules

## Implementation Details

- Model overrides are stored as a parallel array (`modelOverrides[]`) alongside agent names and tasks during dispatch processing
- The resolution logic is centralized in `ResolveModel()` to ensure consistent behavior across all execution paths (parallel and sequential)
- Null/empty string model overrides are treated as "not provided" to enable fallback behavior
- The change is backward compatible: existing dispatch calls without the `model` parameter continue to work as before

https://claude.ai/code/session_01EHPUtxbCQkcspQ1ysUDsnd