### PR TITLE
Add agent effort-tier model selection (A18)

### DIFF
--- a/GxPT.Tests/AgentAvailabilityTests.cs
+++ b/GxPT.Tests/AgentAvailabilityTests.cs
@@ -30,7 +30,7 @@ namespace GxPT.Tests
         private static Agent ReadOnlyAgent(string slug, string[] tools)
         {
             return new Agent(slug, slug, "d", tools, AgentMaxTier.ReadOnly,
-                null, 0, null, AgentSource.Bundled);
+                null, AgentEffort.Unset, 0, null, AgentSource.Bundled);
         }
 
         [Fact]

--- a/GxPT.Tests/AgentCatalogTests.cs
+++ b/GxPT.Tests/AgentCatalogTests.cs
@@ -79,7 +79,8 @@ namespace GxPT.Tests
                 "description: Run the build and tests.",
                 "tools: [files__read, command__run]",
                 "max_tier: write",
-                "model: anthropic/claude-sonnet-4-6");
+                "model: anthropic/claude-sonnet-4-6",
+                "effort: high");
 
             AgentCatalog cat = AgentCatalog.Build(_bundled, _project);
 
@@ -88,6 +89,7 @@ namespace GxPT.Tests
             Assert.Equal(new string[] { "files__read", "command__run" }, a.Tools);
             Assert.Equal(AgentMaxTier.Write, a.MaxTier);
             Assert.Equal("anthropic/claude-sonnet-4-6", a.Model);
+            Assert.Equal(AgentEffort.High, a.Effort);
         }
 
         [Fact]

--- a/GxPT.Tests/AgentDispatcherTests.cs
+++ b/GxPT.Tests/AgentDispatcherTests.cs
@@ -238,6 +238,143 @@ namespace GxPT.Tests
             Assert.Equal("override-model", ui.LastFanOutFirstModel);
         }
 
