### PR TITLE
Add ephemeral (temporary) conversation tabs

### DIFF
--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -79,6 +79,10 @@ namespace GxPT
         public static void Save(Conversation convo)
         {
             if (convo == null) return;
+            // Ephemeral (temporary) conversations never touch disk - this is the single chokepoint every
+            // save path funnels through, so gating here makes "unsaved" hold regardless of which caller
+            // (turn completion, close, detached finalize, etc.) reaches for a save.
+            if (convo.Ephemeral) return;
             string json = ToJson(convo);
             if (json == null) return;
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -388,6 +388,8 @@ namespace GxPT
                             : null;
                         var id = ctx != null && ctx.Conversation != null ? ctx.Conversation.Id : null;
                         if (string.IsNullOrEmpty(id)) continue;
+                        // Temporary conversations die with the app - never record them as open tabs to restore.
+                        if (ctx != null && ctx.Conversation != null && ctx.Conversation.Ephemeral) continue;
                         // Include help tabs (by known help ids) even if marked NoSaveUntilUserSend
                         if (ctx != null && ctx.NoSaveUntilUserSend && !IsHelpConversationId(id)) continue;
                         list.Add(id);
@@ -3364,12 +3366,18 @@ namespace GxPT
 
         // Marker prefixed to a tab title / sidebar row once a conversation has latched ZDR.
         internal const string ZdrTitlePrefix = "[zdr] ";
+        // Marker prefixed to a temporary (ephemeral, never-saved) conversation's tab title. Analogous
+        // to the ZDR marker; the two compose (a temp conversation can also be ZDR).
+        internal const string TempTitlePrefix = "[...] ";
 
-        // The display title for a conversation: its name, prefixed with the ZDR marker once latched.
+        // The display title for a conversation: its name, prefixed with the temporary and/or ZDR
+        // markers as they apply. Both are decorators on the underlying name and stack (temp first).
         internal static string ZdrTitle(Conversation convo, string name)
         {
             string n = string.IsNullOrEmpty(name) ? "Conversation" : name;
-            return (convo != null && convo.ZdrFirstMessageIndex >= 0) ? ZdrTitlePrefix + n : n;
+            if (convo != null && convo.ZdrFirstMessageIndex >= 0) n = ZdrTitlePrefix + n;
+            if (convo != null && convo.Ephemeral) n = TempTitlePrefix + n;
+            return n;
         }
 
         // Recompute the active tab's title to reflect a newly-latched ZDR state.
@@ -3803,8 +3811,13 @@ namespace GxPT
                             && dispatcherForTurn.LastTranscripts != null)
                         {
                             AgentTranscriptStore.Put(recKey, dispatcherForTurn.LastTranscripts);
-                            try { AgentTranscriptPersistence.Save(ConvId(ctx), recKey, dispatcherForTurn.LastTranscripts); }
-                            catch { }
+                            // Ephemeral conversations leave nothing on disk - the in-memory store above
+                            // still resolves "View transcript" links for the app's lifetime.
+                            if (ctx.Conversation == null || !ctx.Conversation.Ephemeral)
+                            {
+                                try { AgentTranscriptPersistence.Save(ConvId(ctx), recKey, dispatcherForTurn.LastTranscripts); }
+                                catch { }
+                            }
                         }
                         string marker = McpMarkers.IsDenied(resultText)
                             ? McpMarkers.Denied(name)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3368,7 +3368,7 @@ namespace GxPT
         internal const string ZdrTitlePrefix = "[zdr] ";
         // Marker prefixed to a temporary (ephemeral, never-saved) conversation's tab title. Analogous
         // to the ZDR marker; the two compose (a temp conversation can also be ZDR).
-        internal const string TempTitlePrefix = "[...] ";
+        internal const string TempTitlePrefix = "[temp] ";
 
         // The display title for a conversation: its name, prefixed with the temporary and/or ZDR
         // markers as they apply. Both are decorators on the underlying name and stack (temp first).

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3368,7 +3368,7 @@ namespace GxPT
         internal const string ZdrTitlePrefix = "[zdr] ";
         // Marker prefixed to a temporary (ephemeral, never-saved) conversation's tab title. Analogous
         // to the ZDR marker; the two compose (a temp conversation can also be ZDR).
