### PR TITLE
Add horizontal divider (---) support to markdown rendering

### DIFF
--- a/GxPT.Tests/MarkdownParserTests.cs
+++ b/GxPT.Tests/MarkdownParserTests.cs
@@ -222,6 +222,60 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void Divider_TripleDash_ProducesDividerBlock()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("above\n\n---\n\nbelow");
+            Assert.NotNull(FirstBlock<DividerBlock>(blocks));
+            // The divider separates the two paragraphs.
+            int dividerIdx = blocks.FindIndex(b => b is DividerBlock);
+            Assert.True(dividerIdx > 0 && dividerIdx < blocks.Count - 1);
+            Assert.IsType<ParagraphBlock>(blocks[dividerIdx - 1]);
+            Assert.IsType<ParagraphBlock>(blocks[dividerIdx + 1]);
+        }
+
+        [Fact]
+        public void Divider_AsteriskAndUnderscoreMarkers_ProduceDividers()
+        {
+            Assert.NotNull(FirstBlock<DividerBlock>(MarkdownParser.ParseMarkdown("***")));
+            Assert.NotNull(FirstBlock<DividerBlock>(MarkdownParser.ParseMarkdown("___")));
+            Assert.NotNull(FirstBlock<DividerBlock>(MarkdownParser.ParseMarkdown("-----")));
+        }
+
+        [Fact]
+        public void Divider_SpacedDashes_AreNotBullets()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("- - -");
+            Assert.NotNull(FirstBlock<DividerBlock>(blocks));
+            Assert.Null(FirstBlock<BulletListBlock>(blocks));
+        }
+
+        [Fact]
+        public void Divider_TwoDashes_IsNotADivider()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("--");
+            Assert.Null(FirstBlock<DividerBlock>(blocks));
+        }
+
+        [Fact]
+        public void Divider_AfterParagraphWithoutBlankLine_SplitsParagraph()
+        {
+            var blocks = MarkdownParser.ParseMarkdown("text\n---");
+            var p = FirstBlock<ParagraphBlock>(blocks);
+            Assert.NotNull(p);
+            Assert.Equal("text", InlineText(p.Inlines));
+            Assert.NotNull(FirstBlock<DividerBlock>(blocks));
+        }
+
+        [Fact]
+        public void Divider_TableSeparator_IsStillParsedAsTable()
+        {
+            // A "---" separator that belongs to a pipe table must not be hijacked as a divider.
+            var blocks = MarkdownParser.ParseMarkdown("| A | B |\n| --- | --- |\n| 1 | 2 |");
+            Assert.NotNull(FirstBlock<TableBlock>(blocks));
+            Assert.Null(FirstBlock<DividerBlock>(blocks));
+        }
+
+        [Fact]
         public void Crlf_IsNormalized()
         {
             var blocks = MarkdownParser.ParseMarkdown("# Heading\r\n\r\nA paragraph");

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -64,7 +64,7 @@ namespace GxPT
         private const int CodeBlockPadding = 6;
 
         // Horizontal rule ("---" divider): vertical padding above and below the 1px line.
-        private const int DividerVPad = 6;
+        private const int DividerVPad = 11;
         private const int DividerHeight = DividerVPad * 2 + 1;
 
         // Edit-diff record layout: a one-line clickable header, then (when expanded) a chromeless

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -64,7 +64,7 @@ namespace GxPT
         private const int CodeBlockPadding = 6;
 
         // Horizontal rule ("---" divider): vertical padding above and below the 1px line.
-        private const int DividerVPad = 11;
+        private const int DividerVPad = 16;
         private const int DividerHeight = DividerVPad * 2 + 1;
 
         // Edit-diff record layout: a one-line clickable header, then (when expanded) a chromeless

--- a/GxPT/Controls/ChatTranscriptControl.cs
+++ b/GxPT/Controls/ChatTranscriptControl.cs
@@ -63,6 +63,10 @@ namespace GxPT
         private const int BulletGap = 8;
         private const int CodeBlockPadding = 6;
 
+        // Horizontal rule ("---" divider): vertical padding above and below the 1px line.
+        private const int DividerVPad = 6;
+        private const int DividerHeight = DividerVPad * 2 + 1;
+
         // Edit-diff record layout: a one-line clickable header, then (when expanded) a chromeless
         // diff body indented under it.
         private const int EditDiffHeaderPad = 3;  // vertical padding around the header text
@@ -1619,6 +1623,11 @@ namespace GxPT
                         var er = (ErrorBlock)blk;
                         return MeasureInlineParagraph(g, BuildErrorInlines(er.Message), _baseFont, maxWidth, true);
                     }
+                case BlockType.Divider:
+                    {
+                        // A full-width thematic break; the line is centered in DividerHeight vertically.
+                        return new Size(maxWidth, DividerHeight);
+                    }
                 case BlockType.Table:
                     {
                         var t = (TableBlock)blk;
@@ -2393,6 +2402,23 @@ namespace GxPT
                         owner.RetryRect = btn;
                         y += btnSz.Height;
                     }
