### PR TITLE
Document edge routing constraints for HTML table nodes

### DIFF
--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -108,11 +108,17 @@ routing around these nodes gets fragile in three specific ways. They apply equal
 diagrams, ER diagrams, database schema diagrams, component/deployment diagrams, and any other
 diagram where a structured multi-row HTML table replaces a plain text label.
 
-- **Don't use `splines=ortho` with HTML-table nodes.** Ortho forces every edge into right-angle
-  segments and computes its corner points from the node bounding box. With the box pulled tight
-  against the table, the orthogonal router can't find valid attachment points at the border and
-  ends up routing *through* the node interior. Leave splines at the default - the default router
-  attaches to the border correctly.
+- **`splines=ortho` needs a real node boundary - give it one with `shape=box`.** Ortho forces
+  every edge into right-angle segments and computes its corner points from the node's geometry.
+  With `shape=none` the node has no shape of its own, so its boundary is *inferred* from the label
+  size and pulled tight against the table - the router can't find valid attachment points and ends
+  up routing *through* the node interior. The fix is to give the node a genuine rectangle: switch
+  `shape=none` to `shape=box` and set the `<table>`'s `border="0"` so the box draws the single
+  outer border (no double border) and ortho attaches to it cleanly. The trade-off is that the
+  outer border is now a plain rectangle - you lose table-level border styling like rounded corners
+  or per-side outer borders, though inner `cellborder` row separators are unaffected. If you don't
+  need ortho, plain `shape=none` with the default spline router also attaches to the border
+  correctly; if you want styled outer borders *and* ortho, you can't have both, so pick one.
 
 - **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`) on HTML-table nodes.** With `shape=none`
   the node's logical boundary is derived from the label's computed size and can be misaligned from
@@ -130,8 +136,9 @@ diagram where a structured multi-row HTML table replaces a plain text label.
 
 A UML class diagram - colored header `<td>`, separate rows for attributes and operations,
 inheritance via an empty arrowhead, and an association with quoted multiplicity labels pushed
-clear of the boxes via `labeldistance`/`labelangle` (and note: no `splines=ortho`, no port
-anchors):
+clear of the boxes via `labeldistance`/`labelangle`. It uses `shape=none` with the default spline
+router and no port anchors; to route these edges with `splines=ortho` instead, switch the node
+default to `shape=box` and set each `<table>`'s `border="0"` as described above:
 
 ```dot
 digraph {

--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -115,10 +115,13 @@ diagram where a structured multi-row HTML table replaces a plain text label.
   up routing *through* the node interior. The fix is to give the node a genuine rectangle: switch
   `shape=none` to `shape=box` and set the `<table>`'s `border="0"` so the box draws the single
   outer border (no double border) and ortho attaches to it cleanly. The trade-off is that the
-  outer border is now a plain rectangle - you lose table-level border styling like rounded corners
-  or per-side outer borders, though inner `cellborder` row separators are unaffected. If you don't
-  need ortho, plain `shape=none` with the default spline router also attaches to the border
-  correctly; if you want styled outer borders *and* ortho, you can't have both, so pick one.
+  outer border is now a single enclosing rectangle: rounded corners, color, and thickness are
+  still available (`style=rounded`, `color`, `penwidth` on the node), but border effects that
+  aren't one uniform rectangle are not - a border offset from the cells via `cellspacing`, or a
+  partial/per-side outer border such as a rule under just the header. Inner `cellborder` row
+  separators are unaffected either way. If you don't need ortho, plain `shape=none` with the
+  default spline router also attaches to the border correctly; reach for `shape=box` only when you
+  want ortho and a plain rectangular outer border is acceptable.
 
 - **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`) on HTML-table nodes.** With `shape=none`
   the node's logical boundary is derived from the label's computed size and can be misaligned from

--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -115,13 +115,16 @@ diagram where a structured multi-row HTML table replaces a plain text label.
   up routing *through* the node interior. The fix is to give the node a genuine rectangle: switch
   `shape=none` to `shape=box` and set the `<table>`'s `border="0"` so the box draws the single
   outer border (no double border) and ortho attaches to it cleanly. The trade-off is that the
-  outer border is now a single enclosing rectangle: rounded corners, color, and thickness are
-  still available (`style=rounded`, `color`, `penwidth` on the node), but border effects that
-  aren't one uniform rectangle are not - a border offset from the cells via `cellspacing`, or a
-  partial/per-side outer border such as a rule under just the header. Inner `cellborder` row
-  separators are unaffected either way. If you don't need ortho, plain `shape=none` with the
-  default spline router also attaches to the border correctly; reach for `shape=box` only when you
-  want ortho and a plain rectangular outer border is acceptable.
+  outer border is now a square rectangle drawn by the node: `color` and `penwidth` work, but keep
+  the corners square - **do not add `style=rounded`** on a `shape=box` table node. The box rounds
+  only the outline, not the square `bgcolor` cell fills inside the table, so a colored header bleeds
+  past the rounded corner (and `cellspacing` insets don't reliably hide it across Graphviz
+  versions). Other table-drawn border effects are likewise unavailable - a border offset from the
+  cells via `cellspacing`, or a partial/per-side outer border such as a rule under just the header.
+  Inner `cellborder` row separators are unaffected. If you need rounded corners or those other
+  effects, keep `shape=none` (where the table draws its own border and `<table style="rounded">`
+  clips the fill correctly) and don't use ortho. In short: `shape=box` + `border="0"` for ortho
+  with a plain square border; `shape=none` + the default spline router for anything fancier.
 
 - **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`) on HTML-table nodes.** With `shape=none`
   the node's logical boundary is derived from the label's computed size and can be misaligned from