+        // ---- effort tier resolution ----
+
+        // The standard test effort map: low/medium/high -> distinct sentinel model ids.
+        private static Func<AgentEffort, string> EffortMap()
+        {
+            return delegate(AgentEffort e)
+            {
+                switch (e)
+                {
+                    case AgentEffort.Low: return "model-low";
+                    case AgentEffort.Medium: return "model-medium";
+                    case AgentEffort.High: return "model-high";
+                    default: return null;
+                }
+            };
+        }
+
+        // Writes an agent whose frontmatter pins an effort tier.
+        private Agent WriteAgentWithEffort(string slug, string effort)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file,
+                "---\nname: " + slug + "\ndescription: d\neffort: " + effort + "\n---\nbody\n",
+                new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        [Fact]
+        public void EffortArg_ResolvesViaEffortMap()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.EffortModel = EffortMap();
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\",\"effort\":\"high\"}]}");
+
+            Assert.Equal("model-high", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void ModelArg_BeatsEffortArg()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.EffortModel = EffortMap();
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\",\"effort\":\"high\",\"model\":\"explicit\"}]}");
+
+            Assert.Equal("explicit", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void EffortArg_BeatsFrontmatterModel()
+        {
+            Agent a = WriteAgentWithModel("explorer", "frontmatter-model");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.EffortModel = EffortMap();
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\",\"effort\":\"low\"}]}");
+
+            Assert.Equal("model-low", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void FrontmatterEffort_ResolvesWhenNoArgsOrModel()
+        {
+            Agent a = WriteAgentWithEffort("explorer", "medium");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.EffortModel = EffortMap();
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.Equal("model-medium", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void FrontmatterModel_BeatsFrontmatterEffort()
+        {
+            // An agent that pins BOTH model and effort: the explicit model is more specific and wins.
+            string file = Path.Combine(_dir, "explorer.md");
+            File.WriteAllText(file,
+                "---\nname: explorer\ndescription: d\nmodel: pinned-model\neffort: high\n---\nbody\n",
+                new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a; cat.TryGet("explorer", out a);
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            AgentDispatcher d = Dispatcher(streamer, a);
+            d.EffortModel = EffortMap();
+
+            d.Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.Equal("pinned-model", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void FrontmatterEffort_WithNoEffortHook_FallsBackToParentModel()
+        {
+            // No EffortModel host hook set (e.g. the dispatcher wasn't given a settings map): the effort tier
+            // resolves to nothing and the chain lands on the parent model rather than crashing.
+            Agent a = WriteAgentWithEffort("explorer", "high");
+            ScriptedStreamer streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, a)   // EffortModel left null; parent model is "parent-model"
+                .Dispatch("{\"agents\":[{\"name\":\"explorer\",\"task\":\"t\"}]}");
+
+            Assert.Equal("parent-model", streamer.SeenModels[0]);
+        }
+
+        [Fact]
+        public void DispatchAgentDef_ExposesEffortEnum()
+        {
+            Agent a = WriteAgent("explorer", "Explore.", "You explore.");
+            JObject def = Dispatcher(new ScriptedStreamer(), a).DispatchAgentDef();
+            JToken props = def["function"]["parameters"]["properties"]["agents"]["items"]["properties"];
+            Assert.NotNull(props["effort"]);
+            JArray en = (JArray)props["effort"]["enum"];
+            Assert.Contains("low", en.Values<string>());
+            Assert.Contains("medium", en.Values<string>());
+            Assert.Contains("high", en.Values<string>());
+            // effort is optional: only name and task are required.
+            JArray required = (JArray)def["function"]["parameters"]["properties"]["agents"]["items"]["required"];
+            Assert.DoesNotContain("effort", required.Values<string>());
+        }
+
         [Fact]
         public void HasAgents_ReflectsCatalog()
         {

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -15,6 +15,7 @@ namespace GxPT.Tests
                 "tools: [files__read, files__list, files__search]\n" +
                 "max_tier: readonly\n" +
                 "model: anthropic/claude-sonnet-4-6\n" +
+                "effort: high\n" +
                 "---\n" +
                 "\n" +
                 "You are a code-exploration specialist.\n";
@@ -27,7 +28,21 @@ namespace GxPT.Tests
             Assert.Equal(new string[] { "files__read", "files__list", "files__search" }, fm.Tools);
             Assert.Equal(AgentMaxTier.ReadOnly, fm.MaxTier);
             Assert.Equal("anthropic/claude-sonnet-4-6", fm.Model);
+            Assert.Equal(AgentEffort.High, fm.Effort);
             Assert.Equal("You are a code-exploration specialist.", fm.Body);
+        }
+
+        [Theory]
+        [InlineData("low", AgentEffort.Low)]
+        [InlineData("medium", AgentEffort.Medium)]
+        [InlineData("MED", AgentEffort.Medium)]      // alias + case-insensitive
+        [InlineData("high", AgentEffort.High)]
+        [InlineData("turbo", AgentEffort.Unset)]     // unrecognized => Unset (lenient, not rejected)
+        public void Parse_ReadsEffort(string value, AgentEffort expected)
+        {
+            AgentFrontmatter fm = AgentFrontmatter.Parse(
+                "---\ndescription: d\neffort: " + value + "\n---\nbody\n");
+            Assert.Equal(expected, fm.Effort);
         }
 
         [Fact]
@@ -45,6 +60,7 @@ namespace GxPT.Tests
             Assert.Null(fm.Tools);                          // absent => null (resolved to ReadOnly default later)
             Assert.Equal(AgentMaxTier.Write, fm.MaxTier);   // default ceiling
             Assert.Null(fm.Model);
+            Assert.Equal(AgentEffort.Unset, fm.Effort);     // absent => no effort hint
         }
 
         [Fact]

--- a/GxPT.Tests/AgentFrontmatterTests.cs
+++ b/GxPT.Tests/AgentFrontmatterTests.cs
@@ -32,17 +32,19 @@ namespace GxPT.Tests
             Assert.Equal("You are a code-exploration specialist.", fm.Body);
         }
 
+        // expectedName is the AgentEffort member name (compared via ToString) so the public test signature
+        // doesn't expose the internal AgentEffort enum (which would be CS0051: inconsistent accessibility).
         [Theory]
-        [InlineData("low", AgentEffort.Low)]
-        [InlineData("medium", AgentEffort.Medium)]
-        [InlineData("MED", AgentEffort.Medium)]      // alias + case-insensitive
-        [InlineData("high", AgentEffort.High)]
-        [InlineData("turbo", AgentEffort.Unset)]     // unrecognized => Unset (lenient, not rejected)
-        public void Parse_ReadsEffort(string value, AgentEffort expected)
+        [InlineData("low", "Low")]
+        [InlineData("medium", "Medium")]
+        [InlineData("MED", "Medium")]      // alias + case-insensitive
+        [InlineData("high", "High")]
+        [InlineData("turbo", "Unset")]     // unrecognized => Unset (lenient, not rejected)
+        public void Parse_ReadsEffort(string value, string expectedName)
         {
             AgentFrontmatter fm = AgentFrontmatter.Parse(
                 "---\ndescription: d\neffort: " + value + "\n---\nbody\n");
-            Assert.Equal(expected, fm.Effort);
+            Assert.Equal(expectedName, fm.Effort.ToString());
         }
 
         [Fact]

--- a/GxPT.Tests/AgentInjectionTests.cs
+++ b/GxPT.Tests/AgentInjectionTests.cs
@@ -9,7 +9,7 @@ namespace GxPT.Tests
         private static Agent A(string slug, string desc)
         {
             return new Agent(slug, slug, desc, null, AgentMaxTier.Write, null,
-                             0, slug + ".md", AgentSource.Bundled);
+                             AgentEffort.Unset, 0, slug + ".md", AgentSource.Bundled);
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
+++ b/GxPT.Tests/Mcp/OrchestratorAgentStopTests.cs
@@ -22,7 +22,7 @@ namespace GxPT.Tests.Mcp
             // returns partial + the stop directive, and the orchestrator should force the wrap-up.
             RequestCancellation group = new RequestCancellation();
             group.Cancel();
-            Agent agent = new Agent("x", "x", "d", null, AgentMaxTier.ReadOnly, null, 0,
+            Agent agent = new Agent("x", "x", "d", null, AgentMaxTier.ReadOnly, null, AgentEffort.Unset, 0,
                 "nonexistent.md", AgentSource.Bundled);
             AgentDispatcher dispatcher = new AgentDispatcher(new List<Agent> { agent }, new ScriptedStreamer(),
                 null, null, "m", null, null, delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);

--- a/GxPT.Tests/PluginImportExportServiceTests.cs
+++ b/GxPT.Tests/PluginImportExportServiceTests.cs
@@ -52,7 +52,7 @@ namespace GxPT.Tests
                 "---\nname: " + slug + "\ndescription: " + description + "\ntools: [a]\n---\n\nPrompt.\n",
                 new UTF8Encoding(false));
             return new Agent(slug, slug, description, new string[] { "a" },
-                AgentMaxTier.Write, null, 0, file, AgentSource.User);
+                AgentMaxTier.Write, null, AgentEffort.Unset, 0, file, AgentSource.User);
         }
 
         private string ExportSample(string name, string version, IEnumerable<Skill> skills, IEnumerable<Agent> agents)

--- a/GxPT.Tests/SettingsSchemaTests.cs
+++ b/GxPT.Tests/SettingsSchemaTests.cs
@@ -55,6 +55,22 @@ namespace GxPT.Tests
         }
 
         [Fact]
+        public void EffortTierDefaults_SeededFromCatalog()
+        {
+            var d = SettingsSchema.BuildDefaults();
+            // Each agent effort tier seeds a concrete, in-catalog model so a fresh install resolves cleanly.
+            Assert.Equal(ModelDefaults.DefaultEffortLow, SettingsSchema.StringDefault("model_effort_low"));
+            Assert.Equal(ModelDefaults.DefaultEffortMedium, SettingsSchema.StringDefault("model_effort_medium"));
+            Assert.Equal(ModelDefaults.DefaultEffortHigh, SettingsSchema.StringDefault("model_effort_high"));
+            // Medium mirrors the overall default model.
+            Assert.Equal(ModelDefaults.DefaultModel, SettingsSchema.StringDefault("model_effort_medium"));
+            // The seeded tier models are part of the shipped catalog.
+            var models = new System.Collections.Generic.List<string>((string[])d["models"]);
+            Assert.Contains(ModelDefaults.DefaultEffortLow, models);
+            Assert.Contains(ModelDefaults.DefaultEffortHigh, models);
+        }
+
+        [Fact]
         public void NumericDefaults_AreSane()
         {
             Assert.Equal(40, SettingsSchema.DoubleDefault("mcp_memory_max_lines"));

--- a/GxPT.Tests/SettingsSchemaTests.cs
+++ b/GxPT.Tests/SettingsSchemaTests.cs
@@ -62,11 +62,10 @@ namespace GxPT.Tests
             Assert.Equal(ModelDefaults.DefaultEffortLow, SettingsSchema.StringDefault("model_effort_low"));
             Assert.Equal(ModelDefaults.DefaultEffortMedium, SettingsSchema.StringDefault("model_effort_medium"));
             Assert.Equal(ModelDefaults.DefaultEffortHigh, SettingsSchema.StringDefault("model_effort_high"));
-            // Medium mirrors the overall default model.
-            Assert.Equal(ModelDefaults.DefaultModel, SettingsSchema.StringDefault("model_effort_medium"));
-            // The seeded tier models are part of the shipped catalog.
+            // The seeded tier models are all part of the shipped catalog (so the combos start on a real model).
             var models = new System.Collections.Generic.List<string>((string[])d["models"]);
             Assert.Contains(ModelDefaults.DefaultEffortLow, models);
+            Assert.Contains(ModelDefaults.DefaultEffortMedium, models);
             Assert.Contains(ModelDefaults.DefaultEffortHigh, models);
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3602,6 +3602,20 @@ namespace GxPT
                                 // the parent orchestrator was configured with above.
                                 dispatcher.Zdr = orch.Zdr;
                                 dispatcher.ProviderDataCollectionAllowed = orch.ProviderDataCollectionAllowed;
+                                // Map agent effort tiers to the models the user configured in Settings, so a
+                                // frontmatter `effort:` or a dispatch `effort` arg resolves to a real id.
+                                // Read live from AppSettings (EnsureSeeded guarantees a value); a blank tier
+                                // simply falls through to the model/parent fallbacks in ResolveModel.
+                                dispatcher.EffortModel = delegate(AgentEffort eff)
+                                {
+                                    switch (eff)
+                                    {
+                                        case AgentEffort.Low: return AppSettings.GetString("model_effort_low");
+                                        case AgentEffort.Medium: return AppSettings.GetString("model_effort_medium");
+                                        case AgentEffort.High: return AppSettings.GetString("model_effort_high");
+                                        default: return null;
+                                    }
+                                };
                                 // Child usage adds to cost/token totals but must NOT move the parent's context
                                 // gauge (the child has its own isolated context) - so it routes through the
                                 // updateContextGauge=false overload, not orch.UsageReported.

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3263,10 +3263,18 @@ namespace GxPT
         // value stays the full "author/model" id.
         private void cmbModel_DrawItem(object sender, DrawItemEventArgs e)
         {
+            DrawModelComboItem(e, this.cmbModel);
+        }
+
+        // Shared owner-draw for any model-list combo: render only the short model name (ShortModelName)
+        // while the item value stays the full "author/model" id. Used by the main window's model selector
+        // and the settings effort-tier pickers so the two render identically.
+        internal static void DrawModelComboItem(DrawItemEventArgs e, ComboBox combo)
+        {
             e.DrawBackground();
-            if (e.Index >= 0 && this.cmbModel != null && e.Index < this.cmbModel.Items.Count)
+            if (combo != null && e.Index >= 0 && e.Index < combo.Items.Count)
             {
-                string full = Convert.ToString(this.cmbModel.Items[e.Index]);
+                string full = Convert.ToString(combo.Items[e.Index]);
                 // Clip the name at the edge like a native combo (no ellipsis).
                 TextRenderer.DrawText(e.Graphics, ShortModelName(full), e.Font, e.Bounds, e.ForeColor,
                     TextFormatFlags.Left | TextFormatFlags.VerticalCenter);

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -45,6 +45,12 @@ namespace GxPT
         // Tooltip explaining why the Git toggle is disabled when git isn't on PATH.
         private readonly ToolTip _mcpTip = new ToolTip();
 
+        // Agent effort-tier model pickers (low/medium/high), built in code into the Models groupbox. Narrow
+        // owner-drawn combos that show just the model name while storing the full "author/model" id.
+        private ComboBox cmbEffortLow;
+        private ComboBox cmbEffortMedium;
+        private ComboBox cmbEffortHigh;
+
         public SettingsForm()
         {
             InitializeComponent();
@@ -171,6 +177,11 @@ namespace GxPT
                 // Toggling the command server enables/disables its dependent scratch-dir option.
                 this.chkMcpCommand.CheckedChanged += McpCredential_TextChanged;
             }
+            catch { }
+
+            // Build the agent effort-tier pickers into the Models groupbox (before dirty-tracking is wired,
+            // so the new combos are covered too).
+            try { BuildEffortRow(); }
             catch { }
 
             // Track edits across every input so the Apply button can light up only when there are
@@ -929,6 +940,11 @@ namespace GxPT
             }
             finally { this.cmbDefaultModel.EndUpdate(); }
 
+            // Effort-tier pickers: same model list, each seeded with its configured (or default) model.
+            SyncEffortCombo(this.cmbEffortLow, s.models, s.model_effort_low);
+            SyncEffortCombo(this.cmbEffortMedium, s.models, s.model_effort_medium);
+            SyncEffortCombo(this.cmbEffortHigh, s.models, s.model_effort_high);
+
             // Font size
             try
             {
@@ -1057,6 +1073,12 @@ namespace GxPT
             if (string.IsNullOrEmpty(sel)) sel = this.cmbDefaultModel.Text;
             if (string.IsNullOrEmpty(sel)) sel = models.FirstOrDefault() ?? string.Empty;
             target.default_model = sel ?? string.Empty;
+
+            // Effort tiers from their combos (fall back to the existing working value if a combo is empty,
+            // so a tier is never silently wiped).
+            target.model_effort_low = EffortComboValue(this.cmbEffortLow, target.model_effort_low);
+            target.model_effort_medium = EffortComboValue(this.cmbEffortMedium, target.model_effort_medium);
+            target.model_effort_high = EffortComboValue(this.cmbEffortHigh, target.model_effort_high);
 
             // Font size
             try { target.font_size = (double)this.nudFontSize.Value; }
@@ -1257,6 +1279,157 @@ namespace GxPT
             }
         }
 
+        // Builds the "Effort tiers" row (three model pickers) into the Models groupbox in code, so the
+        // designer's absolute layout is left untouched. tblModels' first row is Percent(100) (the models
+        // textbox), so adding an auto-height row just shrinks the textbox a little - the groupbox keeps its
+        // size and no other section moves.
+        private void BuildEffortRow()
+        {
+            if (this.tblModels == null) return;
+            this.tblModels.SuspendLayout();
+            try
+            {
+                Label lbl = new Label();
+                lbl.Text = "Effort tiers";
+                lbl.AutoSize = true;
+                lbl.Anchor = AnchorStyles.Right;
+                lbl.Margin = new Padding(3, 8, 3, 0);
+
+                // A 6-column inner grid: caption + stretchy combo for each of low/medium/high. The combo
+                // columns are Percent so all three always fit the available width (no horizontal overflow).
+                TableLayoutPanel grid = new TableLayoutPanel();
+                grid.Dock = DockStyle.Fill;
+                grid.ColumnCount = 6;
+                grid.RowCount = 1;
+                grid.Margin = new Padding(0, 2, 0, 2);
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+                grid.RowStyles.Add(new RowStyle());
+
+                this.cmbEffortLow = MakeEffortCombo();
+                this.cmbEffortMedium = MakeEffortCombo();
+                this.cmbEffortHigh = MakeEffortCombo();
+
+                grid.Controls.Add(MakeEffortCaption("Low"), 0, 0);
+                grid.Controls.Add(this.cmbEffortLow, 1, 0);
+                grid.Controls.Add(MakeEffortCaption("Medium"), 2, 0);
+                grid.Controls.Add(this.cmbEffortMedium, 3, 0);
+                grid.Controls.Add(MakeEffortCaption("High"), 4, 0);
+                grid.Controls.Add(this.cmbEffortHigh, 5, 0);
+
+                int row = this.tblModels.RowCount;
+                this.tblModels.RowCount = row + 1;
+                this.tblModels.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
+                this.tblModels.Controls.Add(lbl, 0, row);
+                this.tblModels.Controls.Add(grid, 1, row);
+
+                _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. Agents (and "
+                    + "dispatch_agent) can ask for low/medium/high without naming a model.");
+            }
+            finally { this.tblModels.ResumeLayout(); }
+        }
+
+        private static Label MakeEffortCaption(string text)
+        {
+            Label c = new Label();
+            c.Text = text;
+            c.AutoSize = true;
+            c.Anchor = AnchorStyles.Left;
+            c.Margin = new Padding(6, 0, 3, 0);
+            c.TextAlign = ContentAlignment.MiddleLeft;
+            return c;
+        }
+
+        private ComboBox MakeEffortCombo()
+        {
+            ComboBox c = new ComboBox();
+            c.Dock = DockStyle.Fill;
+            c.Margin = new Padding(0, 2, 6, 2);
+            c.DropDownStyle = ComboBoxStyle.DropDownList;
+            c.DrawMode = DrawMode.OwnerDrawFixed;   // show just the model name; the item value stays the full id
+            c.DrawItem += EffortCombo_DrawItem;
+            c.DropDown += EffortCombo_DropDown;
+            return c;
+        }
+
+        // Owner-draw: render only the short model name (MainForm.ShortModelName) while the item value stays
+        // the full "author/model" id - the same trick the main window's model combo uses to stay compact.
+        private void EffortCombo_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            e.DrawBackground();
+            ComboBox combo = sender as ComboBox;
+            if (combo != null && e.Index >= 0 && e.Index < combo.Items.Count)
+            {
+                string full = Convert.ToString(combo.Items[e.Index]);
+                TextRenderer.DrawText(e.Graphics, MainForm.ShortModelName(full), e.Font, e.Bounds,
+                    e.ForeColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+            }
+            e.DrawFocusRectangle();
+        }
+
+        // The box is narrow, so widen the dropdown to fit the longest (short) model name when it opens.
+        private void EffortCombo_DropDown(object sender, EventArgs e)
+        {
+            ComboBox combo = sender as ComboBox;
+            if (combo == null) return;
+            int w = combo.Width;
+            try
+            {
+                using (Graphics g = combo.CreateGraphics())
+                {
+                    foreach (object item in combo.Items)
+                    {
+                        string s = MainForm.ShortModelName(Convert.ToString(item));
+                        int tw = TextRenderer.MeasureText(g, s, combo.Font).Width + 24;
+                        if (tw > w) w = tw;
+                    }
+                }
+                combo.DropDownWidth = Math.Min(w, 600);
+            }
+            catch { }
+        }
+
+        // Repopulate one effort combo from the model list, preserving (or seeding) its selection. A stored
+        // value not in the list is still added so it stays visible/selectable (mirrors cmbDefaultModel).
+        private void SyncEffortCombo(ComboBox combo, IList<string> models, string selected)
+        {
+            if (combo == null) return;
+            combo.BeginUpdate();
+            try
+            {
+                combo.Items.Clear();
+                if (models != null)
+                    foreach (var m in models) combo.Items.Add(m);
+                string sel = selected ?? string.Empty;
+                if (sel.Length > 0 && !ContainsOrdinalIgnoreCase(models, sel))
+                    combo.Items.Add(sel);
+                combo.SelectedItem = sel;
+            }
+            finally { combo.EndUpdate(); }
+        }
+
+        private static bool ContainsOrdinalIgnoreCase(IList<string> list, string value)
+        {
+            if (list == null) return false;
+            for (int i = 0; i < list.Count; i++)
+                if (string.Equals(list[i], value, StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+
+        // The selected model id for an effort combo, or the fallback (the existing working value) when the
+        // combo is empty - so capturing settings never silently clears a tier.
+        private static string EffortComboValue(ComboBox combo, string fallback)
+        {
+            if (combo == null) return fallback ?? string.Empty;
+            string sel = combo.SelectedItem as string;
+            if (string.IsNullOrEmpty(sel)) sel = combo.Text;
+            return string.IsNullOrEmpty(sel) ? (fallback ?? string.Empty) : sel;
+        }
+
         private void TxtModels_TextChanged(object sender, EventArgs e)
         {
             if (_isSyncing) return;
@@ -1303,6 +1476,11 @@ namespace GxPT
             {
                 this.cmbDefaultModel.EndUpdate();
             }
+
+            // Keep the effort-tier pickers in step with the model list too, preserving each selection.
+            SyncEffortCombo(this.cmbEffortLow, models, this.cmbEffortLow != null ? this.cmbEffortLow.SelectedItem as string : null);
+            SyncEffortCombo(this.cmbEffortMedium, models, this.cmbEffortMedium != null ? this.cmbEffortMedium.SelectedItem as string : null);
+            SyncEffortCombo(this.cmbEffortHigh, models, this.cmbEffortHigh != null ? this.cmbEffortHigh.SelectedItem as string : null);
 
             UpdateRecommendedButtonStates();
         }
@@ -1558,6 +1736,11 @@ namespace GxPT
             public string openrouter_api_key { get; set; }
             public List<string> models { get; set; }
             public string default_model { get; set; }
+            // Agent effort tiers: each maps a capability level the model/agent can request to a model id.
+            // Round-tripped through the form (and the raw JSON editor) like any other setting.
+            public string model_effort_low { get; set; }
+            public string model_effort_medium { get; set; }
+            public string model_effort_high { get; set; }
             // Fingerprint (ModelDefaults.RecommendedHash) of the recommended catalog the user has
             // acknowledged. Carried through here so saving settings doesn't drop the key the
             // "updated recommended models" banner relies on. Not surfaced in the visual editor.

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1289,19 +1289,22 @@ namespace GxPT
             this.grpAgents.SuspendLayout();
             try
             {
-                // Give the Sub-agents group room for the extra row (its tblMcp row is Absolute height).
+                // Give the Sub-agents group room for the stacked caption + combo row (its tblMcp row is
+                // Absolute height).
                 if (this.tblMcp != null && this.tblMcp.RowStyles.Count > 2
                     && this.tblMcp.RowStyles[2] is RowStyle)
                 {
                     ((RowStyle)this.tblMcp.RowStyles[2]).SizeType = SizeType.Absolute;
-                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 96F;
+                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 112F;
                 }
 
+                // Left row-label, vertically centered against the taller stacked row (Anchor=Left with no
+                // Top/Bottom centers it in the cell).
                 Label lbl = new Label();
-                lbl.Text = "Effort tier models";
+                lbl.Text = "Effort models";
                 lbl.AutoSize = true;
                 lbl.Anchor = AnchorStyles.Left;
-                lbl.Margin = new Padding(3, 6, 8, 0);
+                lbl.Margin = new Padding(3, 0, 8, 0);
                 _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. An agent (or "
                     + "dispatch_agent) can ask for low/medium/high without naming a model.");
 
@@ -1329,7 +1332,7 @@ namespace GxPT
                 layout.RowCount = 2;
                 layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
                 layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 46F));
                 layout.Controls.Add(this.chkAgents, 0, 0);
                 layout.Controls.Add(effortRow, 0, 1);
                 this.grpAgents.Controls.Add(layout);
@@ -1337,44 +1340,44 @@ namespace GxPT
             finally { this.grpAgents.ResumeLayout(); }
         }
 
-        // The three captioned effort-tier pickers in a 6-column grid (caption + stretchy combo for each of
-        // low/medium/high). Percent combo columns so all three always fit the width (no horizontal overflow).
+        // The three effort-tier pickers as a 3-column x 2-row grid: each tier's caption (Low/Medium/High)
+        // sits directly above its combo. Equal Percent columns so all three fit the width with no clipping;
+        // the caption centers over its combo.
         private TableLayoutPanel BuildEffortGrid()
         {
             TableLayoutPanel grid = new TableLayoutPanel();
             grid.Dock = DockStyle.Fill;
-            grid.ColumnCount = 6;
-            grid.RowCount = 1;
-            grid.Margin = new Padding(0, 2, 0, 2);
-            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            grid.ColumnCount = 3;
+            grid.RowCount = 2;
+            grid.Margin = new Padding(0, 1, 0, 1);
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
-            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
-            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
-            grid.RowStyles.Add(new RowStyle());
+            grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));   // captions
+            grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));   // combos
 
             this.cmbEffortLow = MakeEffortCombo();
             this.cmbEffortMedium = MakeEffortCombo();
             this.cmbEffortHigh = MakeEffortCombo();
 
             grid.Controls.Add(MakeEffortCaption("Low"), 0, 0);
-            grid.Controls.Add(this.cmbEffortLow, 1, 0);
-            grid.Controls.Add(MakeEffortCaption("Medium"), 2, 0);
-            grid.Controls.Add(this.cmbEffortMedium, 3, 0);
-            grid.Controls.Add(MakeEffortCaption("High"), 4, 0);
-            grid.Controls.Add(this.cmbEffortHigh, 5, 0);
+            grid.Controls.Add(MakeEffortCaption("Medium"), 1, 0);
+            grid.Controls.Add(MakeEffortCaption("High"), 2, 0);
+            grid.Controls.Add(this.cmbEffortLow, 0, 1);
+            grid.Controls.Add(this.cmbEffortMedium, 1, 1);
+            grid.Controls.Add(this.cmbEffortHigh, 2, 1);
             return grid;
         }
 
