### PR TITLE
Add vertical spacing between plugin download button and contents link on narrow screens

### DIFF
--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -22,7 +22,7 @@
     .plugin .members li { padding: 3px 0; border-top: 1px solid #eef1f6; }
     .plugin .members .kind { display: inline-block; min-width: 46px; color: #3a5d96; font-weight: bold; }
     .plugin .members .mdesc { color: #5a6678; }
-    .plugin .pfoot { margin-top: 10px; }
+    .plugin .pfoot { margin-top: 10px; display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
     .toggle { background: none; border: 0; color: #3a5d96; cursor: pointer; padding: 0; font: inherit; text-decoration: underline; }
     #plugin-status { color: #5a6678; }
   </style>


### PR DESCRIPTION
Make the plugin card footer a flex container with an 8px gap so the
'Show contents' link no longer crowds the download button when it wraps
to a new line on mobile, matching the download page's button spacing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUHQw8rdYp41cHTqq4vB21