+                    numberedCounters.Clear();
+                }
+                else if (blk.Type == BlockType.Divider)
+                {
+                    // Full-width horizontal rule, centered vertically within DividerHeight.
+                    int lineY = y + DividerVPad;
+                    using (var pen = new Pen(_clrCodeBorder))
+                        g.DrawLine(pen, x0, lineY, x0 + maxWidth, lineY);
+                    // Record a selectable segment so the rule round-trips through copy as "---".
+                    if (owner != null)
+                    {
+                        if (owner.DrawnSegments == null) owner.DrawnSegments = new List<DrawnSeg>();
+                        owner.DrawnSegments.Add(new DrawnSeg { IsNewLine = true, IsHardBreak = true, Rect = new Rectangle(x0, y, 0, 0), Text = null, Font = _baseFont });
+                        owner.DrawnSegments.Add(new DrawnSeg { Rect = new Rectangle(x0, lineY, maxWidth, 1), Text = "---", Font = _baseFont, IsLogicalLineStart = true, LineFirstTextLeft = x0 });
+                        owner.DrawnSegments.Add(new DrawnSeg { IsNewLine = true, IsHardBreak = true, Rect = new Rectangle(x0, y + DividerHeight, 0, 0), Text = null, Font = _baseFont });
+                    }
+                    y += DividerHeight;
                     numberedCounters.Clear();
                 }
                 else if (blk.Type == BlockType.CodeBlock)
@@ -3990,6 +4016,10 @@ namespace GxPT
                                 int used = MeasureInlineParagraphHeight(g, contentW - (textX - contentX), item.Content, _baseFont);
                                 y += Math.Max(used, _baseFont.Height) + 2;
                             }
+                        }
+                        else if (blk.Type == BlockType.Divider)
+                        {
+                            y += DividerHeight;
                         }
                         else if (blk.Type == BlockType.CodeBlock)
                         {

--- a/GxPT/Services/MarkdownParser.cs
+++ b/GxPT/Services/MarkdownParser.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 namespace GxPT
 {
     // ---------- Markdown model ----------
-    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table, EditDiff, Error }
+    public enum BlockType { Paragraph, Heading, CodeBlock, BulletList, NumberedList, Table, EditDiff, Error, Divider }
 
     [Flags]
     public enum RunStyle { Normal = 0, Bold = 1, Italic = 2, Code = 4, Link = 8 }
@@ -53,6 +53,12 @@ namespace GxPT
     public sealed class ErrorBlock : Block
     {
         public string Message;
+    }
+
+    // A horizontal rule / thematic break, emitted for a line of 3+ '-', '*', or '_' (the markdown
+    // "---" divider syntax). Carries no content; the transcript control draws a full-width line.
+    public sealed class DividerBlock : Block
+    {
     }
 
     public sealed class BulletListBlock : Block
@@ -290,6 +296,17 @@ namespace GxPT
                     flushBullets();
                     flushNumbered();
                     blocks.Add(new ErrorBlock { Type = BlockType.Error, Message = errorMessage });
+                    continue;
+                }
+
+                // horizontal rule / thematic break (--- / *** / ___)? Checked before bullets so that a
+                // spaced rule like "- - -" isn't mistaken for a bullet item.
+                if (IsHorizontalRule(line))
+                {
+                    flushParagraph();
+                    flushBullets();
+                    flushNumbered();
+                    blocks.Add(new DividerBlock { Type = BlockType.Divider });
                     continue;
                 }
 
@@ -648,6 +665,28 @@ namespace GxPT
                 return true;
             }
             return false;
+        }
+
+        // A thematic break: a line made up solely of 3 or more of the same marker ('-', '*', or '_'),
+        // optionally separated by spaces or tabs (e.g. "---", "***", "___", "- - -"). Matches the
+        // CommonMark thematic-break rule. Note a lone "---" never reaches the table path because that
+        // requires a preceding header row containing a pipe.
+        private static bool IsHorizontalRule(string line)
+        {
+            if (line == null) return false;
+            string s = line.Trim();
+            if (s.Length < 3) return false;
+            char marker = s[0];
+            if (marker != '-' && marker != '*' && marker != '_') return false;
+            int count = 0;
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (c == marker) count++;
+                else if (c == ' ' || c == '\t') continue;
+                else return false;
+            }
+            return count >= 3;
         }
 
         private static int HeadingLevel(string line)


### PR DESCRIPTION
## Summary

Adds support for markdown horizontal dividers (thematic breaks) written as a line of 3 or more `-`, `*`, or `_` characters. These now render as a full-width horizontal rule in the chat transcript instead of literal text.

## Changes

**`GxPT/Services/MarkdownParser.cs`**
- New `Divider` block type and `DividerBlock` model class.
- `IsHorizontalRule(...)` recognizes a line made up solely of 3+ of the same marker (`-`, `*`, or `_`), optionally space/tab-separated — so `---`, `***`, `___`, and `- - -` all qualify (CommonMark thematic-break rule).
- The check runs *before* bullet parsing so a spaced rule like `- - -` isn't mistaken for a list item, and it flushes any open paragraph/list first. Pipe-table separators are unaffected (those require a preceding header row containing `|`).

**`GxPT/Controls/ChatTranscriptControl.cs`** — updated the three places that key off `BlockType` so layout, painting, and interaction stay in sync:
- **Measure:** a divider reports a full-width box of `DividerHeight`.
- **Draw:** a centered 1px line in the theme-aware code-border color, plus a selectable `---` segment so the rule round-trips through copy as text.
- **Hit-test:** advances `y` by `DividerHeight` so code blocks/tables after a divider still hit-test correctly.
- `DividerVPad` controls the vertical padding above and below the rule (currently 16px).

## Tests

`GxPT.Tests/MarkdownParserTests.cs` — added coverage for the three marker variants, spaced-dash vs. bullet disambiguation, the 2-dash negative case, paragraph splitting, and confirmation that table separators still parse as tables.

## Verification note

`dotnet` isn't available in the dev environment, so the build/tests weren't run locally. CI builds the test project (which links `MarkdownParser.cs`) and will exercise the new parser tests. `ChatTranscriptControl.cs` is the .NET 3.5 WinForms UI that CI doesn't compile; those edits were reviewed against the surrounding code (they mirror the existing `Error`/`CodeBlock` block patterns) but the rendering itself hasn't been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVnnqfYKuUEKk9nkotBpP3)_