+        // A tier caption that centers over its combo: Dock=Fill + centered text, with the same right margin
+        // the combo uses so the two line up.
         private static Label MakeEffortCaption(string text)
         {
             Label c = new Label();
             c.Text = text;
-            c.AutoSize = true;
-            c.Anchor = AnchorStyles.Left;
-            c.Margin = new Padding(6, 0, 3, 0);
-            c.TextAlign = ContentAlignment.MiddleLeft;
+            c.Dock = DockStyle.Fill;
+            c.TextAlign = ContentAlignment.MiddleCenter;
+            c.Margin = new Padding(0, 0, 6, 0);
             return c;
         }
 

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1295,7 +1295,7 @@ namespace GxPT
                     && this.tblMcp.RowStyles[2] is RowStyle)
                 {
                     ((RowStyle)this.tblMcp.RowStyles[2]).SizeType = SizeType.Absolute;
-                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 94F;
+                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 100F;
                 }
 
                 // Re-host the existing enable checkbox + the effort grid in a 2-row table docked into the group
@@ -1310,7 +1310,7 @@ namespace GxPT
                 layout.RowCount = 2;
                 layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
                 layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 42F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 46F));
                 layout.Controls.Add(this.chkAgents, 0, 0);
                 layout.Controls.Add(BuildEffortGrid(), 0, 1);
                 this.grpAgents.Controls.Add(layout);

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1295,7 +1295,7 @@ namespace GxPT
                     && this.tblMcp.RowStyles[2] is RowStyle)
                 {
                     ((RowStyle)this.tblMcp.RowStyles[2]).SizeType = SizeType.Absolute;
-                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 112F;
+                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 94F;
                 }
 
                 // Re-host the existing enable checkbox + the effort grid in a 2-row table docked into the group
@@ -1310,7 +1310,7 @@ namespace GxPT
                 layout.RowCount = 2;
                 layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
                 layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 46F));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 42F));
                 layout.Controls.Add(this.chkAgents, 0, 0);
                 layout.Controls.Add(BuildEffortGrid(), 0, 1);
                 this.grpAgents.Controls.Add(layout);

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1298,13 +1298,13 @@ namespace GxPT
                     ((RowStyle)this.tblMcp.RowStyles[2]).Height = 112F;
                 }
 
-                // Left row-label, vertically centered against the taller stacked row (Anchor=Left with no
-                // Top/Bottom centers it in the cell).
+                // Left row-label in a fixed-width column, filling the cell with vertically-centered text so it
+                // lines up midway between the captions and the combos. Kept short so the pickers get the width.
                 Label lbl = new Label();
-                lbl.Text = "Effort models";
-                lbl.AutoSize = true;
-                lbl.Anchor = AnchorStyles.Left;
-                lbl.Margin = new Padding(3, 0, 8, 0);
+                lbl.Text = "Models";
+                lbl.Dock = DockStyle.Fill;
+                lbl.TextAlign = ContentAlignment.MiddleLeft;
+                lbl.Margin = new Padding(3, 0, 6, 0);
                 _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. An agent (or "
                     + "dispatch_agent) can ask for low/medium/high without naming a model.");
 
@@ -1314,7 +1314,7 @@ namespace GxPT
                 effortRow.ColumnCount = 2;
                 effortRow.RowCount = 1;
                 effortRow.Margin = new Padding(0);
-                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 56F));
                 effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
                 effortRow.RowStyles.Add(new RowStyle());
                 effortRow.Controls.Add(lbl, 0, 0);

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -179,8 +179,8 @@ namespace GxPT
             }
             catch { }
 
-            // Build the agent effort-tier pickers into the Models groupbox (before dirty-tracking is wired,
-            // so the new combos are covered too).
+            // Build the agent effort-tier pickers into the Sub-agents groupbox (before dirty-tracking is
+            // wired, so the new combos are covered too).
             try { BuildEffortRow(); }
             catch { }
 
@@ -1279,58 +1279,92 @@ namespace GxPT
             }
         }
 
-        // Builds the "Effort tiers" row (three model pickers) into the Models groupbox in code, so the
-        // designer's absolute layout is left untouched. tblModels' first row is Percent(100) (the models
-        // textbox), so adding an auto-height row just shrinks the textbox a little - the groupbox keeps its
-        // size and no other section moves.
+        // Builds the effort-tier model pickers into the "Sub-agents" groupbox (Tools tab) in code, so the
+        // designer's layout is left untouched. The existing enable checkbox and the new pickers are re-hosted
+        // in a small docked table; the group's row in tblMcp is grown to fit (its neighbour is Percent(100),
+        // which absorbs the change, so no other section moves).
         private void BuildEffortRow()
         {
-            if (this.tblModels == null) return;
-            this.tblModels.SuspendLayout();
+            if (this.grpAgents == null || this.chkAgents == null) return;
+            this.grpAgents.SuspendLayout();
             try
             {
+                // Give the Sub-agents group room for the extra row (its tblMcp row is Absolute height).
+                if (this.tblMcp != null && this.tblMcp.RowStyles.Count > 2
+                    && this.tblMcp.RowStyles[2] is RowStyle)
+                {
+                    ((RowStyle)this.tblMcp.RowStyles[2]).SizeType = SizeType.Absolute;
+                    ((RowStyle)this.tblMcp.RowStyles[2]).Height = 96F;
+                }
+
                 Label lbl = new Label();
-                lbl.Text = "Effort tiers";
+                lbl.Text = "Effort tier models";
                 lbl.AutoSize = true;
-                lbl.Anchor = AnchorStyles.Right;
-                lbl.Margin = new Padding(3, 8, 3, 0);
-
-                // A 6-column inner grid: caption + stretchy combo for each of low/medium/high. The combo
-                // columns are Percent so all three always fit the available width (no horizontal overflow).
-                TableLayoutPanel grid = new TableLayoutPanel();
-                grid.Dock = DockStyle.Fill;
-                grid.ColumnCount = 6;
-                grid.RowCount = 1;
-                grid.Margin = new Padding(0, 2, 0, 2);
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-                grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
-                grid.RowStyles.Add(new RowStyle());
-
-                this.cmbEffortLow = MakeEffortCombo();
-                this.cmbEffortMedium = MakeEffortCombo();
-                this.cmbEffortHigh = MakeEffortCombo();
-
-                grid.Controls.Add(MakeEffortCaption("Low"), 0, 0);
-                grid.Controls.Add(this.cmbEffortLow, 1, 0);
-                grid.Controls.Add(MakeEffortCaption("Medium"), 2, 0);
-                grid.Controls.Add(this.cmbEffortMedium, 3, 0);
-                grid.Controls.Add(MakeEffortCaption("High"), 4, 0);
-                grid.Controls.Add(this.cmbEffortHigh, 5, 0);
-
-                int row = this.tblModels.RowCount;
-                this.tblModels.RowCount = row + 1;
-                this.tblModels.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
-                this.tblModels.Controls.Add(lbl, 0, row);
-                this.tblModels.Controls.Add(grid, 1, row);
-
-                _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. Agents (and "
+                lbl.Anchor = AnchorStyles.Left;
+                lbl.Margin = new Padding(3, 6, 8, 0);
+                _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. An agent (or "
                     + "dispatch_agent) can ask for low/medium/high without naming a model.");
+
+                // The effort row: a left caption + the three captioned model pickers.
+                TableLayoutPanel effortRow = new TableLayoutPanel();
+                effortRow.Dock = DockStyle.Fill;
+                effortRow.ColumnCount = 2;
+                effortRow.RowCount = 1;
+                effortRow.Margin = new Padding(0);
+                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+                effortRow.RowStyles.Add(new RowStyle());
+                effortRow.Controls.Add(lbl, 0, 0);
+                effortRow.Controls.Add(BuildEffortGrid(), 1, 0);
+
+                // Re-host the existing enable checkbox + the effort row in a 2-row table docked into the group
+                // (the checkbox keeps its name/state/wiring - only its parent changes).
+                this.grpAgents.Controls.Remove(this.chkAgents);
+                this.chkAgents.Anchor = AnchorStyles.Left;
+                this.chkAgents.Margin = new Padding(3, 3, 3, 2);
+
+                TableLayoutPanel layout = new TableLayoutPanel();
+                layout.Dock = DockStyle.Fill;
+                layout.ColumnCount = 1;
+                layout.RowCount = 2;
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+                layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 30F));
+                layout.Controls.Add(this.chkAgents, 0, 0);
+                layout.Controls.Add(effortRow, 0, 1);
+                this.grpAgents.Controls.Add(layout);
             }
-            finally { this.tblModels.ResumeLayout(); }
+            finally { this.grpAgents.ResumeLayout(); }
+        }
+
+        // The three captioned effort-tier pickers in a 6-column grid (caption + stretchy combo for each of
+        // low/medium/high). Percent combo columns so all three always fit the width (no horizontal overflow).
+        private TableLayoutPanel BuildEffortGrid()
+        {
+            TableLayoutPanel grid = new TableLayoutPanel();
+            grid.Dock = DockStyle.Fill;
+            grid.ColumnCount = 6;
+            grid.RowCount = 1;
+            grid.Margin = new Padding(0, 2, 0, 2);
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
+            grid.RowStyles.Add(new RowStyle());
+
+            this.cmbEffortLow = MakeEffortCombo();
+            this.cmbEffortMedium = MakeEffortCombo();
+            this.cmbEffortHigh = MakeEffortCombo();
+
+            grid.Controls.Add(MakeEffortCaption("Low"), 0, 0);
+            grid.Controls.Add(this.cmbEffortLow, 1, 0);
+            grid.Controls.Add(MakeEffortCaption("Medium"), 2, 0);
+            grid.Controls.Add(this.cmbEffortMedium, 3, 0);
+            grid.Controls.Add(MakeEffortCaption("High"), 4, 0);
+            grid.Controls.Add(this.cmbEffortHigh, 5, 0);
+            return grid;
         }
 
         private static Label MakeEffortCaption(string text)
@@ -1356,19 +1390,11 @@ namespace GxPT
             return c;
         }
 
-        // Owner-draw: render only the short model name (MainForm.ShortModelName) while the item value stays
-        // the full "author/model" id - the same trick the main window's model combo uses to stay compact.
+        // Owner-draw via the shared helper so the effort pickers render the short model name exactly like
+        // the main window's model selector.
         private void EffortCombo_DrawItem(object sender, DrawItemEventArgs e)
         {
-            e.DrawBackground();
-            ComboBox combo = sender as ComboBox;
-            if (combo != null && e.Index >= 0 && e.Index < combo.Items.Count)
-            {
-                string full = Convert.ToString(combo.Items[e.Index]);
-                TextRenderer.DrawText(e.Graphics, MainForm.ShortModelName(full), e.Font, e.Bounds,
-                    e.ForeColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
-            }
-            e.DrawFocusRectangle();
+            MainForm.DrawModelComboItem(e, sender as ComboBox);
         }
 
         // The box is narrow, so widen the dropdown to fit the longest (short) model name when it opens.

--- a/GxPT/Forms/SettingsForm.cs
+++ b/GxPT/Forms/SettingsForm.cs
@@ -1298,29 +1298,7 @@ namespace GxPT
                     ((RowStyle)this.tblMcp.RowStyles[2]).Height = 112F;
                 }
 
-                // Left row-label in a fixed-width column, filling the cell with vertically-centered text so it
-                // lines up midway between the captions and the combos. Kept short so the pickers get the width.
-                Label lbl = new Label();
-                lbl.Text = "Models";
-                lbl.Dock = DockStyle.Fill;
-                lbl.TextAlign = ContentAlignment.MiddleLeft;
-                lbl.Margin = new Padding(3, 0, 6, 0);
-                _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. An agent (or "
-                    + "dispatch_agent) can ask for low/medium/high without naming a model.");
-
-                // The effort row: a left caption + the three captioned model pickers.
-                TableLayoutPanel effortRow = new TableLayoutPanel();
-                effortRow.Dock = DockStyle.Fill;
-                effortRow.ColumnCount = 2;
-                effortRow.RowCount = 1;
-                effortRow.Margin = new Padding(0);
-                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 56F));
-                effortRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-                effortRow.RowStyles.Add(new RowStyle());
-                effortRow.Controls.Add(lbl, 0, 0);
-                effortRow.Controls.Add(BuildEffortGrid(), 1, 0);
-
-                // Re-host the existing enable checkbox + the effort row in a 2-row table docked into the group
+                // Re-host the existing enable checkbox + the effort grid in a 2-row table docked into the group
                 // (the checkbox keeps its name/state/wiring - only its parent changes).
                 this.grpAgents.Controls.Remove(this.chkAgents);
                 this.chkAgents.Anchor = AnchorStyles.Left;
@@ -1334,38 +1312,51 @@ namespace GxPT
                 layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
                 layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 46F));
                 layout.Controls.Add(this.chkAgents, 0, 0);
-                layout.Controls.Add(effortRow, 0, 1);
+                layout.Controls.Add(BuildEffortGrid(), 0, 1);
                 this.grpAgents.Controls.Add(layout);
             }
             finally { this.grpAgents.ResumeLayout(); }
         }
 
-        // The three effort-tier pickers as a 3-column x 2-row grid: each tier's caption (Low/Medium/High)
-        // sits directly above its combo. Equal Percent columns so all three fit the width with no clipping;
-        // the caption centers over its combo.
+        // The effort-tier pickers: a 4-column x 2-row grid. Column 0 is the "Models" row-label (spanning both
+        // rows so it centers vertically against the caption+combo block); columns 1-3 stack each tier's caption
+        // ("Low/Medium/High effort") directly above its combo. Equal Percent tier columns fit the width with no
+        // clipping; each caption centers over its combo.
         private TableLayoutPanel BuildEffortGrid()
         {
             TableLayoutPanel grid = new TableLayoutPanel();
             grid.Dock = DockStyle.Fill;
-            grid.ColumnCount = 3;
+            grid.ColumnCount = 4;
             grid.RowCount = 2;
             grid.Margin = new Padding(0, 1, 0, 1);
+            grid.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 56F));   // row label
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.34F));
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
             grid.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.33F));
             grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));   // captions
             grid.RowStyles.Add(new RowStyle(SizeType.AutoSize));   // combos
 