-        internal const string TempTitlePrefix = "[temp] ";
+        internal const string TempTitlePrefix = "[tmp] ";
 
         // The display title for a conversation: its name, prefixed with the temporary and/or ZDR
         // markers as they apply. Both are decorators on the underlying name and stack (temp first).

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -304,6 +304,11 @@ namespace GxPT
             var convo = new Conversation(_mainForm.GetClient());
             convo.SelectedModel = ctx.SelectedModel;
             convo.Ephemeral = ephemeral;
+            // A temporary conversation defaults to ZDR on (checked) - it's the privacy-forward choice
+            // for a chat that's already meant to leave no trace. Seed the toggle only, not the latch
+            // (ZdrFirstMessageIndex stays -1), so the checkbox is checked but still unlockable until the
+            // first send - the user can uncheck it beforehand.
+            if (ephemeral) convo.Zdr = true;
             _mainForm.EnsureConversationId(convo);
             ctx.Conversation = convo;
             // Reflect the ephemeral marker on the tab title up front (before any generated name lands).

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -981,14 +981,12 @@ namespace GxPT
                     path.AddLine(left, bottom, left, sidesTop);
                     path.AddArc(left, top, dome * 2f, dome * 2f, 180f, 180f);
                     path.AddLine(right, sidesTop, right, bottom);
-                    // Scalloped bottom, right -> left: three feet with up-notches between them.
-                    float s = (right - left) / 3f;
+                    // Scalloped bottom, right -> left: two up-notches (one fewer point than before).
+                    float s = (right - left) / 2f;
                     path.AddLine(right, bottom, right - s * 0.5f, bottom - footH);
                     path.AddLine(right - s * 0.5f, bottom - footH, right - s, bottom);
                     path.AddLine(right - s, bottom, right - s * 1.5f, bottom - footH);
-                    path.AddLine(right - s * 1.5f, bottom - footH, right - s * 2f, bottom);
-                    path.AddLine(right - s * 2f, bottom, right - s * 2.5f, bottom - footH);
-                    path.AddLine(right - s * 2.5f, bottom - footH, left, bottom);
+                    path.AddLine(right - s * 1.5f, bottom - footH, left, bottom);
                     path.CloseFigure();
                     g.DrawPath(pen, path);
                 }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -155,7 +155,7 @@ namespace GxPT
                 _miTabRename = new ToolStripMenuItem("Rename");
                 // Only meaningful for a temporary (ephemeral) tab: promotes it to a normal saved
                 // conversation. Hidden for ordinary tabs (which are already saved).
-                _miTabSaveToDisk = new ToolStripMenuItem("Save to Disk");
+                _miTabSaveToDisk = new ToolStripMenuItem("Save to History");
                 _miTabExport = new ToolStripMenuItem("Export");
                 _miTabDelete = new ToolStripMenuItem("Delete");
                 _miTabDelete.Image = ResourceManager.TryGetAssemblyImage("ExplorerDelete.png");
@@ -706,7 +706,7 @@ namespace GxPT
                 _miTabClose.Enabled = hasTarget;
                 _miTabCloseOthers.Enabled = hasTarget && _tabControl.Pages.Count > 1;
                 _miTabRename.Enabled = hasTarget;
-                // "Save to Disk" only appears for a temporary tab - it converts it to a normal saved one.
+                // "Save to History" only appears for a temporary tab - it converts it to a normal saved one.
                 _miTabSaveToDisk.Visible = hasTarget && IsEphemeralTab(_tabCtxTarget);
                 // Export packages the conversation's saved file (like the sidebar's Export), and
                 // Delete removes it - both need the file to exist. A brand-new, message-less tab

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -26,6 +26,7 @@ namespace GxPT
 
         // Custom toolbar buttons
         private GlyphToolStripButton _btnNewTab;
+        private GlyphToolStripButton _btnNewTempTab;
         private GlyphToolStripButton _btnCloseTab;
 
         public event Action<KryptonPage> TabSelected;
@@ -184,14 +185,23 @@ namespace GxPT
                     _btnNewTab.Click += delegate { CreateConversationTab(); };
                     _btnNewTab.Alignment = ToolStripItemAlignment.Right;
 
