### PR TITLE
Add assembly version verification workflow

### DIFF
--- a/.github/scripts/verify-assembly-versions.sh
+++ b/.github/scripts/verify-assembly-versions.sh
@@ -55,6 +55,14 @@ match_ref() {
   printf '%s' "$out"
 }
 
+# Normalize a version to its leading X.Y.Z, discarding any 4th+ component
+# (e.g. "0.23.1.0" and "0.23.1.%2a" both become "0.23.1").
+xyz() {
+  local out
+  out="$(printf '%s' "$1" | grep -oP '^\d+\.\d+\.\d+')" || true
+  printf '%s' "$out"
+}
+
 # True if any changed path is inside the given directory.
 dir_changed() {
   local dir="$1"
@@ -146,6 +154,28 @@ if (( changed_asmver || changed_asmfile || changed_appver || changed_prodver ));
   (( changed_prodcode )) || { errors+=("GxPT version is being changed, but the installer ProductCode in $GXPT_VDPROJ was not regenerated."); }
 else
   echo "  No GxPT release version change detected; nothing to enforce."
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: the X.Y.Z prefix must match across all four GxPT version fields
+# (any 4th+ component, e.g. ".0" or ".%2a", is disregarded).
+# ---------------------------------------------------------------------------
+echo "== Check 3: X.Y.Z consistency across GxPT version fields =="
+
+v_asmver="$(xyz "$new_asmver")"
+v_asmfile="$(xyz "$new_asmfile")"
+v_appver="$(xyz "$new_appver")"
+v_prodver="$(xyz "$new_prodver")"
+
+echo "    AssemblyVersion     ($GXPT_ASM):    $v_asmver"
+echo "    AssemblyFileVersion ($GXPT_ASM):    $v_asmfile"
+echo "    ApplicationVersion  ($GXPT_CSPROJ): $v_appver"
+echo "    ProductVersion      ($GXPT_VDPROJ): $v_prodver"
+
+if [[ "$v_asmver" == "$v_asmfile" && "$v_asmver" == "$v_appver" && "$v_asmver" == "$v_prodver" ]]; then
+  echo "  All four agree on $v_asmver  OK"
+else
+  errors+=("GxPT version fields disagree on X.Y.Z: AssemblyVersion=$v_asmver, AssemblyFileVersion=$v_asmfile, ApplicationVersion=$v_appver, ProductVersion=$v_prodver. They must all share the same X.Y.Z.")
 fi
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/verify-assembly-versions.sh
+++ b/.github/scripts/verify-assembly-versions.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Verifies assembly / installer version bumps for the GxPT solution.
+#
+# Two independent checks are performed against a base git ref:
+#
+#   1. For every assembly EXCEPT the main GxPT application and the test
+#      projects: if any file under that assembly's project directory was
+#      modified, its [assembly: AssemblyVersion(...)] must have been bumped.
+#
+#   2. The GxPT application version lives in three places that are only ever
+#      changed together when prepping a release:
+#         - GxPT/Properties/AssemblyInfo.cs  (AssemblyVersion + AssemblyFileVersion)
+#         - GxPT/GxPT.csproj                 (ApplicationVersion)
+#         - GxPT.Setup/GxPT.Setup.vdproj     (ProductVersion)
+#      If any one of them changes, all of them must change, AND the installer
+#      ProductCode (a GUID) in the .vdproj must have been regenerated.
+#
+# Usage: verify-assembly-versions.sh <base-ref>
+#   <base-ref> is the git ref/sha to compare the current tree against
+#   (e.g. origin/main, or the "before" sha of a push).
+#
+set -euo pipefail
+
+BASE="${1:-${BASE_SHA:-}}"
+if [[ -z "$BASE" || "$BASE" =~ ^0+$ ]]; then
+  echo "No base ref to compare against; skipping assembly version verification."
+  exit 0
+fi
+
+# Compare against the merge-base so we only look at changes introduced on top
+# of the base branch (this mirrors what GitHub shows as the PR diff).
+if ! MB="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
+  echo "Could not determine merge-base with '$BASE'; comparing against it directly."
+  MB="$BASE"
+fi
+
+CHANGED="$(git diff --name-only "$MB" HEAD)"
+
+errors=()
+
+# Extract the first match of a Perl regex (with a \K look-behind) from a file in
+# the current working tree. Prints empty string if the file or pattern is absent.
+match_head() {
+  local path="$1" re="$2" out
+  [[ -f "$path" ]] || { printf ''; return; }
+  out="$(grep -oP "$re" "$path" 2>/dev/null | head -1)" || true
+  printf '%s' "$out"
+}
+
+# Same, but reads the file as it existed at the given git ref.
+match_ref() {
+  local ref="$1" path="$2" re="$3" out
+  out="$(git show "$ref:$path" 2>/dev/null | grep -oP "$re" | head -1)" || true
+  printf '%s' "$out"
+}
+
+# True if any changed path is inside the given directory.
+dir_changed() {
+  local dir="$1"
+  printf '%s\n' "$CHANGED" | grep -q "^${dir}/"
+}
+
+# Regexes. AssemblyVersion lines are anchored to the start of the line so the
+# commented-out "// [assembly: AssemblyVersion(\"1.0.*\")]" example is ignored.
+RE_ASMVER='^\[assembly: AssemblyVersion\("\K[^"]+'
+RE_ASMFILE='^\[assembly: AssemblyFileVersion\("\K[^"]+'
+RE_APPVER='<ApplicationVersion>\K[^<]+'
+RE_PRODVER='"ProductVersion" = "8:\K[^"]+'
+RE_PRODCODE='"ProductCode" = "8:\K\{[^"]+'   # only the GUID ProductCode, not prerequisites
+
+# ---------------------------------------------------------------------------
+# Check 1: non-main, non-test assemblies must bump AssemblyVersion when touched
+# ---------------------------------------------------------------------------
+echo "== Check 1: AssemblyVersion bumps for modified assemblies =="
+
+mapfile -t ASM_INFOS < <(
+  git ls-files \
+    | grep -E 'Properties/AssemblyInfo\.cs$' \
+    | grep -v '^GxPT/Properties/AssemblyInfo.cs$' \
+    | grep -viE '\.tests/|/tests/'
+)
+
+for info in "${ASM_INFOS[@]}"; do
+  # project dir = parent of the Properties/ folder
+  proj_dir="$(dirname "$(dirname "$info")")"
+
+  if ! dir_changed "$proj_dir"; then
+    echo "  - $proj_dir: unchanged, skipping"
+    continue
+  fi
+
+  old_ver="$(match_ref "$MB" "$info" "$RE_ASMVER")"
+  if [[ -z "$old_ver" ]]; then
+    echo "  - $proj_dir: new assembly (no base version), skipping"
+    continue
+  fi
+
+  new_ver="$(match_head "$info" "$RE_ASMVER")"
+  if [[ "$old_ver" == "$new_ver" ]]; then
+    errors+=("Assembly '$proj_dir' was modified but its AssemblyVersion was not updated (still $new_ver). Bump AssemblyVersion in $info.")
+    echo "  - $proj_dir: MODIFIED but version unchanged ($new_ver)  <-- FAIL"
+  else
+    echo "  - $proj_dir: modified, version $old_ver -> $new_ver  OK"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Check 2: GxPT release version triple + installer ProductCode
+# ---------------------------------------------------------------------------
+echo "== Check 2: GxPT release version consistency =="
+
+GXPT_ASM="GxPT/Properties/AssemblyInfo.cs"
+GXPT_CSPROJ="GxPT/GxPT.csproj"
+GXPT_VDPROJ="GxPT.Setup/GxPT.Setup.vdproj"
+
+old_asmver="$(match_ref "$MB" "$GXPT_ASM" "$RE_ASMVER")"
+new_asmver="$(match_head "$GXPT_ASM" "$RE_ASMVER")"
+old_asmfile="$(match_ref "$MB" "$GXPT_ASM" "$RE_ASMFILE")"
+new_asmfile="$(match_head "$GXPT_ASM" "$RE_ASMFILE")"
+old_appver="$(match_ref "$MB" "$GXPT_CSPROJ" "$RE_APPVER")"
+new_appver="$(match_head "$GXPT_CSPROJ" "$RE_APPVER")"
+old_prodver="$(match_ref "$MB" "$GXPT_VDPROJ" "$RE_PRODVER")"
+new_prodver="$(match_head "$GXPT_VDPROJ" "$RE_PRODVER")"
+old_prodcode="$(match_ref "$MB" "$GXPT_VDPROJ" "$RE_PRODCODE")"
+new_prodcode="$(match_head "$GXPT_VDPROJ" "$RE_PRODCODE")"
+
+changed_asmver=$([[ "$old_asmver"  != "$new_asmver"  ]] && echo 1 || echo 0)
+changed_asmfile=$([[ "$old_asmfile" != "$new_asmfile" ]] && echo 1 || echo 0)
+changed_appver=$([[ "$old_appver"  != "$new_appver"  ]] && echo 1 || echo 0)
+changed_prodver=$([[ "$old_prodver" != "$new_prodver" ]] && echo 1 || echo 0)
+changed_prodcode=$([[ "$old_prodcode" != "$new_prodcode" ]] && echo 1 || echo 0)
+
+if (( changed_asmver || changed_asmfile || changed_appver || changed_prodver )); then
+  echo "  GxPT version change detected:"
+  echo "    AssemblyVersion     $old_asmver -> $new_asmver"
+  echo "    AssemblyFileVersion $old_asmfile -> $new_asmfile"
+  echo "    ApplicationVersion  $old_appver -> $new_appver"
+  echo "    ProductVersion      $old_prodver -> $new_prodver"
+  echo "    ProductCode         $old_prodcode -> $new_prodcode"
+
+  (( changed_asmver ))  || { errors+=("GxPT version is being changed, but AssemblyVersion in $GXPT_ASM was not updated."); }
+  (( changed_asmfile )) || { errors+=("GxPT version is being changed, but AssemblyFileVersion in $GXPT_ASM was not updated."); }
+  (( changed_appver ))  || { errors+=("GxPT version is being changed, but ApplicationVersion in $GXPT_CSPROJ was not updated."); }
+  (( changed_prodver )) || { errors+=("GxPT version is being changed, but ProductVersion in $GXPT_VDPROJ was not updated."); }
+  (( changed_prodcode )) || { errors+=("GxPT version is being changed, but the installer ProductCode in $GXPT_VDPROJ was not regenerated."); }
+else
+  echo "  No GxPT release version change detected; nothing to enforce."
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+if (( ${#errors[@]} > 0 )); then
+  echo ""
+  echo "Assembly version verification FAILED:"
+  for e in "${errors[@]}"; do
+    echo "  ✗ $e"
+  done
+  exit 1
+fi
+
+echo ""
+echo "Assembly version verification passed."

--- a/.github/workflows/assembly-versions.yml
+++ b/.github/workflows/assembly-versions.yml
@@ -1,0 +1,26 @@
+name: Assembly Versions
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  verify-versions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the base branch / previous commit.
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
+
+      - name: Verify assembly versions
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
+        run: bash .github/scripts/verify-assembly-versions.sh "$BASE_SHA"


### PR DESCRIPTION
## Summary
This PR adds automated verification of assembly and installer version bumps for the GxPT solution through a new GitHub Actions workflow and supporting bash script.

## Key Changes
- **New GitHub Actions workflow** (`.github/workflows/assembly-versions.yml`): Runs on push to main and on all pull requests to verify version consistency
- **New verification script** (`.github/scripts/verify-assembly-versions.sh`): Implements three independent checks:
  1. **Assembly version bumps**: For all assemblies except the main GxPT application and test projects, verifies that if any files in a project directory were modified, the `AssemblyVersion` must have been bumped
  2. **GxPT release version consistency**: Ensures that when any of the three GxPT version locations change (AssemblyInfo.cs, GxPT.csproj, or GxPT.Setup.vdproj), all three must change together, and the installer ProductCode GUID must be regenerated
  3. **X.Y.Z version alignment**: Validates that all four GxPT version fields (AssemblyVersion, AssemblyFileVersion, ApplicationVersion, ProductVersion) share the same X.Y.Z prefix

## Implementation Details
- The script uses git diff against the merge-base to compare only changes introduced in the PR (matching GitHub's PR diff view)
- Supports both pull request and push events, using appropriate base refs (`origin/{base_ref}` for PRs, `github.event.before` for pushes)
- Gracefully skips verification if no base ref is available
- Uses Perl regex patterns with look-behind assertions to extract version strings from multiple file formats (C#, XML, VBScript project files)
- Provides clear, actionable error messages when version requirements are not met

https://claude.ai/code/session_01JBnkZ76PL7eP9ZYQ5UCFoi