### PR TITLE
Add capability badges to model combo boxes

### DIFF
--- a/GxPT/Controls/ModelComboBox.cs
+++ b/GxPT/Controls/ModelComboBox.cs
@@ -10,9 +10,15 @@ namespace GxPT
     // stripped) while storing the full "author/model" id, and auto-sizes its dropdown to fit.
     //
     // Shared by the main window's model selector (cmbModel) and the settings effort-tier pickers.
-    // No owner-draw: KryptonComboBox paints its own closed box from the item's ToString(), so a small
-    // display wrapper is used instead - that way BOTH the closed box and the dropdown show the short
-    // name (owner-draw only reached the dropdown). Callers work in full ids via SetModels/SelectedModelId.
+    // The item's ToString() is always the bare short name: KryptonComboBox paints its own closed box
+    // from ToString() (owner-draw only reaches the dropdown rows), and Sorted sorts on it - so the
+    // closed box and sort order stay clean regardless of the badge feature below.
+    //
+    // ShowCapabilityBadges (opt-in, off by default) turns on owner-draw so the DROPDOWN ROWS append a
+    // "[v]"/"[f]" capability suffix from the model catalog; the closed box keeps the bare name because
+    // Krypton paints it from ToString(). The settings effort combos leave it off and behave exactly as
+    // before; only the main window's model selector sets it on. Callers work in full ids via
+    // SetModels/SelectedModelId.
     internal class ModelComboBox : KryptonComboBox
     {
         // Combo item that displays the short model name but remembers the full id. Equality is on the
@@ -37,6 +43,25 @@ namespace GxPT
         {
             DropDownStyle = ComboBoxStyle.DropDownList;
             DropDown += delegate { AdjustDropDownWidth(); };
+            DrawItem += OnDrawModelItem;
+        }
+
+        private bool _showCapabilityBadges;
+
+        // When true, dropdown rows append a "[v]"/"[f]" capability suffix (vision / file input) read
+        // from the model catalog. Off by default so the settings effort combos render bare names.
+        // Toggling flips owner-draw on/off; the closed box is unaffected (Krypton paints it from
+        // ToString()), so only the dropdown gains the badges.
+        public bool ShowCapabilityBadges
+        {
+            get { return _showCapabilityBadges; }
+            set
+            {
+                if (_showCapabilityBadges == value) return;
+                _showCapabilityBadges = value;
+                DrawMode = value ? DrawMode.OwnerDrawFixed : DrawMode.Normal;
+                AdjustDropDownWidth();
+            }
         }
 
         // Replace the item list with the given model ids and select selectedId (added if not present,
@@ -87,7 +112,80 @@ namespace GxPT
             return -1;
         }
 