+                    _btnNewTempTab = new GlyphToolStripButton(GlyphToolStripButton.GlyphType.Ghost);
+                    _btnNewTempTab.Margin = new Padding(2, 2, 2, 2);
+                    _btnNewTempTab.ToolTipText = "New Temporary Tab (not saved to disk)";
+                    _btnNewTempTab.Click += delegate { CreateEphemeralConversationTab(); };
+                    _btnNewTempTab.Alignment = ToolStripItemAlignment.Right;
+
                     _btnCloseTab = new GlyphToolStripButton(GlyphToolStripButton.GlyphType.Close);
                     _btnCloseTab.Margin = new Padding(2, 2, 3, 2);
                     _btnCloseTab.ToolTipText = "Close Tab";
                     _btnCloseTab.Click += delegate { CloseActiveConversationTab(); };
                     _btnCloseTab.Alignment = ToolStripItemAlignment.Right;
 
+                    // Right-aligned items lay out right-to-left in add order, so this yields a
+                    // left-to-right visual order of: [ghost] [+] [x].
                     menuStrip.Items.Add(_btnCloseTab);
                     menuStrip.Items.Add(_btnNewTab);
+                    menuStrip.Items.Add(_btnNewTempTab);
                 }
             }
             catch { }
@@ -253,6 +263,19 @@ namespace GxPT
 
         public ChatTabContext CreateConversationTab()
         {
+            return CreateConversationTab(false);
+        }
+
+        // Create a temporary (ephemeral) conversation tab: identical to a normal new tab except the
+        // conversation is flagged Ephemeral, so it is never saved to disk, never listed in the history
+        // sidebar, and not restored on the next launch. Its tab title carries the "[...] " marker.
+        public ChatTabContext CreateEphemeralConversationTab()
+        {
+            return CreateConversationTab(true);
+        }
+
+        private ChatTabContext CreateConversationTab(bool ephemeral)
+        {
             if (_tabControl == null) return null;
 
             var page = new KryptonPage("New Conversation");
@@ -275,8 +298,15 @@ namespace GxPT
             // map (a brand-new Conversation has no id until EnsureConversationId runs).
             var convo = new Conversation(_mainForm.GetClient());
             convo.SelectedModel = ctx.SelectedModel;
+            convo.Ephemeral = ephemeral;
             _mainForm.EnsureConversationId(convo);
             ctx.Conversation = convo;
+            // Reflect the ephemeral marker on the tab title up front (before any generated name lands).
+            if (ephemeral)
+            {
+                try { page.Text = MainForm.ZdrTitle(convo, convo.Name); }
+                catch { }
+            }
 
             // Wire edit-request, retry and name-generated handlers for this tab
             HookEditRequest(ctx);
@@ -884,7 +914,7 @@ namespace GxPT
         // uses for the menu-bar text so it blends with File/View/Help.
         private sealed class GlyphToolStripButton : ToolStripButton
         {
-            public enum GlyphType { Plus, Close }
+            public enum GlyphType { Plus, Close, Ghost }
             private readonly GlyphType _glyph;
 
             public GlyphToolStripButton(GlyphType glyph)
@@ -919,11 +949,48 @@ namespace GxPT
                         g.DrawLine(pen, cx - len, cy, cx + len, cy);
                         g.DrawLine(pen, cx, cy - len, cx, cy + len);
                     }
-                    else
+                    else if (_glyph == GlyphType.Close)
                     {
                         g.DrawLine(pen, cx - len, cy - len, cx + len, cy + len);
                         g.DrawLine(pen, cx - len, cy + len, cx + len, cy - len);
                     }
+                    else // Ghost: a little pac-man style ghost (rounded dome + scalloped feet)
+                    {
+                        DrawGhost(g, pen, cx, cy);
+                    }
+                }
+            }
+
+            // Stroked ghost outline only (semicircular dome on top, three scalloped feet at the
+            // bottom), centered at (cx, cy). Line-art style to match the +/x glyphs.
+            private static void DrawGhost(Graphics g, Pen pen, int cx, int cy)
+            {
+                float hw = 6f;              // half width of the body
+                float top = cy - 7f;        // top of the dome
+                float bottom = cy + 6f;     // baseline the feet hang from
+                float left = cx - hw;
+                float right = cx + hw;
+                float dome = hw;            // dome radius (spans the full width)
+                float sidesTop = top + dome; // y where the straight sides meet the dome
+                float footH = 2.5f;         // depth of the scallop notches
+
+                using (var path = new System.Drawing.Drawing2D.GraphicsPath())
+                {
+                    path.StartFigure();
+                    // Left side up, over the dome, right side down.
+                    path.AddLine(left, bottom, left, sidesTop);
+                    path.AddArc(left, top, dome * 2f, dome * 2f, 180f, 180f);
+                    path.AddLine(right, sidesTop, right, bottom);
+                    // Scalloped bottom, right -> left: three feet with up-notches between them.
+                    float s = (right - left) / 3f;
+                    path.AddLine(right, bottom, right - s * 0.5f, bottom - footH);
+                    path.AddLine(right - s * 0.5f, bottom - footH, right - s, bottom);
+                    path.AddLine(right - s, bottom, right - s * 1.5f, bottom - footH);
+                    path.AddLine(right - s * 1.5f, bottom - footH, right - s * 2f, bottom);
+                    path.AddLine(right - s * 2f, bottom, right - s * 2.5f, bottom - footH);
+                    path.AddLine(right - s * 2.5f, bottom - footH, left, bottom);
+                    path.CloseFigure();
+                    g.DrawPath(pen, path);
                 }
             }
         }

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -268,7 +268,7 @@ namespace GxPT
 
         // Create a temporary (ephemeral) conversation tab: identical to a normal new tab except the
         // conversation is flagged Ephemeral, so it is never saved to disk, never listed in the history