--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -101,8 +101,37 @@ anywhere a table replaces a plain text label. They do **not** apply to plain-tex
 (`label="Customer"` on a `shape=box, style=rounded`); that case has neither problem, so only reach
 for `shape=none, margin=0` when you're actually using a `<table>` label.
 
+### Three routing constraints these nodes impose
+
+Because `shape=none, margin=0` tightens the logical boundary right up against the table, edge
+routing around these nodes gets fragile in three specific ways. They apply equally to UML class
+diagrams, ER diagrams, database schema diagrams, component/deployment diagrams, and any other
+diagram where a structured multi-row HTML table replaces a plain text label.
+
+- **Don't use `splines=ortho` with HTML-table nodes.** Ortho forces every edge into right-angle
+  segments and computes its corner points from the node bounding box. With the box pulled tight
+  against the table, the orthogonal router can't find valid attachment points at the border and
+  ends up routing *through* the node interior. Leave splines at the default - the default router
+  attaches to the border correctly.
+
+- **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`) on HTML-table nodes.** With `shape=none`
+  the node's logical boundary is derived from the label's computed size and can be misaligned from
+  the rendered table edge, so `Node:e` / `Node:w` attach to that invisible boundary - arrows look
+  detached or start/end inside the box. Let Graphviz pick the nearest border point automatically.
+  The one exception is a named cell port (`<td port="pk">...</td>`), which targets a specific cell
+  *inside* the table and does attach reliably; reference it as `Node:pk`.
+
+- **Tune `labeldistance` and `labelangle` for `headlabel`/`taillabel`.** Their defaults place
+  multiplicity/role labels right at the arrowhead, where they overlap the node border - worse on
+  nodes made wide by long table content. A `labeldistance` around `2.0`-`2.5` plus a `labelangle`
+  that pushes the label off the edge line clears it. These are layout-specific adjustments, not
+  fixed defaults: the right values depend on node size and edge direction, so expect to tweak them
+  per diagram.
+
 A UML class diagram - colored header `<td>`, separate rows for attributes and operations,
-inheritance via an empty arrowhead, and an association with quoted multiplicity labels:
+inheritance via an empty arrowhead, and an association with quoted multiplicity labels pushed
+clear of the boxes via `labeldistance`/`labelangle` (and note: no `splines=ortho`, no port
+anchors):
 
 ```dot
 digraph {
@@ -133,6 +162,8 @@ digraph {
   Dog -> Animal;
 
   edge [arrowhead="none"];
-  Owner -> Dog [headlabel="1..*", taillabel="1", label="owns"];
+  Owner -> Dog [label="owns",
+                headlabel="1..*", taillabel="1",
+                labeldistance=2.2, labelangle=25];
 }
 ```


### PR DESCRIPTION
## Summary
This change expands the Graphviz diagrams skill documentation to thoroughly explain three critical edge routing constraints that arise when using `shape=none, margin=0` with HTML table labels in structured diagrams (UML class, ER, database schema, etc.).

## Key Changes
- **Added "Three routing constraints these nodes impose" section** that details specific limitations and workarounds:
  - `splines=ortho` incompatibility with `shape=none` and the fix using `shape=box` with `border="0"`
  - Compass port anchor issues (`:e`, `:w`, `:n`, `:s`) and recommendation to use automatic border point selection or named cell ports
  - Label positioning challenges with `headlabel`/`taillabel` and tuning guidance for `labeldistance` and `labelangle`

- **Updated the UML class diagram example** to:
  - Demonstrate the `labeldistance` and `labelangle` parameters in practice
  - Clarify that the example uses `shape=none` with default spline routing
  - Document how to adapt the example for `splines=ortho` routing

## Notable Details
The documentation now provides concrete, actionable guidance for common edge routing problems that developers encounter with structured diagram layouts, including trade-offs (e.g., losing styled outer borders when switching to `shape=box` for ortho routing) and layout-specific tuning expectations.

https://claude.ai/code/session_015kLKwKTTCHceBTskRXJ43A