+            // Row label spanning both rows -> vertically centered across the caption+combo block.
+            Label lbl = new Label();
+            lbl.Text = "Models";
+            lbl.Dock = DockStyle.Fill;
+            lbl.TextAlign = ContentAlignment.MiddleLeft;
+            lbl.Margin = new Padding(3, 0, 6, 0);
+            grid.Controls.Add(lbl, 0, 0);
+            grid.SetRowSpan(lbl, 2);
+            _mcpTip.SetToolTip(lbl, "Pick the model used for each agent effort tier. An agent (or "
+                + "dispatch_agent) can ask for low/medium/high without naming a model.");
+
             this.cmbEffortLow = MakeEffortCombo();
             this.cmbEffortMedium = MakeEffortCombo();
             this.cmbEffortHigh = MakeEffortCombo();
 
-            grid.Controls.Add(MakeEffortCaption("Low"), 0, 0);
-            grid.Controls.Add(MakeEffortCaption("Medium"), 1, 0);
-            grid.Controls.Add(MakeEffortCaption("High"), 2, 0);
-            grid.Controls.Add(this.cmbEffortLow, 0, 1);
-            grid.Controls.Add(this.cmbEffortMedium, 1, 1);
-            grid.Controls.Add(this.cmbEffortHigh, 2, 1);
+            grid.Controls.Add(MakeEffortCaption("Low effort"), 1, 0);
+            grid.Controls.Add(MakeEffortCaption("Medium effort"), 2, 0);
+            grid.Controls.Add(MakeEffortCaption("High effort"), 3, 0);
+            grid.Controls.Add(this.cmbEffortLow, 1, 1);
+            grid.Controls.Add(this.cmbEffortMedium, 2, 1);
+            grid.Controls.Add(this.cmbEffortHigh, 3, 1);
             return grid;
         }
 

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -16,6 +16,12 @@ namespace GxPT
         // Selected by default on a fresh install. Must be one of Models below.
         public const string DefaultModel = "~anthropic/claude-sonnet-latest";
 
+        // Default model for each agent effort tier (Settings > Models). Each must be one of Models below so a
+        // fresh install's tier combos start on a real, in-list model. low = cheap/fast, high = most capable.
+        public const string DefaultEffortLow = "~anthropic/claude-haiku-latest";
+        public const string DefaultEffortMedium = DefaultModel;   // ~anthropic/claude-sonnet-latest
+        public const string DefaultEffortHigh = "~anthropic/claude-opus-latest";
+
         // Default catalog, in display order (the model combo is sorted, so order is cosmetic there;
         // it is preserved verbatim in the seeded settings.json).
         public static readonly string[] Models = new string[]

--- a/GxPT/Models/ModelDefaults.cs
+++ b/GxPT/Models/ModelDefaults.cs
@@ -16,10 +16,11 @@ namespace GxPT
         // Selected by default on a fresh install. Must be one of Models below.
         public const string DefaultModel = "~anthropic/claude-sonnet-latest";
 
-        // Default model for each agent effort tier (Settings > Models). Each must be one of Models below so a
-        // fresh install's tier combos start on a real, in-list model. low = cheap/fast, high = most capable.
-        public const string DefaultEffortLow = "~anthropic/claude-haiku-latest";
-        public const string DefaultEffortMedium = DefaultModel;   // ~anthropic/claude-sonnet-latest
+        // Default model for each agent effort tier (Settings > Tools > Sub-agents). Each must be one of
+        // Models below so a fresh install's tier combos start on a real, in-list model. low = cheap/fast,
+        // high = most capable.
+        public const string DefaultEffortLow = "deepseek/deepseek-v4-flash";
+        public const string DefaultEffortMedium = "z-ai/glm-5.2";
         public const string DefaultEffortHigh = "~anthropic/claude-opus-latest";
 
         // Default catalog, in display order (the model combo is sorted, so order is cosmetic there;

--- a/GxPT/Services/Agents/Agent.cs
+++ b/GxPT/Services/Agents/Agent.cs
@@ -23,6 +23,20 @@ namespace GxPT
         Destructive
     }
 
+    // The model "effort" an agent prefers (design A18): a user-configurable capability level the host maps
+    // to a concrete model in settings (Settings > Models: low/medium/high -> a model id each). It lets an
+    // agent - or a single dispatch - ask for "high effort" without naming a model slug, so the author/model
+    // never has to know provider ids. Unset => no effort hint (resolution falls through to an explicit model,
+    // then the parent turn's model). Deliberately NOT named "tier": AgentMaxTier already owns "tier" for the
+    // tool-permission ceiling, which is a different axis entirely.
+    internal enum AgentEffort
+    {
+        Unset,
+        Low,
+        Medium,
+        High
+    }
+
     // One discovered sub-agent: a flat <slug>.md file whose frontmatter declares the agent's contract
     // and whose body is the agent's system prompt (design A4 - one file per agent, no folder). The
     // catalog holds a slug -> Agent map. The body is read from FilePath on dispatch (a single small
@@ -50,6 +64,11 @@ namespace GxPT
         // Optional model id override; null/empty => the parent turn's model.
         public string Model { get; private set; }
 
+        // Optional model effort (capability tier). Unset => no effort hint. Resolved to a concrete model
+        // against the user's settings at dispatch (AgentDispatcher.ResolveModel); an explicit Model wins
+        // over Effort, matching "a specific id beats the abstraction".
+        public AgentEffort Effort { get; private set; }
+
         // Per-agent iteration budget (design A17), fed to the child orchestrator's maxIterations. 0 => unset
         // (use the host default). Lets an explore agent cap low and a coder run long; a tight budget is also
         // a safety bound on an unattended run.
@@ -61,7 +80,7 @@ namespace GxPT
         public AgentSource Source { get; private set; }
 
         public Agent(string slug, string name, string description, string[] tools,
-                     AgentMaxTier maxTier, string model, int maxTurns,
+                     AgentMaxTier maxTier, string model, AgentEffort effort, int maxTurns,
                      string filePath, AgentSource source)
         {
             Slug = slug;
@@ -70,6 +89,7 @@ namespace GxPT
             Tools = tools;
             MaxTier = maxTier;
             Model = model;
+            Effort = effort;
             MaxTurns = maxTurns;
             FilePath = filePath;
             Source = source;

--- a/GxPT/Services/Agents/AgentCatalog.cs
+++ b/GxPT/Services/Agents/AgentCatalog.cs
@@ -104,7 +104,7 @@ namespace GxPT
 
             string name = (fm.Name != null && fm.Name.Length > 0) ? fm.Name : slug;
             return new Agent(slug, name, fm.Description, fm.Tools, fm.MaxTier, fm.Model,
-                             fm.MaxTurns, file, source);
+                             fm.Effort, fm.MaxTurns, file, source);
         }
 
         // The manifest body the model sees: one "- <slug> - <description>" line per agent, slug-ordered

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -125,10 +125,10 @@ namespace GxPT
             JObject effortP = new JObject();
             effortP["type"] = "string";
             effortP["enum"] = new JArray("low", "medium", "high");
-            effortP["description"] = "Optional capability level to run this agent at: \"low\" (fastest, "
-                + "cheapest), \"medium\", or \"high\" (most capable). The user maps each level to a model in "
-                + "settings, so pick by how hard the task is - you do not need a model id. Overrides the "
-                + "agent's frontmatter effort for this dispatch only; omit to use the agent's own setting.";
+            effortP["description"] = "Optional override for the effort level (low | medium | high) this "
+                + "agent runs at. Each agent already has a tuned default, so normally omit this and let it "
+                + "run at its configured effort. Set it only when the user or a skill explicitly asks for a "
+                + "different level.";
             JObject modelP = new JObject();
             modelP["type"] = "string";
             modelP["description"] = "Optional explicit model id, in OpenRouter format "

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -42,6 +42,11 @@ namespace GxPT
         public Action<ResponseUsage> UsageReported { get; set; }
         public RequestCancellation Cancellation { get; set; }
 
+        // Maps a model effort (low/medium/high) to the model id the user configured for it in settings, or
+        // null/empty when that tier is unset. Set by the host from AppSettings; null here (e.g. in tests)
+        // means effort never resolves and the model/parent fallbacks apply. See ResolveModel.
+        public Func<AgentEffort, string> EffortModel { get; set; }
+
         // The parent turn's privacy settings, propagated to every child request (set by the host). A
         // sub-agent runs in a fresh orchestrator that would otherwise default to no ZDR / provider
         // default - so without this, a child would send the conversation's data to a non-ZDR endpoint
@@ -112,20 +117,28 @@ namespace GxPT
 
         public bool IsDispatchAgent(string functionName) { return functionName == DispatchAgentName; }
 
-        // The OpenAI-style function definition: dispatch_agent({ agents: [{ name, task, model? }] }).
+        // The OpenAI-style function definition: dispatch_agent({ agents: [{ name, task, effort?, model? }] }).
         public JObject DispatchAgentDef()
         {
             JObject nameP = new JObject(); nameP["type"] = "string";
             JObject taskP = new JObject(); taskP["type"] = "string";
+            JObject effortP = new JObject();
+            effortP["type"] = "string";
+            effortP["enum"] = new JArray("low", "medium", "high");
+            effortP["description"] = "Optional capability level to run this agent at: \"low\" (fastest, "
+                + "cheapest), \"medium\", or \"high\" (most capable). The user maps each level to a model in "
+                + "settings, so pick by how hard the task is - you do not need a model id. Overrides the "
+                + "agent's frontmatter effort for this dispatch only; omit to use the agent's own setting.";
             JObject modelP = new JObject();
             modelP["type"] = "string";
-            modelP["description"] = "Optional model id to run this agent with, in OpenRouter format "
-                + "\"model-author/model-name\" (e.g. \"z-ai/glm-5.2\"). Overrides the agent's "
-                + "frontmatter model (and the default parent model) for this dispatch only. Omit to use "
-                + "the agent's own model.";
+            modelP["description"] = "Optional explicit model id, in OpenRouter format "
+                + "\"model-author/model-name\" (e.g. \"z-ai/glm-5.2\"). Prefer \"effort\" unless you need a "
+                + "specific model. Takes precedence over \"effort\" and the agent's frontmatter for this "
+                + "dispatch only. Omit to use effort or the agent's own model.";
             JObject entryProps = new JObject();
             entryProps["name"] = nameP;
             entryProps["task"] = taskP;
+            entryProps["effort"] = effortP;
             entryProps["model"] = modelP;
             JObject entrySchema = new JObject();
             entrySchema["type"] = "object";
@@ -162,7 +175,7 @@ namespace GxPT
         // batch still returns the rest (the open_skill tolerance). Never throws to the caller.
         public string Dispatch(string argumentsJson)
         {
-            List<string[]> entries = ParseEntries(argumentsJson);   // each = { name, task, model }
+            List<string[]> entries = ParseEntries(argumentsJson);   // each = { name, task, model, effort }
             if (entries.Count == 0) return "No agents specified to dispatch.";
 
             int n = entries.Count;
@@ -174,9 +187,10 @@ namespace GxPT
             string[] names = new string[n];
             Agent[] agents = new Agent[n];
             string[] tasks = new string[n];
-            // Optional per-call model override (the dispatch_agent `model` arg). Null => fall back to the
-            // agent's frontmatter model, then the parent model.
+            // Optional per-call overrides (the dispatch_agent `model` / `effort` args). Null => fall back to
+            // the agent's own frontmatter (model, then effort), then the parent model. See ResolveModel.
             string[] modelOverrides = new string[n];
+            string[] effortOverrides = new string[n];
             string[] results = new string[n];
             // Per-slot child transcripts (tier 3): slot i is null until/unless that agent runs a child.
             // Exposed via LastTranscripts so the host can cache them under the dispatch record's key and
@@ -188,6 +202,7 @@ namespace GxPT
                 names[i] = entries[i][0];
                 tasks[i] = entries[i][1];
                 modelOverrides[i] = entries[i][2];
+                effortOverrides[i] = entries[i][3];
                 Agent agent;
                 if (names[i] == null || !_bySlug.TryGetValue(names[i], out agent))
                     results[i] = "Unknown agent: " + (names[i] != null ? names[i] : "(null)");
@@ -210,7 +225,7 @@ namespace GxPT
                     Agent a = agents[slot];
                     slugs.Add(a.Slug);
                     taskList.Add(tasks[slot]);
-                    modelList.Add(ResolveModel(modelOverrides[slot], a));
+                    modelList.Add(ResolveModel(modelOverrides[slot], effortOverrides[slot], a));
                 }
                 ui.OnFanOutStart(slugs, taskList, modelList);
             }
@@ -224,12 +239,13 @@ namespace GxPT
                 // rule). Concurrent children safely share the MCP connections (the transport is multiplexed:
                 // atomic request ids + serialized writes) and the streamer (per-call), so no extra locking.
                 if (RunsInParallel(agents, runnable))
-                    RunParallel(agents, tasks, modelOverrides, runnable, results, transcripts);
+                    RunParallel(agents, tasks, modelOverrides, effortOverrides, runnable, results, transcripts);
                 else
                     for (int k = 0; k < runnable.Count; k++)
                     {
                         int i = runnable[k];
-                        results[i] = RunChildReported(k, i, agents[i], tasks[i], modelOverrides[i], transcripts);
+                        results[i] = RunChildReported(k, i, agents[i], tasks[i], modelOverrides[i],
+                                                      effortOverrides[i], transcripts);
                     }
             }
             finally
@@ -287,7 +303,8 @@ namespace GxPT
         // its own result slot. WaitHandle.WaitAll runs on the parent turn's ThreadPool (MTA) worker, so it
         // is valid here; no lock is held across the join, so the fan-out cannot deadlock. At most
         // MaxParallelAgents worker handles are joined, well under WaitAll's 64-handle limit.
-        private void RunParallel(Agent[] agents, string[] tasks, string[] modelOverrides, List<int> runnable,
+        private void RunParallel(Agent[] agents, string[] tasks, string[] modelOverrides,
+                                 string[] effortOverrides, List<int> runnable,
                                  string[] results, AgentTranscript[] transcripts)
         {
             int count = runnable.Count;
@@ -313,7 +330,8 @@ namespace GxPT
                                 Agent agent = agents[slot];
                                 string task = tasks[slot];
                                 string modelOverride = modelOverrides[slot];
-                                try { results[slot] = RunChildReported(row, slot, agent, task, modelOverride, transcripts); }
+                                string effortOverride = effortOverrides[slot];
+                                try { results[slot] = RunChildReported(row, slot, agent, task, modelOverride, effortOverride, transcripts); }
                                 catch (Exception ex) { results[slot] = "[agent error: " + ex.Message + "]"; }
                             }
                         }
