### PR TITLE
Add periodic doom-loop detection to prevent agent cycles

### DIFF
--- a/GxPT.Tests/GxPT.Tests.csproj
+++ b/GxPT.Tests/GxPT.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\GxPT\Services\Mcp\McpToolRegistry.cs" Link="Linked\Mcp\McpToolRegistry.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IChatStreamer.cs" Link="Linked\Mcp\IChatStreamer.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpChatOrchestrator.cs" Link="Linked\Mcp\McpChatOrchestrator.cs" />
+    <Compile Include="..\GxPT\Services\Mcp\DoomLoopDetector.cs" Link="Linked\Mcp\DoomLoopDetector.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpServerSpec.cs" Link="Linked\Mcp\McpServerSpec.cs" />
     <Compile Include="..\GxPT\Services\Mcp\McpConfig.cs" Link="Linked\Mcp\McpConfig.cs" />
     <Compile Include="..\GxPT\Services\Mcp\IServerConnector.cs" Link="Linked\Mcp\IServerConnector.cs" />

--- a/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
+++ b/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
@@ -1,0 +1,142 @@
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    public class DoomLoopDetectorTests
+    {
+        // Record a sequence of same-arg calls; return the 0-based index of the first call that reports
+        // a loop, or -1 if none did.
+        private static int FirstHit(params string[] names)
+        {
+            var d = new DoomLoopDetector();
+            for (int i = 0; i < names.Length; i++)
+                if (d.Record(names[i], "{}")) return i;
+            return -1;
+        }
+
+        [Fact]
+        public void Period1_needs_three_identical_calls()
+        {
+            Assert.Equal(-1, FirstHit("a", "a"));       // two in a row is not yet a loop
+            Assert.Equal(2, FirstHit("a", "a", "a"));   // the third closes the period-1 cycle
+        }
+
+        [Fact]
+        public void Two_identical_then_a_break_does_not_fire()
+        {
+            Assert.Equal(-1, FirstHit("a", "a", "b"));
+        }
+
+        [Fact]
+        public void Period2_oscillation_fires_on_the_second_repeat()
+        {
+            // The case a consecutive-identical check misses: edit -> test -> edit -> test ...
+            Assert.Equal(-1, FirstHit("a", "b", "a"));      // A B A: one-and-a-half cycles, not yet
+            Assert.Equal(3, FirstHit("a", "b", "a", "b"));  // A B A B: two full period-2 cycles
+        }
+
+        [Fact]
+        public void Period3_and_period4_cycles_are_caught()
+        {
+            Assert.Equal(5, FirstHit("a", "b", "c", "a", "b", "c"));            // period 3, twice
+            Assert.Equal(7, FirstHit("a", "b", "c", "d", "a", "b", "c", "d"));  // period 4, twice
+            // A period-4 pattern that only completes once is not yet a loop.
+            Assert.Equal(-1, FirstHit("a", "b", "c", "d", "a", "b", "c"));
+        }
+
+        [Fact]
+        public void A_non_repeating_sequence_never_fires()
+        {
+            Assert.Equal(-1, FirstHit("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"));
+        }
+
+        [Fact]
+        public void Distinct_leading_calls_do_not_seed_a_false_cycle()
+        {
+            // A unique prefix followed by a genuine period-1 tail fires only when the third identical
+            // call lands - the earlier distinct calls never combine into a phantom cycle.
+            Assert.Equal(5, FirstHit("x", "y", "z", "a", "a", "a"));
+        }
+
+        [Fact]
+        public void Same_tool_with_different_args_is_not_a_cycle()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("files__read", "{\"path\":\"a\"}"));
+            Assert.False(d.Record("files__read", "{\"path\":\"b\"}"));
+            Assert.False(d.Record("files__read", "{\"path\":\"c\"}"));
+        }
+
+        [Fact]
+        public void Argument_key_order_and_whitespace_share_a_signature()
+        {
+            Assert.Equal(
+                DoomLoopDetector.Signature("t", "{\"a\":1,\"b\":2}"),
+                DoomLoopDetector.Signature("t", "{ \"b\": 2, \"a\": 1 }"));
+        }
+
+        [Fact]
+        public void Reordered_identical_calls_normalize_into_one_cycle()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("t", "{\"a\":1,\"b\":2}"));
+            Assert.False(d.Record("t", "{\"b\":2,\"a\":1}"));
+            Assert.True(d.Record("t", "{ \"a\":1, \"b\":2 }"));   // three semantically identical calls
+        }
+
+        [Fact]
+        public void Nested_object_keys_are_sorted_recursively()
+        {
+            Assert.Equal(
+                DoomLoopDetector.Signature("t", "{\"o\":{\"x\":1,\"y\":2}}"),
+                DoomLoopDetector.Signature("t", "{\"o\":{\"y\":2,\"x\":1}}"));
+        }
+
+        [Fact]
+        public void Array_order_stays_significant()
+        {
+            Assert.NotEqual(
+                DoomLoopDetector.Signature("t", "{\"a\":[1,2]}"),
+                DoomLoopDetector.Signature("t", "{\"a\":[2,1]}"));
+        }
+
+        [Fact]
+        public void Different_argument_values_are_different_signatures()
+        {
+            Assert.NotEqual(
+                DoomLoopDetector.Signature("t", "{\"path\":\"a\"}"),
+                DoomLoopDetector.Signature("t", "{\"path\":\"b\"}"));
+        }
+
+        [Fact]
+        public void Unparseable_arguments_fall_back_to_raw_text_without_throwing()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("t", "{not json"));
+            Assert.False(d.Record("t", "{not json"));
+            Assert.True(d.Record("t", "{not json"));   // identical raw junk still forms a cycle
+        }
+
+        [Fact]
+        public void Null_name_and_args_are_handled()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record(null, null));
+            Assert.False(d.Record(null, null));
+            Assert.True(d.Record(null, null));
+        }
+
+        [Fact]
+        public void Clear_resets_the_window()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("a", "{}"));
+            Assert.False(d.Record("a", "{}"));
+            d.Clear();
+            Assert.False(d.Record("a", "{}"));   // the pre-Clear pair no longer counts
+            Assert.False(d.Record("a", "{}"));
+            Assert.True(d.Record("a", "{}"));    // three fresh calls close the cycle
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
+++ b/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
@@ -138,5 +138,25 @@ namespace GxPT.Tests.Mcp
             Assert.False(d.Record("a", "{}"));
             Assert.True(d.Record("a", "{}"));    // three fresh calls close the cycle
         }