-        // sidebar, and not restored on the next launch. Its tab title carries the "[...] " marker.
+        // sidebar, and not restored on the next launch. Its tab title carries the "[temp] " marker.
         public ChatTabContext CreateEphemeralConversationTab()
         {
             return CreateConversationTab(true);

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -20,6 +20,7 @@ namespace GxPT
         private ToolStripMenuItem _miTabCloseOthers;
         private ToolStripMenuItem _miTabWorkdir;
         private ToolStripMenuItem _miTabRename;
+        private ToolStripMenuItem _miTabSaveToDisk;
         private ToolStripMenuItem _miTabExport;
         private ToolStripMenuItem _miTabDelete;
         private KryptonPage _tabCtxTarget;
@@ -152,6 +153,9 @@ namespace GxPT
                 _miTabCloseOthers = new ToolStripMenuItem("Close Others");
                 _miTabWorkdir = new ToolStripMenuItem("Set Working Folder...");
                 _miTabRename = new ToolStripMenuItem("Rename");
+                // Only meaningful for a temporary (ephemeral) tab: promotes it to a normal saved
+                // conversation. Hidden for ordinary tabs (which are already saved).
+                _miTabSaveToDisk = new ToolStripMenuItem("Save to Disk");
                 _miTabExport = new ToolStripMenuItem("Export");
                 _miTabDelete = new ToolStripMenuItem("Delete");
                 _miTabDelete.Image = ResourceManager.TryGetAssemblyImage("ExplorerDelete.png");
@@ -161,10 +165,11 @@ namespace GxPT
                 _miTabCloseOthers.Click += delegate { if (_tabCtxTarget != null) CloseOtherTabs(_tabCtxTarget); };
                 _miTabWorkdir.Click += delegate { if (_tabCtxTarget != null) _mainForm.SetWorkingFolderForTab(_tabCtxTarget); };
                 _miTabRename.Click += delegate { if (_tabCtxTarget != null) RenameConversationTab(_tabCtxTarget); };
+                _miTabSaveToDisk.Click += delegate { if (_tabCtxTarget != null) SaveEphemeralTabToDisk(_tabCtxTarget); };
                 _miTabExport.Click += delegate { if (_tabCtxTarget != null) ExportConversationTab(_tabCtxTarget); };
                 _miTabDelete.Click += delegate { if (_tabCtxTarget != null) DeleteConversationTab(_tabCtxTarget); };
 
-                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabWorkdir, _miTabRename, _miTabExport, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers, new ToolStripSeparator(), _miTabDelete });
+                _tabCtxMenu.Items.AddRange(new ToolStripItem[] { _miTabNew, new ToolStripSeparator(), _miTabWorkdir, _miTabRename, _miTabSaveToDisk, _miTabExport, new ToolStripSeparator(), _miTabClose, _miTabCloseOthers, new ToolStripSeparator(), _miTabDelete });
             }
             catch { }
         }
