### PR TITLE
Document worktree convention to use .worktrees/ subdirectory

### DIFF
--- a/servers/GitMcpServer/GitTools.cs
+++ b/servers/GitMcpServer/GitTools.cs
@@ -24,7 +24,8 @@ namespace GitMcpServer
     ///   - merge/cherry-pick pass --no-edit so git never blocks on an editor.
     ///
     /// Worktrees: the <c>worktree</c> tool creates linked working trees as subdirectories of the
-    /// workspace root (confined by PathSandbox), and every tool accepts an optional <c>cwd</c>
+    /// workspace root (confined by PathSandbox), conventionally under <c>.worktrees/</c>, and every
+    /// tool accepts an optional <c>cwd</c>
     /// argument naming the subdirectory git should run in. Together these let the model carve out a
     /// worktree and then drive its whole git workflow inside it — still inside the sandbox, since a
     /// <c>cwd</c> that resolved outside GXPT_WORKDIR is rejected (servers-spec §2).
@@ -142,10 +143,10 @@ namespace GitMcpServer
                 ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Branch(config, runner, sandbox, ctx); });
 
-            server.AddTool("worktree", "Manage linked working trees (git worktree): list, add, remove, or prune. Added worktrees live in a subdirectory of the workspace root.",
+            server.AddTool("worktree", "Manage linked working trees (git worktree): list, add, remove, or prune. Added worktrees live in a subdirectory of the workspace root; by convention place them under .worktrees/ (e.g. .worktrees/feat).",
                 SchemaBuilder.Object()
                     .Str("action", false, "list | add | remove | prune (default: list)")
-                    .Str("path", false, "Worktree directory, relative to the workspace root (required for add/remove)")
+                    .Str("path", false, "Worktree directory, relative to the workspace root (required for add/remove). Prefer .worktrees/<name> (e.g. .worktrees/feat) to keep worktrees in one tidy, dotfile-hidden location.")
                     .Str("ref", false, "Commit/branch to check out in the new worktree (action=add)")
                     .Str("branch", false, "Create a new branch with this name in the new worktree (action=add, git worktree add -b)")
                     .Bool("force", false, "Force the operation (action=add/remove)")

--- a/servers/GitMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/GitMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("96b66f73-25a8-4b45-994b-d9efafcdf4f7")]
 
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.0")]


### PR DESCRIPTION
## Summary
Updated documentation and tool descriptions to establish and clarify the convention of placing git worktrees under a `.worktrees/` subdirectory within the workspace root.

## Changes
- **Class documentation**: Updated the `GitTools` class documentation to mention that worktrees are conventionally created under `.worktrees/` as a subdirectory of the workspace root
- **Tool description**: Enhanced the `worktree` tool description to explicitly recommend the `.worktrees/<name>` naming convention (e.g., `.worktrees/feat`) for organizing worktrees
- **Parameter documentation**: Expanded the `path` parameter description to provide guidance on using `.worktrees/<name>` format, emphasizing that this keeps worktrees organized in a single, dotfile-hidden location

## Details
These changes establish a clear convention for users and AI models interacting with the git worktree tool, making it easier to maintain an organized workspace structure where all worktrees are grouped together in a hidden directory rather than scattered throughout the workspace root.

https://claude.ai/code/session_01TVTxozCLX85SMXotNBoqSj