@@ -335,7 +353,7 @@ namespace GxPT
         // child's tool calls as the row's live activity line (tier 2); the run's full message list is
         // captured into transcripts[slot] for the tier-3 viewer (even on error - the partial history).
         private string RunChildReported(int row, int slot, Agent agent, string task, string modelOverride,
-                                        AgentTranscript[] transcripts)
+                                        string effortOverride, AgentTranscript[] transcripts)
         {
             IAgentActivityUi ui = ActivityUi;
             if (ui != null) ui.OnAgentStart(row, agent.Slug, task);
@@ -355,7 +373,7 @@ namespace GxPT
             try
             {
                 IList<ChatMessage> history;
-                string answer = RunChild(agent, task, modelOverride, childUi, out history);
+                string answer = RunChild(agent, task, modelOverride, effortOverride, childUi, out history);
                 if (transcripts != null) transcripts[slot] = new AgentTranscript(agent.Slug, task, history);
                 return answer;
             }
@@ -369,10 +387,10 @@ namespace GxPT
         // Builds and runs one child orchestrator to completion, returning its final answer. `history` is set
         // (before the run) to the child's message list so the caller gets the full transcript even if the
         // turn throws. `childUi` receives the child's tool activity (forwarded to the row's activity line).
-        private string RunChild(Agent agent, string task, string modelOverride, IToolLoopUi childUi,
-                                out IList<ChatMessage> history)
+        private string RunChild(Agent agent, string task, string modelOverride, string effortOverride,
+                                IToolLoopUi childUi, out IList<ChatMessage> history)
         {
-            string model = ResolveModel(modelOverride, agent);
+            string model = ResolveModel(modelOverride, effortOverride, agent);
             int maxIter = agent.MaxTurns > 0 ? agent.MaxTurns : _defaultMaxIterations;
 
             McpChatOrchestrator child = new McpChatOrchestrator(_streamer, _registry, _approval, model,
@@ -428,14 +446,51 @@ namespace GxPT
             return ExtractFinalAnswer(msgs);
         }
 
-        // Resolves the model a child runs under, in decreasing precedence: the per-call `model` override
-        // (the dispatch_agent arg), then the agent's frontmatter model, then the parent turn's model. So a
-        // caller can steer a single dispatch onto a different model without editing the agent file.
-        private string ResolveModel(string modelOverride, Agent agent)
+        // Resolves the model a child runs under, in decreasing precedence (design A18). Dispatch-level args
+        // beat the agent's own frontmatter, and an explicit model beats an effort tier within each level:
+        //   1. dispatch `model` arg            (caller named an exact id for this call)
+        //   2. dispatch `effort` arg           (caller asked for a tier; mapped via settings)
+        //   3. frontmatter `model`             (the agent's own pinned model)
+        //   4. frontmatter `effort`            (the agent's own tier; mapped via settings)
+        //   5. the parent turn's model         (the default)
+        // An effort rung is skipped when it maps to nothing (no EffortModel host hook, or that tier is blank
+        // in settings), so the chain always lands on a concrete model.
+        private string ResolveModel(string modelOverride, string effortOverride, Agent agent)
         {
             if (!string.IsNullOrEmpty(modelOverride)) return modelOverride;
+
+            AgentEffort overrideEffort;
+            if (AgentFrontmatter.TryParseEffort(effortOverride, out overrideEffort))
+            {
+                string m = ModelForEffort(overrideEffort);
+                if (!string.IsNullOrEmpty(m)) return m;
+            }
+
             if (agent != null && !string.IsNullOrEmpty(agent.Model)) return agent.Model;
+
+            if (agent != null)
+            {
+                string m = ModelForEffort(agent.Effort);
+                if (!string.IsNullOrEmpty(m)) return m;
+            }
+
             return _parentModel;
+        }
+
+        // The model the user configured for an effort tier, or null when there is no hint (Unset), no host
+        // hook, or that tier is blank in settings. Never throws - a bad hook just falls through to the next
+        // resolution rung.
+        private string ModelForEffort(AgentEffort effort)
+        {
+            if (effort == AgentEffort.Unset) return null;
+            Func<AgentEffort, string> f = EffortModel;
+            if (f == null) return null;
+            try
+            {
+                string s = f(effort);
+                return string.IsNullOrEmpty(s) ? null : s;
+            }
+            catch { return null; }
         }
 
         // The child's final answer is the last assistant message its turn appended to history. Only the
@@ -469,9 +524,9 @@ namespace GxPT
             }
         }
 
-        // Parses { agents: [ { name, task, model? }, ... ] } into a list of {name, task, model} triples
-        // (model null when omitted). Malformed input yields an empty list (the tool then reports "no
-        // agents"), never an exception.
+        // Parses { agents: [ { name, task, model?, effort? }, ... ] } into a list of {name, task, model,
+        // effort} tuples (model/effort null when omitted). Malformed input yields an empty list (the tool
+        // then reports "no agents"), never an exception.
         private static List<string[]> ParseEntries(string argumentsJson)
         {
             List<string[]> list = new List<string[]>();
@@ -486,7 +541,8 @@ namespace GxPT
                     {
                         if (t == null || t.Type != JTokenType.Object) continue;
                         JObject e = (JObject)t;
-                        list.Add(new string[] { AsString(e["name"]), AsString(e["task"]), AsString(e["model"]) });
+                        list.Add(new string[] { AsString(e["name"]), AsString(e["task"]),
+                                                AsString(e["model"]), AsString(e["effort"]) });
                     }
                 }
             }

--- a/GxPT/Services/Agents/AgentFrontmatter.cs
+++ b/GxPT/Services/Agents/AgentFrontmatter.cs
@@ -7,8 +7,9 @@ namespace GxPT
     // Hand-rolled reader for an agent <slug>.md's leading "--- ... ---" frontmatter block (design A5:
     // net35 has no YAML parser and the repo keeps one JSON lib, so we parse the handful of "key: value"
     // lines ourselves). It is the SkillFrontmatter reader extended for the agent contract: besides
-    // `name`/`description` it reads `tools` (an inline list), `max_tier` (an enum, with a default), and
-    // `model`. Unknown keys are ignored (forward-compatible) and each known key is
+    // `name`/`description` it reads `tools` (an inline list), `max_tier` (an enum, with a default),
+    // `model`, and `effort` (low|medium|high, a capability tier mapped to a model in settings). Unknown
+    // keys are ignored (forward-compatible) and each known key is
     // first-wins. Everything after the closing delimiter is the body (the agent's system prompt).
     // Lenient: a missing or unterminated block yields no frontmatter and treats the whole text as body;
     // an unrecognized enum value falls back to the default rather than rejecting the agent.
@@ -25,6 +26,9 @@ namespace GxPT
         public AgentMaxTier MaxTier { get; private set; }
         public string Model { get; private set; }
 
+        // `effort` (low|medium|high); Unset when absent or unrecognized. See Agent.Effort.
+        public AgentEffort Effort { get; private set; }
+
         // Per-agent iteration budget (design A17); 0 => unset (host default). Negative/non-numeric ignored.
         public int MaxTurns { get; private set; }
 
@@ -36,6 +40,7 @@ namespace GxPT
             Body = string.Empty;
             Tools = null;
             MaxTier = AgentMaxTier.Write;     // default ceiling (design A5/sec.3)
+            Effort = AgentEffort.Unset;       // no effort hint unless declared
             MaxTurns = 0;                     // unset
         }
 
@@ -72,7 +77,7 @@ namespace GxPT
             }
 
             fm.HasFrontmatter = true;
-            bool toolsSet = false, tierSet = false;
+            bool toolsSet = false, tierSet = false, effortSet = false;
             for (int j = start; j < close; j++)
             {
                 string line = lines[j];
@@ -95,6 +100,11 @@ namespace GxPT
                 {
                     AgentMaxTier tier;
                     if (!tierSet && TryParseMaxTier(value, out tier)) { fm.MaxTier = tier; tierSet = true; }
+                }
+                else if (key == "effort")
+                {
+                    AgentEffort effort;
+                    if (!effortSet && TryParseEffort(value, out effort)) { fm.Effort = effort; effortSet = true; }
                 }
                 else if (key == "max_turns")
                 {
@@ -157,6 +167,26 @@ namespace GxPT
                     tier = AgentMaxTier.Write; return true;
                 case "destructive":
                     tier = AgentMaxTier.Destructive; return true;
+                default:
+                    return false;
+            }
+        }
+
+        // low | medium | high. Returns false for a blank/unrecognized value, so the caller keeps Unset
+        // (no effort hint) rather than rejecting the agent.
+        internal static bool TryParseEffort(string value, out AgentEffort effort)
+        {
+            effort = AgentEffort.Unset;
+            if (value == null) return false;
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "low":
+                    effort = AgentEffort.Low; return true;
+                case "medium":
+                case "med":
+                    effort = AgentEffort.Medium; return true;
+                case "high":
+                    effort = AgentEffort.High; return true;
                 default:
                     return false;
             }

--- a/GxPT/Services/Plugins/PluginImportExportService.cs
+++ b/GxPT/Services/Plugins/PluginImportExportService.cs
@@ -196,7 +196,7 @@ namespace GxPT
                 string slug = m.Agents[i];
                 string file = CurrentPath(MemberKind.Agent, m.Enabled, skillsRoot, agentsRoot, disabled, slug);
                 if (File.Exists(file))
-                    agents.Add(new Agent(slug, slug, string.Empty, null, AgentMaxTier.Write, null, 0, file, AgentSource.User));
+                    agents.Add(new Agent(slug, slug, string.Empty, null, AgentMaxTier.Write, null, AgentEffort.Unset, 0, file, AgentSource.User));
             }
 
             ExportPlugin(m.Name, m.Version, m.Description, skills, agents, archivePath);

--- a/GxPT/Services/SettingsSchema.cs
+++ b/GxPT/Services/SettingsSchema.cs
@@ -40,6 +40,12 @@ namespace GxPT
             d["models"] = (string[])ModelDefaults.Models.Clone();
             d["default_model"] = ModelDefaults.DefaultModel;
             d["recommended_hash_seen"] = ModelDefaults.RecommendedHash();
+            // Agent effort tiers (design A18): each maps a level the model/agent can request to a concrete
+            // model id, so a dispatch can ask for "high effort" without naming a slug. Seeded from the shared
+            // catalog so they start on real, in-list models.
+            d["model_effort_low"] = ModelDefaults.DefaultEffortLow;
+            d["model_effort_medium"] = ModelDefaults.DefaultEffortMedium;
+            d["model_effort_high"] = ModelDefaults.DefaultEffortHigh;
 
             // --- Appearance ---
             d["theme"] = "light";

--- a/agents/code-explore.md
+++ b/agents/code-explore.md
@@ -3,7 +3,7 @@ name: Code Explore
 description: Read-only code explorer. Dispatch it to locate and summarize how something works in the codebase before you change anything - it returns a tight written brief with file paths. Cannot modify files.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
 max_tier: readonly
-model: deepseek/deepseek-v4-flash
+effort: low
 max_turns: 25
 ---
 You are a code-exploration specialist working inside the user's workspace.

--- a/agents/code-review.md
+++ b/agents/code-review.md
@@ -3,6 +3,7 @@ name: Code Review
 description: Read-only code reviewer. Dispatch it to review a change, diff, or GitHub pull request - it reads the code and reports correctness bugs, risks, and quality issues with file references. Cannot modify files.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, github__*]
 max_tier: readonly
+effort: high
 max_turns: 25
 ---
 You are a code-review specialist.

--- a/agents/general-purpose.md
+++ b/agents/general-purpose.md
@@ -3,6 +3,7 @@ name: General Purpose
 description: General-purpose worker for a self-contained task. Dispatch it when no specialist fits - it can read and edit files, inspect git, and search the web, working in isolation and reporting back. It cannot delete files, push, or run shell commands.
 tools: [files__read, files__list, files__search, files__edit, git__status, git__diff, git__log, git__add, git__commit, web__search, web__extract]
 max_tier: write
+effort: medium
 max_turns: 40
 ---
 You are a capable generalist working on a self-contained task inside the user's workspace.

--- a/agents/plan.md
+++ b/agents/plan.md
@@ -3,6 +3,7 @@ name: Plan
 description: Read-only software architect. Dispatch it to design an implementation plan for a change - it reads the relevant code and returns a step-by-step plan with the files to touch and the trade-offs. Cannot modify files.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, web__search, web__extract]
 max_tier: readonly
+effort: high
 max_turns: 30
 ---
 You are a software architect planning a change inside the user's workspace.

--- a/agents/verify.md
+++ b/agents/verify.md
@@ -3,6 +3,7 @@ name: Verify
 description: Adversarial verifier. Dispatch it to check whether a change actually works - it reads the code, builds the project, and runs tests/commands, then reports pass/fail with evidence.
 tools: [files__read, files__list, files__search, git__status, git__diff, git__log, command__run, msbuild__*]
 max_tier: destructive
+effort: medium
 max_turns: 25
 ---
 You are an adversarial verification specialist. Your job is to find out whether something actually works - not to assume it does.

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -3,7 +3,7 @@ name: Web Research
 description: Read-only web researcher. Dispatch it to research a topic on the internet - it searches the web, reads sources, and returns a synthesized summary with citations. Cannot modify files.
 tools: [web__search, web__extract, web__get]
 max_tier: readonly
-model: deepseek/deepseek-v4-flash
+effort: low
 max_turns: 25
 ---
 You are a web-research specialist.

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -168,7 +168,14 @@ find something after a genuine search, say so and name where you looked.
     child orchestrator's `maxIterations` ctor arg (A17). Omitted ⇒ the host default
     (`DefaultMaxIterations`). Lets an `explore` agent cap at ~15 while a `coder` runs
     ~30, so an unattended specialist's cost is bounded *to its job*, not the parent's.
-  - `model` *(optional)* — model id override; omitted ⇒ the parent turn's model.
+  - `model` *(optional)* — explicit model id override; omitted ⇒ the parent turn's
+    model. Prefer `effort` unless a specific id is required.
+  - `effort` *(optional, A18)* — capability tier `low` \| `medium` \| `high`, mapped
+    to a concrete model id by the user's settings (`model_effort_low/medium/high`).
+    Lets an agent ask for a cheaper/faster or a stronger model **by intent**, without
+    hard-coding a slug. Unrecognized ⇒ ignored (no hint). An explicit `model` is more
+    specific and **wins over `effort`** when both are set. Distinct from `max_tier`
+    (a tool-permission ceiling, a different axis) — deliberately *not* called "tier".
   - ~~`autonomy`~~ — **dropped.** It was redundant with `max_tier` + the approval
     gate (read-only auto-allows, write/destructive prompt — for `gated` *and*
     `auto-readonly` alike), so it never produced a distinct behavior. The key is
@@ -232,11 +239,14 @@ resolution (like `IsOpenSkill`), so it never hits a server.
 ### `dispatch_agent` — the meta-tool
 
 ```
-dispatch_agent(agents: [ { name: string, task: string, model?: string }, … ])   // batch (A9)
+dispatch_agent(agents: [ { name: string, task: string, effort?: string, model?: string }, … ])   // batch (A9)
 ```