-        // Widen the dropdown to fit the longest (short) item text; never narrower than the control.
+        // The text shown for an item in the dropdown: the short model name, plus a " [v]"/" [f]"
+        // capability suffix when ShowCapabilityBadges is on and the catalog knows the model. Unknown
+        // models (not yet fetched) get no suffix rather than a misleading one.
+        private string DisplayText(int index) { return DisplayText(index, true); }
+
+        private string DisplayText(int index, bool withBadge)
+        {
+            object raw = (index >= 0 && index < Items.Count) ? Items[index] : null;
+            Item it = raw as Item;
+            if (it == null) return raw != null ? raw.ToString() : string.Empty;
+
+            string text = it.ToString(); // MainForm.ShortModelName(Id)
+            if (!_showCapabilityBadges || !withBadge) return text;
+
+            ModelInfo info;
+            if (!ModelCatalogService.TryGetModelInfo(it.Id, out info) || info == null) return text;
+            if (info.SupportsImageInput) text += " [v]";
+            if (info.SupportsFileInput) text += " [f]";
+            return text;
+        }
+
+        // Owner-draw for the dropdown rows (only invoked while DrawMode != Normal, i.e. when
+        // ShowCapabilityBadges is on). Theme-aware so the badged dropdown matches the rest of the UI;
+        // the selected row uses the system highlight for guaranteed contrast.
+        private void OnDrawModelItem(object sender, DrawItemEventArgs e)
+        {
+            if (e.Index < 0)
+            {
+                e.DrawBackground();
+                e.DrawFocusRectangle();
+                return;
+            }
+
+            bool selected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
+            // The closed-box (edit portion) keeps the bare name - badges are a dropdown-only affordance.
+            // Krypton paints the closed box from ToString() and normally doesn't route it here, but guard
+            // against it in case it ever does.
+            bool isEditPortion = (e.State & DrawItemState.ComboBoxEdit) == DrawItemState.ComboBoxEdit;
+            ThemeColors colors;
+            try { colors = ThemeService.GetColors(IsDarkTheme()); }
+            catch { colors = null; }
+
+            Color back = selected
+                ? SystemColors.Highlight
+                : (colors != null ? colors.UiBackground : SystemColors.Window);
+            Color fore = selected
+                ? SystemColors.HighlightText
+                : (colors != null ? colors.UiForeground : SystemColors.WindowText);
+
+            using (SolidBrush b = new SolidBrush(back))
+                e.Graphics.FillRectangle(b, e.Bounds);
+
+            TextRenderer.DrawText(e.Graphics, DisplayText(e.Index, !isEditPortion), e.Font ?? Font, e.Bounds, fore,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine
+                    | TextFormatFlags.NoPrefix);
+
+            e.DrawFocusRectangle();
+        }
+
+        // True when the active app theme is dark (mirrors ThemeManager.IsDarkTheme so this control
+        // doesn't need a back-reference to the form).
+        private static bool IsDarkTheme()
+        {
+            try
+            {
+                string theme = AppSettings.GetString("theme");
+                return !string.IsNullOrEmpty(theme) &&
+                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        // Widen the dropdown to fit the longest displayed item text (badges included); never narrower
+        // than the control.
         private void AdjustDropDownWidth()
         {
             try
@@ -97,7 +195,7 @@ namespace GxPT
                 {
                     for (int i = 0; i < Items.Count; i++)
                     {
-                        string s = Items[i] != null ? Items[i].ToString() : string.Empty;
+                        string s = DisplayText(i);
                         if (s.Length == 0) continue;
                         int w = TextRenderer.MeasureText(g, s, Font,
                             new Size(int.MaxValue, int.MaxValue), TextFormatFlags.SingleLine).Width;

--- a/GxPT/Controls/ModelComboBox.cs
+++ b/GxPT/Controls/ModelComboBox.cs
@@ -10,24 +10,29 @@ namespace GxPT
     // stripped) while storing the full "author/model" id, and auto-sizes its dropdown to fit.
     //
     // Shared by the main window's model selector (cmbModel) and the settings effort-tier pickers.
-    // The item's ToString() is always the bare short name: KryptonComboBox paints its own closed box
-    // from ToString() (owner-draw only reaches the dropdown rows), and Sorted sorts on it - so the
-    // closed box and sort order stay clean regardless of the badge feature below.
-    //
-    // ShowCapabilityBadges (opt-in, off by default) turns on owner-draw so the DROPDOWN ROWS append a
-    // "[v]"/"[f]" capability suffix from the model catalog; the closed box keeps the bare name because
-    // Krypton paints it from ToString(). The settings effort combos leave it off and behave exactly as
-    // before; only the main window's model selector sets it on. Callers work in full ids via
-    // SetModels/SelectedModelId.
+    // KryptonComboBox paints BOTH its closed box and its dropdown rows from the item's ToString(), and
+    // this build of Krypton never raises DrawItem, so owner-draw can't be used to badge only the
+    // dropdown. Instead ToString() itself appends the capability suffix when ShowCapabilityBadges is on
+    // (main window), and returns the bare name when off (settings) - so the two use sites differ by one
+    // flag, not a forked control. Callers work in full ids via SetModels/SelectedModelId.
     internal class ModelComboBox : KryptonComboBox
     {
-        // Combo item that displays the short model name but remembers the full id. Equality is on the
-        // id (case-insensitive) so selection/lookup resolve to the right entry.
+        // Combo item that displays the short model name (plus a "[v]"/"[f]" capability badge when its
+        // owner has ShowCapabilityBadges on) but remembers the full id. Equality is on the id
+        // (case-insensitive) so selection/lookup resolve to the right entry, and sorting - which keys on
+        // ToString() - stays by name because the badge is only ever a trailing suffix.
         private sealed class Item
         {
             public readonly string Id;
-            public Item(string id) { Id = id ?? string.Empty; }
-            public override string ToString() { return MainForm.ShortModelName(Id); }
+            private readonly ModelComboBox _owner;
+            public Item(ModelComboBox owner, string id) { _owner = owner; Id = id ?? string.Empty; }
+            public override string ToString()
+            {
+                string name = MainForm.ShortModelName(Id);
+                return (_owner != null && _owner._showCapabilityBadges)
+                    ? name + _owner.CapabilitySuffix(Id)
+                    : name;
+            }
             public override bool Equals(object obj)
             {
                 Item o = obj as Item;
@@ -43,15 +48,15 @@ namespace GxPT
         {
             DropDownStyle = ComboBoxStyle.DropDownList;
             DropDown += delegate { AdjustDropDownWidth(); };
-            DrawItem += OnDrawModelItem;
         }
 
         private bool _showCapabilityBadges;
 
-        // When true, dropdown rows append a "[v]"/"[f]" capability suffix (vision / file input) read
-        // from the model catalog. Off by default so the settings effort combos render bare names.
-        // Toggling flips owner-draw on/off; the closed box is unaffected (Krypton paints it from
-        // ToString()), so only the dropdown gains the badges.
+        // When true, each item's displayed text gains a " [v]" (vision / image input) and/or " [f]"
+        // (native file input) suffix read from the model catalog - in both the dropdown and the closed
+        // box, since Krypton paints both from ToString(). Off by default, so the settings effort combos
+        // render bare model names. Models the catalog doesn't know get no suffix rather than a
+        // misleading one.
         public bool ShowCapabilityBadges
         {
             get { return _showCapabilityBadges; }
@@ -59,9 +64,32 @@ namespace GxPT
             {
                 if (_showCapabilityBadges == value) return;
                 _showCapabilityBadges = value;
-                DrawMode = value ? DrawMode.OwnerDrawFixed : DrawMode.Normal;
-                AdjustDropDownWidth();
+                RefreshItemDisplay();
             }
+        }
+
+        // The " [v]"/" [f]" suffix for a model id, or "" when the catalog has no info for it.
+        private string CapabilitySuffix(string id)
+        {
+            ModelInfo info;
+            if (!ModelCatalogService.TryGetModelInfo(id, out info) || info == null) return string.Empty;
+            string s = string.Empty;
+            if (info.SupportsImageInput) s += " [v]";
+            if (info.SupportsFileInput) s += " [f]";
+            return s;
+        }
+
+        // Force the closed box and dropdown to re-read ToString() after the badge flag flips. In
+        // practice the flag is set once at construction (before items are populated), so this is a
+        // no-op safety net for a runtime toggle.
+        private void RefreshItemDisplay()
+        {
+            try
+            {
+                AdjustDropDownWidth();
+                if (IsHandleCreated) Invalidate();
+            }
+            catch { }
         }
 
         // Replace the item list with the given model ids and select selectedId (added if not present,
@@ -74,10 +102,10 @@ namespace GxPT
                 Items.Clear();
                 if (ids != null)
                     foreach (string id in ids)
-                        if (!string.IsNullOrEmpty(id)) Items.Add(new Item(id));
+                        if (!string.IsNullOrEmpty(id)) Items.Add(new Item(this, id));
 
                 string sel = selectedId ?? string.Empty;
-                if (sel.Length > 0 && IndexOfId(sel) < 0) Items.Add(new Item(sel));
+                if (sel.Length > 0 && IndexOfId(sel) < 0) Items.Add(new Item(this, sel));
                 SelectId(sel);
             }
             finally { EndUpdate(); }
@@ -92,7 +120,7 @@ namespace GxPT
             set
             {
                 string sel = value ?? string.Empty;
-                if (sel.Length > 0 && IndexOfId(sel) < 0) Items.Add(new Item(sel));
+                if (sel.Length > 0 && IndexOfId(sel) < 0) Items.Add(new Item(this, sel));
                 SelectId(sel);
             }
         }
@@ -112,87 +140,6 @@ namespace GxPT
             return -1;
         }
 
-        // The text shown for an item in the dropdown: the short model name, plus a " [v]"/" [f]"
-        // capability suffix when ShowCapabilityBadges is on and the catalog knows the model. Unknown
-        // models (not yet fetched) get no suffix rather than a misleading one.
-        private string DisplayText(int index) { return DisplayText(index, true); }
-
-        private string DisplayText(int index, bool withBadge)
-        {
-            object raw = (index >= 0 && index < Items.Count) ? Items[index] : null;
-            Item it = raw as Item;
-            if (it == null) return raw != null ? raw.ToString() : string.Empty;
-
-            string text = it.ToString(); // MainForm.ShortModelName(Id)
-            if (!_showCapabilityBadges || !withBadge) return text;
-
-            ModelInfo info;
-            bool hit = ModelCatalogService.TryGetModelInfo(it.Id, out info) && info != null;
-            try
-            {
-                Logger.Log("ModelCombo", "badge lookup id=" + it.Id + " hit=" + hit
-                    + (hit ? (" img=" + info.SupportsImageInput + " file=" + info.SupportsFileInput) : ""));
-            }
-            catch { }
-            if (!hit) return text + " [?]"; // TEMP diagnostic: catalog has no info for this id
-            if (info.SupportsImageInput) text += " [v]";
-            if (info.SupportsFileInput) text += " [f]";
-            return text;
-        }
-
-        // Owner-draw for the dropdown rows (only invoked while DrawMode != Normal, i.e. when
-        // ShowCapabilityBadges is on). Theme-aware so the badged dropdown matches the rest of the UI;
-        // the selected row uses the system highlight for guaranteed contrast.
-        private void OnDrawModelItem(object sender, DrawItemEventArgs e)
-        {
-            try { Logger.Log("ModelCombo", "DrawItem fired idx=" + e.Index + " state=" + e.State + " badges=" + _showCapabilityBadges); }
-            catch { }
-            if (e.Index < 0)
-            {
-                e.DrawBackground();
-                e.DrawFocusRectangle();
-                return;
-            }
-
-            bool selected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
-            // The closed-box (edit portion) keeps the bare name - badges are a dropdown-only affordance.
-            // Krypton paints the closed box from ToString() and normally doesn't route it here, but guard
-            // against it in case it ever does.
-            bool isEditPortion = (e.State & DrawItemState.ComboBoxEdit) == DrawItemState.ComboBoxEdit;
-            ThemeColors colors;
-            try { colors = ThemeService.GetColors(IsDarkTheme()); }
-            catch { colors = null; }
-
-            Color back = selected
-                ? SystemColors.Highlight
-                : (colors != null ? colors.UiBackground : SystemColors.Window);
-            Color fore = selected
-                ? SystemColors.HighlightText
-                : (colors != null ? colors.UiForeground : SystemColors.WindowText);
-
-            using (SolidBrush b = new SolidBrush(back))
-                e.Graphics.FillRectangle(b, e.Bounds);
-
-            TextRenderer.DrawText(e.Graphics, DisplayText(e.Index, !isEditPortion), e.Font ?? Font, e.Bounds, fore,
-                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine
-                    | TextFormatFlags.NoPrefix);
-
-            e.DrawFocusRectangle();
-        }
-
-        // True when the active app theme is dark (mirrors ThemeManager.IsDarkTheme so this control
-        // doesn't need a back-reference to the form).
-        private static bool IsDarkTheme()
-        {
-            try
-            {
-                string theme = AppSettings.GetString("theme");
-                return !string.IsNullOrEmpty(theme) &&
-                    theme.Trim().Equals("dark", StringComparison.OrdinalIgnoreCase);
-            }
-            catch { return false; }
-        }
-
         // Widen the dropdown to fit the longest displayed item text (badges included); never narrower
         // than the control.
         private void AdjustDropDownWidth()
@@ -204,7 +151,7 @@ namespace GxPT
                 {
                     for (int i = 0; i < Items.Count; i++)
                     {
-                        string s = DisplayText(i);
+                        string s = Items[i] != null ? Items[i].ToString() : string.Empty;
                         if (s.Length == 0) continue;
                         int w = TextRenderer.MeasureText(g, s, Font,
                             new Size(int.MaxValue, int.MaxValue), TextFormatFlags.SingleLine).Width;

--- a/GxPT/Controls/ModelComboBox.cs
+++ b/GxPT/Controls/ModelComboBox.cs
@@ -127,7 +127,14 @@ namespace GxPT
             if (!_showCapabilityBadges || !withBadge) return text;
 
             ModelInfo info;
-            if (!ModelCatalogService.TryGetModelInfo(it.Id, out info) || info == null) return text;
+            bool hit = ModelCatalogService.TryGetModelInfo(it.Id, out info) && info != null;
+            try
+            {
+                Logger.Log("ModelCombo", "badge lookup id=" + it.Id + " hit=" + hit
+                    + (hit ? (" img=" + info.SupportsImageInput + " file=" + info.SupportsFileInput) : ""));
+            }
+            catch { }
+            if (!hit) return text + " [?]"; // TEMP diagnostic: catalog has no info for this id
             if (info.SupportsImageInput) text += " [v]";
             if (info.SupportsFileInput) text += " [f]";
             return text;
@@ -138,6 +145,8 @@ namespace GxPT
         // the selected row uses the system highlight for guaranteed contrast.
         private void OnDrawModelItem(object sender, DrawItemEventArgs e)
         {
+            try { Logger.Log("ModelCombo", "DrawItem fired idx=" + e.Index + " state=" + e.State + " badges=" + _showCapabilityBadges); }
+            catch { }
             if (e.Index < 0)
             {
                 e.DrawBackground();

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -438,6 +438,9 @@
             this.cmbModel.Location = new System.Drawing.Point(0, 0);
             this.cmbModel.Margin = new System.Windows.Forms.Padding(0);
             this.cmbModel.Name = "cmbModel";
+            // Dropdown rows show a [v]/[f] vision/file-attachment badge from the model catalog; the
+            // settings effort combos leave this off and render bare model names.
+            this.cmbModel.ShowCapabilityBadges = true;
             this.cmbModel.Size = new System.Drawing.Size(146, 21);
             this.cmbModel.Sorted = true;
             this.cmbModel.TabIndex = 2;

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -441,7 +441,10 @@
             // Dropdown rows show a [v]/[f] vision/file-attachment badge from the model catalog; the
             // settings effort combos leave this off and render bare model names.
             this.cmbModel.ShowCapabilityBadges = true;
-            this.cmbModel.Size = new System.Drawing.Size(146, 21);
+            // Widened from 146 so the selected model's "[v]/[f]" capability badge (ShowCapabilityBadges)
+            // fits in the closed box; the ZDR checkbox is Dock.Right so it isn't affected. The dropdown
+            // self-sizes wider still to fit the full badged text.
+            this.cmbModel.Size = new System.Drawing.Size(184, 21);
             this.cmbModel.Sorted = true;
             this.cmbModel.TabIndex = 2;
             // 

--- a/GxPT/Forms/MainForm.Designer.cs
+++ b/GxPT/Forms/MainForm.Designer.cs
@@ -441,10 +441,10 @@
             // Dropdown rows show a [v]/[f] vision/file-attachment badge from the model catalog; the
             // settings effort combos leave this off and render bare model names.
             this.cmbModel.ShowCapabilityBadges = true;
-            // Widened from 146 so the selected model's "[v]/[f]" capability badge (ShowCapabilityBadges)
-            // fits in the closed box; the ZDR checkbox is Dock.Right so it isn't affected. The dropdown
-            // self-sizes wider still to fit the full badged text.
-            this.cmbModel.Size = new System.Drawing.Size(184, 21);
+            // Fixed width - do not grow this to fit the "[v]/[f]" badge, or it clips the Dock.Right ZDR
+            // checkbox. The closed box truncates a long selected name+badge gracefully; the dropdown
+            // still self-sizes wider (DropDownWidth) to show the full badged text.
+            this.cmbModel.Size = new System.Drawing.Size(146, 21);
             this.cmbModel.Sorted = true;
             this.cmbModel.TabIndex = 2;
             // 


### PR DESCRIPTION
## Summary
Enhanced the `ModelComboBox` control to display model capability badges (vision `[v]` and file input `[f]` indicators) in both the dropdown and closed box, controlled by a new `ShowCapabilityBadges` property.

## Key Changes
- **Added `ShowCapabilityBadges` property** to `ModelComboBox` that controls whether capability badges are displayed. When enabled, badges are appended to model names via `ToString()`, allowing both the dropdown and closed box to show them (since Krypton paints both from `ToString()`).

- **Modified `Item` class** to accept a reference to its parent `ModelComboBox` owner, enabling each item to query the badge flag and model catalog info when rendering its display text.

- **Implemented `CapabilitySuffix()` method** that queries the `ModelCatalogService` to determine which capability badges (`[v]` for vision/image input, `[f]` for file input) apply to a given model id.

- **Added `RefreshItemDisplay()` method** to invalidate the control when the badge flag changes at runtime, ensuring both the closed box and dropdown re-render with updated text.

- **Updated all `Item` instantiations** to pass the `ModelComboBox` owner reference.

- **Enabled badges in main window** by setting `ShowCapabilityBadges = true` on the main model selector (`cmbModel`), while settings effort-tier combos leave it off for bare model names.

## Implementation Details
- The badge display is controlled entirely through `ToString()` rather than owner-draw, since this build of Krypton doesn't raise `DrawItem` events.
- Sorting remains by model name alone since badges are only trailing suffixes.
- Models not in the catalog receive no badge rather than a misleading one.
- The main window's fixed-width combo box design is preserved; the dropdown still auto-sizes wider to show full badged text while the closed box truncates gracefully.

https://claude.ai/code/session_01JtZFcyNdTBWNjJd7JTD92L