+
+        [Fact]
+        public void Detection_survives_window_eviction()
+        {
+            // Fill and rotate the bounded window (MaxHistory=12) with distinct calls, then a fresh
+            // period-1 tail: trimming the ring must not corrupt detection - the third identical call
+            // still fires (index 14 of the 15-call sequence).
+            Assert.Equal(14, FirstHit("d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+                                      "d11", "z", "z", "z"));
+        }
+
+        [Fact]
+        public void Widest_cycle_still_fires_after_eviction()
+        {
+            // The 12-entry window must leave room for the widest cycle (period 4 needs 8 signatures)
+            // even after older entries are evicted: an A B C D A B C D tail behind a full window still
+            // fires, on its final call (index 15).
+            Assert.Equal(15, FirstHit("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7",
+                                      "a", "b", "c", "d", "a", "b", "c", "d"));
+        }
     }
 }

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -911,6 +911,93 @@ namespace GxPT.Tests.Mcp
             Assert.False(ui.Completed);
             Assert.Single(history); // only the user message was added
         }
+
+        [Fact]
+        public void Doom_loop_of_identical_calls_wraps_up_before_draining_the_budget()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            // The model calls the same tool with the same args over and over. The detector fires when
+            // the third identical call executes; the batch finishes, then the turn wraps up. A generous
+            // iteration cap (default 25) proves the doom-loop valve - not the cap - stopped the turn.
+            var streamer = new ScriptedStreamer();
+            for (int i = 0; i < 3; i++) streamer.Turns.Add(Chunks.OneToolCall("c" + i, "files__read", "{}"));
+            streamer.Fallback = delegate(int i) { return Chunks.Text("I'm repeating myself; how should I proceed?"); };
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "loop forever", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(4, streamer.Calls);                 // 3 looping iterations + 1 wrap-up
+            Assert.Equal(3, ft.CalledTools.Count);           // the loop ran three times, then stopped
+            // The wrap-up forbids further tools while keeping the cached tools array (as the cap does).
+            Assert.NotNull(streamer.SeenTools[3]);
+            Assert.Equal("none", streamer.SeenProps[3].ToolChoice);
+            Assert.Null(streamer.SeenProps[2].ToolChoice);   // loop iterations leave tool choice default
+            // The wrap-up instruction rides as a trailing user turn (Anthropic hoists in-array system).
+            var wrapMsgs = streamer.SeenMessages[3];
+            var lastSent = wrapMsgs[wrapMsgs.Count - 1];
+            Assert.Equal("user", lastSent.Role);
+            Assert.Contains("loop", lastSent.Content);
+            Assert.Equal("assistant", history[history.Count - 1].Role);
+            Assert.Equal("I'm repeating myself; how should I proceed?", history[history.Count - 1].Content);
+        }
+
+        [Fact]
+        public void Doom_loop_catches_an_A_B_A_B_oscillation()
+        {
+            // The value over a naive "N identical in a row" check: an edit->test->edit->test oscillation
+            // never repeats a single call three times, but is a period-2 cycle. It must be caught.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"), new ToolDef("list"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("r:" + name); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c0", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__list", "{}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c3", "files__list", "{}"));   // closes the period-2 cycle
+            streamer.Fallback = delegate(int i) { return Chunks.Text("Stuck oscillating; how should I proceed?"); };
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "oscillate", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(5, streamer.Calls);   // 4 oscillating iterations + 1 wrap-up
+            Assert.Equal(new[] { "read", "list", "read", "list" }, ft.CalledTools.ToArray());
+            Assert.Equal("none", streamer.SeenProps[4].ToolChoice);
+            Assert.Equal("Stuck oscillating; how should I proceed?", history[history.Count - 1].Content);
+        }
+
+        [Fact]
+        public void Varied_calls_are_not_a_doom_loop_and_the_turn_completes_normally()
+        {
+            // Same tool, different args each time: distinct signatures, so no false positive - the turn
+            // reaches its own final answer instead of a wrap-up.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c0", "files__read", "{\"path\":\"a\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{\"path\":\"b\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{\"path\":\"c\"}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "read three files", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(4, streamer.Calls);
+            Assert.Equal("done", ui.Text.ToString());                      // the model's own answer...
+            Assert.Equal("done", history[history.Count - 1].Content);      // ...not a wrap-up
+            Assert.Null(streamer.SeenProps[3].ToolChoice);                 // never forced to text-only
+        }
     }
 
     internal sealed class DenyAllApprovalPolicy : IToolApprovalPolicy

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -1003,11 +1003,98 @@ namespace GxPT.Tests.Mcp
             Assert.Equal("done", history[history.Count - 1].Content);      // ...not a wrap-up
             Assert.Null(streamer.SeenProps[3].ToolChoice);                 // never forced to text-only
         }