-The optional per-entry `model` overrides that agent's frontmatter model (and the
-default parent model) for this dispatch only — precedence is
-`model` arg → frontmatter `model` → parent turn's model.
+The optional per-entry `effort` (`low`\|`medium`\|`high`) and `model` override that
+agent's own frontmatter for this dispatch only. Full precedence (A18), dispatch-level
+beating frontmatter and an explicit model beating an effort tier within each level:
+`model` arg → `effort` arg → frontmatter `model` → frontmatter `effort` → parent
+turn's model. An effort tier maps to a model via the user's settings; a tier that maps
+to nothing is skipped, so resolution always lands on a concrete model.
 Definition shape mirrors `open_skill`/`reveal_tools` so the model treats it the
 same way. Description: *"Delegate one or more self-contained sub-tasks to specialist
 agents that work in isolation and report back. Pass each agent's slug (from the
@@ -251,7 +261,8 @@ conversation."*
    - history = `[ system: standing-guidance + workspace-block + agent.Body ]`
      then `[ user: task ]`;
    - `WorkingDir` = parent's (so scoped servers route to the same folder);
-   - `model` = `agent.Model ?? parentModel`;
+   - `model` = `ResolveModel` (A18): `model` arg → `effort` arg → `agent.Model` →
+     `agent.Effort` → `parentModel` (effort tiers mapped via settings);
    - **exposed tools restricted** via `AgentToolResolver` (A11) — for a *small*
      declared allowlist the child skips progressive disclosure and is handed those
      defs directly (no `reveal_tools` dance); for `tools: [*]` it gets the normal

--- a/servers/ExtensionsMcpServer/AgentFrontmatter.cs
+++ b/servers/ExtensionsMcpServer/AgentFrontmatter.cs
@@ -17,6 +17,7 @@ namespace ExtensionsMcpServer
         public string ToolsRaw;     // raw value after "tools:", or null when the key was absent
         public string MaxTierRaw;   // raw value after "max_tier:", or null
         public string ModelRaw;     // raw value after "model:", or null
+        public string EffortRaw;    // raw value after "effort:", or null
         public string MaxTurnsRaw;  // raw value after "max_turns:", or null
         public string Body;
 
@@ -60,6 +61,7 @@ namespace ExtensionsMcpServer
                 else if (key == "tools" && fm.ToolsRaw == null) fm.ToolsRaw = value;
                 else if (key == "max_tier" && fm.MaxTierRaw == null) fm.MaxTierRaw = value;
                 else if (key == "model" && fm.ModelRaw == null) fm.ModelRaw = value;
+                else if (key == "effort" && fm.EffortRaw == null) fm.EffortRaw = value;
                 else if (key == "max_turns" && fm.MaxTurnsRaw == null) fm.MaxTurnsRaw = value;
             }
 

--- a/servers/ExtensionsMcpServer/AgentWriter.cs
+++ b/servers/ExtensionsMcpServer/AgentWriter.cs
@@ -14,7 +14,7 @@ namespace ExtensionsMcpServer
     /// <summary>
     /// The agent authoring file operations - the SkillWriter analogue for sub-agents (design A4/phase 10).
     /// An agent is a single flat &lt;slug&gt;.md whose frontmatter (name/description/tools/max_tier/model/
-    /// max_turns) is the security contract and whose body is the system prompt. The server assembles the
+    /// effort/max_turns) is the security contract and whose body is the system prompt. The server assembles the
     /// frontmatter from fields so the model never produces an unloadable agent. Targets the WRITABLE roots
     /// only (project &lt;workdir&gt;/.gxpt/agents, user-global %AppData%/GxPT/agents); the bundled install dir
     /// is never a write target. Atomic writes, UTF-8 (no BOM). Agents have no bundled assets or scripts, so
@@ -37,7 +37,7 @@ namespace ExtensionsMcpServer
 
         // create_agent: a NEW agent (refuses if it exists); assembles a guaranteed-loadable <slug>.md.
         public string CreateAgent(string scope, string slugIn, string name, string description,
-            string[] tools, string maxTier, string model, int maxTurns, string body)
+            string[] tools, string maxTier, string model, string effort, int maxTurns, string body)
         {
             string root = RootFor(scope);
             string slug = RequireSlug(slugIn);
@@ -51,13 +51,14 @@ namespace ExtensionsMcpServer
             string toolsValue = FormatTools(tools);            // null => omit the key
             string tierValue = NormalizeTier(maxTier);          // null => omit (host defaults to write)
             string modelValue = NormalizeModel(model);          // null => omit
+            string effortValue = NormalizeEffort(effort);       // null => omit
             string turnsValue = NormalizeTurns(maxTurns);       // null => omit
 
             string file = Path.Combine(root, slug + ".md");
             if (File.Exists(file))
                 throw new AgentWriteException("agent '" + slug + "' already exists; use update_agent to change it");
 
-            AtomicWrite(file, BuildAgentMd(name, description, toolsValue, tierValue, modelValue, turnsValue, body));
+            AtomicWrite(file, BuildAgentMd(name, description, toolsValue, tierValue, modelValue, effortValue, turnsValue, body));
             return "Created agent '" + slug + "'. It will be available on your next message.";
         }
 
@@ -65,7 +66,7 @@ namespace ExtensionsMcpServer
         // leaves that field unchanged; pass tools: [] to explicitly clear it. max_turns <= 0 leaves it
         // unchanged (clearing it isn't supported - it's a rare need).
         public string UpdateAgent(string scope, string slugIn, string name, string description,
-            string[] tools, string maxTier, string model, int maxTurns, string body)
+            string[] tools, string maxTier, string model, string effort, int maxTurns, string body)
         {
             string root = RootFor(scope);
             string slug = RequireSlug(slugIn);
@@ -86,7 +87,7 @@ namespace ExtensionsMcpServer
 
             AgentFrontmatter fm = AgentFrontmatter.Parse(existing);
             // A present-but-blank scalar means "keep" (same as omitting it): only a non-blank value changes
-            // a field, so passing "" never silently wipes an existing name/description/model/max_tier/body.
+            // a field, so passing "" never silently wipes an existing name/description/model/effort/max_tier/body.
             // Clearing tools is the one explicit clear (pass []); clearing a scalar isn't supported.
             string newName = !IsBlank(name) ? name : fm.Name;     // may stay null -> name line omitted
             string newDesc = !IsBlank(description) ? description : fm.Description;
@@ -95,10 +96,11 @@ namespace ExtensionsMcpServer
             string toolsValue = tools != null ? FormatTools(tools) : fm.ToolsRaw;
             string tierValue = !IsBlank(maxTier) ? NormalizeTier(maxTier) : fm.MaxTierRaw;
             string modelValue = !IsBlank(model) ? NormalizeModel(model) : fm.ModelRaw;
+            string effortValue = !IsBlank(effort) ? NormalizeEffort(effort) : fm.EffortRaw;
             string turnsValue = maxTurns > 0 ? NormalizeTurns(maxTurns) : fm.MaxTurnsRaw;
             string newBody = !IsBlank(body) ? body : fm.Body;
 
-            AtomicWrite(file, BuildAgentMd(newName, newDesc, toolsValue, tierValue, modelValue, turnsValue, newBody));
+            AtomicWrite(file, BuildAgentMd(newName, newDesc, toolsValue, tierValue, modelValue, effortValue, turnsValue, newBody));
             return "Updated agent '" + slug + "'. Changes apply on your next message.";
         }
 
@@ -139,7 +141,7 @@ namespace ExtensionsMcpServer
 
             string updatedBody = replaceAll ? bodyText.Replace(oldB, newB) : ReplaceFirst(bodyText, oldB, newB);
             AtomicWrite(file, BuildAgentMd(fm.Name, fm.Description, fm.ToolsRaw, fm.MaxTierRaw,
-                fm.ModelRaw, fm.MaxTurnsRaw, updatedBody));
+                fm.ModelRaw, fm.EffortRaw, fm.MaxTurnsRaw, updatedBody));
             return "Edited agent '" + slug + "''s body ("
                 + (replaceAll ? count + " replacement" + (count == 1 ? "" : "s") : "1 replacement") + ").";
         }
@@ -185,7 +187,7 @@ namespace ExtensionsMcpServer
             // Write the new file first, then remove the old one. The collision guard above means the new path
             // never overwrites another agent, and the content is preserved (this is a move, not a rewrite).
             AtomicWrite(newFile, BuildAgentMd(resolvedName, fm.Description, fm.ToolsRaw, fm.MaxTierRaw,
-                fm.ModelRaw, fm.MaxTurnsRaw, fm.Body));
+                fm.ModelRaw, fm.EffortRaw, fm.MaxTurnsRaw, fm.Body));
             try { File.Delete(oldFile); }
             catch (Exception ex)
             {
@@ -253,8 +255,8 @@ namespace ExtensionsMcpServer
         }
 
         // validate_agent (ReadOnly): would this agent load, and is its contract well-formed? (mirrors host
-        // discovery: a non-empty description is what makes it dispatchable.) Also checks the max_tier enum
-        // and that the tools list parses; reports the parsed contract or what is wrong.
+        // discovery: a non-empty description is what makes it dispatchable.) Also checks the max_tier and
+        // effort enums and that the tools list parses; reports the parsed contract or what is wrong.
         public string ValidateAgent(string slugIn)
         {
             string slug = RequireSlug(slugIn);
@@ -279,17 +281,26 @@ namespace ExtensionsMcpServer
                 tierNote = "; WARNING: max_tier '" + fm.MaxTierRaw.Trim()
                     + "' is not recognized (use readonly | write | destructive) - it will fall back to the default";
 
+            // effort, like max_tier, silently falls back to "no hint" at load if it's an unknown value - so
+            // flag a bad value as a warning here rather than failing the agent.
+            string effortNote = "";
+            if (!IsBlank(fm.EffortRaw) && !IsKnownEffort(fm.EffortRaw))
+                effortNote = "; WARNING: effort '" + fm.EffortRaw.Trim()
+                    + "' is not recognized (use low | medium | high) - it will be ignored";
+
             string name = !IsBlank(fm.Name) ? fm.Name : slug;
             string tier = !IsBlank(fm.MaxTierRaw) ? fm.MaxTierRaw.Trim() : "write (default)";
             string tools = fm.ToolsRaw != null ? fm.ToolsRaw : "(none specified)";
+            string effort = !IsBlank(fm.EffortRaw) ? fm.EffortRaw.Trim() : "(unset)";
             return "OK: agent '" + slug + "' loads (" + source + "). name: " + name + "; description: "
-                + fm.Description + "; max_tier: " + tier + "; tools: " + tools + tierNote;
+                + fm.Description + "; max_tier: " + tier + "; effort: " + effort + "; tools: " + tools
+                + tierNote + effortNote;
         }
 
         // ---- frontmatter assembly + field validation ----
 
         private static string BuildAgentMd(string name, string description, string toolsValue,
-            string tierValue, string modelValue, string turnsValue, string body)
+            string tierValue, string modelValue, string effortValue, string turnsValue, string body)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("---\n");
@@ -300,6 +311,7 @@ namespace ExtensionsMcpServer
             if (toolsValue != null) sb.Append("tools: ").Append(toolsValue).Append('\n');
             if (!IsBlank(tierValue)) sb.Append("max_tier: ").Append(tierValue.Trim()).Append('\n');
             if (!IsBlank(modelValue)) sb.Append("model: ").Append(modelValue.Trim()).Append('\n');
+            if (!IsBlank(effortValue)) sb.Append("effort: ").Append(effortValue.Trim()).Append('\n');
             if (!IsBlank(turnsValue)) sb.Append("max_turns: ").Append(turnsValue.Trim()).Append('\n');
             sb.Append("---\n\n");
             string b = body != null ? body : string.Empty;
@@ -381,6 +393,43 @@ namespace ExtensionsMcpServer
             if (v.Length == 0) return null;
             RequireSingleLine(v, "model");
             return v;
+        }
+
+        // low | medium | high. Returns the canonical lower form, null for a blank/absent value (the field is
+        // optional), or throws on an unrecognized value so the author fixes it at write time.
+        private static string NormalizeEffort(string effort)
+        {
+            if (effort == null || effort.Trim().Length == 0) return null;
+            string canonical;
+            if (TryNormalizeEffort(effort, out canonical)) return canonical;
+            throw new AgentWriteException("effort must be one of: low, medium, high (got '"
+                + effort.Trim() + "')");
+        }
+
+        // The single source of accepted effort spellings: canonical lower form + true, or false for a blank/
+        // unrecognized value. NormalizeEffort (throws) and IsKnownEffort (returns the bool) both build on it.
+        private static bool TryNormalizeEffort(string effort, out string canonical)
+        {
+            canonical = null;
+            if (effort == null) return false;
+            switch (effort.Trim().ToLowerInvariant())
+            {
+                case "low":
+                    canonical = "low"; return true;
+                case "medium":
+                case "med":
+                    canonical = "medium"; return true;
+                case "high":
+                    canonical = "high"; return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsKnownEffort(string raw)
+        {
+            string canonical;
+            return TryNormalizeEffort(raw, out canonical);
         }
 
         private static string NormalizeTurns(int maxTurns)

--- a/servers/ExtensionsMcpServer/ExtensionsServerTools.cs
+++ b/servers/ExtensionsMcpServer/ExtensionsServerTools.cs
@@ -263,7 +263,10 @@ namespace ExtensionsMcpServer
                         + "pass [] for an agent with no tools.")
                     .Str("max_tier", false, "Capability ceiling: 'readonly', 'write' (default), or 'destructive'. "
                         + "Caps the allowlist regardless of what tools names.")
-                    .Str("model", false, "Optional model id override; omit to use the parent turn's model.")
+                    .Str("model", false, "Optional explicit model id override; prefer 'effort' unless a "
+                        + "specific model is needed. Omit to use effort or the parent turn's model.")
+                    .Str("effort", false, "Optional capability tier: 'low', 'medium', or 'high'. The user "
+                        + "maps each to a model in settings, so the agent can ask for a tier without a slug.")
                     .Int("max_turns", false, "Optional per-agent iteration budget; omit for the host default.")
                     .Str("scope", false, scopeDesc)
                     .Build(),
@@ -275,7 +278,7 @@ namespace ExtensionsMcpServer
                         return ToolResults.Text(agents.CreateAgent(
                             Str(ctx, "scope"), Str(ctx, "slug"), Str(ctx, "name"), Str(ctx, "description"),
                             StrArrayOrNull(ctx, "tools"), Str(ctx, "max_tier"), Str(ctx, "model"),
-                            IntArg(ctx, "max_turns", 0, 0, 100000), Str(ctx, "body")));
+                            Str(ctx, "effort"), IntArg(ctx, "max_turns", 0, 0, 100000), Str(ctx, "body")));
                     }
                     catch (AgentWriteException ex) { return ToolResults.Error(ex.Message); }
                 });
