### PR TITLE
Refine skill invocation instructions to reduce narration

### DIFF
--- a/GxPT/Services/Skills/SkillInjection.cs
+++ b/GxPT/Services/Skills/SkillInjection.cs
@@ -36,7 +36,9 @@ namespace GxPT
             + "open_skill is directly callable - you do NOT need to reveal it first - and you may open "
             + "several at once. The <scope> is where the skill lives (user or project; bundled skills are "
             + "read-only); pass it as the `scope` argument when editing a skill so the edit targets the "
-            + "right one. Do not mention skills unless they are relevant to the request.";
+            + "right one. Do not mention skills unless they are relevant to the request. Do not narrate "
+            + "or announce calling open_skill (no \"let me open the skill\" or \"using open_skill\"); just "
+            + "call it and follow the instructions.";
 
         // The DYNAMIC inventory: the slug/scope/description list, for the ephemeral tail. Returns null
         // when the enabled set is empty, so a skill-less or all-disabled conversation injects nothing.

--- a/GxPT/Services/Skills/SkillTools.cs
+++ b/GxPT/Services/Skills/SkillTools.cs
@@ -154,7 +154,8 @@ namespace GxPT
             JObject fn = new JObject();
             fn["name"] = OpenSkillName;
             fn["description"] = "Load one or more skills' full instructions by slug so you can follow "
-                + "them. Pass the slugs from the skills list.";
+                + "them. Pass the slugs from the skills list. Do not narrate or announce calling this "
+                + "tool; just call it and follow the instructions it returns.";
             fn["parameters"] = schema;
 
             JObject def = new JObject();


### PR DESCRIPTION
## Summary
Updated skill-related system prompts to discourage the AI from narrating or announcing when it calls skill tools, encouraging it to invoke them directly and follow their instructions without preamble.

## Key Changes
- **SkillInjection.cs**: Extended the `open_skill` instruction prompt to explicitly instruct against narrating skill calls (e.g., "let me open the skill" or "using open_skill"), directing the AI to call the skill directly and follow instructions instead
- **SkillTools.cs**: Updated the `OpenSkillDef()` function description to include similar guidance against narrating tool invocation, emphasizing direct execution and instruction-following

## Implementation Details
These changes improve the user experience by reducing verbose AI behavior when working with skills. Rather than having the AI announce its actions, it now goes directly to executing the skill and presenting results, making interactions more concise and efficient.

https://claude.ai/code/session_011ng3qfZLb2Lz1UsPZi9yAb