+
+        [Fact]
+        public void Doom_loop_that_closes_mid_batch_finishes_the_batch_before_wrapping_up()
+        {
+            // A cycle can close on a non-final call of a multi-call batch. The batch must still run to
+            // completion so every tool_call keeps a matching tool result (history stays well-formed),
+            // and only then does the turn wrap up.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"), new ToolDef("list"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("r:" + name); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("r0", "files__read", "{}"));   // primes the detector...
+            streamer.Turns.Add(Chunks.OneToolCall("r1", "files__read", "{}"));   // ...with two reads
+            streamer.Turns.Add(new[]                                            // batch: the cycle closes
+            {                                                                   // on the FIRST call (the
+                Chunks.ToolChunk(0, "b0", "files__read", "{}", null),           // 3rd read), but the 2nd
+                Chunks.ToolChunk(1, "b1", "files__list", "{}", "tool_calls")    // call must still run
+            });
+            streamer.Fallback = delegate(int i) { return Chunks.Text("I'm looping; how should I proceed?"); };
+
+            var history = new List<ChatMessage>();
+            var ui = new RecordingUi();
+            New(streamer, reg).RunTurn(history, "go", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(4, streamer.Calls);   // 3 model iterations + 1 wrap-up
+            // The whole batch ran even though the cycle closed on its first call.
+            Assert.Equal(new[] { "read", "read", "read", "list" }, ft.CalledTools.ToArray());
+            // History is well-formed: the batch's assistant message carries 2 tool_calls, each answered.
+            var asst = history[5];
+            Assert.Equal("assistant", asst.Role);
+            Assert.Equal(2, asst.ToolCalls.Count);
+            Assert.Equal("tool", history[6].Role);
+            Assert.Equal("tool", history[7].Role);
+            Assert.Equal(asst.ToolCalls[0].Id, history[6].ToolCallId);
+            Assert.Equal(asst.ToolCalls[1].Id, history[7].ToolCallId);
+            // Then the doom-loop wrap-up closes the turn (tool_choice "none").
+            Assert.Equal("none", streamer.SeenProps[3].ToolChoice);
+            Assert.Equal("assistant", history[8].Role);
+            Assert.Equal("I'm looping; how should I proceed?", history[8].Content);
+        }
+
+        [Fact]
+        public void Denied_calls_do_not_feed_the_doom_loop_detector()
+        {
+            // The detector records only executed calls. Three identical calls where the third is denied
+            // must NOT trip the loop guard on that third call - the denial path (halt + ask) handles it.
+            // If denied calls were recorded, the third identical signature would fire a doom-loop wrap-up
+            // instead of the scripted denial reply we assert on below.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c0", "files__read", "{}"));   // allowed
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));   // allowed
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{}"));   // denied (the 3rd signature)
+            streamer.Turns.Add(Chunks.Text("You denied that; how should I proceed?"));
+
+            var ui = new RecordingUi();
+            var orch = new McpChatOrchestrator(streamer, reg, new AllowTwiceThenDenyPolicy(), "m", null);
+            orch.RevealedToolNames = new List<string> { "files__read" }; // revealed, so calls reach the gate
+            var history = new List<ChatMessage>();
+            orch.RunTurn(history, "go", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(4, streamer.Calls);
+            Assert.Equal(new[] { "read", "read" }, ft.CalledTools.ToArray());   // only the 2 allowed ran
+            // The 3rd call was denied, not looped.
+            Assert.True(ui.ToolErrors[2]);
+            Assert.Equal("[Call denied by user.]", ui.ToolResults[2]);
+            // After the denial the loop forces text-only (the denial path), not a doom-loop wrap-up.
+            Assert.Equal("none", streamer.SeenProps[3].ToolChoice);
+            Assert.Equal("You denied that; how should I proceed?", history[history.Count - 1].Content);
+        }
     }
 
     internal sealed class DenyAllApprovalPolicy : IToolApprovalPolicy
     {
         public ApprovalDecision Check(string functionName, JObject args) { return ApprovalDecision.Deny; }
+    }
+
+    // Allows the first two calls it is asked about and denies every later one. Used to prove that a
+    // call denied at the approval gate is excluded from the doom-loop detector's signature window.
+    internal sealed class AllowTwiceThenDenyPolicy : IToolApprovalPolicy
+    {
+        private int _seen;
+        public ApprovalDecision Check(string functionName, JObject args)
+        {
+            return (_seen++ < 2) ? ApprovalDecision.Allow : ApprovalDecision.Deny;
+        }
     }
 
     // Denies the first call it is asked about and allows every later one. Used to prove that a denial