@@ -292,7 +295,8 @@ namespace ExtensionsMcpServer
                     .Str("body", false, "New system prompt, or omit to keep. (For a focused change use edit_agent.)")
                     .Arr("tools", "string", false, "New tool allowlist, or omit to keep. Pass [] to clear it.")
                     .Str("max_tier", false, "New ceiling (readonly | write | destructive), or omit to keep.")
-                    .Str("model", false, "New model id override, or omit to keep.")
+                    .Str("model", false, "New explicit model id override, or omit to keep.")
+                    .Str("effort", false, "New capability tier (low | medium | high), or omit to keep.")
                     .Int("max_turns", false, "New iteration budget (> 0), or omit to keep.")
                     .Str("scope", false, scopeDesc)
                     .Build(),
@@ -304,7 +308,7 @@ namespace ExtensionsMcpServer
                         return ToolResults.Text(agents.UpdateAgent(
                             Str(ctx, "scope"), Str(ctx, "slug"), Str(ctx, "name"), Str(ctx, "description"),
                             StrArrayOrNull(ctx, "tools"), Str(ctx, "max_tier"), Str(ctx, "model"),
-                            IntArg(ctx, "max_turns", 0, 0, 100000), Str(ctx, "body")));
+                            Str(ctx, "effort"), IntArg(ctx, "max_turns", 0, 0, 100000), Str(ctx, "body")));
                     }
                     catch (AgentWriteException ex) { return ToolResults.Error(ex.Message); }
                 });
@@ -399,7 +403,7 @@ namespace ExtensionsMcpServer
 
             server.AddTool("validate_agent",
                 "Check whether an agent's <slug>.md would load (its frontmatter must declare a non-empty "
-                + "description) and that its contract is well-formed (max_tier enum, tools list). Finds the "
+                + "description) and that its contract is well-formed (max_tier and effort enums, tools list). Finds the "
                 + "agent in any scope (project, user, or bundled); reports the parsed contract and which scope "
                 + "it came from, or what is wrong. Read-only.",
                 SchemaBuilder.Object()

--- a/servers/ExtensionsMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/ExtensionsMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c1d2e3f4-a5b6-47c8-99da-0b1c2d3e4f50")]
 
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/skills/agent-writer/SKILL.md
+++ b/skills/agent-writer/SKILL.md
@@ -50,6 +50,10 @@ producing what? You are capturing how this specialist should behave. Pin down:
   `max_tier` ceiling).
 - Which tools it needs (file read/edit, git, web, command, etc.).
 - Whether it should be capped to a few turns (cheap, fast) or allowed to run longer.
+- **How capable a model the job needs** - this sets the agent's `effort` (`low` | `medium` |
+  `high`). A mechanical retrieval/formatting/search job runs fine on `low`; a general worker on
+  `medium`; deep reasoning (subtle code review, architecture, hard debugging) wants `high`. Settle
+  on a tier for almost every agent - it's a normal part of the interview, not an afterthought.
 
 There is no single right altitude for the system prompt - it depends on the answers above. A
 focused builder the user will hand a precise brief each time wants a lean prompt; a checker that
@@ -79,7 +83,12 @@ Propose, in plain terms:
   `destructive` (can run deleting/irreversible tools). Pick the lowest that still does the job - a
   reviewer or explorer should be `readonly`.
 - **max_turns** - an optional iteration budget; keep explorers/reviewers low.
