### PR TITLE
Move Plugins Manager menu item to designer

### DIFF
--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -40,6 +40,7 @@
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.miImport = new System.Windows.Forms.ToolStripMenuItem();
             this.miExport = new System.Windows.Forms.ToolStripMenuItem();
+            this.miPluginManage = new System.Windows.Forms.ToolStripMenuItem();
             this.miDeleteConversations = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.miExit = new System.Windows.Forms.ToolStripMenuItem();
@@ -133,6 +134,7 @@
             this.toolStripSeparator4,
             this.miImport,
             this.miExport,
+            this.miPluginManage,
             this.miDeleteConversations,
             this.toolStripSeparator1,
             this.miExit});
@@ -193,7 +195,14 @@
             this.miExport.Size = new System.Drawing.Size(221, 22);
             this.miExport.Text = "&Export";
             this.miExport.Click += new System.EventHandler(this.miExport_Click);
-            // 
+            //
+            // miPluginManage
+            //
+            this.miPluginManage.Name = "miPluginManage";
+            this.miPluginManage.Size = new System.Drawing.Size(221, 22);
+            this.miPluginManage.Text = "&Plugins Manager...";
+            this.miPluginManage.Click += new System.EventHandler(this.miPluginManage_Click);
+            //
             // miDeleteConversations
             // 
             this.miDeleteConversations.Name = "miDeleteConversations";
@@ -785,6 +794,7 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem miImport;
         private System.Windows.Forms.ToolStripMenuItem miExport;
+        private System.Windows.Forms.ToolStripMenuItem miPluginManage;
         private System.Windows.Forms.Button btnAttach;
         private System.Windows.Forms.Panel pnlButtons;
         private System.Windows.Forms.FlowLayoutPanel pnlAttachmentsBanner;

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -69,7 +69,6 @@ namespace GxPT
             HookEvents();
             InitializeDragAndDrop();
             InitializeClient();
-            BuildPluginsMenu();
 
             // Setup initial tab context for the designer-created tab
             SetupInitialConversationTab();
@@ -2259,25 +2258,8 @@ namespace GxPT
             SlashRefreshSkillsServer();
         }
 
-        // Adds a single "Plugins Manager..." item to the File menu (after Export) in code rather than the
-        // Designer, to avoid hand-editing generated menu plumbing. Install/uninstall/export/author all live
-        // in the dialog, so one entry suffices; /plugin still offers the same actions from the command bar.
-        private void BuildPluginsMenu()
-        {
-            try
-            {
-                if (miFile == null) return;
-
-                var manage = new ToolStripMenuItem("&Plugins Manager...");
-                manage.Click += new EventHandler(miPluginManage_Click);
-
-                int idx = miExport != null ? miFile.DropDownItems.IndexOf(miExport) : -1;
-                if (idx >= 0) miFile.DropDownItems.Insert(idx + 1, manage);
-                else miFile.DropDownItems.Add(manage);
-            }
-            catch { }
-        }
-
+        // File > Plugins Manager... lives in the Designer; install/uninstall/export/author all live in the
+        // dialog, so one entry suffices; /plugin still offers the same actions from the command bar.
         private void miPluginManage_Click(object sender, EventArgs e) { SlashManagePlugins(); }
 
         // /plugin enable|disable <name>: move the plugin's skills/agents into or out of the active roots.


### PR DESCRIPTION
## Summary
Moved the "Plugins Manager..." menu item from being dynamically created in code to being defined in the Windows Forms Designer, simplifying the initialization logic.

## Key Changes
- Removed the `BuildPluginsMenu()` method that dynamically created and inserted the menu item into the File menu at runtime
- Removed the call to `BuildPluginsMenu()` from the `MainForm` constructor
- Added `miPluginManage` as a designed menu item in `MainForm.Designer.cs`, positioned after the Export menu item in the File menu
- Updated the comment to reflect that the menu item now lives in the Designer rather than being code-generated
- Kept the `miPluginManage_Click` event handler unchanged, maintaining the same functionality

## Implementation Details
- The menu item is now part of the designer-generated UI definition, making it more maintainable and consistent with other menu items
- The positioning after the Export menu item is preserved through the designer's item ordering
- No functional changes to the plugin management feature itself; only the menu creation mechanism was refactored

https://claude.ai/code/session_01TL3F6qvAdv7jfvjg8NKXaM