--- a/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
+++ b/GxPT.Tests/Mcp/McpChatOrchestratorTests.cs
@@ -470,7 +470,10 @@ namespace GxPT.Tests.Mcp
             ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
 
             var streamer = new ScriptedStreamer();
-            for (int i = 0; i < 3; i++) streamer.Turns.Add(Chunks.OneToolCall("c" + i, "files__read", "{}"));
+            // Distinct args per iteration so this exercises the iteration cap specifically - identical
+            // repeated calls would trip the doom-loop guard (its own tests) before the cap is reached.
+            for (int i = 0; i < 3; i++)
+                streamer.Turns.Add(Chunks.OneToolCall("c" + i, "files__read", "{\"path\":\"" + i + "\"}"));
             // The tool-less wrap-up call (after the cap) gets this text.
             streamer.Fallback = delegate(int i) { return Chunks.Text("Summary; how should I proceed?"); };
 
@@ -506,7 +509,9 @@ namespace GxPT.Tests.Mcp
             ft.OnCall = delegate(string name, JObject args) { return RegistryFakeTransport.TextResult("x"); };
 
             var streamer = new ScriptedStreamer();
-            streamer.Fallback = delegate(int i) { return Chunks.OneToolCall("c" + i, "files__read", "{}"); };
+            // Vary the args per call so the budget/continuation path is what's under test, not the
+            // doom-loop guard (which would fire first on identical repeats).
+            streamer.Fallback = delegate(int i) { return Chunks.OneToolCall("c" + i, "files__read", "{\"n\":" + i + "}"); };
 
             var orch = new McpChatOrchestrator(streamer, reg, null, "m", null, 2, 1000);
             int asked = 0;

--- a/GxPT/GxPT.csproj
+++ b/GxPT/GxPT.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Services\Mcp\HostTool.cs" />
     <Compile Include="Services\Mcp\McpToolRegistry.cs" />
     <Compile Include="Services\Mcp\McpChatOrchestrator.cs" />
+    <Compile Include="Services\Mcp\DoomLoopDetector.cs" />
     <Compile Include="Services\Mcp\McpServerSpec.cs" />
     <Compile Include="Services\Mcp\McpConfig.cs" />
     <Compile Include="Services\Mcp\MemoryInjection.cs" />

--- a/GxPT/Services/Agents/Agent.cs
+++ b/GxPT/Services/Agents/Agent.cs
@@ -23,7 +23,7 @@ namespace GxPT
         Destructive
     }
 
-    // The model "effort" an agent prefers (design A18): a user-configurable capability level the host maps
+    // The model "effort" an agent prefers (design A21): a user-configurable capability level the host maps
     // to a concrete model in settings (Settings > Models: low/medium/high -> a model id each). It lets an
     // agent - or a single dispatch - ask for "high effort" without naming a model slug, so the author/model
     // never has to know provider ids. Unset => no effort hint (resolution falls through to an explicit model,

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -446,7 +446,7 @@ namespace GxPT
             return ExtractFinalAnswer(msgs);
         }
 
-        // Resolves the model a child runs under, in decreasing precedence (design A18). Dispatch-level args
+        // Resolves the model a child runs under, in decreasing precedence (design A21). Dispatch-level args
         // beat the agent's own frontmatter, and an explicit model beats an effort tier within each level:
         //   1. dispatch `model` arg            (caller named an exact id for this call)
         //   2. dispatch `effort` arg           (caller asked for a tier; mapped via settings)