-- **model** - usually omit (inherits the parent's model); set it only if they want a specific one.
+- **effort** - the capability tier the agent runs at: `low` (cheap/fast), `medium`, or `high` (most
+  capable); the user maps each to a model in settings. **Set this by default** - pick the tier that
+  fits the job (see step 2). This is the normal way to choose an agent's model.
+- **model** - a specific model id. Set this *only* if the user explicitly wants one particular
+  model; it overrides `effort`. Set `effort` OR `model`, never both. Leave **both** blank only when
+  the user wants the agent to inherit whatever model the conversation is currently using.
 
 ## 4. Propose, then confirm
 
@@ -100,8 +109,9 @@ the app (like `code-explore`) as well as user/project ones - and adapt it. `read
 agent in any scope, so you don't pass a scope to it.
 
 Creating a new agent:
-- `create_agent(slug, name, description, body, tools, max_tier, model, max_turns)` - the body is the
-  agent's system prompt. Follow the four-part structure from `writing-agents.md`, in order:
+- `create_agent(slug, name, description, body, tools, max_tier, model, effort, max_turns)` - the body
+  is the agent's system prompt. Set `effort` (not `model`) unless the user asked for a specific model.
+  Follow the four-part structure from `writing-agents.md`, in order:
   (1) a second-person identity line ("You are a …"); (2) the one job plus a bullet list of what the
   written result must contain; (3) the rules and boundaries (state read-only limits explicitly); and
   (4) the **final instructions** - the closing paragraph that every built-in agent ends on, telling
@@ -119,8 +129,8 @@ read the one you want before changing it):
   targeted edit that replaces an exact span in the body. Don't re-send the whole prompt for a small
   change.
 - `update_agent(slug, ...)` - for the frontmatter contract (`name`, `description`, `tools`,
-  `max_tier`, `model`, `max_turns`), or when replacing the whole body. Pass only the fields that
-  change; the rest stay. Pass `tools: []` to clear the allowlist.
+  `max_tier`, `model`, `effort`, `max_turns`), or when replacing the whole body. Pass only the
+  fields that change; the rest stay. Pass `tools: []` to clear the allowlist.
 - `delete_agent(slug)` removes the whole agent. It's destructive - the user confirms, so only reach
   for it when asked.
 

--- a/skills/agent-writer/writing-agents.md
+++ b/skills/agent-writer/writing-agents.md
@@ -36,8 +36,14 @@ You are a code-exploration specialist working inside the user's workspace.
   - `destructive` - can also run irreversible tools (delete, git push/reset, command__run, etc.).
     Opt into this only when the job truly needs it.
   Pick the **lowest** tier that does the job.
-- **model** - an optional model id override. Omit it to inherit the parent turn's model. Set it
-  only when the user wants a specific (often cheaper/faster) model for this agent.
+- **model** - an optional explicit model id override. Omit it to inherit the parent turn's model.
+  Set it only when the user wants a specific model for this agent. Prefer **effort** unless a
+  particular model id is genuinely required.
+- **effort** - an optional capability tier: `low`, `medium`, or `high`. The user maps each tier to
+  a model in Settings > Models, so this picks a cheaper/faster or a stronger model *by intent*
+  without hard-coding a slug (e.g. `effort: low` for a quick explorer, `effort: high` for a hard
+  reasoning job). Set **either `model` or `effort`, not both** - if both are present the explicit
+  `model` wins and `effort` is ignored.
 - **max_turns** - an optional iteration budget (tool-call rounds). Keep explorers and reviewers
   low (e.g. 20-30); allow a builder more. A tight budget is also a safety bound on an unattended
   run. Omit for the host default.

--- a/skills/agent-writer/writing-agents.md
+++ b/skills/agent-writer/writing-agents.md
@@ -40,7 +40,7 @@ You are a code-exploration specialist working inside the user's workspace.
   Set it only when the user wants a specific model for this agent. Prefer **effort** unless a
   particular model id is genuinely required.
 - **effort** - an optional capability tier: `low`, `medium`, or `high`. The user maps each tier to
-  a model in Settings > Models, so this picks a cheaper/faster or a stronger model *by intent*
+  a model under Settings > Tools > Sub-agents, so this picks a cheaper/faster or a stronger model *by intent*
   without hard-coding a slug (e.g. `effort: low` for a quick explorer, `effort: high` for a hard
   reasoning job). Set **either `model` or `effort`, not both** - if both are present the explicit
   `model` wins and `effort` is ignored.

--- a/tests/ExtensionsMcpServer.Tests/AgentWriterTests.cs
+++ b/tests/ExtensionsMcpServer.Tests/AgentWriterTests.cs
@@ -41,7 +41,7 @@ namespace ExtensionsMcpServer.Tests
         public void CreateAgent_WritesValidAgentMd()
         {
             _writer.CreateAgent(null, "explorer", "Explorer", "Use this agent to explore code.",
-                new[] { "files__read", "git__status" }, "readonly", "deepseek/x", 25, "You are an explorer.");
+                new[] { "files__read", "git__status" }, "readonly", "deepseek/x", null, 25, "You are an explorer.");
 
             string text = File.ReadAllText(AgentFile("explorer"));
             Assert.Contains("name: Explorer", text);
@@ -65,7 +65,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void CreateAgent_NormalizesSlug()
         {
-            _writer.CreateAgent(null, "Code Reviewer", "Code Reviewer", "Reviews code.", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "Code Reviewer", "Code Reviewer", "Reviews code.", null, null, null, null, 0, "body");
             Assert.True(File.Exists(AgentFile("code-reviewer")));
         }
 
@@ -74,7 +74,7 @@ namespace ExtensionsMcpServer.Tests
         {
             // slug 'code-review' but name 'Code Reviewer' -> they describe different handles.
             AgentWriteException ex = Assert.Throws<AgentWriteException>(() =>
-                _writer.CreateAgent(null, "code-review", "Code Reviewer", "Reviews code.", null, null, null, 0, "body"));
+                _writer.CreateAgent(null, "code-review", "Code Reviewer", "Reviews code.", null, null, null, null, 0, "body"));
             Assert.Contains("don't match", ex.Message);
             Assert.False(File.Exists(AgentFile("code-review")));  // nothing written on rejection
         }
@@ -85,7 +85,7 @@ namespace ExtensionsMcpServer.Tests
             // A name with no letters/digits can't form a handle - the error should say so, not give the
             // circular "set slug to <slug>" guidance.
             AgentWriteException ex = Assert.Throws<AgentWriteException>(() =>
-                _writer.CreateAgent(null, "my-agent", "!!!", "desc", null, null, null, 0, "body"));
+                _writer.CreateAgent(null, "my-agent", "!!!", "desc", null, null, null, null, 0, "body"));
             Assert.Contains("no letters or digits", ex.Message);
             Assert.False(File.Exists(AgentFile("my-agent")));
         }
@@ -95,7 +95,7 @@ namespace ExtensionsMcpServer.Tests
         {
             // 'GitHub Researcher' kebab-splits oddly, but ignoring word boundaries it matches the slug.
             _writer.CreateAgent(null, "github-researcher", "GitHub Researcher", "Researches a repo.",
-                null, null, null, 0, "body");
+                null, null, null, null, 0, "body");
             Assert.True(File.Exists(AgentFile("github-researcher")));
             Assert.Contains("name: GitHub Researcher", File.ReadAllText(AgentFile("github-researcher")));
         }
@@ -103,9 +103,9 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void UpdateAgent_RejectsNameThatDivergesFromSlug()
         {
-            _writer.CreateAgent(null, "code-explore", "Code Explore", "Explores code.", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "code-explore", "Code Explore", "Explores code.", null, null, null, null, 0, "body");
             AgentWriteException ex = Assert.Throws<AgentWriteException>(() =>
-                _writer.UpdateAgent(null, "code-explore", "Code Reviewer", null, null, null, null, 0, null));
+                _writer.UpdateAgent(null, "code-explore", "Code Reviewer", null, null, null, null, null, 0, null));
             Assert.Contains("rename", ex.Message);
             // The original name is left intact - the rejected update wrote nothing.
             Assert.Contains("name: Code Explore", File.ReadAllText(AgentFile("code-explore")));
@@ -114,8 +114,8 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void UpdateAgent_AllowsNameReCasingThatPreservesSlug()
         {
-            _writer.CreateAgent(null, "release-notes", "Release Notes", "Drafts notes.", null, null, null, 0, "body");
-            _writer.UpdateAgent(null, "release-notes", "RELEASE notes", null, null, null, null, 0, null);
+            _writer.CreateAgent(null, "release-notes", "Release Notes", "Drafts notes.", null, null, null, null, 0, "body");
+            _writer.UpdateAgent(null, "release-notes", "RELEASE notes", null, null, null, null, null, 0, null);
             Assert.Contains("name: RELEASE notes", File.ReadAllText(AgentFile("release-notes")));
         }
 
@@ -123,7 +123,7 @@ namespace ExtensionsMcpServer.Tests
         public void RenameAgent_MovesFileDerivesNameAndPreservesContract()
         {
             _writer.CreateAgent(null, "code-explore", "Code Explore", "Explores code.",
-                new[] { "files__read" }, "readonly", "deepseek/x", 20, "You are an explorer.");
+                new[] { "files__read" }, "readonly", "deepseek/x", null, 20, "You are an explorer.");
 
             _writer.RenameAgent(null, "code-explore", "code-search", null);   // no new_name -> derived
 
@@ -141,7 +141,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void RenameAgent_KeepsExplicitNameWhenAligned()
         {
-            _writer.CreateAgent(null, "github-sync", "GitHub Sync", "Syncs a repo.", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "github-sync", "GitHub Sync", "Syncs a repo.", null, null, null, null, 0, "body");
             _writer.RenameAgent(null, "github-sync", "github-mirror", "GitHub Mirror");  // acronym casing preserved
             Assert.Contains("name: GitHub Mirror", File.ReadAllText(AgentFile("github-mirror")));
         }
@@ -149,8 +149,8 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void RenameAgent_RefusesExistingTarget()
         {
-            _writer.CreateAgent(null, "alpha", "Alpha", "d", null, null, null, 0, "b");
-            _writer.CreateAgent(null, "beta", "Beta", "d", null, null, null, 0, "b");
+            _writer.CreateAgent(null, "alpha", "Alpha", "d", null, null, null, null, 0, "b");
+            _writer.CreateAgent(null, "beta", "Beta", "d", null, null, null, null, 0, "b");
             Assert.Throws<AgentWriteException>(() => _writer.RenameAgent(null, "alpha", "beta", null));
             Assert.True(File.Exists(AgentFile("alpha")));   // source untouched on refusal
             Assert.True(File.Exists(AgentFile("beta")));
@@ -159,7 +159,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void RenameAgent_RejectsNameNotMatchingNewSlug()
         {
-            _writer.CreateAgent(null, "code-explore", "Code Explore", "Explores code.", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "code-explore", "Code Explore", "Explores code.", null, null, null, null, 0, "body");
             Assert.Throws<AgentWriteException>(() =>
                 _writer.RenameAgent(null, "code-explore", "code-search", "Totally Different"));
             Assert.True(File.Exists(AgentFile("code-explore")));      // nothing moved
@@ -180,7 +180,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void CreateAgent_OmitsOptionalFieldsWhenAbsent()
         {
-            _writer.CreateAgent(null, "minimal", "Minimal", "A minimal agent.", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "minimal", "Minimal", "A minimal agent.", null, null, null, null, 0, "body");
             string text = File.ReadAllText(AgentFile("minimal"));
             Assert.DoesNotContain("tools:", text);
             Assert.DoesNotContain("max_tier:", text);
@@ -192,37 +192,37 @@ namespace ExtensionsMcpServer.Tests
         public void CreateAgent_EmptyToolsArray_WritesExplicitEmptyList()
         {
             _writer.CreateAgent(null, "notools", "No Tools", "An agent with no tools.",
-                new string[0], null, null, 0, "body");
+                new string[0], null, null, null, 0, "body");
             Assert.Contains("tools: []", File.ReadAllText(AgentFile("notools")));
         }
 
         [Fact]
         public void CreateAgent_RefusesExisting()
         {
-            _writer.CreateAgent(null, "dup", "Dup", "desc", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "dup", "Dup", "desc", null, null, null, null, 0, "body");
             Assert.Throws<AgentWriteException>(() =>
-                _writer.CreateAgent(null, "dup", "Dup", "desc", null, null, null, 0, "body"));
+                _writer.CreateAgent(null, "dup", "Dup", "desc", null, null, null, null, 0, "body"));
         }
 
         [Fact]
         public void CreateAgent_RejectsUnknownMaxTier()
         {
             Assert.Throws<AgentWriteException>(() =>
-                _writer.CreateAgent(null, "bad", "Bad", "desc", null, "sometimes", null, 0, "body"));
+                _writer.CreateAgent(null, "bad", "Bad", "desc", null, "sometimes", null, null, 0, "body"));
         }
 
         [Fact]
         public void CreateAgent_RejectsToolWithComma()
         {
             Assert.Throws<AgentWriteException>(() =>
-                _writer.CreateAgent(null, "bad", "Bad", "desc", new[] { "files__read, git__log" }, null, null, 0, "body"));
+                _writer.CreateAgent(null, "bad", "Bad", "desc", new[] { "files__read, git__log" }, null, null, null, 0, "body"));
         }
 
         [Fact]
         public void UpdateAgent_PartialFields_KeepOthers()
         {
-            _writer.CreateAgent(null, "a", "A", "old desc", new[] { "files__read" }, "readonly", "m", 10, "old body");
-            _writer.UpdateAgent(null, "a", null, "new desc", null, null, null, 0, null);
+            _writer.CreateAgent(null, "a", "A", "old desc", new[] { "files__read" }, "readonly", "m", null, 10, "old body");
+            _writer.UpdateAgent(null, "a", null, "new desc", null, null, null, null, 0, null);
 
             string text = File.ReadAllText(AgentFile("a"));
             Assert.Contains("description: new desc", text);
@@ -236,8 +236,8 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void UpdateAgent_EmptyToolsArray_ClearsTools()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", new[] { "files__read" }, null, null, 0, "body");
-            _writer.UpdateAgent(null, "a", null, null, new string[0], null, null, 0, null);
+            _writer.CreateAgent(null, "a", "A", "desc", new[] { "files__read" }, null, null, null, 0, "body");
+            _writer.UpdateAgent(null, "a", null, null, new string[0], null, null, null, 0, null);
             Assert.Contains("tools: []", File.ReadAllText(AgentFile("a")));
         }
 
@@ -245,13 +245,13 @@ namespace ExtensionsMcpServer.Tests
         public void UpdateAgent_MissingAgent_Throws()
         {
             Assert.Throws<AgentWriteException>(() =>
-                _writer.UpdateAgent(null, "ghost", "G", "desc", null, null, null, 0, null));
+                _writer.UpdateAgent(null, "ghost", "G", "desc", null, null, null, null, 0, null));
         }
 
         [Fact]
         public void EditAgent_ReplacesInBodyOnly()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", null, "write", null, 0, "Step one. Step two.");
+            _writer.CreateAgent(null, "a", "A", "desc", null, "write", null, null, 0, "Step one. Step two.");
             _writer.EditAgent(null, "a", "Step two.", "Step three.", false);
 
             string text = File.ReadAllText(AgentFile("a"));
@@ -264,14 +264,14 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void EditAgent_NonUniqueWithoutReplaceAll_Throws()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, 0, "x and x and x");
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, null, 0, "x and x and x");
             Assert.Throws<AgentWriteException>(() => _writer.EditAgent(null, "a", "x", "y", false));
         }
 
         [Fact]
         public void ReadAgent_ReturnsFullText()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, 0, "the body");
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, null, 0, "the body");
             string text = _writer.ReadAgent("a");
             Assert.Contains("name: A", text);
             Assert.Contains("the body", text);
@@ -308,7 +308,7 @@ namespace ExtensionsMcpServer.Tests
         public void ReadAgent_ProjectShadowsBundled()
         {
             MakeBundled("explore", "bundled body");
-            _writer.CreateAgent(null, "explore", "Explore", "desc", null, null, null, 0, "project body");
+            _writer.CreateAgent(null, "explore", "Explore", "desc", null, null, null, null, 0, "project body");
             Assert.Contains("project body", _writer.ReadAgent("explore"));
         }
 
@@ -316,7 +316,7 @@ namespace ExtensionsMcpServer.Tests
         public void ListAgents_SpansScopesWithSource()
         {
             MakeBundled("explore", "b");
-            _writer.CreateAgent(null, "alpha", "Alpha", "d", null, null, null, 0, "b");
+            _writer.CreateAgent(null, "alpha", "Alpha", "d", null, null, null, null, 0, "b");
             string listing = _writer.ListAgents();
             Assert.Contains("- alpha (project)", listing);
             Assert.Contains("- explore (bundled)", listing);
@@ -327,7 +327,7 @@ namespace ExtensionsMcpServer.Tests
         {
             MakeBundled("explore", "bundled body");
             AgentWriteException ex = Assert.Throws<AgentWriteException>(
-                () => _writer.UpdateAgent(null, "explore", null, "new desc", null, null, null, 0, null));
+                () => _writer.UpdateAgent(null, "explore", null, "new desc", null, null, null, null, 0, null));
             Assert.Contains("bundled", ex.Message);
             Assert.Contains("create_agent", ex.Message); // points at the override path
         }
@@ -345,7 +345,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void DeleteAgent_RemovesFile()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, 0, "body");
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, null, 0, "body");
             _writer.DeleteAgent(null, "a");
             Assert.False(File.Exists(AgentFile("a")));
         }
@@ -353,7 +353,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void ValidateAgent_OkForLoadableAgent()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", new[] { "files__read" }, "readonly", null, 0, "body");
+            _writer.CreateAgent(null, "a", "A", "desc", new[] { "files__read" }, "readonly", null, null, 0, "body");
             Assert.StartsWith("OK:", _writer.ValidateAgent("a"));
         }
 
@@ -372,8 +372,8 @@ namespace ExtensionsMcpServer.Tests
         public void UpdateAgent_BlankScalarKeepsExisting()
         {
             // A present-but-empty model/name means "keep", not "clear" (only a non-blank value changes it).
-            _writer.CreateAgent(null, "a", "A", "desc", null, "readonly", "deepseek/x", 0, "body");
-            _writer.UpdateAgent(null, "a", "", "new desc", null, null, "", 0, null); // name="" and model="" => keep
+            _writer.CreateAgent(null, "a", "A", "desc", null, "readonly", "deepseek/x", null, 0, "body");
+            _writer.UpdateAgent(null, "a", "", "new desc", null, null, "", null, 0, null); // name="" and model="" => keep
             string text = File.ReadAllText(AgentFile("a"));
             Assert.Contains("name: A", text);            // kept (not wiped)
             Assert.Contains("model: deepseek/x", text);  // kept (not wiped)
@@ -386,10 +386,10 @@ namespace ExtensionsMcpServer.Tests
             string user = Path.Combine(_root, "user");
             Directory.CreateDirectory(user);
             AgentWriter w = new AgentWriter(_project, user, _bundled, "project");
-            w.CreateAgent("user", "reviewer", "Reviewer", "desc", null, null, null, 0, "body");
+            w.CreateAgent("user", "reviewer", "Reviewer", "desc", null, null, null, null, 0, "body");
 
             AgentWriteException ex = Assert.Throws<AgentWriteException>(
-                () => w.UpdateAgent("project", "reviewer", null, "new", null, null, null, 0, null));
+                () => w.UpdateAgent("project", "reviewer", null, "new", null, null, null, null, 0, null));
             Assert.Contains("'user' scope", ex.Message);
             Assert.Contains("scope:\"user\"", ex.Message);
         }
@@ -416,7 +416,7 @@ namespace ExtensionsMcpServer.Tests
         [Fact]
         public void EditAgent_MatchesExactly_PaddedOldStringFailsCleanly()
         {
-            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, 0, "You are X.");
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, null, 0, "You are X.");
             // edit_agent matches the body exactly: a whitespace-padded copy does NOT fuzzy-match (it throws
             // rather than silently editing the wrong span).
             Assert.Throws<AgentWriteException>(
@@ -426,6 +426,62 @@ namespace ExtensionsMcpServer.Tests
             string text = File.ReadAllText(AgentFile("a"));
             Assert.Contains("You are Y.", text);
             Assert.DoesNotContain("You are X.", text);
+        }
+
+        [Fact]
+        public void CreateAgent_WritesEffort_RoundTrips()
+        {
+            _writer.CreateAgent(null, "fast", "Fast", "A quick agent.", null, null, null, "low", 0, "body");
+            string text = File.ReadAllText(AgentFile("fast"));
+            Assert.Contains("effort: low", text);
+            Assert.Equal("low", AgentFrontmatter.Parse(text).EffortRaw);
+        }
+
+        [Fact]
+        public void CreateAgent_NormalizesEffortCasingAndAlias()
+        {
+            _writer.CreateAgent(null, "mid", "Mid", "A balanced agent.", null, null, null, "MED", 0, "body");
+            Assert.Contains("effort: medium", File.ReadAllText(AgentFile("mid")));
+        }
+
+        [Fact]
+        public void CreateAgent_RejectsUnknownEffort()
+        {
+            Assert.Throws<AgentWriteException>(() =>
+                _writer.CreateAgent(null, "bad", "Bad", "desc", null, null, null, "turbo", 0, "body"));
+        }
+
+        [Fact]
+        public void UpdateAgent_PreservesEffortWhenOmitted_AndCanChangeIt()
+        {
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, "low", 0, "body");
+            // Omitting effort keeps the existing value.
+            _writer.UpdateAgent(null, "a", null, "new desc", null, null, null, null, 0, null);
+            Assert.Contains("effort: low", File.ReadAllText(AgentFile("a")));
+            // Passing a new effort changes it.
+            _writer.UpdateAgent(null, "a", null, null, null, null, null, "high", 0, null);
+            Assert.Contains("effort: high", File.ReadAllText(AgentFile("a")));
+        }
+
+        [Fact]
+        public void EditAgent_PreservesEffort()
+        {
+            _writer.CreateAgent(null, "a", "A", "desc", null, null, null, "high", 0, "Step one.");
+            _writer.EditAgent(null, "a", "Step one.", "Step two.", false);
+            Assert.Contains("effort: high", File.ReadAllText(AgentFile("a")));
+        }
+
+        [Fact]
+        public void ValidateAgent_ReportsEffort_AndWarnsOnUnknown()
+        {
+            _writer.CreateAgent(null, "good", "Good", "desc", null, null, null, "high", 0, "body");
+            Assert.Contains("effort: high", _writer.ValidateAgent("good"));
+
+            // A bad effort value (written directly, bypassing create's validation) is a warning, not a failure.
+            File.WriteAllText(AgentFile("bad"), "---\nname: Bad\ndescription: d\neffort: bogus\n---\nbody\n");
+            string result = _writer.ValidateAgent("bad");
+            Assert.StartsWith("OK:", result);
+            Assert.Contains("WARNING", result);
         }
     }
 }


### PR DESCRIPTION
## Summary
Implements agent effort-tier model selection (design A18), allowing agents and dispatches to request models by capability level (low/medium/high) rather than hard-coded model IDs. Users configure each tier to a concrete model in Settings, and agents resolve their effort preference through this mapping.

## Key Changes

**Settings UI (SettingsForm.cs)**
- Added three effort-tier model picker combos (low/medium/high) built dynamically into the Sub-agents groupbox
- Implemented owner-drawn combos that display short model names while storing full "author/model" IDs
- Added dropdown width auto-adjustment to fit the longest model name
- Integrated effort-tier pickers with dirty-tracking and settings sync

**Agent Dispatcher (AgentDispatcher.cs)**
- Added `EffortModel` property: a `Func<AgentEffort, string>` that maps effort levels to configured model IDs
- Extended `DispatchAgentDef()` to expose `effort` parameter (low/medium/high) in the dispatch_agent function schema
- Updated `Dispatch()` to parse and apply effort overrides alongside model overrides
- Implemented `ResolveModel()` resolution chain: explicit model > effort override > frontmatter model > frontmatter effort > parent model

**Agent Frontmatter & Catalog**
- Added `AgentEffort` enum (Unset, Low, Medium, High) to represent capability tiers
- Extended `AgentFrontmatter` to parse `effort` field from agent markdown frontmatter
- Updated `Agent` class to carry effort preference from frontmatter
- Modified `AgentCatalog` and `AgentWriter` to handle effort field in agent creation/updates

**Agent Writer (AgentWriter.cs)**
- Added `effort` parameter to `CreateAgent()` and `UpdateAgent()` methods
- Implemented `NormalizeEffort()` to validate and format effort values
- Updated agent markdown generation to include effort field when present

**Settings Schema & Defaults**
- Added `model_effort_low`, `model_effort_medium`, `model_effort_high` settings keys
- Seeded defaults from `ModelDefaults` (each tier maps to a shipped catalog model)
- Updated schema tests to verify effort-tier defaults are in-catalog models

**Main Window (MainForm.cs)**
- Extracted owner-draw logic into shared `DrawModelComboItem()` helper
- Allows effort-tier pickers and main model selector to render identically

**Documentation & Tests**
- Updated design doc (subagents-design.md) with effort-tier semantics and precedence rules
- Added comprehensive test coverage for effort resolution in `AgentDispatcherTests`
- Updated agent writer tests to include effort parameter in all agent creation calls
- Added frontmatter parsing tests for effort field

## Notable Implementation Details

- **Resolution precedence**: explicit `model` arg > `effort` arg > frontmatter `model` > frontmatter `effort` > parent model
- **Fallback safety**: capturing settings never silently clears a tier (uses existing value if combo is empty)
- **Narrow combos**: effort pickers are owner-drawn to show only short model names, with dynamic dropdown width
- **Forward compatibility**: unrecognized effort values are ignored (no error), allowing graceful degradation
- **Distinct from max_tier**: effort is a capability/cost axis; max_tier is a tool-permission ceiling (different concerns)

https://claude.ai/code/session_018HG5C3xFbwLomorfahM2BW