@@ -268,7 +273,7 @@ namespace GxPT
 
         // Create a temporary (ephemeral) conversation tab: identical to a normal new tab except the
         // conversation is flagged Ephemeral, so it is never saved to disk, never listed in the history
-        // sidebar, and not restored on the next launch. Its tab title carries the "[temp] " marker.
+        // sidebar, and not restored on the next launch. Its tab title carries the "[tmp] " marker.
         public ChatTabContext CreateEphemeralConversationTab()
         {
             return CreateConversationTab(true);
@@ -373,6 +378,54 @@ namespace GxPT
                 return !string.IsNullOrEmpty(path) && System.IO.File.Exists(path);
             }
             catch { return false; }
+        }
+
+        // True when the tab backs a temporary (ephemeral) conversation.
+        private bool IsEphemeralTab(KryptonPage page)
+        {
+            try
+            {
+                ChatTabContext ctx;
+                return page != null && _tabContexts.TryGetValue(page, out ctx)
+                    && ctx != null && ctx.Conversation != null && ctx.Conversation.Ephemeral;
+            }
+            catch { return false; }
+        }
+
+        // Promote a temporary (ephemeral) tab to a normal, persisted conversation: clear the Ephemeral
+        // flag so ConversationStore.Save no longer short-circuits, drop the "[tmp] " tab marker, and
+        // write it out now (surfacing it in the history sidebar). An empty conversation isn't written
+        // yet - like any fresh tab it lands on disk with its first user send. No-op for a normal tab.
+        public void SaveEphemeralTabToDisk(KryptonPage page)
+        {
+            try
+            {
+                ChatTabContext ctx;
+                if (page == null || !_tabContexts.TryGetValue(page, out ctx) || ctx == null || ctx.Conversation == null)
+                    return;
+                if (!ctx.Conversation.Ephemeral) return;
+
+                ctx.Conversation.Ephemeral = false;
+                try { page.Text = MainForm.ZdrTitle(ctx.Conversation, ctx.Conversation.Name); }
+                catch { }
+                _mainForm.UpdateWindowTitle();
+
+                // Persist immediately when there's something to keep; refresh the sidebar so the newly
+                // saved conversation appears. A race with a running turn's history mutation throws and
+                // is skipped - the next regular save catches up.
+                try
+                {
+                    if (ctx.Conversation.History != null && ctx.Conversation.History.Count > 0)
+                    {
+                        ctx.NoSaveUntilUserSend = false;
+                        ConversationStore.Save(ctx.Conversation);
+                        var sidebar = _mainForm.GetSidebarManager();
+                        if (sidebar != null) sidebar.RefreshSidebarList();
+                    }
+                }
+                catch { }
+            }
+            catch { }
         }
 
         // Export the conversation backing a tab: the single-conversation export, identical to the
@@ -648,6 +701,8 @@ namespace GxPT
                 _miTabClose.Enabled = hasTarget;
                 _miTabCloseOthers.Enabled = hasTarget && _tabControl.Pages.Count > 1;
                 _miTabRename.Enabled = hasTarget;
+                // "Save to Disk" only appears for a temporary tab - it converts it to a normal saved one.
+                _miTabSaveToDisk.Visible = hasTarget && IsEphemeralTab(_tabCtxTarget);
                 // Export packages the conversation's saved file (like the sidebar's Export), and
                 // Delete removes it - both need the file to exist. A brand-new, message-less tab
                 // has nothing to export or delete.

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -54,7 +54,7 @@ namespace GxPT
         // never written to disk (ConversationStore.Save short-circuits on this flag), never appears in
         // the history sidebar (that list is built from disk files), and is not restored on the next
         // launch. Runtime-only and intentionally NOT part of the persisted DTO - once the tab closes or