--- a/GxPT/Services/Mcp/DoomLoopDetector.cs
+++ b/GxPT/Services/Mcp/DoomLoopDetector.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GxPT
+{
+    // Periodic doom-loop / cycle detection (design A18). An unattended agent can drain its whole
+    // max_turns budget while stuck in a repeating cycle - edit -> test-fails -> revert -> edit ... -
+    // that a naive "N identical calls in a row" check never catches, because the calls oscillate
+    // rather than repeat verbatim. This detector keeps a short rolling window of recent
+    // `name:normalized-args` tool-call signatures and reports a loop when the tail is `reps`
+    // consecutive repetitions of a period-`p` block (p in 1..MaxPeriod; reps = 3 for p==1, else 2).
+    // Ported from the OpenMonoAgent DoomLoopDetector shape (MaxPeriod=4, MaxHistory=12, arguments
+    // JSON-normalized with sorted object keys). Pure logic - no UI, no model: the orchestrator feeds
+    // each executed tool call in and, on a positive, wraps the turn up as content (never a throw), so
+    // the main agent and every sub-agent are covered by the same valve.
+    internal sealed class DoomLoopDetector
+    {
+        // Longest cycle period considered. A period-p cycle repeated `reps` times needs p*reps
+        // signatures; the widest lookback is p=1 (3 reps) and p=4 (2 reps) => max 8, so a 12-entry
+        // window carries ample headroom while staying cheap.
+        internal const int MaxPeriod = 4;
+        internal const int MaxHistory = 12;
+
+        private readonly List<string> _sigs = new List<string>();
+
+        // Record one executed tool call (in call order) and report whether its arrival closes a
+        // repeating cycle. Call exactly once per call the model actually ran.
+        public bool Record(string name, string argumentsJson)
+        {
+            _sigs.Add(Signature(name, argumentsJson));
+            // Bound the window so an old, unrelated prefix can never combine with the recent tail to
+            // fake a cycle, and so memory stays O(1) across a long turn.
+            while (_sigs.Count > MaxHistory) _sigs.RemoveAt(0);
+            return HasCycle();
+        }
+
+        // Drop the window. The orchestrator owns one detector per turn, but this keeps reuse safe.
+        public void Clear() { _sigs.Clear(); }
+
+        // The smallest qualifying period wins, so p=1 (the same call over and over) is reported as a
+        // period-1 cycle rather than being mistaken for a wider one.
+        private bool HasCycle()
+        {
+            int n = _sigs.Count;
+            for (int p = 1; p <= MaxPeriod; p++)
+            {
+                int reps = (p == 1) ? 3 : 2;
+                int need = p * reps;
+                if (n < need) continue;
+                if (IsPeriodic(p, need)) return true;
+            }
+            return false;
+        }
+
+        // Are the last `need` signatures periodic with period `p`? Equivalent to: every entry in the
+        // window equals the one `p` positions before it (which, checked across `need` = p*reps
+        // entries, proves `reps` back-to-back copies of the trailing p-block).
+        private bool IsPeriodic(int p, int need)
+        {
+            int n = _sigs.Count;
+            for (int k = n - need + p; k < n; k++)
+                if (!string.Equals(_sigs[k], _sigs[k - p], StringComparison.Ordinal))
+                    return false;
+            return true;
+        }
+
+        // `name:normalized-args`. Arguments are parsed and re-serialized with object keys sorted, so
+        // two semantically identical calls that differ only in key order or whitespace collapse to one
+        // signature. Unparseable arguments fall back to the raw (trimmed) text.
+        internal static string Signature(string name, string argumentsJson)
+        {
+            return (name ?? string.Empty) + ":" + NormalizeArgs(argumentsJson);
+        }
+
+        internal static string NormalizeArgs(string argumentsJson)
+        {
+            if (string.IsNullOrEmpty(argumentsJson)) return string.Empty;
+            try
+            {
+                JToken parsed = JToken.Parse(argumentsJson);
+                return Canonicalize(parsed).ToString(Formatting.None);
+            }
+            catch (JsonException)
+            {
+                return argumentsJson.Trim();
+            }
+        }
+
+        // Recursively sort object property names so key order can't split a signature. Array order is
+        // left intact - order is semantically meaningful in a JSON array.
+        private static JToken Canonicalize(JToken token)
+        {
+            JObject obj = token as JObject;
+            if (obj != null)
+            {
+                List<string> keys = new List<string>();
+                foreach (JProperty prop in obj.Properties()) keys.Add(prop.Name);
+                keys.Sort(StringComparer.Ordinal);
+                JObject sorted = new JObject();
+                foreach (string key in keys) sorted[key] = Canonicalize(obj[key]);
+                return sorted;
+            }
+            JArray arr = token as JArray;
+            if (arr != null)
+            {
+                JArray copy = new JArray();
+                foreach (JToken item in arr) copy.Add(Canonicalize(item));
+                return copy;
+            }
+            // A leaf value still belongs to the parsed tree; detach a copy so re-parenting it into the
+            // freshly built container above can't fault on an already-owned token.
+            return token.DeepClone();
+        }
+    }
+}

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -389,6 +389,12 @@ namespace GxPT
             // which mean the user wants to take control rather than have the model work around them.
             // Reset each iteration once consumed.
             bool forceTextThisCall = false;
+            // Periodic doom-loop detection (A18), one detector per turn: bounds *repetition* the way
+            // the budget bounds *total* work. It records each executed tool call's `name:normalized-args`
+            // signature and, when the recent window collapses into a repeating cycle, wraps the turn up
+            // as content rather than draining the whole budget spinning - the valve an unattended
+            // sub-agent (no continuation prompt) most needs, and a backstop for the main agent too.
+            DoomLoopDetector doomLoop = new DoomLoopDetector();
             for (int iter = 0; ; iter++)
             {
                 // Stop requested between iterations (e.g. while the previous iteration's tools ran):
@@ -588,6 +594,10 @@ namespace GxPT
                 // none do. That keeps the displayed count exact even when a denial cuts the batch short.
                 int runOrdinal = 0; // 1-based position within the current ask_user run (0 = not in a run)
                 int runTotal = 0;   // length of the current run
+                // Set when an executed call closes a repeating cycle. The batch still runs to
+                // completion (every tool_call needs a matching tool result, or the next request is
+                // malformed); the wrap-up fires only after, once history is well-formed.
+                bool doomLoopHit = false;
                 for (int c = 0; c < asm.Calls.Count; c++)
                 {
                     ToolCall call = asm.Calls[c];
@@ -637,6 +647,14 @@ namespace GxPT
                             batchDenied = true;
                             forceTextThisCall = true;
                         }
+                        else if (doomLoop.Record(call.Name, call.ArgumentsJson))
+                        {
+                            // This executed call closed a repeating cycle. Note it and let the batch
+                            // finish; the wrap-up runs once the loop below is done and history is valid.
+                            doomLoopHit = true;
+                            _log.Log("mcp", "[turn " + turnId + "] doom-loop detected at iteration "
+                                + (iter + 1) + " (cycle on '" + call.Name + "'); wrapping up");
+                        }
                     }
 
                     if (ui != null) ui.OnToolResult(call.Name, result, isError, call.Id);
