### PR TITLE
Note double-click install on the plugins page

### DIFF
--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -53,7 +53,9 @@
         </div>
         <div class="sidenote">
           <b>Installing a plugin</b><br>
-          Download the <code>.gxpl</code>, then in GxPT open the Plugins Manager and import it.
+          Download the <code>.gxpl</code> and double-click it to install (GxPT registers the file
+          type when installed via the <code>.msi</code>). Or, in GxPT, open the Plugins Manager and
+          import it &mdash; handy for portable installs.
         </div>
       </div>
 
@@ -61,8 +63,8 @@
         <div class="section">
           <h2 class="bar">Plugins</h2>
           <p>Plugins bundle <b>skills</b> and <b>sub-agents</b> you can add to GxPT. Download a
-            <code>.gxpl</code> file and import it from the in-app Plugins Manager. Plugins aren't
-            installed by default &mdash; you choose what to add.</p>
+            <code>.gxpl</code> file and double-click it to install, or import it from the in-app
+            Plugins Manager. Plugins aren't installed by default &mdash; you choose what to add.</p>
           <div id="plugin-list">
             <p id="plugin-status">Loading plugins&hellip;</p>
           </div>


### PR DESCRIPTION
Follow-up to the Xtra Powers plugin work (#238): clarify on the plugins download page how to install a `.gxpl`.

## What changed

`docs/plugins.html` only:
- **Intro paragraph** — now says a downloaded `.gxpl` can be **double-clicked to install**, with the in-app Plugins Manager import as the alternative.
- **Sidebar note** — explains double-click works because GxPT registers the `.gxpl` file type when installed via the `.msi`, and points portable-install users to the Plugins Manager.

## Why

Verified the install path in the codebase: `GxPT.Setup.vdproj` registers a `FileType` association for `.gxpl` (with an `import` verb), and `Program.cs` imports a `.gxpl` passed on the command line on startup, routing it to the plugin importer. So double-click installs for MSI-installed users; portable users use the Plugins Manager. The page now reflects both.

No code or behavior changes — documentation/site copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012BY2MLQFeBnT5EJK25mzcG)_