### PR TITLE
graphviz skill: UML/table recipe split out, plus dividers, edge-font, and architecture-diagram guidance

### DIFF
--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -83,7 +83,7 @@ relationship kinds (solid for ownership, `dashed` with a label for a transport h
 
 ```dot
 digraph {
-  rankdir=BT;
+  rankdir=TB;
   node [shape=box, style=rounded, fontname="Arial", fontsize=10];
   edge [color="#333333"];
 

--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -76,107 +76,20 @@ graph {
 }
 ```
 
-## UML-style and structured HTML-label nodes
+## Multi-compartment nodes (UML classes, ER entities, DB tables)
 
-Multi-compartment boxes - UML classes, ER entities, database tables, component boxes with a
-header and a body - are drawn with an **HTML table label** (`label=<...>`), the standard way to
-get several rows inside one node. Two defaults sabotage these, and both must be overridden on the
-node defaults:
+When a node needs several rows - a UML class with a name / attributes / operations stack, an ER
+entity, a database table, a component box with a header and a body - its label is an HTML `<table>`
+(`label=<...>`) rather than plain text. These nodes have their own rules, and getting them wrong is
+what makes a hand-written class box look double-bordered, cramped, or covered in oversized
+overlapping edge labels. The essentials:
 
-```dot
-node [shape=none, margin=0, fontname="Arial", fontsize=11];
-```
+- `shape=none, margin=0` on the node defaults are **mandatory** for any `<table>` label.
+- Separate compartments with `<hr/>` rules, and set a small `edge [fontsize=10]` so association
+  labels don't render oversized.
+- `splines=ortho`, compass port anchors, and `headlabel`/`taillabel` multiplicity each have
+  gotchas.
 
-- **`shape=none`** suppresses the node's own shape. Without it, the default shape (or `shape=plain`)
-  draws a border around the *whole node* in addition to the borders of your `<table>`/`<td>`, so
-  every box appears double-bordered.
-- **`margin=0`** pulls the node's logical boundary tight against the table. Even with `shape=none`,
-  Graphviz keeps a default margin around the label, so the node's edge sits *outside* the visible
-  table - and edges then attach to that invisible boundary, leaving arrows looking detached from
-  the box.
-
-These two settings are universal to **any node whose label is an HTML `<table>`**: UML class
-diagrams, ER diagrams, database schemas, component/deployment boxes, swim-lane or action nodes -
-anywhere a table replaces a plain text label. They do **not** apply to plain-text labels
-(`label="Customer"` on a `shape=box, style=rounded`); that case has neither problem, so only reach
-for `shape=none, margin=0` when you're actually using a `<table>` label.
-
-### Three routing constraints these nodes impose
-
-Because `shape=none, margin=0` tightens the logical boundary right up against the table, edge
-routing around these nodes gets fragile in three specific ways. They apply equally to UML class
-diagrams, ER diagrams, database schema diagrams, component/deployment diagrams, and any other
-diagram where a structured multi-row HTML table replaces a plain text label.
-
-- **`splines=ortho` needs a real node boundary - give it one with `shape=box`.** Ortho forces
-  every edge into right-angle segments and computes its corner points from the node's geometry.
-  With `shape=none` the node has no shape of its own, so its boundary is *inferred* from the label
-  size and pulled tight against the table - the router can't find valid attachment points and ends
-  up routing *through* the node interior. The fix is to give the node a genuine rectangle: switch
-  `shape=none` to `shape=box` and set the `<table>`'s `border="0"` so the box draws the single
-  outer border (no double border) and ortho attaches to it cleanly. The trade-off is that the
-  outer border is now a square rectangle drawn by the node: `color` and `penwidth` work, but keep
-  the corners square - **do not add `style=rounded`** on a `shape=box` table node. The box rounds
-  only the outline, not the square `bgcolor` cell fills inside the table, so a colored header bleeds
-  past the rounded corner (and `cellspacing` insets don't reliably hide it across Graphviz
-  versions). Other table-drawn border effects are likewise unavailable - a border offset from the
-  cells via `cellspacing`, or a partial/per-side outer border such as a rule under just the header.
-  Inner `cellborder` row separators are unaffected. If you need rounded corners or those other
-  effects, keep `shape=none` (where the table draws its own border and `<table style="rounded">`
-  clips the fill correctly) and don't use ortho. In short: `shape=box` + `border="0"` for ortho
-  with a plain square border; `shape=none` + the default spline router for anything fancier.
-
-- **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`) on HTML-table nodes.** With `shape=none`
-  the node's logical boundary is derived from the label's computed size and can be misaligned from
-  the rendered table edge, so `Node:e` / `Node:w` attach to that invisible boundary - arrows look
-  detached or start/end inside the box. Let Graphviz pick the nearest border point automatically.
-  The one exception is a named cell port (`<td port="pk">...</td>`), which targets a specific cell
-  *inside* the table and does attach reliably; reference it as `Node:pk`.
-
-- **Tune `labeldistance` and `labelangle` for `headlabel`/`taillabel`.** Their defaults place
-  multiplicity/role labels right at the arrowhead, where they overlap the node border - worse on
-  nodes made wide by long table content. A `labeldistance` around `2.0`-`2.5` plus a `labelangle`
-  that pushes the label off the edge line clears it. These are layout-specific adjustments, not
-  fixed defaults: the right values depend on node size and edge direction, so expect to tweak them
-  per diagram.
-
-A UML class diagram - colored header `<td>`, separate rows for attributes and operations,
-inheritance via an empty arrowhead, and an association with quoted multiplicity labels pushed
-clear of the boxes via `labeldistance`/`labelangle`. It uses `shape=none` with the default spline
-router and no port anchors; to route these edges with `splines=ortho` instead, switch the node
-default to `shape=box` and set each `<table>`'s `border="0"` as described above:
-
-```dot
-digraph {
-  rankdir=BT;
-  node [shape=none, margin=0, fontname="Arial", fontsize=11];
-
-  Animal [label=<
-    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
-      <tr><td bgcolor="#cfe2ff"><b>Animal</b></td></tr>
-      <tr><td align="left">- name: String</td></tr>
-      <tr><td align="left">+ makeSound(): void</td></tr>
-    </table>>];
-
-  Dog [label=<
-    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
-      <tr><td bgcolor="#cfe2ff"><b>Dog</b></td></tr>
-      <tr><td align="left">- breed: String</td></tr>
-      <tr><td align="left">+ makeSound(): void</td></tr>
-    </table>>];
-
-  Owner [label=<
-    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
-      <tr><td bgcolor="#d1e7dd"><b>Owner</b></td></tr>
-      <tr><td align="left">- name: String</td></tr>
-    </table>>];
-
-  edge [arrowhead="empty"];
-  Dog -> Animal;
-
-  edge [arrowhead="none"];
-  Owner -> Dog [label="owns",
-                headlabel="1..*", taillabel="1",
-                labeldistance=2.2, labelangle=25];
-}
-```
+**Before drawing one, read `html-table-nodes.md` in this skill folder** (with `read_skill_file`) -
+it has the full recipe, the reasoning behind each rule, and a worked class-diagram example. None of
+this applies to plain-text labels, so only reach for it when a node's label is actually a `<table>`.

--- a/skills/graphviz-diagrams/SKILL.md
+++ b/skills/graphviz-diagrams/SKILL.md
@@ -76,13 +76,53 @@ graph {
 }
 ```
 
+An architecture diagram that groups nodes into layers with `subgraph cluster_*`. Each cluster gets
+a `style="rounded,dashed"` outline in its own `color` (with a matching `fontcolor` for its label),
+the nodes are plain `shape=box, style=rounded` with `\n` line breaks, and edge styles distinguish
+relationship kinds (solid for ownership, `dashed` with a label for a transport hop):
+
+```dot
+digraph {
+  rankdir=BT;
+  node [shape=box, style=rounded, fontname="Arial", fontsize=10];
+  edge [color="#333333"];
+
+  subgraph cluster_ui {
+    label="UI Layer"; style="rounded,dashed"; color="#4A90D9"; fontcolor="#4A90D9"; fontsize=11;
+    MainForm [label="MainForm\n(app shell)"];
+    TabManager [label="TabManager\n(conversation lifecycle)"];
+  }
+
+  subgraph cluster_services {
+    label="Core Services"; style="rounded,dashed"; color="#2ECC71"; fontcolor="#2ECC71"; fontsize=11;
+    Orchestrator [label="McpChatOrchestrator\n(tool-call loop)"];
+    McpHost [label="McpHost\n(connection mgmt)"];
+  }
+
+  subgraph cluster_servers {
+    label="MCP Servers"; style="rounded,dashed"; color="#9B59B6"; fontcolor="#9B59B6"; fontsize=11;
+    Files [label="FilesMcpServer\n(read/write)"];
+    Git [label="GitMcpServer\n(git commands)"];
+  }
+
+  MainForm -> TabManager;
+  TabManager -> Orchestrator;
+  Orchestrator -> McpHost;
+  McpHost -> Files [style=dashed, label="stdio"];
+  McpHost -> Git [style=dashed];
+}
+```
+
 ## Multi-compartment nodes (UML classes, ER entities, DB tables)
 
-When a node needs several rows - a UML class with a name / attributes / operations stack, an ER
-entity, a database table, a component box with a header and a body - its label is an HTML `<table>`
-(`label=<...>`) rather than plain text. These nodes have their own rules, and getting them wrong is
-what makes a hand-written class box look double-bordered, cramped, or covered in oversized
-overlapping edge labels. The essentials:
+When a node needs **visible internal structure** - compartment dividers, a colored header band,
+per-cell borders, or named cell ports, as in a UML class with a name / attributes / operations
+stack, an ER entity, or a database table - its label is an HTML `<table>` (`label=<...>`) rather
+than plain text. A box that is just a title and a few lines of description is **not** this case:
+that's a plain `shape=box` node with `\n` line breaks (see the architecture example above), and none
+of the rules below apply to it. When you do need a table, these nodes have their own rules, and
+getting them wrong is what makes a hand-written class box look double-bordered, cramped, or covered
+in oversized overlapping edge labels. The essentials:
 
 - `shape=none, margin=0` on the node defaults are **mandatory** for any `<table>` label.
 - Separate compartments with `<hr/>` rules, and set a small `edge [fontsize=10]` so association

--- a/skills/graphviz-diagrams/html-table-nodes.md
+++ b/skills/graphviz-diagrams/html-table-nodes.md
@@ -1,0 +1,148 @@
+# Structured HTML-table nodes (UML, ER, schemas)
+
+Multi-compartment boxes - UML classes, ER entities, database tables, component boxes with a
+header and a body - are drawn with an **HTML `<table>` label** (`label=<...>`), the standard way to
+get several rows inside one node. Read this file whenever a node's label is a `<table>`; the rules
+below are what separate a clean class box from a cramped, double-bordered, overlapping one.
+
+## The two mandatory node defaults
+
+Two Graphviz defaults sabotage table nodes, and both must be overridden on the node defaults:
+
+```dot
+node [shape=none, margin=0, fontname="Arial", fontsize=11];
+```
+
+- **`shape=none`** suppresses the node's own shape. Without it, the default shape (or `shape=plain`)
+  draws a border around the *whole node* in addition to the borders of your `<table>`/`<td>`, so
+  every box appears double-bordered.
+- **`margin=0`** pulls the node's logical boundary tight against the table. Even with `shape=none`,
+  Graphviz keeps a default margin around the label, so the node's edge sits *outside* the visible
+  table - and edges then attach to that invisible boundary, leaving arrows looking detached from
+  the box.
+
+These apply to **any node whose label is an HTML `<table>`**: UML class diagrams, ER diagrams,
+database schemas, component/deployment boxes, swim-lane or action nodes. They do **not** apply to
+plain-text labels (`label="Customer"` on a `shape=box, style=rounded`); that case has neither
+problem, so only reach for `shape=none, margin=0` when you're actually using a `<table>` label.
+
+## Compartment dividers - use `<hr/>`
+
+A UML class or ER entity reads as a stack of compartments - name, then attributes, then operations
+- separated by horizontal rules. Put those rules in with `<hr/>` between the row groups, on a table
+that draws a single outer border (`border="1" cellborder="0"`):
+
+```dot
+<table border="1" cellborder="0" cellspacing="0" cellpadding="4">
+  <tr><td bgcolor="#cfe2ff"><b>ClassName</b></td></tr>
+  <hr/>
+  <tr><td align="left">- field: Type</td></tr>
+  <hr/>
+  <tr><td align="left">+ method(): Type</td></tr>
+</table>
+```
+
+Without the `<hr/>` rules the compartments blur into one block separated only by blank space - the
+single most common reason a hand-written class box looks worse than it should. (`cellborder="1"` on
+the whole table is an alternative: it draws a line around *every* cell, which also separates the
+compartments but boxes each one individually rather than giving the classic header-rule look.)
+
+## Keep edge and association labels legible - set an edge font
+
+Edge labels (association names, multiplicity, roles) **default to a larger font than your nodes** -
+Graphviz edges render at roughly 14pt regardless of the node `fontsize`. On a class diagram that
+makes association labels tower over the class text and collide with each other where edges cross.
+Set an edge default that matches the nodes:
+
+```dot
+edge [fontname="Arial", fontsize=10];
+```
+
+This single line is usually the difference between readable association labels and an overlapping
+mess - it is the most common fix for a class diagram whose edge text looks oversized.
+
+## Multiplicity and role labels
+
+Two ways to place a multiplicity (`1`, `*`, `1..*`):
+
+- **Inline in the edge `label` - simplest and most predictable.** Write the multiplicity straight
+  into the association label, with a couple of leading spaces to push it off the line:
+  `label="  teaches  1..*"`. One label, one position, nothing to tune. Reach for this by default.
+- **`headlabel` / `taillabel` - proper UML, but fiddlier.** These pin a separate label at each
+  association end (the textbook way to show the multiplicity nearest each class). Their defaults sit
+  right on the arrowhead and overlap the node border, so you must tune `labeldistance` (≈2.0-2.5)
+  and `labelangle` to push them clear, and the right values depend on node size and edge direction.
+  Use these only when end-precise multiplicity matters; expect per-diagram tweaking, and always pair
+  them with the small edge `fontsize` above or they overlap badly.
+
+## Two routing constraints
+
+`shape=none, margin=0` tightens the logical boundary against the table, which makes edge routing
+fragile in two specific ways:
+
+- **`splines=ortho` needs a real node boundary - give it one with `shape=box`.** Ortho forces every
+  edge into right-angle segments and computes its corner points from the node's geometry. With
+  `shape=none` the node has no shape of its own, so its boundary is inferred from the label size and
+  pulled tight against the table - the router can't find valid attachment points and routes *through*
+  the node interior. The fix: switch `shape=none` to `shape=box` and set the `<table>`'s `border="0"`
+  so the box draws the single outer border (no double border) and ortho attaches cleanly. The
+  trade-off is that the outer border is now a square rectangle drawn by the node: `color` and
+  `penwidth` work, but keep the corners square - **do not add `style=rounded`** on a `shape=box`
+  table node. The box rounds only the outline, not the square `bgcolor` cell fills, so a colored
+  header bleeds past the rounded corner (and `cellspacing` insets don't reliably hide it across
+  Graphviz versions). If you need rounded corners, keep `shape=none` (where the table draws its own
+  border and `<table style="rounded">` clips the fill correctly) and don't use ortho. In short:
+  `shape=box` + `border="0"` for ortho with a plain square border; `shape=none` + the default spline
+  router for anything fancier.
+
+- **Omit compass port anchors (`:e`, `:w`, `:n`, `:s`).** With `shape=none` the node's logical
+  boundary is derived from the label's computed size and can be misaligned from the rendered table
+  edge, so `Node:e` / `Node:w` attach to that invisible boundary - arrows look detached or start/end
+  inside the box. Let Graphviz pick the nearest border point automatically. The one exception is a
+  named cell port (`<td port="pk">...</td>`), which targets a specific cell *inside* the table and
+  does attach reliably; reference it as `Node:pk`.
+
+## A worked example
+
+A UML class diagram pulling the rules together - `shape=none, margin=0` node defaults, a small edge
+font, `<hr/>` compartment dividers, inheritance via a hollow (empty) arrowhead, and an association
+with inline multiplicity:
+
+```dot
+digraph {
+  rankdir=BT;
+  node [shape=none, margin=0, fontname="Arial", fontsize=11];
+  edge [fontname="Arial", fontsize=10];
+
+  Animal [label=<
+    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
+      <tr><td bgcolor="#cfe2ff"><b>Animal</b></td></tr>
+      <hr/>
+      <tr><td align="left">- name: String</td></tr>
+      <hr/>
+      <tr><td align="left">+ makeSound(): void</td></tr>
+    </table>>];
+
+  Dog [label=<
+    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
+      <tr><td bgcolor="#cfe2ff"><b>Dog</b></td></tr>
+      <hr/>
+      <tr><td align="left">- breed: String</td></tr>
+      <hr/>
+      <tr><td align="left">+ makeSound(): void</td></tr>
+    </table>>];
+
+  Owner [label=<
+    <table border="1" cellborder="0" cellspacing="0" cellpadding="4">
+      <tr><td bgcolor="#d1e7dd"><b>Owner</b></td></tr>
+      <hr/>
+      <tr><td align="left">- name: String</td></tr>
+    </table>>];
+
+  edge [arrowhead="empty"];
+  Dog -> Animal;
+
+  edge [arrowhead="none"];
+  Owner -> Dog [label="  owns  1..*"];
+}
+```


### PR DESCRIPTION
Follow-up to #231. Improves the Graphviz Diagrams skill based on real rendered diagrams, and restructures it so the deep HTML-table material no longer crowds the core guidance.

## What changed

**Split the skill into two files (progressive disclosure).**
- `SKILL.md` stays lean: when to draw, engine selection, rendering rules, and worked examples. The core engine-selection guidance is unchanged.
- New `html-table-nodes.md` holds the full HTML-table/UML recipe. GxPT lists a skill's bundled files and the model reads them on demand via `read_skill_file`, so this is the intended "needed sometimes, keep SKILL.md lean" pattern.

**New findings folded into the table recipe** (each verified by rendering with `dot`):
- **Compartment dividers** — use `<hr/>` between row groups (with `border="1" cellborder="0"`) so a class reads as name / attributes / operations compartments instead of one undivided block.
- **Edge-label font** — Graphviz edges default to ~14pt regardless of node `fontsize`, so association/multiplicity labels render oversized and overlap where edges cross. Set `edge [fontsize=10]`.
- **Multiplicity** — prefer inline multiplicity in the edge label (`label="  owns  1..*"`) as the predictable default; keep `headlabel`/`taillabel` + `labeldistance`/`labelangle` as the fiddlier proper-UML option.

**Protected the plain architecture-diagram style.**
- Added a core example: a `subgraph cluster_*` architecture diagram with per-cluster rounded dashed colored outlines, plain `shape=box` `\n`-label nodes, canonical top-down (`rankdir=TB`) arrows, and dashed/labeled edges.
- Retargeted the HTML-table trigger from "needs several rows / a header and a body" to "needs **visible internal structure**" (dividers, header band, per-cell borders, cell ports). A box that's just a title plus a few description lines is explicitly called out as a plain `\n` label, not a table — so a "show me the high-level architecture" prompt still lands on the clustered rounded-box style rather than being steered toward tables.

## Files
- `skills/graphviz-diagrams/SKILL.md` — trimmed core + new architecture example + scoped table trigger
- `skills/graphviz-diagrams/html-table-nodes.md` — new supporting file with the full table/UML recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kLKwKTTCHceBTskRXJ43A

---
_Generated by [Claude Code](https://claude.ai/code/session_015kLKwKTTCHceBTskRXJ43A)_