@@ -651,6 +669,17 @@ namespace GxPT
                         && AgentDispatcher.GroupCancellation != null
                         && AgentDispatcher.GroupCancellation.IsCancelled)
                         forceTextThisCall = true;
+                }
+
+                // A repeating cycle closed during this batch: the whole batch has now run (history is
+                // well-formed), so end the turn with a text-only wrap-up instead of spinning through the
+                // rest of the budget. A user Stop that landed while the tools ran takes precedence.
+                if (doomLoopHit)
+                {
+                    if (CancelRequested()) { FinishCancelled(history, null, ui, turnId); return; }
+                    RunWrapUp(history, _lastOfferedTools, ui, turnId,
+                              DoomLoopWrapUpInstruction, DoomLoopWrapUpFallback, "doom-loop");
+                    return;
                 }
                 // Loop: re-call the model with the tool results in context.
             }
@@ -739,6 +768,23 @@ namespace GxPT
                 + (asm.Truncated ? " [TRUNCATED: model output cut off by length]" : ""));
         }
 
+        // Wrap-up instruction + fallback for the two forced-stop paths (iteration cap, doom loop). Both
+        // end the turn the same way: force a text-only answer that summarizes and hands back to the user.
+        private const string CapWrapUpInstruction =
+            "You have reached the maximum number of tool calls allowed for this turn. Do not "
+            + "request any more tools now. Briefly summarize what you have done so far and what "
+            + "still remains, then ask the user how they would like to proceed.";
+        private const string CapWrapUpFallback =
+            "I've reached the tool-call limit for this turn. Let me know how you'd like to proceed.";
+        private const string DoomLoopWrapUpInstruction =
+            "You appear to be repeating the same sequence of tool calls without making progress - a "
+            + "loop. Stop and do not request any more tools now. Briefly summarize what you were "
+            + "trying to accomplish and what seems to be blocking progress, then ask the user how they "
+            + "would like to proceed.";
+        private const string DoomLoopWrapUpFallback =
+            "I seem to be repeating the same steps without making progress. Let me know how you'd like "
+            + "to proceed.";
+
         // Cap reached and not continued: one final model call (tool_choice "none") asking it to
         // summarize and ask how to proceed, so the turn ends with a readable assistant message
         // rather than a cryptic dead-end. The user can simply reply to keep going (a fresh budget
@@ -749,6 +795,15 @@ namespace GxPT
         // turn (back on tool_choice auto) still extends the loop's cached prefix unharmed.
         private void RunCapWrapUp(IList<ChatMessage> history, IList<JObject> tools, IToolLoopUi ui,
                                   string turnId)