-        // the app exits, the conversation is gone. Shown with a "[...] " marker on its tab title.
+        // the app exits, the conversation is gone. Shown with a "[temp] " marker on its tab title.
         public bool Ephemeral { get; set; }
         // Per-conversation skill enablement overrides (design S10/sec.7), combined with the global default
         // (skills.json) by SkillResolve. SkillsFeatureOff: null = inherit global, true/false = force the

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -50,6 +50,12 @@ namespace GxPT
         // never clears, so the checkbox locks on and the tab/messages are marked from that point.
         public bool Zdr { get; set; }
         public int ZdrFirstMessageIndex { get; set; }
+        // Temporary (ephemeral) conversation: lives only in memory for the lifetime of the app. It is
+        // never written to disk (ConversationStore.Save short-circuits on this flag), never appears in
+        // the history sidebar (that list is built from disk files), and is not restored on the next
+        // launch. Runtime-only and intentionally NOT part of the persisted DTO - once the tab closes or
+        // the app exits, the conversation is gone. Shown with a "[...] " marker on its tab title.
+        public bool Ephemeral { get; set; }
         // Per-conversation skill enablement overrides (design S10/sec.7), combined with the global default
         // (skills.json) by SkillResolve. SkillsFeatureOff: null = inherit global, true/false = force the
         // whole feature off/on for this conversation. SkillOverrides: slug -> bool (true = force on, false

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -54,7 +54,7 @@ namespace GxPT
         // never written to disk (ConversationStore.Save short-circuits on this flag), never appears in
         // the history sidebar (that list is built from disk files), and is not restored on the next
         // launch. Runtime-only and intentionally NOT part of the persisted DTO - once the tab closes or
-        // the app exits, the conversation is gone. Shown with a "[temp] " marker on its tab title.
+        // the app exits, the conversation is gone. Shown with a "[tmp] " marker on its tab title.
         public bool Ephemeral { get; set; }
         // Per-conversation skill enablement overrides (design S10/sec.7), combined with the global default
         // (skills.json) by SkillResolve. SkillsFeatureOff: null = inherit global, true/false = force the


### PR DESCRIPTION
## Summary
This PR introduces support for ephemeral (temporary) conversation tabs that exist only in memory during the app's lifetime. These tabs are never persisted to disk, don't appear in the history sidebar, and are not restored on the next launch.

## Key Changes

- **New UI Controls**: Added a "New Temporary Tab" toolbar button with a ghost glyph icon, alongside the existing "New Tab" button
- **Tab Context Menu**: Added "Save to History" menu item that promotes an ephemeral tab to a normal persisted conversation
- **Ephemeral Flag**: Added `Ephemeral` property to `Conversation` model to mark temporary conversations
- **Persistence Layer**: Modified `ConversationStore.Save()` to skip writing ephemeral conversations to disk
- **Tab Restoration**: Updated `GetOpenConversationIdsInOrder()` to exclude ephemeral conversations from the list of tabs to restore on app launch
- **Tab Titles**: Ephemeral conversations display a `[tmp]` prefix on their tab titles (composable with existing `[zdr]` marker)
- **Privacy Defaults**: Ephemeral conversations default to ZDR (Zero Data Retention) enabled for privacy-forward behavior
- **Transcript Handling**: Agent transcripts for ephemeral conversations are kept in memory but not persisted to disk
- **Ghost Glyph**: Implemented new `GlyphType.Ghost` button glyph (pac-man style ghost outline) to visually distinguish the temporary tab button

## Implementation Details

- The ephemeral flag is runtime-only and intentionally NOT part of the persisted conversation DTO
- `SaveEphemeralTabToDisk()` method allows users to convert a temporary tab to a normal saved conversation
- All save paths funnel through `ConversationStore.Save()`, making it the single chokepoint for enforcing the ephemeral behavior
- Tab title markers stack when applicable (e.g., `[tmp] [zdr] Conversation Name`)
- Empty ephemeral conversations are not written to disk even when promoted, following the same pattern as new tabs

https://claude.ai/code/session_01N6TRYGKAtRjV82ajmEh4gN