+        {
+            RunWrapUp(history, tools, ui, turnId, CapWrapUpInstruction, CapWrapUpFallback, "cap");
+        }
+
+        // Force the model to text-only closure. Shared by the iteration-cap and doom-loop stops: append
+        // a trailing instruction, re-send the same (cached) tools array under tool_choice "none", and
+        // record the model's summary - or a fallback - as the turn's final assistant message.
+        private void RunWrapUp(IList<ChatMessage> history, IList<JObject> tools, IToolLoopUi ui,
+                               string turnId, string instruction, string fallback, string kind)
         {
             List<ChatMessage> requestMessages = BuildStableHead(SkillsActive, AgentsActive);
             int headCount = requestMessages.Count;
@@ -761,10 +816,7 @@ namespace GxPT
             // on a tool result and the model with nothing in-position to answer (it replies with a
             // near-empty acknowledgment). A trailing user turn keeps the instruction in place so the
             // model actually summarizes.
-            requestMessages.Add(new ChatMessage("user",
-                "You have reached the maximum number of tool calls allowed for this turn. Do not "
-                + "request any more tools now. Briefly summarize what you have done so far and what "
-                + "still remains, then ask the user how they would like to proceed."));
+            requestMessages.Add(new ChatMessage("user", instruction));
 
             // tool_choice "none": the model must answer with text, while the unchanged tools array
             // keeps the cached prefix intact.
@@ -776,15 +828,17 @@ namespace GxPT
             if (errored || IsEmptyText(asm.Text))
             {
                 if (errored)
-                    _log.Log("mcp", "[turn " + turnId + "] wrap-up stream error: " + (errMessage ?? "(none)"));
-                text = "I've reached the tool-call limit for this turn. Let me know how you'd like to proceed.";
+                    _log.Log("mcp", "[turn " + turnId + "] " + kind + " wrap-up stream error: "
+                        + (errMessage ?? "(none)"));
+                text = fallback;
                 // StreamOnce streamed nothing usable, so emit the fallback to the UI ourselves.
                 if (ui != null) ui.AppendTextDelta(text);
             }
             else
             {
                 text = asm.Text;
-                _log.Log("mcp", "[turn " + turnId + "] wrap-up complete (" + text.Length + " chars)");
+                _log.Log("mcp", "[turn " + turnId + "] " + kind + " wrap-up complete ("
+                    + text.Length + " chars)");
             }
 
             history.Add(new ChatMessage("assistant", text));

--- a/GxPT/Services/SettingsSchema.cs
+++ b/GxPT/Services/SettingsSchema.cs
@@ -40,7 +40,7 @@ namespace GxPT
             d["models"] = (string[])ModelDefaults.Models.Clone();
             d["default_model"] = ModelDefaults.DefaultModel;
             d["recommended_hash_seen"] = ModelDefaults.RecommendedHash();
-            // Agent effort tiers (design A18): each maps a level the model/agent can request to a concrete
+            // Agent effort tiers (design A21): each maps a level the model/agent can request to a concrete
             // model id, so a dispatch can ask for "high effort" without naming a slug. Seeded from the shared
             // catalog so they start on real, in-list models.
             d["model_effort_low"] = ModelDefaults.DefaultEffortLow;

--- a/docs/subagents-design.md
+++ b/docs/subagents-design.md
@@ -100,6 +100,7 @@ tabs — `McpChatOrchestrator` RunTurn, MainForm's per-tab `ThreadPool` dispatch
 | A18 | **Periodic doom-loop detection in the orchestrator**: over a short rolling window of recent `name:normalized-args` signatures, abort with a wrap-up when a cycle of period *p* (1–4) repeats (≥3× for *p*=1, ≥2× for *p*=2–4) | The `MaxIterations` cap bounds *total* work but a stuck agent still burns the whole budget on a cycle — worse for an unattended sub-agent (A14). The OpenMono `DoomLoopDetector` (from source: `MaxPeriod=4`, `MaxHistory=12`, `reps = period==1 ? 3 : 2`, args JSON-normalized with sorted keys) is smarter than "N identical in a row": it catches **oscillations** (edit→test-fail→revert→edit…, an A→B→A→B period-2 cycle) a consecutive-only check misses. Cheap (a ~12-entry signature ring in `RunTurn`), benefits the **main** agent too, ends as content not a throw. |
 | A19 | **Allowlist `tools` supports glob wildcards** (`files__*`, `mcp__*`, `*__read`, `*`) matched against the qualified catalog | Server-qualified names (`files__read`, `git__status`) make prefix/suffix globs natural and far less brittle than enumerating every tool — "all file tools" is `files__*`, "everything a server exposes" is `mcp__myserver__*`. The OpenMono precedent ("allow-lists support `*`, `mcp__*`"). Still intersected with parent-available and `max_tier` (A11), so a wildcard never widens past the parent or the ceiling. |
 | A20 | **Running agents are surfaced in-transcript (the dispatch panel) and stopped all-at-once by repurposing the turn's Stop button to `Stop N agents`** (v1: stop-all; N includes queued) | A fan-out the user can't see or stop is unacceptable for an unattended feature. The status bar can't host an `Agents: N` count — mid-turn that region is the marquee + Stop button — and the dispatch is the *latest* thing in the transcript, so it's already on screen (no nav affordance needed). Visibility is the `AgentActivityPanel` (one row per child: glyph + slug + live status), modeled on `ToolApprovalPanel`/`TranscriptContinuationPrompt`. Control is the existing Stop button, relabeled to **`Stop N agents`** while the fan-out runs (N = all not-yet-finished children, running *and* queued, ticking down) and reverted to plain **`Stop`** when the model resumes. The children share a **group `RequestCancellation`** (distinct from the parent turn's), so `Stop N agents` cancels the fan-out — *not* the turn: each child finalizes via `FinishCancelled` (keeps partial), its result is marked `[stopped by user]`, and the parent model resumes with a **tailored wrap-up directive** (sibling of the cap wrap-up, phrased for an interrupted fan-out: summarize partials + ask how to proceed, don't silently restart). A full turn abort is then one more click on the reverted `Stop`. Per-agent stop is deferred (§12). Full design + tiers in §14. |
+| A21 | **Per-dispatch model selection via `model` + `effort`**, resolved by a fixed precedence in `ResolveModel` | An agent should be able to ask for a stronger or cheaper/faster model **by intent** without hard-coding a slug. Both a frontmatter default and a per-dispatch override are supported; `ResolveModel` picks the first that resolves to a concrete model: `model` arg → `effort` arg → frontmatter `model` → frontmatter `effort` → parent turn's model. An `effort` tier (`low`\|`medium`\|`high`) maps to a concrete id via the user's `model_effort_low/medium/high` settings; a tier that maps to nothing is skipped, so resolution always lands on a real model. (Distinct from the doom-loop guard A18 — the two were briefly conflated under one number.) |
 
 ---
 
@@ -170,7 +171,7 @@ find something after a genuine search, say so and name where you looked.
     ~30, so an unattended specialist's cost is bounded *to its job*, not the parent's.
   - `model` *(optional)* — explicit model id override; omitted ⇒ the parent turn's
     model. Prefer `effort` unless a specific id is required.
-  - `effort` *(optional, A18)* — capability tier `low` \| `medium` \| `high`, mapped
+  - `effort` *(optional, A21)* — capability tier `low` \| `medium` \| `high`, mapped
     to a concrete model id by the user's settings (`model_effort_low/medium/high`).
     Lets an agent ask for a cheaper/faster or a stronger model **by intent**, without
     hard-coding a slug. Unrecognized ⇒ ignored (no hint). An explicit `model` is more
@@ -242,7 +243,7 @@ resolution (like `IsOpenSkill`), so it never hits a server.
 dispatch_agent(agents: [ { name: string, task: string, effort?: string, model?: string }, … ])   // batch (A9)
 ```
 The optional per-entry `effort` (`low`\|`medium`\|`high`) and `model` override that
-agent's own frontmatter for this dispatch only. Full precedence (A18), dispatch-level
+agent's own frontmatter for this dispatch only. Full precedence (A21), dispatch-level
 beating frontmatter and an explicit model beating an effort tier within each level:
 `model` arg → `effort` arg → frontmatter `model` → frontmatter `effort` → parent
 turn's model. An effort tier maps to a model via the user's settings; a tier that maps
@@ -261,7 +262,7 @@ conversation."*
    - history = `[ system: standing-guidance + workspace-block + agent.Body ]`
      then `[ user: task ]`;
    - `WorkingDir` = parent's (so scoped servers route to the same folder);
-   - `model` = `ResolveModel` (A18): `model` arg → `effort` arg → `agent.Model` →
+   - `model` = `ResolveModel` (A21): `model` arg → `effort` arg → `agent.Model` →
      `agent.Effort` → `parentModel` (effort tiers mapped via settings);
    - **exposed tools restricted** via `AgentToolResolver` (A11) — for a *small*
      declared allowlist the child skips progressive disclosure and is handed those


### PR DESCRIPTION
## Summary
Implements periodic doom-loop detection in the MCP chat orchestrator to prevent agents from spinning indefinitely in repeating cycles of tool calls. This complements the existing iteration cap by detecting oscillating patterns (e.g., edit→test→edit→test) that never repeat a single call three times in a row.

## Key Changes

- **New `DoomLoopDetector` class** (`GxPT/Services/Mcp/DoomLoopDetector.cs`):
  - Maintains a rolling window of recent tool-call signatures (max 12 entries)
  - Detects repeating cycles with periods 1–4 (period-1 requires 3 repetitions, periods 2–4 require 2)
  - Normalizes JSON arguments by sorting object keys recursively, so semantically identical calls with different key order collapse to the same signature
  - Falls back to raw text for unparseable arguments
  - Catches both consecutive repeats (e.g., `a, a, a`) and oscillations (e.g., `a, b, a, b`)

- **Integration into `McpChatOrchestrator`**:
  - One detector instance per turn
  - Records each executed tool call's name and normalized arguments
  - When a cycle is detected, the current batch completes (ensuring history remains well-formed), then triggers a wrap-up instead of continuing the loop
  - Wrap-up forces the model to text-only mode (`tool_choice: "none"`) with an instruction to summarize and ask the user how to proceed
  - Logs the detection event with turn ID and iteration number

- **Shared wrap-up infrastructure**:
  - Extracted common wrap-up logic used by both iteration-cap and doom-loop stops
  - Separate instructions and fallback messages for each stop reason
  - Preserves cached tool definitions in the request to maintain prefix integrity

- **Comprehensive test coverage** (`GxPT.Tests/Mcp/DoomLoopDetectorTests.cs`):
  - Period-1, period-2, period-3, and period-4 cycle detection
  - JSON normalization (key order, whitespace, nested objects)
  - Array order preservation
  - Unparseable argument handling
  - Null safety
  - Window reset behavior

- **Integration tests** in `McpChatOrchestratorTests`:
  - Identical-call loop detection
  - Oscillation (A→B→A→B) detection
  - Varied calls (different arguments) do not trigger false positives

## Implementation Details

- Signatures are computed as `name:normalized-args` to uniquely identify tool calls
- JSON normalization recursively sorts object keys (using ordinal comparison) while preserving array order
- The detector uses a simple periodic check: for each period *p*, verify that the last *p×reps* entries match the pattern where each entry equals the one *p* positions before it
- Detection is non-throwing and graceful: unparseable JSON falls back to trimmed raw text
- The wrap-up message is appended as a trailing user turn to ensure the model actually responds with a summary rather than an empty acknowledgment

https://claude.ai/code/session_01KtX1EVtDbxd7FGVpDwhZjv