### PR TITLE
Fix mid-turn MCP host rebuilds stranding in-flight turns (cd-only sub-agents)

### DIFF
--- a/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
+++ b/GxPT.Tests/Mcp/DoomLoopDetectorTests.cs
@@ -60,6 +60,56 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Scope_salt_distinguishes_identical_calls_in_different_directories()
+        {
+            // A directory walk up a tree: "list ." then "cd .." repeated VERBATIM while moving through
+            // different directories. Without the scope salt this read as a period-2 cycle and wrapped
+            // a legitimately exploring agent up early (observed false positive).
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("files__list", "{\"path\":\".\"}", "C:\\r\\a\\b\\c"));
+            Assert.False(d.Record("cd", "{\"path\":\"..\"}", "C:\\r\\a\\b"));
+            Assert.False(d.Record("files__list", "{\"path\":\".\"}", "C:\\r\\a\\b"));
+            Assert.False(d.Record("cd", "{\"path\":\"..\"}", "C:\\r\\a"));
+            Assert.False(d.Record("files__list", "{\"path\":\".\"}", "C:\\r\\a"));
+            Assert.False(d.Record("cd", "{\"path\":\"..\"}", "C:\\r"));
+            Assert.False(d.Record("files__list", "{\"path\":\".\"}", "C:\\r"));
+        }
+
+        [Fact]
+        public void Same_place_repetition_still_fires()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("files__write", "{\"path\":\"x\"}", "C:\\r\\sub"));
+            Assert.False(d.Record("files__write", "{\"path\":\"x\"}", "C:\\r\\sub"));
+            Assert.True(d.Record("files__write", "{\"path\":\"x\"}", "C:\\r\\sub"));
+        }
+
+        [Fact]
+        public void Cycle_that_returns_to_the_same_places_still_fires()
+        {
+            // Oscillating between two directories doing the same things: the scopes repeat along with
+            // the calls, so the salted period-4 cycle is still caught on its second full repetition.
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("cd", "{\"path\":\"sub\"}", "C:\\r\\sub"));
+            Assert.False(d.Record("files__edit", "{\"path\":\"f\"}", "C:\\r\\sub"));
+            Assert.False(d.Record("cd", "{\"path\":\"..\"}", "C:\\r"));
+            Assert.False(d.Record("command__run", "{\"cmd\":\"test\"}", "C:\\r"));
+            Assert.False(d.Record("cd", "{\"path\":\"sub\"}", "C:\\r\\sub"));
+            Assert.False(d.Record("files__edit", "{\"path\":\"f\"}", "C:\\r\\sub"));
+            Assert.False(d.Record("cd", "{\"path\":\"..\"}", "C:\\r"));
+            Assert.True(d.Record("command__run", "{\"cmd\":\"test\"}", "C:\\r"));
+        }
+
+        [Fact]
+        public void Null_scope_and_the_two_arg_overload_are_equivalent()
+        {
+            var d = new DoomLoopDetector();
+            Assert.False(d.Record("a", "{}"));
+            Assert.False(d.Record("a", "{}", null));
+            Assert.True(d.Record("a", "{}"));
+        }
+
+        [Fact]
         public void Same_tool_with_different_args_is_not_a_cycle()
         {
             var d = new DoomLoopDetector();

--- a/GxPT.Tests/Mcp/DoomLoopTurnTests.cs
+++ b/GxPT.Tests/Mcp/DoomLoopTurnTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // Turn-level behavior of the doom-loop valve after the false-positive and affordance fixes:
+    // directory walks (identical calls from different directories) no longer trip it, a genuinely
+    // stuck repetition consults DoomLoopContinuationDecider before wrapping up, and malformed tool
+    // arguments carry the parser's own diagnosis instead of a bare "not valid JSON".
+    public class DoomLoopTurnTests : IDisposable
+    {
+        private readonly string _anchor;
+
+        public DoomLoopTurnTests()
+        {
+            _anchor = Path.Combine(Path.GetTempPath(), "doomturn_" + Guid.NewGuid().ToString("N"));
+            // anchor/a/b/c for the walk test.
+            Directory.CreateDirectory(Path.Combine(Path.Combine(Path.Combine(_anchor, "a"), "b"), "c"));
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_anchor, true); } catch { }
+        }
+
+        private static McpToolRegistry RegistryWith(out RegistryFakeTransport ft, string server, params ToolDef[] tools)
+        {
+            var conn = FakeConn.Ready(server, out ft, tools);
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            return reg;
+        }
+
+        [Fact]
+        public void Directory_walk_up_the_tree_is_not_flagged_as_a_doom_loop()
+        {
+            // "list ." then "cd .." repeated verbatim while climbing anchor/a/b/c back to the root:
+            // seven calls whose name+args form a textbook period-2 pattern, but each pair runs in a
+            // DIFFERENT directory. The cwd-salted signature must let the walk finish normally.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("list"));
+            ft.OnCall = delegate(string n, JObject a) { return RegistryFakeTransport.TextResult("[]"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", "{\"path\":\"a/b/c\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__list", "{\"path\":\".\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c3", "cd", "{\"path\":\"..\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c4", "files__list", "{\"path\":\".\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c5", "cd", "{\"path\":\"..\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c6", "files__list", "{\"path\":\".\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c7", "cd", "{\"path\":\"..\"}"));
+            streamer.Turns.Add(Chunks.Text("walked"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.WorkingDir = _anchor;
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            bool deciderConsulted = false;
+            orch.DoomLoopContinuationDecider = delegate(int n) { deciderConsulted = true; return false; };
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "explore", ui);
+
+            Assert.True(ui.Completed);
+            Assert.False(deciderConsulted);        // never even paused
+            Assert.Equal(7, ui.ToolCalls.Count);   // the whole walk ran
+            Assert.Equal("walked", ui.Text.ToString());
+            Assert.Equal(8, streamer.Calls);       // no wrap-up call was appended
+        }
+
+        [Fact]
+        public void Stuck_repetition_consults_the_decider_and_wraps_when_declined()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string n, JObject a) { return RegistryFakeTransport.TextResult("same"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c3", "files__read", "{\"path\":\"x\"}")); // closes p=1
+            streamer.Turns.Add(Chunks.Text("Wrapped summary."));                              // wrap-up call
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            int deciderCalls = 0;
+            orch.DoomLoopContinuationDecider = delegate(int n) { deciderCalls++; return false; };
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.Equal(1, deciderCalls);
+            Assert.True(ui.Completed);
+            Assert.Equal(3, ui.ToolCalls.Count);
+            Assert.Contains("Wrapped summary.", ui.Text.ToString()); // the wrap-up text, not more tools
+            Assert.Equal(4, streamer.Calls);
+        }
+
+        [Fact]
+        public void Decider_can_grant_a_continuation_and_the_window_resets()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string n, JObject a) { return RegistryFakeTransport.TextResult("same"); };
+
+            var streamer = new ScriptedStreamer();
+            for (int i = 0; i < 6; i++)
+                streamer.Turns.Add(Chunks.OneToolCall("c" + i, "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.Text("Wrapped."));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            int deciderCalls = 0;
+            // First detection: continue (window cleared). Second detection (3 more identical calls
+            // re-fill the fresh window): stop.
+            orch.DoomLoopContinuationDecider = delegate(int n) { return ++deciderCalls == 1; };
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.Equal(2, deciderCalls);
+            Assert.Equal(6, ui.ToolCalls.Count);   // 3 before each detection
+            Assert.Contains("Wrapped.", ui.Text.ToString());
+            Assert.Equal(7, streamer.Calls);
+        }
+
+        [Fact]
+        public void Sub_agent_without_a_decider_still_wraps_up_unattended()
+        {
+            // No DoomLoopContinuationDecider (how AgentDispatcher builds children): the A18 valve
+            // wraps the turn up on its own, exactly as before the affordance existed.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            ft.OnCall = delegate(string n, JObject a) { return RegistryFakeTransport.TextResult("same"); };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c3", "files__read", "{\"path\":\"x\"}"));
+            streamer.Turns.Add(Chunks.Text("Auto-wrapped."));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.Completed);
+            Assert.Equal(3, ui.ToolCalls.Count);
+            Assert.Contains("Auto-wrapped.", ui.Text.ToString());
+        }
+
+        [Fact]
+        public void Malformed_arguments_error_carries_the_parsers_diagnosis()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{\"path\": \"unterminated"));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("Invalid tool arguments for 'files__read'", ui.ToolResults[0]);
+            Assert.Contains("line", ui.ToolResults[0]);      // Newtonsoft's line/position diagnosis
+            Assert.Contains("re-issue the call", ui.ToolResults[0]);
+            Assert.Empty(ft.CalledTools);
+        }
+
+        [Fact]
+        public void Non_object_arguments_say_so_explicitly()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "[1,2]"));
+            streamer.Turns.Add(Chunks.Text("ok"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("must be a JSON object", ui.ToolResults[0]);
+            Assert.Empty(ft.CalledTools);
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/FailFastGuardrailTests.cs
+++ b/GxPT.Tests/Mcp/FailFastGuardrailTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GxPT;
+using Mcp35.Client;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // Fail-fast guardrails (doom-loop fixes, step 4): a toolless turn keeps a recovery handle
+    // (reveal_tools), resolution failures distinguish "server down" from "name wrong", and a child
+    // whose declared allowlist resolves to nothing fails its dispatch loudly instead of burning its
+    // whole budget with host tools alone.
+    public class FailFastGuardrailTests
+    {
+        [Fact]
+        public void Toolless_turn_still_exposes_reveal_tools()
+        {
+            // Registry present but empty (servers faulted / mid-reconnect): the turn must keep the
+            // reveal_tools def as its recovery handle. It used to be gated behind hasMcpTools, so
+            // exactly the turns that most needed recovery had no handle at all.
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.NotNull(streamer.SeenTools[0]);
+            Assert.Single(streamer.SeenTools[0]);
+            Assert.Equal("reveal_tools", (string)streamer.SeenTools[0][0]["function"]["name"]);
+        }
+
+        [Fact]
+        public void No_registry_still_means_no_tools()
+        {
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+            var orch = new McpChatOrchestrator(streamer, null, null, "test-model", null);
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+            Assert.Null(streamer.SeenTools[0]);
+        }
+
+        [Fact]
+        public void Unresolved_server_tool_reports_unavailable_when_no_servers_are_connected()
+        {
+            var reg = new McpToolRegistry(null); // no servers at all
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("temporarily unavailable", ui.ToolResults[0]);
+            Assert.Contains("Retry", ui.ToolResults[0]);
+            Assert.DoesNotContain("Unknown tool", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Unresolved_tool_names_its_missing_server_when_others_are_up()
+        {
+            // files is connected, git is not: calling git__status is an outage of the git server,
+            // not an unknown name — say which server is missing.
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "git__status", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("'git' server has no tools connected", ui.ToolResults[0]);
+            Assert.DoesNotContain("Unknown tool", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Wrong_name_on_a_present_server_stays_unknown_tool()
+        {
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__nope", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("Unknown tool: files__nope", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Host_tool_names_never_get_the_unavailable_message()
+        {
+            // open_skill is a host meta-tool name (no server__ prefix); with an empty registry it must
+            // still fall through as Unknown, not masquerade as a server outage.
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "open_skill", "{\"names\":[\"x\"]}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("Unknown tool", ui.ToolResults[0]);
+        }
+    }
+
+    // The dispatch-time guard: an agent that PROMISES specific tools must not run without them.
+    public sealed class EmptyToolsetDispatchTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public EmptyToolsetDispatchTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gxpt_emptyset_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        private Agent WriteAgent(string slug, string frontmatterExtra, string body)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file, "---\nname: " + slug + "\ndescription: d\n" + frontmatterExtra
+                + "---\n" + body + "\n", new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        private AgentDispatcher Dispatcher(ScriptedStreamer streamer, McpToolRegistry reg, params Agent[] agents)
+        {
+            return new AgentDispatcher(new List<Agent>(agents), streamer, reg, null,
+                "parent-model", "C:\\proj", null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+        }
+
+        [Fact]
+        public void Declared_allowlist_resolving_to_nothing_fails_dispatch_loudly()
+        {
+            // The plan-implementer disaster: 14 declared tools, none available (registry emptied by a
+            // mid-turn rebuild), child burned 40 iterations with only cd. Now the dispatch itself
+            // fails with a retryable error, and the child never runs.
+            Agent a = WriteAgent("worker", "tools: [files__read, files__write]\n", "You work.");
+            var reg = new McpToolRegistry(null); // nothing available
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("should never stream"));
+
+            string result = Dispatcher(streamer, reg, a)
+                .Dispatch("{\"agents\":[{\"name\":\"worker\",\"task\":\"t\"}]}");
+
+            Assert.Contains("NOT dispatched", result);
+            Assert.Contains("worker", result);
+            Assert.Equal(0, streamer.Calls); // the child never ran
+        }
+
+        [Fact]
+        public void Star_allowlist_with_a_toolless_parent_still_runs()
+        {
+            // "*" means "whatever the parent has" — an empty result is consistent with it, so the
+            // child runs as a text-only agent (no broken promise to report).
+            Agent a = WriteAgent("generalist", "tools: [\"*\"]\n", "You answer.");
+            var reg = new McpToolRegistry(null);
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("answered"));
+
+            string result = Dispatcher(streamer, reg, a)
+                .Dispatch("{\"agents\":[{\"name\":\"generalist\",\"task\":\"t\"}]}");
+
+            Assert.Contains("answered", result);
+            Assert.Equal(1, streamer.Calls);
+        }
+
+        [Fact]
+        public void Declared_allowlist_with_available_tools_dispatches_normally()
+        {
+            Agent a = WriteAgent("worker", "tools: [files__read]\n", "You work.");
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn, "C:\\proj");
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            string result = Dispatcher(streamer, reg, a)
+                .Dispatch("{\"agents\":[{\"name\":\"worker\",\"task\":\"t\"}]}");
+
+            Assert.Contains("done", result);
+            Assert.DoesNotContain("NOT dispatched", result);
+        }
+    }
+
+    // Step 6: a faulted/closed scoped connection must not leave its workdir key behind — that made
+    // EnsureWorkingDir a permanent no-op ("already connected") with zero tools until an app restart.
+    public class FaultedConnectionRecoveryTests
+    {
+        private static List<string> Manifest(McpToolRegistry reg)
+        {
+            var names = new List<string>();
+            foreach (var line in reg.NamesManifestSystemMessage().Split('\n'))
+                if (line.StartsWith("- ")) names.Add(line.Substring(2));
+            return names;
+        }
+
+        [Fact]
+        public void Faulted_scoped_connection_can_reconnect_via_EnsureWorkingDir()
+        {
+            var connector = new FakeServerConnector();
+            var reg = new McpToolRegistry(null);
+            var host = new McpHost(connector, reg, null, 2000);
+            host.Start(new[] { Specs.Scoped("files", true) });
+            host.EnsureWorkingDir("C:\\a");
+            Assert.Contains("files__files_tool", Manifest(reg));
+
+            connector.Created[0].Dispose(); // fault: StateChanged(Closed) fires into the host
+
+            // The dead set is fully forgotten: registry emptied AND the workdir key released.
+            Assert.Empty(Manifest(reg));
+            Assert.DoesNotContain("C:\\a", host.ActiveWorkingDirs);
+
+            // ...so the same folder can reconnect (this used to be a silent no-op forever).
+            host.EnsureWorkingDir("C:\\a");
+            Assert.Equal(2, connector.CreatedNames.FindAll(delegate(string n) { return n == "files"; }).Count);
+            Assert.Contains("files__files_tool", Manifest(reg));
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("files__files_tool", "C:\\a", out r, out tool));
+            Assert.Same(connector.Created[1], r);
+        }
+
+        [Fact]
+        public void Faulting_one_workdirs_server_leaves_other_workdirs_alone()
+        {
+            var connector = new FakeServerConnector();
+            var reg = new McpToolRegistry(null);
+            var host = new McpHost(connector, reg, null, 2000);
+            host.Start(new[] { Specs.Scoped("files", true) });
+            host.EnsureWorkingDir("C:\\a");
+            var connA = connector.Created.Last();
+            host.EnsureWorkingDir("C:\\b");
+            var connB = connector.Created.Last();
+
+            connA.Dispose();
+
+            Assert.DoesNotContain("C:\\a", host.ActiveWorkingDirs);
+            Assert.Contains("C:\\b", host.ActiveWorkingDirs);
+            Assert.Equal(ConnectionState.Ready, connB.State);
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("files__files_tool", "C:\\b", out r, out tool));
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/FrozenToolDefsTests.cs
+++ b/GxPT.Tests/Mcp/FrozenToolDefsTests.cs
@@ -1,0 +1,337 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // The frozen-defs sub-agent path (design A11): an allowlisted child's MCP tool defs are
+    // snapshotted at dispatch and exposed verbatim every iteration, so registry churn during a long
+    // parent turn (the mid-turn host rebuild that produced the "cd-only agent" doom loop) cannot
+    // change what the child sees. These tests drive McpChatOrchestrator.RunTurn directly with
+    // FrozenToolDefs set, the way AgentDispatcher.RunChild configures a child.
+    public class FrozenToolDefsTests
+    {
+        private static McpChatOrchestrator New(ScriptedStreamer s, McpToolRegistry reg, string model)
+        {
+            return new McpChatOrchestrator(s, reg, null, model, null);
+        }
+
+        [Fact]
+        public void Frozen_defs_survive_registry_emptying_mid_turn()
+        {
+            // THE doom-loop regression: the registry empties under a running turn (exactly what a
+            // mid-turn RebuildMcpHost teardown did) and the frozen exposure must not collapse.
+            RegistryFakeTransport ft;
+            var conn = FakeConn.Ready("files", out ft, new ToolDef("read"), new ToolDef("write"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            var names = new List<string>(reg.NamesForWorkdir(null));
+            Assert.Equal(2, names.Count);
+
+            // The tool call itself performs the "host rebuild": the catalog empties while the turn runs.
+            ft.OnCall = delegate(string name, JObject args)
+            {
+                reg.RemoveConnection(conn);
+                return RegistryFakeTransport.TextResult("contents");
+            };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "test-model");
+            orch.RevealedToolNames = names;
+            orch.FrozenToolDefs = reg.FunctionDefsForNames(null, names);
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.Equal(2, streamer.Calls);
+            Assert.False(ui.ToolErrors[0]); // the call before the churn succeeded
+            // The SECOND request — after the registry emptied — still exposes both frozen defs.
+            Assert.NotNull(streamer.SeenTools[1]);
+            Assert.Equal(2, streamer.SeenTools[1].Count);
+            var exposed = new List<string>();
+            foreach (var def in streamer.SeenTools[1]) exposed.Add((string)def["function"]["name"]);
+            Assert.Contains("files__read", exposed);
+            Assert.Contains("files__write", exposed);
+        }
+
+        [Fact]
+        public void Live_derivation_collapses_when_registry_empties_mid_turn()
+        {
+            // Control for the regression test above: WITHOUT freezing, the same mid-turn churn strips
+            // the next iteration's tools entirely. This documents the failure mode the freeze fixes —
+            // if this test ever starts failing because tools survive, the live path grew its own
+            // resilience and the freeze may be simplifiable.
+            RegistryFakeTransport ft;
+            var conn = FakeConn.Ready("files", out ft, new ToolDef("read"), new ToolDef("write"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            ft.OnCall = delegate(string name, JObject args)
+            {
+                reg.RemoveConnection(conn);
+                return RegistryFakeTransport.TextResult("contents");
+            };
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "test-model");
+            orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Equal(2, streamer.Calls);
+            Assert.Null(streamer.SeenTools[1]); // every tool gone on the next iteration
+        }
+
+        [Fact]
+        public void Frozen_turn_is_exempt_from_reveal_eviction_on_noncaching_models()
+        {
+            // Eviction trims RevealedToolNames to the cap on non-caching providers — but a frozen
+            // turn's exposure never shrinks with that list, so trimming it would only desync the
+            // reveal-enforcement gate from the schemas the model can plainly see.
+            var tools = new List<ToolDef>();
+            for (int i = 0; i < 30; i++) tools.Add(new ToolDef("t" + i.ToString("00")));
+            var conn = FakeConn.Ready("files", tools.ToArray());
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            var names = new List<string>(reg.NamesForWorkdir(null));
+            Assert.True(names.Count > McpChatOrchestrator.RevealEvictionCap);
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "mistralai/mistral-large"); // non-caching per model catalog
+            orch.RevealedToolNames = names;
+            orch.FrozenToolDefs = reg.FunctionDefsForNames(null, names);
+
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Equal(30, names.Count); // NOT trimmed to the cap
+            Assert.Equal(30, streamer.SeenTools[0].Count); // all frozen defs exposed, no reveal_tools
+        }
+
+        [Fact]
+        public void Nonfrozen_turn_still_evicts_on_noncaching_models()
+        {
+            // Guard: the frozen exemption must not have disabled eviction for ordinary turns.
+            var tools = new List<ToolDef>();
+            for (int i = 0; i < 30; i++) tools.Add(new ToolDef("t" + i.ToString("00")));
+            var conn = FakeConn.Ready("files", tools.ToArray());
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            var names = new List<string>(reg.NamesForWorkdir(null));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "mistralai/mistral-large");
+            orch.RevealedToolNames = names;
+
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Equal(McpChatOrchestrator.RevealEvictionCap, names.Count); // trimmed
+            // reveal_tools + the surviving revealed defs
+            Assert.Equal(McpChatOrchestrator.RevealEvictionCap + 1, streamer.SeenTools[0].Count);
+        }
+
+        [Fact]
+        public void Frozen_turn_out_of_set_call_gets_honest_error_not_reveal_hint()
+        {
+            // A frozen child has no reveal_tools, so the standard "reveal it first" recovery hint
+            // would send the model chasing a tool it cannot call — its own doom-loop seed.
+            RegistryFakeTransport ft;
+            var conn = FakeConn.Ready("files", out ft, new ToolDef("read"), new ToolDef("write"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__write", "{}")); // resolvable but out of set
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "test-model");
+            orch.RevealedToolNames = new List<string> { "files__read" };
+            orch.FrozenToolDefs = reg.FunctionDefsForNames(null, orch.RevealedToolNames);
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("not in this agent's tool set", ui.ToolResults[0]);
+            Assert.DoesNotContain("reveal_tools", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Frozen_turn_exposes_no_reveal_tools_and_no_names_manifest()
+        {
+            // A11: nothing to progressively discover — no reveal_tools def, no <available_tools> tail.
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = New(streamer, reg, "test-model");
+            orch.RevealedToolNames = new List<string> { "files__read" };
+            orch.FrozenToolDefs = reg.FunctionDefsForNames(null, orch.RevealedToolNames);
+
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            Assert.Single(streamer.SeenTools[0]);
+            Assert.Equal("files__read", (string)streamer.SeenTools[0][0]["function"]["name"]);
+            foreach (var m in streamer.SeenMessages[0])
+                if (m.Content != null)
+                    Assert.DoesNotContain("available_tools", m.Content);
+        }
+    }
+
+    public class FunctionDefsForNamesTests
+    {
+        [Fact]
+        public void Matches_ExposedFunctionDefs_minus_the_leading_reveal_tools_def()
+        {
+            var conn = FakeConn.Ready("files", new ToolDef("read"), new ToolDef("write"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            var names = new List<string>(reg.NamesForWorkdir(null));
+
+            var exposed = reg.ExposedFunctionDefs(null, names);
+            var frozen = reg.FunctionDefsForNames(null, names);
+
+            Assert.Equal(exposed.Count - 1, frozen.Count);
+            Assert.True(reg.IsRevealTools((string)exposed[0]["function"]["name"]));
+            for (int i = 0; i < frozen.Count; i++)
+                Assert.True(JToken.DeepEquals(exposed[i + 1], frozen[i]),
+                    "def " + i + " diverged from ExposedFunctionDefs");
+        }
+
+        [Fact]
+        public void Null_or_unknown_names_yield_no_defs()
+        {
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+
+            Assert.Empty(reg.FunctionDefsForNames(null, null));
+            Assert.Empty(reg.FunctionDefsForNames(null, new[] { "files__nope", "ghost__tool" }));
+        }
+
+        [Fact]
+        public void Workdir_scoped_defs_resolve_only_for_their_folder()
+        {
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn, "C:\\a");
+            var names = new[] { "files__read" };
+
+            Assert.Single(reg.FunctionDefsForNames("C:\\a", names));
+            Assert.Empty(reg.FunctionDefsForNames("C:\\b", names));
+        }
+    }
+
+    // AgentDispatcher.RunChild wiring of the freeze: a child gets its parent-derived defs frozen at
+    // dispatch, and an EMPTY resolution falls back to live derivation instead of pinning toollessness.
+    public sealed class AgentDispatcherFreezeTests : System.IDisposable
+    {
+        private readonly string _dir;
+
+        public AgentDispatcherFreezeTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gxpt_freeze_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        private Agent WriteAgent(string slug, string desc, string body)
+        {
+            string file = Path.Combine(_dir, slug + ".md");
+            File.WriteAllText(file, "---\nname: " + slug + "\ndescription: " + desc + "\n---\n" + body + "\n",
+                              new UTF8Encoding(false));
+            AgentCatalog cat = AgentCatalog.Build(_dir, null);
+            Agent a;
+            cat.TryGet(slug, out a);
+            return a;
+        }
+
+        private AgentDispatcher Dispatcher(ScriptedStreamer streamer, McpToolRegistry reg, string workdir,
+                                           params Agent[] agents)
+        {
+            return new AgentDispatcher(new List<Agent>(agents), streamer, reg, null,
+                "parent-model", workdir, null,
+                delegate(string n) { return ToolTier.ReadOnly; }, 25, 60000);
+        }
+
+        [Fact]
+        public void Child_is_dispatched_with_frozen_defs_and_no_reveal_manifest()
+        {
+            Agent a = WriteAgent("worker", "Works.", "You work.");
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn, "C:\\proj");
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            Dispatcher(streamer, reg, "C:\\proj", a)
+                .Dispatch("{\"agents\":[{\"name\":\"worker\",\"task\":\"t\"}]}");
+
+            // The child's request exposes the frozen MCP def plus the cd host tool — no reveal_tools.
+            var tools = streamer.SeenTools[0];
+            Assert.NotNull(tools);
+            var exposedNames = new List<string>();
+            foreach (var def in tools) exposedNames.Add((string)def["function"]["name"]);
+            Assert.Contains("files__read", exposedNames);
+            Assert.Contains("cd", exposedNames);
+            Assert.DoesNotContain("reveal_tools", exposedNames);
+            // Frozen turns carry no <available_tools> names manifest — nothing to discover.
+            foreach (var m in streamer.SeenMessages[0])
+                if (m.Content != null)
+                    Assert.DoesNotContain("available_tools", m.Content);
+        }
+
+        [Fact]
+        public void Empty_resolution_at_dispatch_falls_back_to_live_derivation_and_recovers()
+        {
+            // A child dispatched while the registry is empty (servers faulted or mid-reconnect) must
+            // NOT be pinned toolless for its whole run: with no frozen defs it re-derives live, so
+            // when the registry refills mid-run its tools (reveal_tools + manifest) appear.
+            Agent a = WriteAgent("worker", "Works.", "You work.");
+            var reg = new McpToolRegistry(null); // empty at dispatch
+            var conn = FakeConn.Ready("files", new ToolDef("read"));
+
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "files__read", "{}")); // fails: no registry entry
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "files__read", "{}")); // gate: not revealed yet
+            streamer.Turns.Add(Chunks.Text("done"));
+            // The registry refills between the child's first and second iterations ("server back up").
+            streamer.OnCall = delegate(int idx) { if (idx == 1) reg.AddConnection(conn, "C:\\proj"); };
+
+            Dispatcher(streamer, reg, "C:\\proj", a)
+                .Dispatch("{\"agents\":[{\"name\":\"worker\",\"task\":\"t\"}]}");
+
+            Assert.Equal(3, streamer.Calls);
+            // Third request sees the recovered registry: reveal_tools is back in the exposed defs and
+            // the ephemeral tail advertises the recovered tool. A frozen-empty child would have kept
+            // the first request's toolless shape forever.
+            var lastTools = streamer.SeenTools[2];
+            Assert.NotNull(lastTools);
+            bool hasReveal = false;
+            foreach (var def in lastTools)
+                if ((string)def["function"]["name"] == "reveal_tools") hasReveal = true;
+            Assert.True(hasReveal, "live derivation did not resume after the registry refilled");
+            var msgs = streamer.SeenMessages[2];
+            Assert.Contains("files__read", msgs[msgs.Count - 1].Content);
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/FrozenToolDefsTests.cs
+++ b/GxPT.Tests/Mcp/FrozenToolDefsTests.cs
@@ -61,12 +61,14 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
-        public void Live_derivation_collapses_when_registry_empties_mid_turn()
+        public void Live_derivation_collapses_to_the_recovery_handle_when_registry_empties_mid_turn()
         {
             // Control for the regression test above: WITHOUT freezing, the same mid-turn churn strips
-            // the next iteration's tools entirely. This documents the failure mode the freeze fixes —
-            // if this test ever starts failing because tools survive, the live path grew its own
-            // resilience and the freeze may be simplifiable.
+            // the next iteration's tools down to the bare reveal_tools recovery handle (the fail-fast
+            // guardrail keeps that one def so the turn can pull tools back in when servers return).
+            // This documents the failure mode the freeze fixes — if this test ever starts failing
+            // because the full tool set survives, the live path grew real resilience and the freeze
+            // may be simplifiable.
             RegistryFakeTransport ft;
             var conn = FakeConn.Ready("files", out ft, new ToolDef("read"), new ToolDef("write"));
             var reg = new McpToolRegistry(null);
@@ -87,7 +89,11 @@ namespace GxPT.Tests.Mcp
             orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
 
             Assert.Equal(2, streamer.Calls);
-            Assert.Null(streamer.SeenTools[1]); // every tool gone on the next iteration
+            // Every real tool is gone on the next iteration; only the reveal_tools recovery handle
+            // remains (the fail-fast guardrail — before it, the array was null and unrecoverable).
+            Assert.NotNull(streamer.SeenTools[1]);
+            Assert.Single(streamer.SeenTools[1]);
+            Assert.Equal("reveal_tools", (string)streamer.SeenTools[1][0]["function"]["name"]);
         }
 
         [Fact]

--- a/GxPT.Tests/Mcp/McpHostServerToggleTests.cs
+++ b/GxPT.Tests/Mcp/McpHostServerToggleTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using GxPT;
+using Mcp35.Client;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // McpHost.SetBuiltInServerEnabled: the narrow runtime start/stop of one built-in server (the
+    // skills-enablement refresh) that replaced the full host rebuild — the rebuild swapped the
+    // registry object out from under in-flight turns (the "cd-only sub-agent" doom loop).
+    public class McpHostServerToggleTests
+    {
+        private static List<string> Manifest(McpToolRegistry reg)
+        {
+            var names = new List<string>();
+            foreach (var line in reg.NamesManifestSystemMessage().Split('\n'))
+                if (line.StartsWith("- ")) names.Add(line.Substring(2));
+            return names;
+        }
+
+        private static McpHost NewHost(out FakeServerConnector connector, out McpToolRegistry reg)
+        {
+            connector = new FakeServerConnector();
+            reg = new McpToolRegistry(null);
+            return new McpHost(connector, reg, null, 2000);
+        }
+
+        private static McpServerSpec SkillsSpec(bool enabled)
+        {
+            var s = Specs.Scoped("skills", enabled);
+            s.RunsWithoutWorkdir = true; // like the real extensions server
+            return s;
+        }
+
+        [Fact]
+        public void Disable_tears_down_only_that_servers_instances()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true), SkillsSpec(true) });
+            host.EnsureWorkingDir("C:\\a");
+            // Live: skills eager (null workdir), files@a, skills@a.
+            Assert.Equal(3, c.Created.Count);
+
+            Assert.True(host.SetBuiltInServerEnabled("skills", false));
+
+            foreach (var conn in c.Created)
+            {
+                if (conn.Name == "skills") Assert.Equal(ConnectionState.Closed, conn.State);
+                else Assert.Equal(ConnectionState.Ready, conn.State); // files untouched
+            }
+            var m = Manifest(reg);
+            Assert.DoesNotContain("skills__skills_tool", m);
+            Assert.Contains("files__files_tool", m);
+            Assert.Contains("C:\\a", host.ActiveWorkingDirs); // the workdir set itself survives
+        }
+
+        [Fact]
+        public void Enable_connects_eager_and_one_instance_per_live_workdir()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { Specs.Scoped("files", true), SkillsSpec(false) });
+            host.EnsureWorkingDir("C:\\a");
+            host.EnsureWorkingDir("C:\\b");
+            Assert.DoesNotContain("skills", c.CreatedNames); // disabled at Start
+
+            Assert.True(host.SetBuiltInServerEnabled("skills", true));
+
+            var skillsWorkdirs = new List<string>();
+            for (int i = 0; i < c.CreatedNames.Count; i++)
+                if (c.CreatedNames[i] == "skills") skillsWorkdirs.Add(c.Workdirs[i]);
+            Assert.Contains(null, skillsWorkdirs);     // the eager, workdir-less instance
+            Assert.Contains("C:\\a", skillsWorkdirs);
+            Assert.Contains("C:\\b", skillsWorkdirs);
+            Assert.Equal(3, skillsWorkdirs.Count);
+
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("skills__skills_tool", "C:\\a", out r, out tool));
+            Assert.True(reg.TryResolve("skills__skills_tool", "C:\\b", out r, out tool));
+        }
+
+        [Fact]
+        public void Enable_skips_scratch_dirs_the_spec_is_not_eligible_for()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            var command = Specs.Scoped("command", true);
+            command.RunsInScratch = true;
+            host.Start(new[] { command, SkillsSpec(false) });
+            host.EnsureScratchDir("C:\\scratch\\abc");
+
+            Assert.True(host.SetBuiltInServerEnabled("skills", true));
+
+            var skillsWorkdirs = new List<string>();
+            for (int i = 0; i < c.CreatedNames.Count; i++)
+                if (c.CreatedNames[i] == "skills") skillsWorkdirs.Add(c.Workdirs[i]);
+            Assert.Equal(new string[] { null }, skillsWorkdirs.ToArray()); // eager only, never the scratch dir
+        }
+
+        [Fact]
+        public void Toggle_is_idempotent_and_spawns_nothing_new()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+            host.Start(new[] { SkillsSpec(true) });
+            int before = c.Created.Count;
+
+            Assert.True(host.SetBuiltInServerEnabled("skills", true)); // already enabled
+
+            Assert.Equal(before, c.Created.Count);
+        }
+
+        [Fact]
+        public void Toggle_reports_failure_when_it_cannot_commit()
+        {
+            FakeServerConnector c; McpToolRegistry reg;
+            var host = NewHost(out c, out reg);
+
+            // Before Start: nothing to flip — the caller must roll back its optimistic state.
+            Assert.False(host.SetBuiltInServerEnabled("skills", true));
+
+            host.Start(new[] { SkillsSpec(true) });
+            Assert.False(host.SetBuiltInServerEnabled("ghost", true)); // unknown spec
+
+            host.Dispose();
+            Assert.False(host.SetBuiltInServerEnabled("skills", false)); // disposed
+        }
+
+        [Fact]
+        public void Enable_waits_for_a_mid_connect_workdir_and_tops_it_up()
+        {
+            // The _connecting race: a workdir's scoped set is mid-handshake (its ConnectScoped spec
+            // snapshot saw skills DISABLED) when the enable lands. The toggle must wait for that
+            // publish and then top the set up, not silently miss the folder until the next rebuild.
+            var connector = new GatedServerConnector();
+            var reg = new McpToolRegistry(null);
+            var host = new McpHost(connector, reg, null, 5000);
+            var skills = Specs.Scoped("skills", false); // plain scoped: no eager instance to gate
+            host.Start(new[] { Specs.Scoped("files", true), skills });
+
+            var ensureThread = new Thread(delegate() { host.EnsureWorkingDir("C:\\a"); });
+            ensureThread.IsBackground = true;
+            ensureThread.Start();
+            Assert.True(connector.Opening.WaitOne(5000), "connect never reached Open()");
+
+            bool ok = false;
+            var toggleThread = new Thread(delegate() { ok = host.SetBuiltInServerEnabled("skills", true); });
+            toggleThread.IsBackground = true;
+            toggleThread.Start();
+
+            connector.OpenGate.Set(); // release the parked handshake (stays signaled for later opens)
+            Assert.True(ensureThread.Join(5000), "ensure thread did not finish");
+            Assert.True(toggleThread.Join(5000), "toggle thread did not finish");
+
+            Assert.True(ok);
+            McpServerConnection r; string tool;
+            Assert.True(reg.TryResolve("skills__skills_tool", "C:\\a", out r, out tool),
+                "skills server missing for the workdir that was mid-connect during the enable");
+        }
+
+        [Fact]
+        public void Disable_mid_connect_discards_the_instance_at_publish()
+        {
+            // Mirror race: skills is ENABLED and mid-handshake for a new workdir when the disable
+            // lands. The disable pass can't see the unpublished connection, so ConnectScoped's own
+            // publish step must discard it — otherwise a live, invisible skills server would expose
+            // its tools to a conversation the flip meant to hide them from.
+            var connector = new GatedServerConnector();
+            var reg = new McpToolRegistry(null);
+            var host = new McpHost(connector, reg, null, 5000);
+            host.Start(new[] { Specs.Scoped("skills", true) });
+
+            var ensureThread = new Thread(delegate() { host.EnsureWorkingDir("C:\\a"); });
+            ensureThread.IsBackground = true;
+            ensureThread.Start();
+            Assert.True(connector.Opening.WaitOne(5000), "connect never reached Open()");
+
+            // Disable while the handshake is parked; nothing is published yet, so this returns fast.
+            Assert.True(host.SetBuiltInServerEnabled("skills", false));
+
+            connector.OpenGate.Set();
+            Assert.True(ensureThread.Join(5000), "ensure thread did not finish");
+
+            Assert.Empty(Manifest(reg)); // never published into the registry
+            Assert.True(connector.Created.All(conn => conn.State == ConnectionState.Closed),
+                "the mid-connect instance of the disabled spec was not torn down");
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/PathOrientationTests.cs
+++ b/GxPT.Tests/Mcp/PathOrientationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GxPT;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxPT.Tests.Mcp
+{
+    // Path-orientation fixes for the original doom loop: cd accepts absolute in-workspace paths and
+    // reports resolved absolute paths in errors and echoes; pwd reports without moving; and
+    // reveal_tools is liberal about the `names` arg shape but loud when nothing usable was passed
+    // (it used to return a silent [] that read as "those tools don't exist").
+    public class PathOrientationTests : IDisposable
+    {
+        private readonly string _anchor;
+        private readonly string _sub;
+
+        public PathOrientationTests()
+        {
+            _anchor = Path.Combine(Path.GetTempPath(), "pathorient_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_anchor);
+            _sub = Path.Combine(_anchor, "sub");
+            Directory.CreateDirectory(_sub);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_anchor, true); } catch { }
+        }
+
+        private static McpToolRegistry RegistryWith(out RegistryFakeTransport ft, string server, params ToolDef[] tools)
+        {
+            var conn = FakeConn.Ready(server, out ft, tools);
+            var reg = new McpToolRegistry(null);
+            reg.AddConnection(conn);
+            return reg;
+        }
+
+        private static McpChatOrchestrator Orch(ScriptedStreamer s, McpToolRegistry reg, string anchor)
+        {
+            var orch = new McpChatOrchestrator(s, reg, null, "test-model", null);
+            if (reg != null) orch.RevealedToolNames = new List<string>(reg.NamesForWorkdir(null));
+            orch.WorkingDir = anchor;
+            return orch;
+        }
+
+        private static string ArgsJson(string key, string value)
+        {
+            var o = new JObject();
+            o[key] = value;
+            return o.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        [Fact]
+        public void Cd_accepts_an_absolute_path_inside_the_workspace()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", ArgsJson("path", _sub)));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Equal(Path.GetFullPath(_sub), orch.CurrentDir);
+            Assert.Contains("Current directory is now `sub`", ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Cd_rejects_an_absolute_path_outside_the_workspace()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            string outside = Path.GetFullPath(Path.Combine(_anchor, ".."));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", ArgsJson("path", outside)));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("above the workspace root", ui.ToolResults[0]);
+            Assert.Null(orch.CurrentDir);
+        }
+
+        [Fact]
+        public void Cd_not_found_error_reports_the_resolved_absolute_path()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", "{\"path\":\"missing\"}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains(Path.Combine(Path.GetFullPath(_anchor), "missing"), ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Cd_success_echo_includes_the_absolute_path()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", "{\"path\":\"sub\"}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Contains(Path.GetFullPath(_sub), ui.ToolResults[0]);
+        }
+
+        [Fact]
+        public void Pwd_reports_the_current_dir_without_moving()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "cd", "{\"path\":\"sub\"}"));
+            streamer.Turns.Add(Chunks.OneToolCall("c2", "pwd", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.False(ui.ToolErrors[1]);
+            Assert.Contains("`sub`", ui.ToolResults[1]);
+            Assert.Contains(Path.GetFullPath(_sub), ui.ToolResults[1]);
+            // pwd did NOT reset the current dir (a no-arg cd would have).
+            Assert.Equal(Path.GetFullPath(_sub), orch.CurrentDir);
+        }
+
+        [Fact]
+        public void Pwd_is_exposed_alongside_cd()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            orch.RunTurn(new List<ChatMessage>(), "go", new RecordingUi());
+
+            var names = new List<string>();
+            foreach (var def in streamer.SeenTools[0]) names.Add((string)def["function"]["name"]);
+            Assert.Contains("cd", names);
+            Assert.Contains("pwd", names);
+        }
+
+        [Fact]
+        public void Reveal_accepts_a_stringified_names_array()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            // The array arrives STRINGIFIED - the exact malformation observed in the doom loop.
+            streamer.Turns.Add(Chunks.OneToolCall("r1", "reveal_tools", ArgsJson("names", "[\"files__read\"]")));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>();
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Contains("files__read", ui.ToolResults[0]); // the def came back
+            Assert.Contains("files__read", orch.RevealedToolNames);
+        }
+
+        [Fact]
+        public void Reveal_accepts_a_single_bare_name()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("r1", "reveal_tools", ArgsJson("names", "files__read")));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>();
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.False(ui.ToolErrors[0]);
+            Assert.Contains("files__read", orch.RevealedToolNames);
+        }
+
+        [Fact]
+        public void Reveal_with_no_usable_names_is_a_loud_error()
+        {
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("r1", "reveal_tools", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = new McpChatOrchestrator(streamer, reg, null, "test-model", null);
+            orch.RevealedToolNames = new List<string>();
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            Assert.True(ui.ToolErrors[0]);
+            Assert.Contains("no tool names given", ui.ToolResults[0]);
+        }
+    }
+}

--- a/GxPT/Controls/ToolApprovalPanel.cs
+++ b/GxPT/Controls/ToolApprovalPanel.cs
@@ -723,21 +723,34 @@ namespace GxPT
         // onto the UI thread by TranscriptContinuationPrompt; the click signals the blocked worker.
         public void ShowContinuation(int iterationsSoFar, Action<bool> callback)
         {
+            ShowContinuation(iterationsSoFar, false, callback);
+        }
+
+        // doomLoop=true is the doom-loop variant (the detector saw a repeating call cycle): same
+        // Continue/Stop flow, wording that says WHY the turn paused — "limit reached" would be a lie
+        // there, and the user's judgement call is different ("is this repetition intentional?").
+        public void ShowContinuation(int iterationsSoFar, bool doomLoop, Action<bool> callback)
+        {
             _onChoose = null;
             _onContinue = callback;
-            // The iteration-cap prompt is not a command tool: never offer Explain here.
+            // The continuation prompt is not a command tool: never offer Explain here.
             _explainCommand = null;
             _explainIsPowerShell = false;
             UpdateExplainButton(false);
 
-            _header.Text = "Tool-call limit reached";
+            _header.Text = doomLoop ? "Repeating tool calls detected" : "Tool-call limit reached";
             _currentTier = ToolTier.Write; // informational; reuse the Write (goldenrod) badge color
             _tierBadge.Text = "Paused after " + iterationsSoFar + " tool iteration(s) this turn";
 
             _previewLabel.Text = "Details:";
-            _preview.Text = "The agent has been working for a long time. Do you want to continue?\r\n\r\n"
-                + "Choose Continue to let it keep working, or Stop to have it summarize progress and "
-                + "ask how you'd like to proceed.";
+            _preview.Text = doomLoop
+                ? "The agent appears to be repeating the same tool calls in a cycle without making "
+                    + "progress. Do you want to let it keep trying?\r\n\r\n"
+                    + "Choose Continue if the repetition looks intentional, or Stop to have it "
+                    + "summarize progress and ask how you'd like to proceed."
+                : "The agent has been working for a long time. Do you want to continue?\r\n\r\n"
+                    + "Choose Continue to let it keep working, or Stop to have it summarize progress and "
+                    + "ask how you'd like to proceed.";
             _diffPanel.Visible = false;
             _preview.Visible = true;
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -870,6 +870,14 @@ namespace GxPT
             string activeRef = active;
             bool activeScratchRef = activeScratch;
             string[] inUseArr = inUse.ToArray();
+            // The RELEASE half of the reconcile (RetainOnly) is deferred while any turn is in flight:
+            // tearing down a folder's servers removes their tools from the live registry the running
+            // turn — or a detached turn whose tab just closed, the usual reason a folder leaves the
+            // in-use set — still holds, stranding its remaining calls exactly like a mid-turn rebuild
+            // would. The ENSURE half stays immediate: it only ever adds. The deferred release re-runs
+            // this whole reconcile (fresh tab state) when the last turn ends.
+            bool deferRelease = AnyTurnInFlight();
+            if (deferRelease) _workdirReleaseDeferred = true;
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
                 try
@@ -879,7 +887,8 @@ namespace GxPT
                         if (activeScratchRef) hostRef.EnsureScratchDir(activeRef);
                         else hostRef.EnsureWorkingDir(activeRef);
                     }
-                    hostRef.RetainOnly(inUseArr); // release folders whose last tab closed
+                    if (!deferRelease)
+                        hostRef.RetainOnly(inUseArr); // release folders whose last tab closed
                 }
                 catch (Exception ex) { try { Logger.Log("mcp", "MCP workdir reconcile failed: " + ex.Message); } catch { } }
             });
@@ -1776,7 +1785,9 @@ namespace GxPT
             // can send a tool call before the window is visible - RestoreSessionAfterShown does the
             // first build post-Shown). On every LATER call - the Settings dialog's close paths run
             // InitializeClient to apply changes - the gate is already lifted, so new keys, server
-            // toggles, and mcp.json edits take effect immediately, as they did before the deferral.
+            // toggles, and mcp.json edits take effect immediately UNLESS a turn is in flight, in
+            // which case the rebuild is deferred until the last turn ends (rebuilding mid-turn would
+            // strand the running turn's registry - see RebuildMcpHost).
             RebuildMcpHost();
         }
 
@@ -1799,13 +1810,37 @@ namespace GxPT
         // stopping the extensions server mid-turn strips its tools out of the live registry).
         private bool _skillsRefreshDeferred;
 
-        // True while any tab's turn is running. Detached turns count: a recycled tab's context stays
-        // in TabContexts with IsSending held until the turn finalizes. UI-thread only, like every
-        // IsSending write.
+        // A workdir-server release (SyncMcpWorkingDirFromActiveTab's RetainOnly) was skipped because a
+        // turn was in flight; the reconcile re-runs when the last turn ends.
+        private bool _workdirReleaseDeferred;
+
+        // Contexts whose tab was closed out from under a running send (TabManager.CloseConversationTab
+        // removes them from TabContexts unconditionally, but the turn keeps running detached and still
+        // holds the registry). Tracked here so AnyTurnInFlight keeps deferring host churn until they
+        // finalize; pruned on every check once IsSending clears (finalization always runs — the close
+        // path resolves any blocking approval prompt first). The LAST-tab close is different: its
+        // context is recycled in place and stays in TabContexts, so the normal scan covers it.
+        private readonly List<TabManager.ChatTabContext> _detachedTurnCtxs =
+            new List<TabManager.ChatTabContext>();
+
+        // Called by TabManager just before it drops a still-sending context from TabContexts.
+        internal void TrackDetachedTurn(TabManager.ChatTabContext ctx)
+        {
+            if (ctx == null || !ctx.IsSending) return;
+            if (!_detachedTurnCtxs.Contains(ctx)) _detachedTurnCtxs.Add(ctx);
+        }
+
+        // True while any turn is running: a tab's send (IsSending; the last-tab recycle path keeps its
+        // context in TabContexts with IsSending held), or a detached turn whose tab was closed
+        // (_detachedTurnCtxs). UI-thread only, like every IsSending write.
         private bool AnyTurnInFlight()
         {
             try
             {
+                for (int i = _detachedTurnCtxs.Count - 1; i >= 0; i--)
+                    if (_detachedTurnCtxs[i] == null || !_detachedTurnCtxs[i].IsSending)
+                        _detachedTurnCtxs.RemoveAt(i);
+                if (_detachedTurnCtxs.Count > 0) return true;
                 if (_tabManager == null) return false;
                 foreach (var c in _tabManager.TabContexts.Values)
                     if (c != null && c.IsSending) return true;
@@ -1821,18 +1856,23 @@ namespace GxPT
         private void FlushDeferredMcpWork()
         {
             if (_mcpHostStartupDeferred) return;
-            if (!_mcpRebuildDeferred && !_skillsRefreshDeferred) return;
+            if (!_mcpRebuildDeferred && !_skillsRefreshDeferred && !_workdirReleaseDeferred) return;
             if (AnyTurnInFlight()) return;
             bool rebuild = _mcpRebuildDeferred;
+            bool skills = _skillsRefreshDeferred;
+            bool workdirs = _workdirReleaseDeferred;
             _mcpRebuildDeferred = false;
             _skillsRefreshDeferred = false;
+            _workdirReleaseDeferred = false;
             if (rebuild)
             {
                 try { Logger.Log("mcp", "applying deferred host rebuild (last turn ended)"); }
                 catch { }
-                RebuildMcpHost();
+                RebuildMcpHost(); // subsumes the skills flip AND rebinds/releases workdirs itself
+                return;
             }
-            else ApplySkillsServerEnablement();
+            if (skills) ApplySkillsServerEnablement();
+            if (workdirs) SyncMcpWorkingDirFromActiveTab(); // re-runs the reconcile with fresh tab state
         }
 
         // Assembles MCP server specs from settings and (re)starts the host. Safe to call repeatedly
@@ -2380,11 +2420,22 @@ namespace GxPT
             UpdateToolSkillCounts();
         }
 
+        // Monotonic id of the newest skills-server flip request. ThreadPool work items are not
+        // guaranteed to run in queue order, so without this two rapid flips (tab A -> B -> A) could
+        // apply out of order and leave the server in the OLDER state while the flag claims the newer.
+        // A stale applier sees a newer generation and drops out; the lock serializes the appliers
+        // themselves. UI thread increments; workers read under the lock.
+        private int _skillsFlipGen;
+        private readonly object _skillsFlipLock = new object();
+
         // Start or stop JUST the extensions (skills/agents) server to match the active conversation's
         // skill enablement. No-ops while the host doesn't exist yet (startup-deferred): the post-Shown
         // RebuildMcpHost reads live enablement itself. Re-checks the boundary so a stale deferred
         // request self-cancels when the state flipped back meanwhile (e.g. the user returned to the
-        // original tab before the turn ended).
+        // original tab before the turn ended). The flag is committed optimistically on the UI thread
+        // (the boundary check needs it synchronous) but ROLLED BACK if the async apply reports it
+        // committed nothing — otherwise a silent no-op (host mid-rebuild, spawn failure) would leave
+        // the flag lying and the boundary check would suppress every retry forever.
         private void ApplySkillsServerEnablement()
         {
             McpHost hostRef = _mcpHost;
@@ -2392,16 +2443,38 @@ namespace GxPT
             bool want = ActiveConversationHasEnabledSkills();
             if (want == _skillsServerEnabled) return;
             _skillsServerEnabled = want;
+            int gen = ++_skillsFlipGen;
             // Connecting (process spawn + handshake) can block — do it off the UI thread, like
             // RebuildMcpHost's start path.
             System.Threading.ThreadPool.QueueUserWorkItem(delegate
             {
-                try { hostRef.SetBuiltInServerEnabled(McpConfig.ExtensionsName, want); }
+                bool applied = false;
+                try
+                {
+                    lock (_skillsFlipLock)
+                    {
+                        if (gen != _skillsFlipGen) return; // superseded by a newer flip
+                        applied = hostRef.SetBuiltInServerEnabled(McpConfig.ExtensionsName, want);
+                    }
+                }
                 catch (Exception ex)
                 {
                     try { Logger.Log("mcp", "skills server refresh failed: " + ex.Message); }
                     catch { }
                 }
+                if (applied) return;
+                try
+                {
+                    BeginInvoke((MethodInvoker)delegate
+                    {
+                        // Roll the flag back only if nothing newer moved it and the host is still the
+                        // one we tried to flip (a rebuild recomputes the flag itself).
+                        if (gen == _skillsFlipGen && ReferenceEquals(_mcpHost, hostRef)
+                            && _skillsServerEnabled == want)
+                            _skillsServerEnabled = !want;
+                    });
+                }
+                catch { }
             });
         }
 

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1121,6 +1121,10 @@ namespace GxPT
                     SyncGenerationIndicatorFromActiveTab();
             }
             catch { }
+            // Every turn-finalization site funnels through here right after clearing ctx.IsSending
+            // (this method has no other callers), making it the single "a turn just ended" point:
+            // apply any MCP host work that was deferred because a turn was in flight.
+            FlushDeferredMcpWork();
         }
 
         // Called by AgentActivityUiBridge (on the UI thread) when a fan-out starts/ends on a tab, so the
@@ -1783,6 +1787,54 @@ namespace GxPT
         // host assembly back onto the launch path.
         private bool _mcpHostStartupDeferred = true;
 
+        // A RebuildMcpHost was requested while a turn was in flight and is waiting for the last turn
+        // to end. Rebuilding mid-turn swaps the host AND the registry object out from under the
+        // running orchestrator — its AgentDispatcher and child agents keep the old, force-emptied
+        // registry and never re-bind (only the NEXT user turn reads the fresh field), so every
+        // sub-agent dispatched after the swap is born with no MCP tools (the "cd-only agent" doom
+        // loop). FlushDeferredMcpWork applies the rebuild when the last turn finalizes.
+        private bool _mcpRebuildDeferred;
+
+        // A skills-server enablement flip was requested while a turn was in flight (same rationale:
+        // stopping the extensions server mid-turn strips its tools out of the live registry).
+        private bool _skillsRefreshDeferred;
+
+        // True while any tab's turn is running. Detached turns count: a recycled tab's context stays
+        // in TabContexts with IsSending held until the turn finalizes. UI-thread only, like every
+        // IsSending write.
+        private bool AnyTurnInFlight()
+        {
+            try
+            {
+                if (_tabManager == null) return false;
+                foreach (var c in _tabManager.TabContexts.Values)
+                    if (c != null && c.IsSending) return true;
+            }
+            catch { }
+            return false;
+        }
+
+        // Apply MCP host work that was deferred because a turn was in flight. Called from the shared
+        // turn-finalization tail (HideGenerationBar); no-ops until the LAST in-flight turn has ended.
+        // A full rebuild subsumes the skills refresh (it recomputes skills enablement itself), and the
+        // skills path re-checks the enablement boundary, so a stale deferral self-cancels.
+        private void FlushDeferredMcpWork()
+        {
+            if (_mcpHostStartupDeferred) return;
+            if (!_mcpRebuildDeferred && !_skillsRefreshDeferred) return;
+            if (AnyTurnInFlight()) return;
+            bool rebuild = _mcpRebuildDeferred;
+            _mcpRebuildDeferred = false;
+            _skillsRefreshDeferred = false;
+            if (rebuild)
+            {
+                try { Logger.Log("mcp", "applying deferred host rebuild (last turn ended)"); }
+                catch { }
+                RebuildMcpHost();
+            }
+            else ApplySkillsServerEnablement();
+        }
+
         // Assembles MCP server specs from settings and (re)starts the host. Safe to call repeatedly
         // (e.g. after Settings is saved). Workdir-independent servers (web + GitHub + custom) connect
         // here; files/git/command are deferred until a working-directory UX exists.
@@ -1792,6 +1844,19 @@ namespace GxPT
             // of _mcpHost is null-tolerant, and the post-Shown build reads the same settings/skill
             // enablement any gated early call would have.
             if (_mcpHostStartupDeferred) return;
+            // Never rebuild while a turn is running: disposing the host force-empties the registry the
+            // in-flight orchestrator (and its sub-agents) still hold, and the new registry object is
+            // only picked up by the NEXT user turn — so a mid-turn rebuild strands the rest of the
+            // running turn with no MCP tools. Defer; the shared turn-finalization tail flushes it.
+            if (AnyTurnInFlight())
+            {
+                _mcpRebuildDeferred = true;
+                try { Logger.Log("mcp", "RebuildMcpHost deferred: a turn is in flight"); }
+                catch { }
+                return;
+            }
+            _mcpRebuildDeferred = false;
+            _skillsRefreshDeferred = false; // a full rebuild recomputes skills enablement too
             try
             {
                 // Tear down any previous host (servers from the old settings).
@@ -2295,15 +2360,49 @@ namespace GxPT
                 AppDomain.CurrentDomain.BaseDirectory, workdir, convFeatureOff, convOverrides);
         }
 
-        // The Skills MCP server tracks skill enablement; rebuild the host only when that crosses the
+        // The Skills MCP server (extensions) tracks skill enablement; act only when that crosses the
         // on/off boundary (so per-skill toggles that don't change whether ANY skill is enabled cost
-        // nothing). Called after skills slash-command changes and on tab switches.
+        // nothing). Called after skills slash-command changes and on tab switches. Deliberately NARROW:
+        // this used to run a full RebuildMcpHost, which tore down and recreated every server AND the
+        // tool registry on each tab switch between conversations with differing skills state — and a
+        // mid-turn rebuild strands the running orchestrator (and its sub-agents) on the old, emptied
+        // registry: the "cd-only sub-agent" doom loop. Now only the extensions server starts/stops,
+        // and even that is deferred while any turn is in flight (stopping it would strip its tools
+        // out of the live registry mid-turn).
         internal void SlashRefreshSkillsServer()
         {
             if (ActiveConversationHasEnabledSkills() != _skillsServerEnabled)
-                RebuildMcpHost();
+            {
+                if (AnyTurnInFlight()) _skillsRefreshDeferred = true;
+                else ApplySkillsServerEnablement();
+            }
             // Per-skill toggles change the counts even when they don't cross the server boundary.
             UpdateToolSkillCounts();
+        }
+
+        // Start or stop JUST the extensions (skills/agents) server to match the active conversation's
+        // skill enablement. No-ops while the host doesn't exist yet (startup-deferred): the post-Shown
+        // RebuildMcpHost reads live enablement itself. Re-checks the boundary so a stale deferred
+        // request self-cancels when the state flipped back meanwhile (e.g. the user returned to the
+        // original tab before the turn ended).
+        private void ApplySkillsServerEnablement()
+        {
+            McpHost hostRef = _mcpHost;
+            if (hostRef == null) return;
+            bool want = ActiveConversationHasEnabledSkills();
+            if (want == _skillsServerEnabled) return;
+            _skillsServerEnabled = want;
+            // Connecting (process spawn + handshake) can block — do it off the UI thread, like
+            // RebuildMcpHost's start path.
+            System.Threading.ThreadPool.QueueUserWorkItem(delegate
+            {
+                try { hostRef.SetBuiltInServerEnabled(McpConfig.ExtensionsName, want); }
+                catch (Exception ex)
+                {
+                    try { Logger.Log("mcp", "skills server refresh failed: " + ex.Message); }
+                    catch { }
+                }
+            });
         }
 
         internal IDictionary<string, bool> SlashGetConversationSkillOverrides()

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -3775,6 +3775,10 @@ namespace GxPT
                             return usable ? p : null;
                         });
                         orch.ContinuationDecider = delegate(int n) { return contPrompt.Ask(n); };
+                        // Doom-loop pause gets the same in-transcript prompt with its own wording:
+                        // the user may know the repetition is intentional. Sub-agents never get a
+                        // decider — the detector wraps them up unattended (A18).
+                        orch.DoomLoopContinuationDecider = delegate(int n) { return contPrompt.AskDoomLoop(n); };
                     }
                     // ask_user: expose the question tool, routed to this tab's QuestionPanel. The panel
                     // resolver uses the same recycled-tab guard as the approval prompt - it yields null

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -623,6 +623,13 @@ namespace GxPT
                     catch { }
                 }
 
+                // The context is about to leave TabContexts while its turn may still be running
+                // detached (the Deny above unblocks it; it wraps up on its own worker). Hand it to
+                // the host so "any turn in flight" checks — which gate MCP host rebuilds and server
+                // teardowns — keep seeing it until that turn finalizes.
+                try { if (ctx != null && ctx.IsSending) _mainForm.TrackDetachedTurn(ctx); }
+                catch { }
+
                 if (_tabContexts.ContainsKey(page))
                     _tabContexts.Remove(page);
 

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -430,10 +430,16 @@ namespace GxPT
                 // whole, no reveal_tools dance). Snapshotting the concrete defs — not just the names —
                 // means the child's exposure no longer re-reads the registry each iteration, so registry
                 // churn during a long parent turn can't strip a running child's tools out from under it.
-                child.FrozenToolDefs = _registry.FunctionDefsForNames(_workingDir, allowed);
-                if (child.FrozenToolDefs.Count == 0 && allowed.Count > 0)
-                    _log.Log("agents", "child '" + agent.Slug + "' froze 0 tool defs from " + allowed.Count
-                        + " allowed name(s) (workdir=" + (_workingDir ?? "") + ") - registry empty or servers down?");
+                // Never freeze EMPTINESS, though: 0 defs at dispatch means the registry is empty or the
+                // servers are mid-(re)connect, and pinning that would leave the child toolless for its
+                // whole budget. Falling back to live derivation lets it recover as the registry refills
+                // (the pre-seeded RevealedToolNames make its tools appear without a reveal round-trip).
+                IList<JObject> frozen = _registry.FunctionDefsForNames(_workingDir, allowed);
+                if (frozen.Count > 0) child.FrozenToolDefs = frozen;
+                else if (allowed.Count > 0)
+                    _log.Log("agents", "child '" + agent.Slug + "' resolved 0 tool defs from " + allowed.Count
+                        + " allowed name(s) (workdir=" + (_workingDir ?? "") + ") - registry empty or servers"
+                        + " down? Falling back to live derivation.");
             }
 
             List<ChatMessage> msgs = new List<ChatMessage>();

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -424,6 +424,24 @@ namespace GxPT
                 List<string> allowed = new List<string>();
                 for (int i = 0; i < parentNames.Count; i++)
                     if (!hidden.Contains(parentNames[i])) allowed.Add(parentNames[i]);
+
+                // A child whose frontmatter promises SPECIFIC tools but whose effective set resolved to
+                // nothing would burn its whole MaxTurns budget improvising with host tools alone (the
+                // observed cd-only doom loop: 40 iterations of directory-walking with no way to work).
+                // Fail the dispatch loudly instead — the parent can retry once the workspace servers
+                // are back, or surface the misconfiguration to the user. A bare "*" allowlist (or none)
+                // inherits "whatever the parent has", so an empty result there is consistent rather
+                // than a broken promise, and such children still run (e.g. text-only agents).
+                if (allowed.Count == 0 && DeclaresConcreteTools(agent.Tools))
+                {
+                    history = new List<ChatMessage>();
+                    _log.Log("agents", "child '" + agent.Slug + "' not dispatched: its declared tool "
+                        + "allowlist resolved to 0 available tools (workdir=" + (_workingDir ?? "") + ")");
+                    return "[agent error: '" + agent.Slug + "' declares specific tools in its frontmatter, "
+                        + "but none of them are currently available in this workspace (the workspace tool "
+                        + "servers may be down or restarting). The agent was NOT dispatched — retry once "
+                        + "tools are available.]";
+                }
                 child.RevealedToolNames = allowed;
 
                 // Freeze the child's MCP defs NOW (A11: an allowlisted child is handed its tool defs
@@ -459,6 +477,21 @@ namespace GxPT
                 return "[agent error: " + ex.Message + "]";
             }
             return ExtractFinalAnswer(msgs);
+        }
+
+        // True when the frontmatter allowlist names at least one CONCRETE tool pattern ("files__*",
+        // "git__status") — i.e. the agent definition promises specific tools. A bare "*" only says
+        // "whatever the parent has", so an empty effective set is consistent with it, not a broken
+        // promise.
+        private static bool DeclaresConcreteTools(string[] tools)
+        {
+            if (tools == null) return false;
+            for (int i = 0; i < tools.Length; i++)
+            {
+                string t = tools[i];
+                if (!string.IsNullOrEmpty(t) && t.Trim() != "*") return true;
+            }
+            return false;
         }
 
         // Resolves the model a child runs under, in decreasing precedence (design A21). Dispatch-level args

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -425,6 +425,15 @@ namespace GxPT
                 for (int i = 0; i < parentNames.Count; i++)
                     if (!hidden.Contains(parentNames[i])) allowed.Add(parentNames[i]);
                 child.RevealedToolNames = allowed;
+
+                // Freeze the child's MCP defs NOW (A11: an allowlisted child is handed its tool defs
+                // whole, no reveal_tools dance). Snapshotting the concrete defs — not just the names —
+                // means the child's exposure no longer re-reads the registry each iteration, so registry
+                // churn during a long parent turn can't strip a running child's tools out from under it.
+                child.FrozenToolDefs = _registry.FunctionDefsForNames(_workingDir, allowed);
+                if (child.FrozenToolDefs.Count == 0 && allowed.Count > 0)
+                    _log.Log("agents", "child '" + agent.Slug + "' froze 0 tool defs from " + allowed.Count
+                        + " allowed name(s) (workdir=" + (_workingDir ?? "") + ") - registry empty or servers down?");
             }
 
             List<ChatMessage> msgs = new List<ChatMessage>();

--- a/GxPT/Services/Mcp/DoomLoopDetector.cs
+++ b/GxPT/Services/Mcp/DoomLoopDetector.cs
@@ -29,10 +29,22 @@ namespace GxPT
         // repeating cycle. Call exactly once per call the model actually ran.
         public bool Record(string name, string argumentsJson)
         {
-            _sigs.Add(Signature(name, argumentsJson));
+            return Record(name, argumentsJson, null);
+        }
+
+        // `scope` is the location the call ran in — the host current directory in effect after the
+        // call (null at the workspace root). It is part of the signature because a legitimate
+        // directory WALK repeats name+args verbatim ("cd ..", then "list .") while moving through
+        // DIFFERENT directories; without the salt, walking up a tree reads as a period-1/2 cycle
+        // (an observed false positive). A genuinely stuck loop repeats in place — or cycles back
+        // through the same places, which repeats the scopes too — so true positives still match.
+        public bool Record(string name, string argumentsJson, string scope)
+        {
+            _sigs.Add(Signature(name, argumentsJson) + "@" + (scope ?? string.Empty));
             // Bound the window so an old, unrelated prefix can never combine with the recent tail to
-            // fake a cycle, and so memory stays O(1) across a long turn.
-            while (_sigs.Count > MaxHistory) _sigs.RemoveAt(0);
+            // fake a cycle, and so memory stays O(1) across a long turn. Record adds exactly one
+            // entry, so a single removal restores the bound.
+            if (_sigs.Count > MaxHistory) _sigs.RemoveAt(0);
             return HasCycle();
         }
 

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -234,6 +234,17 @@ namespace GxPT
         // Set per send (the orchestrator is built fresh each turn), so it's not shared/racy.
         public ICollection<string> HiddenToolNames { get; set; }
 
+        // When set (sub-agent turns; AgentDispatcher.RunChild), the MCP tool defs offered to the model
+        // are EXACTLY this list, frozen at dispatch time, instead of being re-derived from the live
+        // registry every loop iteration. A child's tool set is fixed by its frontmatter (A11), and
+        // deriving it live made the child's exposure depend on registry state that can shift under a
+        // long-running parent turn (a mid-turn host rebuild empties the old registry), which stranded
+        // children with no tools at all. reveal_tools is deliberately absent from the frozen list — an
+        // allowlisted child skips progressive disclosure — and no names manifest is emitted (nothing to
+        // discover). Host tools are still appended and HiddenToolNames still filters. Tool CALLS still
+        // resolve against the live registry (execution needs a live server); only exposure is frozen.
+        public IList<JObject> FrozenToolDefs { get; set; }
+
         // Sticky provider routing (prompt caching): the provider endpoint that last DEMONSTRATED a
         // cache hit for this conversation (cached_tokens > 0 on its response), seeded by the host
         // from Conversation.CacheWarmProvider. Prompt caches live per provider, so on
@@ -427,13 +438,27 @@ namespace GxPT
                 // actually contributes tools; a skills-only turn skips both and offers just open_skill.
                 // Filter by THIS turn's workdir so a folderless turn never advertises another folder's
                 // scoped tools (files/git/run_skill_script, ...) that it couldn't actually call.
+                // A sub-agent turn with FrozenToolDefs set bypasses the registry derivation entirely:
+                // its defs were fixed at dispatch (no reveal_tools, no manifest — nothing to discover),
+                // so registry churn during the turn cannot change what the child sees.
                 string resolveDir = ResolutionWorkdir;
-                bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(resolveDir);
-                IList<JObject> tools = hasMcpTools
-                    ? _registry.ExposedFunctionDefs(resolveDir, RevealedToolNames) : null;
-                // The tail carries the tool INVENTORY only (names + git steering); the reveal-before-call
-                // rule is static framing and lives in the cached agent system prompt, not re-sent here.
-                string manifest = hasMcpTools ? _registry.NamesManifestList(resolveDir) : null;
+                IList<JObject> tools;
+                string manifest;
+                if (FrozenToolDefs != null)
+                {
+                    tools = FrozenToolDefs.Count > 0 ? new List<JObject>(FrozenToolDefs) : null;
+                    manifest = null;
+                }
+                else
+                {
+                    bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(resolveDir);
+                    tools = hasMcpTools
+                        ? _registry.ExposedFunctionDefs(resolveDir, RevealedToolNames) : null;
+                    // The tail carries the tool INVENTORY only (names + git steering); the reveal-before-
+                    // call rule is static framing and lives in the cached agent system prompt, not re-sent
+                    // here.
+                    manifest = hasMcpTools ? _registry.NamesManifestList(resolveDir) : null;
+                }
                 // Append the host ("meta") tool defs from the SAME table ExecuteCall dispatches against, so
                 // a tool is exposed here exactly when it is dispatch-exempt there (see BuildHostTools).
                 // reveal_tools is skipped: ExposedFunctionDefs already emitted it in lead position 0 (an

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -287,6 +287,13 @@ namespace GxPT
         // user answers, which is correct (the user is present).
         public Func<int, bool> ContinuationDecider { get; set; }
 
+        // Like ContinuationDecider, but consulted when the doom-loop detector fires mid-turn: return
+        // true to clear the detector's window and keep going (the user judges the repetition
+        // intentional), false to wrap the turn up as content. Null => wrap up, which is what
+        // sub-agents get by design — an unattended child needs the automatic valve (A18); only the
+        // interactive main turn has a person to ask.
+        public Func<int, bool> DoomLoopContinuationDecider { get; set; }
+
         // Per-turn cancellation handle for the in-flight model request (may be null). When the user
         // stops the turn, Cancel() kills the current model stream via the streamer; this loop also
         // reads IsCancelled to bail out cleanly between steps - the partial assistant text is kept and
@@ -435,7 +442,12 @@ namespace GxPT
                     {
                         _log.Log("mcp", "[turn " + turnId + "] iteration cap reached at " + iter
                             + "; wrapping up");
-                        RunCapWrapUp(history, _lastOfferedTools, ui, turnId);
+                        // Cap reached and not continued: one final model call (tool_choice "none")
+                        // asking it to summarize and ask how to proceed, so the turn ends with a
+                        // readable assistant message rather than a cryptic dead-end. The user can
+                        // simply reply to keep going (a fresh budget next turn).
+                        RunWrapUp(history, _lastOfferedTools, ui, turnId,
+                                  CapWrapUpInstruction, CapWrapUpFallback, "cap");
                         return;
                     }
                 }
@@ -698,13 +710,16 @@ namespace GxPT
                             batchDenied = true;
                             forceTextThisCall = true;
                         }
-                        else if (doomLoop.Record(call.Name, call.ArgumentsJson))
+                        // The current dir (post-call: an executed cd has already moved it) scopes the
+                        // signature, so a legitimate directory walk — identical name+args repeated
+                        // from different places — never reads as a cycle.
+                        else if (doomLoop.Record(call.Name, call.ArgumentsJson, CurrentDir))
                         {
                             // This executed call closed a repeating cycle. Note it and let the batch
                             // finish; the wrap-up runs once the loop below is done and history is valid.
                             doomLoopHit = true;
                             _log.Log("mcp", "[turn " + turnId + "] doom-loop detected at iteration "
-                                + (iter + 1) + " (cycle on '" + call.Name + "'); wrapping up");
+                                + (iter + 1) + " (cycle on '" + call.Name + "')");
                         }
                     }
 
@@ -723,14 +738,28 @@ namespace GxPT
                 }
 
                 // A repeating cycle closed during this batch: the whole batch has now run (history is
-                // well-formed), so end the turn with a text-only wrap-up instead of spinning through the
-                // rest of the budget. A user Stop that landed while the tools ran takes precedence.
+                // well-formed). Like the iteration cap, the interactive main turn asks the user first
+                // (they may know the repetition is intentional); a sub-agent has no decider and wraps
+                // up unattended — the A18 valve. A user Stop that landed while the tools ran takes
+                // precedence over both.
                 if (doomLoopHit)
                 {
                     if (CancelRequested()) { FinishCancelled(history, null, ui, turnId); return; }
-                    RunWrapUp(history, _lastOfferedTools, ui, turnId,
-                              DoomLoopWrapUpInstruction, DoomLoopWrapUpFallback, "doom-loop");
-                    return;
+                    if (DoomLoopContinuationDecider != null && DoomLoopContinuationDecider(iter))
+                    {
+                        // Fresh window: the user chose to push on, so the calls recorded so far must
+                        // not immediately re-trigger on the next iteration.
+                        doomLoop.Clear();
+                        _log.Log("mcp", "[turn " + turnId
+                            + "] user chose to continue after doom-loop detection");
+                    }
+                    else
+                    {
+                        _log.Log("mcp", "[turn " + turnId + "] wrapping up after doom-loop detection");
+                        RunWrapUp(history, _lastOfferedTools, ui, turnId,
+                                  DoomLoopWrapUpInstruction, DoomLoopWrapUpFallback, "doom-loop");
+                        return;
+                    }
                 }
                 // Loop: re-call the model with the tool results in context.
             }
@@ -836,23 +865,14 @@ namespace GxPT
             "I seem to be repeating the same steps without making progress. Let me know how you'd like "
             + "to proceed.";
 
-        // Cap reached and not continued: one final model call (tool_choice "none") asking it to
-        // summarize and ask how to proceed, so the turn ends with a readable assistant message
-        // rather than a cryptic dead-end. The user can simply reply to keep going (a fresh budget
-        // next turn). The request reuses the loop's prompt shape - same stable head, same history,
-        // same tools array - rather than dropping tools: on Anthropic a tool_choice change
-        // invalidates only the message-tier cache, while removing the tools array would change
-        // position 0 of the prompt and invalidate the tools+system tiers as well. The next user
-        // turn (back on tool_choice auto) still extends the loop's cached prefix unharmed.
-        private void RunCapWrapUp(IList<ChatMessage> history, IList<JObject> tools, IToolLoopUi ui,
-                                  string turnId)
-        {
-            RunWrapUp(history, tools, ui, turnId, CapWrapUpInstruction, CapWrapUpFallback, "cap");
-        }
-
         // Force the model to text-only closure. Shared by the iteration-cap and doom-loop stops: append
         // a trailing instruction, re-send the same (cached) tools array under tool_choice "none", and
-        // record the model's summary - or a fallback - as the turn's final assistant message.
+        // record the model's summary - or a fallback - as the turn's final assistant message. The
+        // request reuses the loop's prompt shape - same stable head, same history, same tools array -
+        // rather than dropping tools: on Anthropic a tool_choice change invalidates only the
+        // message-tier cache, while removing the tools array would change position 0 of the prompt and
+        // invalidate the tools+system tiers as well. The next user turn (back on tool_choice auto)
+        // still extends the loop's cached prefix unharmed.
         private void RunWrapUp(IList<ChatMessage> history, IList<JObject> tools, IToolLoopUi ui,
                                string turnId, string instruction, string fallback, string kind)
         {
@@ -1199,12 +1219,19 @@ namespace GxPT
             RevealedToolNames.Add(call.Name);
 
             JObject args;
-            if (!TryParseArgs(call.ArgumentsJson, out args))
+            string parseError;
+            if (!TryParseArgs(call.ArgumentsJson, out args, out parseError))
             {
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] invalid arguments for '" + call.Name
-                    + "' (not valid JSON)");
-                return "[Invalid tool arguments: not valid JSON.]";
+                    + "': " + parseError);
+                // The parser's own diagnosis (what it saw, and where: line/position/path) rides
+                // along. The old bare "not valid JSON" gave the model nothing to fix, so it would
+                // re-generate the same broken payload — typically a large inline file body with one
+                // escaping slip — and loop on the identical failure.
+                return "[Invalid tool arguments for '" + call.Name + "': " + parseError
+                    + " Fix the JSON (check quote/backslash/newline escaping inside large string "
+                    + "values) and re-issue the call.]";
             }
 
             // Logged before the approval check: if the next line for this call is far behind in
@@ -1266,9 +1293,13 @@ namespace GxPT
 
         // ---- helpers ----
 
-        private static bool TryParseArgs(string argumentsJson, out JObject args)
+        // On failure, `parseError` carries the parser's own diagnosis — Newtonsoft's message includes
+        // the offending character, line, position, and JSON path — so the model can FIX its payload
+        // instead of blindly regenerating it (the inline-file-content escaping doom loop).
+        private static bool TryParseArgs(string argumentsJson, out JObject args, out string parseError)
         {
             args = null;
+            parseError = null;
             try
             {
                 if (string.IsNullOrEmpty(argumentsJson))
@@ -1278,10 +1309,12 @@ namespace GxPT
                 }
                 JToken t = JToken.Parse(argumentsJson);
                 if (t.Type == JTokenType.Object) { args = (JObject)t; return true; }
+                parseError = "the arguments must be a JSON object, but a " + t.Type + " was sent.";
                 return false;
             }
-            catch
+            catch (Exception ex)
             {
+                parseError = ex.Message;
                 return false;
             }
         }

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -376,7 +376,12 @@ namespace GxPT
             _hostTools = BuildHostTools();
             // Provider-gated eviction, at turn boundaries only (mid-loop eviction would churn the
             // tools array between iterations for no benefit). See RevealedToolNames for the rationale.
-            if (RevealedToolNames.Count > RevealEvictionCap
+            // A frozen-def turn (sub-agents) is exempt: its exposure never shrinks with this list, so
+            // evicting here would only desync the reveal-enforcement gate from the schemas the model
+            // can plainly see — and the gate's recovery hint points at reveal_tools, which a frozen
+            // child deliberately doesn't have.
+            if (FrozenToolDefs == null
+                && RevealedToolNames.Count > RevealEvictionCap
                 && !OpenRouterClient.ModelSupportsPromptCaching(_model))
             {
                 int evicted = 0;
@@ -1136,6 +1141,10 @@ namespace GxPT
             {
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] blocked unrevealed tool '" + call.Name + "'");
+                // A frozen-def turn has no reveal_tools, so the standard "reveal it first" hint would
+                // send the model chasing a tool it cannot call; its tool set is fixed, full stop.
+                if (FrozenToolDefs != null)
+                    return "[Tool '" + call.Name + "' is not in this agent's tool set.]";
                 return "[Tool '" + call.Name + "' is not revealed yet, so its parameters are unknown. "
                     + "Call reveal_tools({\"names\":[\"" + call.Name + "\"]}) first to load its schema, "
                     + "then call " + call.Name + " with the correct arguments.]";

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -458,12 +458,32 @@ namespace GxPT
                 else
                 {
                     bool hasMcpTools = _registry != null && _registry.HasToolsForWorkdir(resolveDir);
-                    tools = hasMcpTools
-                        ? _registry.ExposedFunctionDefs(resolveDir, RevealedToolNames) : null;
-                    // The tail carries the tool INVENTORY only (names + git steering); the reveal-before-
-                    // call rule is static framing and lives in the cached agent system prompt, not re-sent
-                    // here.
-                    manifest = hasMcpTools ? _registry.NamesManifestList(resolveDir) : null;
+                    if (hasMcpTools)
+                    {
+                        tools = _registry.ExposedFunctionDefs(resolveDir, RevealedToolNames);
+                        // The tail carries the tool INVENTORY only (names + git steering); the reveal-
+                        // before-call rule is static framing and lives in the cached agent system
+                        // prompt, not re-sent here.
+                        manifest = _registry.NamesManifestList(resolveDir);
+                    }
+                    else if (_registry != null)
+                    {
+                        // Registry present but nothing resolvable for this workdir right now (servers
+                        // faulted or mid-(re)connect). Still expose reveal_tools: it is the turn's only
+                        // recovery handle — without it, a turn that starts (or goes) toolless has no
+                        // way to pull tools back in when the servers return. Previously the def was
+                        // emitted solely via ExposedFunctionDefs behind the hasMcpTools gate (the
+                        // host-tool loop below always skips it), so exactly the turns that most needed
+                        // recovery had no handle.
+                        tools = new List<JObject>();
+                        tools.Add(McpToolRegistry.RevealToolsDef());
+                        manifest = null;
+                    }
+                    else
+                    {
+                        tools = null;
+                        manifest = null;
+                    }
                 }
                 // Append the host ("meta") tool defs from the SAME table ExecuteCall dispatches against, so
                 // a tool is exposed here exactly when it is dispatch-exempt there (see BuildHostTools).
@@ -1142,6 +1162,13 @@ namespace GxPT
                 isError = true;
                 _log.Log("mcp", "[turn " + turnId + "] unresolved tool '" + call.Name + "' (workdir="
                     + (string.IsNullOrEmpty(resolveDir) ? "(none)" : resolveDir) + ")");
+                // Distinguish "the name is wrong" from "the server is gone". A server-qualified name
+                // (server__tool) whose server currently contributes NOTHING for this workdir did not
+                // stop existing — its server is down, restarting, or disabled. Reporting that as
+                // "[Unknown tool]" taught models the tool was never real, and they doom-looped
+                // improvising around it instead of simply retrying.
+                string unavailable = _registry != null ? DescribeUnresolved(call.Name, resolveDir) : null;
+                if (unavailable != null) return unavailable;
                 return "[Unknown tool: " + call.Name + "]";
             }
 
@@ -1257,6 +1284,32 @@ namespace GxPT
             {
                 return false;
             }
+        }
+
+        // For a resolution failure: when the called name is server-qualified (server__tool) and that
+        // server currently contributes NO tools for this workdir, the honest diagnosis is an outage,
+        // not a bad name — return a retryable "unavailable" message naming the server. Returns null
+        // when the failure should be reported as a plain unknown tool (host-tool names without the
+        // server prefix, or the server IS present and the tool name is simply wrong).
+        private string DescribeUnresolved(string name, string resolveDir)
+        {
+            int sep = name != null ? name.IndexOf("__", StringComparison.Ordinal) : -1;
+            if (sep <= 0) return null; // not server-qualified — a genuinely unknown (or host) name
+
+            if (!_registry.HasToolsForWorkdir(resolveDir))
+                return "[Tool '" + name + "' is temporarily unavailable: no workspace tool servers are "
+                    + "connected for this conversation right now (they may be restarting). Retry shortly, "
+                    + "or finish without it.]";
+
+            string prefix = name.Substring(0, sep + 2);
+            IList<string> names = _registry.NamesForWorkdir(resolveDir);
+            for (int i = 0; i < names.Count; i++)
+                if (names[i] != null && names[i].StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return null; // the server is present; the tool name itself is wrong
+
+            return "[Tool '" + name + "' is temporarily unavailable: the '" + name.Substring(0, sep)
+                + "' server has no tools connected for this workspace right now (down, restarting, or "
+                + "disabled). Retry shortly, or finish without it.]";
         }
 
         private static string[] ParseRevealNames(string argumentsJson)

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -38,6 +38,7 @@ namespace GxPT
 
         // The host `cd` meta-tool: moves the conversation's current directory within the workspace anchor.
         internal const string CdToolName = "cd";
+        internal const string PwdToolName = "pwd";
 
         // Request-only "keep going" message used once when a response comes back empty even after the
         // inline bare retry (see the empty-response handling in RunTurn). Appended to that one request
@@ -1032,8 +1033,17 @@ namespace GxPT
                     delegate { return McpToolRegistry.RevealToolsDef(); },
                     delegate(ToolCall c, out bool err)
                     {
+                        string[] revealNames = ParseRevealNames(c.ArgumentsJson);
+                        // No usable names is a usage error, said out loud. It used to return a silent
+                        // "[]", which the model read as "those tools don't exist" and retried forever.
+                        if (revealNames.Length == 0)
+                        {
+                            err = true;
+                            return "[reveal_tools: no tool names given. Pass a JSON array of tool-name "
+                                + "strings from the available-tools list, e.g. {\"names\":[\"files__read\"]}.]";
+                        }
                         err = false;
-                        return _registry.Reveal(ParseRevealNames(c.ArgumentsJson), ResolutionWorkdir, RevealedToolNames);
+                        return _registry.Reveal(revealNames, ResolutionWorkdir, RevealedToolNames);
                     }));
             }
             // cd: move the conversation's current directory within the workspace anchor. Offered only when
@@ -1044,6 +1054,11 @@ namespace GxPT
                 list.Add(new HostTool(CdToolName,
                     delegate { return CdDef(); },
                     delegate(ToolCall c, out bool err) { return HandleCd(c, out err); }));
+                // pwd rides along with cd: wherever the model can move, it can also ASK where it is
+                // (observability the original path doom loop lacked). Host state only — instant.
+                list.Add(new HostTool(PwdToolName,
+                    delegate { return PwdDef(); },
+                    delegate(ToolCall c, out bool err) { return HandlePwd(out err); }));
             }
             if (SkillsActive)
             {
@@ -1251,6 +1266,24 @@ namespace GxPT
             {
                 JObject o = JObject.Parse(argumentsJson);
                 JToken arr = o["names"];
+                // Liberal in what we accept: the canonical form is a JSON array of strings, but models
+                // recurrently send the array STRINGIFIED ("names": "[\"a\",\"b\"]") or a single bare
+                // name ("names": "files__read"). Both used to fall through to an empty list and a
+                // silent [] result — which reads as "these tools don't exist" and seeds retry loops.
+                if (arr != null && arr.Type == JTokenType.String)
+                {
+                    string s = ((string)arr).Trim();
+                    if (s.StartsWith("[", StringComparison.Ordinal))
+                    {
+                        try { arr = JArray.Parse(s); }
+                        catch { /* not an array after all — fall through to the bare-name case */ }
+                    }
+                    if (arr.Type == JTokenType.String)
+                    {
+                        if (s.Length > 0) names.Add(s);
+                        return names.ToArray();
+                    }
+                }
                 if (arr != null && arr.Type == JTokenType.Array)
                 {
                     foreach (JToken n in (JArray)arr)
@@ -1261,7 +1294,7 @@ namespace GxPT
             }
             catch
             {
-                // malformed reveal args → no names; Reveal returns an empty def list.
+                // malformed reveal args → no names; the caller reports the usage error.
             }
             return names.ToArray();
         }
@@ -1288,15 +1321,16 @@ namespace GxPT
 
         // ---- cd host tool ----
 
-        // The cd tool's schema: an optional `path` (relative to the current directory). Omitting it
-        // returns to the workspace root (the anchor = "home"). Absolute paths are rejected.
+        // The cd tool's schema: an optional `path` (relative to the current directory, or absolute
+        // inside the workspace). Omitting it returns to the workspace root (the anchor = "home").
         internal static JObject CdDef()
         {
             JObject pathProp = new JObject();
             pathProp["type"] = "string";
             pathProp["description"] =
-                "A subdirectory to change into, relative to the current directory (shell-like; '..' is "
-                + "allowed but cannot rise above the workspace root). Omit to return to the workspace root.";
+                "A directory to change into: relative to the current directory (shell-like; '..' is "
+                + "allowed but cannot rise above the workspace root), or an absolute path inside the "
+                + "workspace. Omit to return to the workspace root.";
 
             JObject props = new JObject();
             props["path"] = pathProp;
@@ -1308,9 +1342,44 @@ namespace GxPT
 
             return McpToolRegistryFunctionDef(CdToolName,
                 "Change the conversation's current working directory within the workspace. Subsequent "
-                + "file, git, and command operations run there until you cd again. You can only move at or "
-                + "below the workspace root; cd with no argument returns to the workspace root.",
+                + "file, git, and command operations run there — their path arguments resolve relative to "
+                + "the CURRENT directory, not the workspace root — until you cd again. You can only move at "
+                + "or below the workspace root; cd with no argument returns to the workspace root. Use pwd "
+                + "to check where you are without moving.",
                 schema);
+        }
+
+        // pwd: report the current directory without changing anything. Purely observational — the
+        // antidote to the model losing track of where it is (the original path doom loop had no way
+        // to ask, and a no-arg cd RESETS to the root as a side effect, so "checking" relocated it).
+        internal static JObject PwdDef()
+        {
+            JObject schema = new JObject();
+            schema["type"] = "object";
+            schema["properties"] = new JObject();
+            return McpToolRegistryFunctionDef(PwdToolName,
+                "Report the conversation's current working directory (workspace-root-relative and "
+                + "absolute) without changing it. File, git, and command operations resolve their path "
+                + "arguments relative to this directory.",
+                schema);
+        }
+
+        private string HandlePwd(out bool isError)
+        {
+            isError = false;
+            string anchor = WorkingDir;
+            if (string.IsNullOrEmpty(anchor))
+            {
+                isError = true;
+                return "[pwd is unavailable: this conversation has no workspace folder.]";
+            }
+            PathSandbox anchorSb = new PathSandbox(anchor, "workspace root");
+            string cur = !string.IsNullOrEmpty(CurrentDir) ? CurrentDir : anchorSb.Root;
+            string relDisp = anchorSb.ToRelative(cur);
+            if (string.IsNullOrEmpty(relDisp)) relDisp = ".";
+            relDisp = relDisp.Replace('\\', '/');
+            return "Current directory: `" + relDisp + "` (relative to the workspace root; absolute: "
+                + cur + "). Workspace root: " + anchorSb.Root + ".";
         }
 
         // Builds an OpenAI-format function def (mirrors McpToolRegistry.FunctionDef, which is private).
@@ -1326,12 +1395,16 @@ namespace GxPT
             return def;
         }
 
-        // Move the current directory. Resolves `path` relative to the CURRENT directory (shell-like),
-        // canonicalizes, and requires the result to be an EXISTING directory at or below the workspace
-        // anchor. Rising above the anchor is an error (the floor is kept visible, not silently clamped);
-        // absolute paths are rejected (mirrors PathSandbox, one mental model). On success it updates the
-        // current directory, notifies the host (CurrentDirChanged), and echoes the new location as an
-        // anchor-relative string. Host state only - no server contact - so it is instant.
+        // Move the current directory. Resolves `path` relative to the CURRENT directory (shell-like) —
+        // or takes it verbatim when absolute — canonicalizes, and requires the result to be an EXISTING
+        // directory at or below the workspace anchor. Rising above the anchor is an error (the floor is
+        // kept visible, not silently clamped). Absolute paths inside the workspace are ACCEPTED: the
+        // host echoes absolute paths in its results, and models reasonably paste them back — the old
+        // outright rejection contradicted those echoes and fed retry loops. Errors and the success echo
+        // both carry the RESOLVED absolute path, so a mis-framed path (e.g. workspace-root-relative
+        // issued from a subfolder) is visible immediately instead of surfacing as a bare "not found".
+        // On success it updates the current directory, notifies the host (CurrentDirChanged), and echoes
+        // the new location. Host state only - no server contact - so it is instant.
         private string HandleCd(ToolCall call, out bool isError)
         {
             isError = false;
@@ -1344,6 +1417,7 @@ namespace GxPT
 
             PathSandbox anchorSb = new PathSandbox(anchor, "workspace root");
             string rel = ParseCdPath(call.ArgumentsJson);
+            string baseDir = !string.IsNullOrEmpty(CurrentDir) ? CurrentDir : anchorSb.Root;
 
             string target;
             if (string.IsNullOrEmpty(rel))
@@ -1352,26 +1426,32 @@ namespace GxPT
             }
             else
             {
-                if (Path.IsPathRooted(rel) || rel.IndexOf(':') >= 0)
-                {
-                    isError = true;
-                    return "[cd: absolute paths are not allowed; pass a path relative to the current directory.]";
-                }
-                string baseDir = !string.IsNullOrEmpty(CurrentDir) ? CurrentDir : anchorSb.Root;
                 string full;
-                try { full = Path.GetFullPath(Path.Combine(baseDir, rel)); }
-                catch (Exception) { isError = true; return "[cd: invalid path: " + rel + "]"; }
+                if (Path.IsPathRooted(rel))
+                {
+                    try { full = Path.GetFullPath(rel); }
+                    catch (Exception) { isError = true; return "[cd: invalid path: " + rel + "]"; }
+                }
+                else
+                {
+                    try { full = Path.GetFullPath(Path.Combine(baseDir, rel)); }
+                    catch (Exception) { isError = true; return "[cd: invalid path: " + rel + "]"; }
+                }
 
                 if (!anchorSb.IsWithin(full))
                 {
                     isError = true;
-                    return "[cd: '" + rel + "' is above the workspace root, which is the floor. cd with no "
-                        + "argument to return to the workspace root and regain full-workspace access.]";
+                    return "[cd: '" + rel + "' resolves to " + full + ", which is above the workspace root ("
+                        + anchorSb.Root + ") - the floor. cd with no argument to return to the workspace "
+                        + "root and regain full-workspace access.]";
                 }
                 if (!Directory.Exists(full))
                 {
                     isError = true;
-                    return "[cd: directory not found: " + rel + "]";
+                    string curDisp = anchorSb.ToRelative(baseDir);
+                    if (string.IsNullOrEmpty(curDisp)) curDisp = ".";
+                    return "[cd: directory not found: " + rel + " (resolves to " + full
+                        + "; the current directory is `" + curDisp.Replace('\\', '/') + "`).]";
                 }
                 target = full;
             }
@@ -1384,8 +1464,9 @@ namespace GxPT
             string relDisp = anchorSb.ToRelative(target);
             if (string.IsNullOrEmpty(relDisp)) relDisp = ".";
             relDisp = relDisp.Replace('\\', '/');
-            return "Current directory is now `" + relDisp + "` (relative to the workspace root). File, git, "
-                + "and command operations now run there.";
+            return "Current directory is now `" + relDisp + "` (relative to the workspace root; absolute: "
+                + target + "). File, git, and command operations now run there, and their path arguments "
+                + "resolve relative to it.";
         }
 
         // Reads the cd tool's optional `path` string argument; missing/malformed -> null (return to anchor).

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -535,7 +535,28 @@ namespace GxPT
             if (e.NewState == ConnectionState.Faulted || e.NewState == ConnectionState.Closed)
             {
                 McpServerConnection conn = sender as McpServerConnection;
-                if (conn != null) _registry.RemoveConnection(conn);
+                if (conn == null) return;
+                _registry.RemoveConnection(conn);
+                // Also forget the dead connection in the host's OWN collections. Leaving it in
+                // _scopedByWorkdir made EnsureWorkingDir a permanent no-op for that folder ("already
+                // connected" by key) even though the registry had dropped its tools — reconnection
+                // was impossible until an app restart. When a workdir's LAST connection dies, its key
+                // goes too, so the next EnsureWorkingDir relaunches the full set. Taking _lock here
+                // is safe: every deliberate Teardown unsubscribes this handler before shutting the
+                // connection down, so no caller already holding _lock can re-enter through it.
+                lock (_lock)
+                {
+                    if (_disposed) return;
+                    _eager.Remove(conn);
+                    List<string> emptied = null;
+                    foreach (KeyValuePair<string, List<McpServerConnection>> kv in _scopedByWorkdir)
+                    {
+                        if (kv.Value.Remove(conn) && kv.Value.Count == 0)
+                            (emptied ?? (emptied = new List<string>())).Add(kv.Key);
+                    }
+                    if (emptied != null)
+                        for (int i = 0; i < emptied.Count; i++) _scopedByWorkdir.Remove(emptied[i]);
+                }
             }
         }
 

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -247,23 +247,37 @@ namespace GxPT
             }
             finally
             {
-                bool discard;
+                List<McpServerConnection> drop = null;
                 lock (_lock)
                 {
                     _connecting.Remove(workdir);
                     if (_disposed || _scopedByWorkdir.ContainsKey(workdir))
                     {
-                        discard = true;
+                        drop = conns;
                     }
                     else
                     {
-                        for (int i = 0; i < conns.Count; i++) _registry.AddConnection(conns[i], workdir);
-                        _scopedByWorkdir[workdir] = conns;
-                        discard = false;
+                        List<McpServerConnection> keep = new List<McpServerConnection>();
+                        for (int i = 0; i < conns.Count; i++)
+                        {
+                            // A spec disabled while this connect was in flight (SetBuiltInServerEnabled
+                            // ran between our spec snapshot and this publish) must not be published —
+                            // that would orphan a live instance the disable pass couldn't see, exposing
+                            // its tools to a conversation the flip meant to hide them from.
+                            if (SpecDisabledLocked(conns[i].Name))
+                            {
+                                if (drop == null) drop = new List<McpServerConnection>();
+                                drop.Add(conns[i]);
+                                continue;
+                            }
+                            _registry.AddConnection(conns[i], workdir);
+                            keep.Add(conns[i]);
+                        }
+                        _scopedByWorkdir[workdir] = keep;
                     }
                 }
-                if (discard)
-                    for (int i = 0; i < conns.Count; i++) Teardown(conns[i], true);
+                if (drop != null)
+                    for (int i = 0; i < drop.Count; i++) Teardown(drop[i], true);
                 reservation.Set();
             }
         }
@@ -274,28 +288,34 @@ namespace GxPT
         // rebuild — which swaps the registry object out from under an in-flight turn (the running
         // orchestrator/dispatcher/children keep the old, emptied registry and lose every tool: the
         // "cd-only sub-agent" doom loop). Enabling connects the server's eager workdir-less instance
-        // (if the spec runs one) plus one instance per already-live workdir; disabling tears down just
-        // that server's instances. Blocking (spawns/handshakes) — call off the UI thread. Races with a
-        // concurrent ConnectScoped are benign: it re-reads spec.Enabled per server, and the publish
-        // steps below re-check the live collections under the lock before adding.
-        public void SetBuiltInServerEnabled(string name, bool enabled)
+        // (if the spec runs one) plus one instance per live workdir — including workdirs whose scoped
+        // set is CONNECTING right now (their ConnectScoped snapshot may have seen the spec disabled;
+        // we wait for the publish, then top the set up). Disabling tears down just that server's
+        // instances; a mid-connect instance of a disabled spec is discarded by ConnectScoped's own
+        // publish step (SpecDisabledLocked). Returns false when nothing could be committed (disposed,
+        // not started, unknown spec) so the caller can retract optimistic state; true when the spec
+        // was flipped (or already matched). Blocking (spawns/handshakes) — call off the UI thread.
+        public bool SetBuiltInServerEnabled(string name, bool enabled)
         {
-            if (string.IsNullOrEmpty(name)) return;
+            if (string.IsNullOrEmpty(name)) return false;
 
             McpServerSpec spec = null;
             List<McpServerConnection> toClose = null;
-            List<string> connectDirs = null;
-            bool needEager = false;
+            List<string> ensureDirs = null;
+            List<string> pendingDirs = null;
+            List<ManualResetEvent> pendingEvents = null;
+            bool ensureEager = false;
             lock (_lock)
             {
-                if (_disposed || !_started) return;
+                if (_disposed || !_started) return false;
                 for (int i = 0; i < _scopedSpecs.Count; i++)
                 {
                     McpServerSpec s = _scopedSpecs[i];
                     if (s != null && string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase))
                     { spec = s; break; }
                 }
-                if (spec == null || spec.Enabled == enabled) return;
+                if (spec == null) return false;
+                if (spec.Enabled == enabled) return true;
                 spec.Enabled = enabled; // future ConnectScoped calls follow the new state
 
                 if (!enabled)
@@ -312,22 +332,17 @@ namespace GxPT
                 }
                 else
                 {
-                    needEager = spec.RunsWithoutWorkdir;
-                    if (needEager)
-                        for (int i = 0; i < _eager.Count; i++)
-                            if (string.Equals(_eager[i].Name, name, StringComparison.OrdinalIgnoreCase))
-                            { needEager = false; break; }
-                    // Launch an instance for every workdir that already has a live scoped set (skipping
-                    // scratch dirs the spec isn't eligible for, and dirs that somehow already have one).
-                    connectDirs = new List<string>();
-                    foreach (KeyValuePair<string, List<McpServerConnection>> kv in _scopedByWorkdir)
+                    ensureEager = spec.RunsWithoutWorkdir;
+                    ensureDirs = new List<string>(_scopedByWorkdir.Keys);
+                    foreach (KeyValuePair<string, ManualResetEvent> kv in _connecting)
                     {
-                        if (_scratchWorkdirs.ContainsKey(kv.Key) && !spec.RunsInScratch) continue;
-                        bool has = false;
-                        for (int i = 0; i < kv.Value.Count; i++)
-                            if (string.Equals(kv.Value[i].Name, name, StringComparison.OrdinalIgnoreCase))
-                            { has = true; break; }
-                        if (!has) connectDirs.Add(kv.Key);
+                        if (pendingDirs == null)
+                        {
+                            pendingDirs = new List<string>();
+                            pendingEvents = new List<ManualResetEvent>();
+                        }
+                        pendingDirs.Add(kv.Key);
+                        pendingEvents.Add(kv.Value);
                     }
                 }
             }
@@ -335,57 +350,79 @@ namespace GxPT
             if (toClose != null)
                 for (int i = 0; i < toClose.Count; i++) Teardown(toClose[i]);
 
-            if (needEager && !_disposed)
+            if (enabled)
             {
-                McpServerConnection conn = CreateAndOpen(spec, null);
-                if (conn != null)
+                if (ensureEager) EnsureInstance(spec, null);
+                for (int i = 0; i < ensureDirs.Count; i++) EnsureInstance(spec, ensureDirs[i]);
+                if (pendingDirs != null)
                 {
-                    bool discard;
-                    lock (_lock)
+                    // Workdirs that were mid-connect when the flip landed: wait (unlocked) for their
+                    // owner to publish, then top the published set up with this server.
+                    for (int i = 0; i < pendingDirs.Count; i++)
                     {
-                        // Re-check under the lock: a concurrent disable (or Dispose) may have run
-                        // while the unlocked handshake was in progress.
-                        discard = _disposed || !spec.Enabled;
-                        if (!discard)
-                        {
-                            _registry.AddConnection(conn, null);
-                            _eager.Add(conn);
-                        }
+                        pendingEvents[i].WaitOne();
+                        EnsureInstance(spec, pendingDirs[i]);
                     }
-                    if (discard) Teardown(conn, true);
                 }
             }
-            if (connectDirs != null)
+            return true;
+        }
+
+        // Connect and publish one instance of `spec` for `workdir` (null = the eager, workdir-less
+        // instance). Idempotent and race-safe: skips the spawn when an instance with the same name is
+        // already present, the spec is disabled, the workdir's set is gone, or the workdir is a
+        // scratch dir the spec isn't eligible for — and re-checks all of that under the lock before
+        // publishing, discarding the freshly opened connection if anything changed meanwhile.
+        private void EnsureInstance(McpServerSpec spec, string workdir)
+        {
+            lock (_lock)
             {
-                for (int w = 0; w < connectDirs.Count; w++)
+                if (_disposed || !spec.Enabled) return;
+                List<McpServerConnection> have;
+                if (workdir == null) have = _eager;
+                else if (!_scopedByWorkdir.TryGetValue(workdir, out have)) return; // set gone
+                if (HasNamed(have, spec.Name)) return;
+                if (workdir != null && _scratchWorkdirs.ContainsKey(workdir) && !spec.RunsInScratch) return;
+            }
+
+            McpServerConnection conn = CreateAndOpen(spec, workdir);
+            if (conn == null) return;
+            bool discard;
+            lock (_lock)
+            {
+                List<McpServerConnection> list;
+                if (workdir == null) list = _eager;
+                else if (!_scopedByWorkdir.TryGetValue(workdir, out list)) list = null;
+                if (_disposed || !spec.Enabled || list == null || HasNamed(list, spec.Name))
+                    discard = true;
+                else
                 {
-                    if (_disposed) break;
-                    McpServerConnection conn = CreateAndOpen(spec, connectDirs[w]);
-                    if (conn == null) continue;
-                    bool discard;
-                    lock (_lock)
-                    {
-                        // Publish only if the workdir's set still exists, the spec wasn't re-disabled
-                        // while we connected, and nothing raced in a duplicate instance.
-                        List<McpServerConnection> conns;
-                        if (_disposed || !spec.Enabled || !_scopedByWorkdir.TryGetValue(connectDirs[w], out conns))
-                            discard = true;
-                        else
-                        {
-                            discard = false;
-                            for (int i = 0; i < conns.Count; i++)
-                                if (string.Equals(conns[i].Name, name, StringComparison.OrdinalIgnoreCase))
-                                { discard = true; break; }
-                            if (!discard)
-                            {
-                                _registry.AddConnection(conn, connectDirs[w]);
-                                conns.Add(conn);
-                            }
-                        }
-                    }
-                    if (discard) Teardown(conn, true);
+                    _registry.AddConnection(conn, workdir);
+                    list.Add(conn);
+                    discard = false;
                 }
             }
+            if (discard) Teardown(conn, true);
+        }
+
+        private static bool HasNamed(List<McpServerConnection> conns, string name)
+        {
+            if (conns == null) return false;
+            for (int i = 0; i < conns.Count; i++)
+                if (string.Equals(conns[i].Name, name, StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+
+        // True when a scoped spec with this name exists and is currently disabled. Caller holds _lock.
+        private bool SpecDisabledLocked(string name)
+        {
+            for (int i = 0; i < _scopedSpecs.Count; i++)
+            {
+                McpServerSpec s = _scopedSpecs[i];
+                if (s != null && string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase))
+                    return !s.Enabled;
+            }
+            return false;
         }
 
         // Tear down the scoped servers for a single working directory (e.g. its last tab closed).

--- a/GxPT/Services/Mcp/McpHost.cs
+++ b/GxPT/Services/Mcp/McpHost.cs
@@ -268,6 +268,126 @@ namespace GxPT
             }
         }
 
+        // Enable or disable ONE named workdir-scoped built-in server at runtime, without touching any
+        // other server or the registry identity. Used by the skills-enablement refresh: the extensions
+        // server follows "any enabled skill" per conversation, and flipping it used to run a full host
+        // rebuild — which swaps the registry object out from under an in-flight turn (the running
+        // orchestrator/dispatcher/children keep the old, emptied registry and lose every tool: the
+        // "cd-only sub-agent" doom loop). Enabling connects the server's eager workdir-less instance
+        // (if the spec runs one) plus one instance per already-live workdir; disabling tears down just
+        // that server's instances. Blocking (spawns/handshakes) — call off the UI thread. Races with a
+        // concurrent ConnectScoped are benign: it re-reads spec.Enabled per server, and the publish
+        // steps below re-check the live collections under the lock before adding.
+        public void SetBuiltInServerEnabled(string name, bool enabled)
+        {
+            if (string.IsNullOrEmpty(name)) return;
+
+            McpServerSpec spec = null;
+            List<McpServerConnection> toClose = null;
+            List<string> connectDirs = null;
+            bool needEager = false;
+            lock (_lock)
+            {
+                if (_disposed || !_started) return;
+                for (int i = 0; i < _scopedSpecs.Count; i++)
+                {
+                    McpServerSpec s = _scopedSpecs[i];
+                    if (s != null && string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase))
+                    { spec = s; break; }
+                }
+                if (spec == null || spec.Enabled == enabled) return;
+                spec.Enabled = enabled; // future ConnectScoped calls follow the new state
+
+                if (!enabled)
+                {
+                    // Collect this server's live instances (eager + every workdir) for teardown below.
+                    toClose = new List<McpServerConnection>();
+                    for (int i = _eager.Count - 1; i >= 0; i--)
+                        if (string.Equals(_eager[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                        { toClose.Add(_eager[i]); _eager.RemoveAt(i); }
+                    foreach (List<McpServerConnection> conns in _scopedByWorkdir.Values)
+                        for (int i = conns.Count - 1; i >= 0; i--)
+                            if (string.Equals(conns[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                            { toClose.Add(conns[i]); conns.RemoveAt(i); }
+                }
+                else
+                {
+                    needEager = spec.RunsWithoutWorkdir;
+                    if (needEager)
+                        for (int i = 0; i < _eager.Count; i++)
+                            if (string.Equals(_eager[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                            { needEager = false; break; }
+                    // Launch an instance for every workdir that already has a live scoped set (skipping
+                    // scratch dirs the spec isn't eligible for, and dirs that somehow already have one).
+                    connectDirs = new List<string>();
+                    foreach (KeyValuePair<string, List<McpServerConnection>> kv in _scopedByWorkdir)
+                    {
+                        if (_scratchWorkdirs.ContainsKey(kv.Key) && !spec.RunsInScratch) continue;
+                        bool has = false;
+                        for (int i = 0; i < kv.Value.Count; i++)
+                            if (string.Equals(kv.Value[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                            { has = true; break; }
+                        if (!has) connectDirs.Add(kv.Key);
+                    }
+                }
+            }
+
+            if (toClose != null)
+                for (int i = 0; i < toClose.Count; i++) Teardown(toClose[i]);
+
+            if (needEager && !_disposed)
+            {
+                McpServerConnection conn = CreateAndOpen(spec, null);
+                if (conn != null)
+                {
+                    bool discard;
+                    lock (_lock)
+                    {
+                        // Re-check under the lock: a concurrent disable (or Dispose) may have run
+                        // while the unlocked handshake was in progress.
+                        discard = _disposed || !spec.Enabled;
+                        if (!discard)
+                        {
+                            _registry.AddConnection(conn, null);
+                            _eager.Add(conn);
+                        }
+                    }
+                    if (discard) Teardown(conn, true);
+                }
+            }
+            if (connectDirs != null)
+            {
+                for (int w = 0; w < connectDirs.Count; w++)
+                {
+                    if (_disposed) break;
+                    McpServerConnection conn = CreateAndOpen(spec, connectDirs[w]);
+                    if (conn == null) continue;
+                    bool discard;
+                    lock (_lock)
+                    {
+                        // Publish only if the workdir's set still exists, the spec wasn't re-disabled
+                        // while we connected, and nothing raced in a duplicate instance.
+                        List<McpServerConnection> conns;
+                        if (_disposed || !spec.Enabled || !_scopedByWorkdir.TryGetValue(connectDirs[w], out conns))
+                            discard = true;
+                        else
+                        {
+                            discard = false;
+                            for (int i = 0; i < conns.Count; i++)
+                                if (string.Equals(conns[i].Name, name, StringComparison.OrdinalIgnoreCase))
+                                { discard = true; break; }
+                            if (!discard)
+                            {
+                                _registry.AddConnection(conn, connectDirs[w]);
+                                conns.Add(conn);
+                            }
+                        }
+                    }
+                    if (discard) Teardown(conn, true);
+                }
+            }
+        }
+
         // Tear down the scoped servers for a single working directory (e.g. its last tab closed).
         public void ReleaseWorkingDir(string workdir)
         {

--- a/GxPT/Services/Mcp/McpToolRegistry.cs
+++ b/GxPT/Services/Mcp/McpToolRegistry.cs
@@ -387,9 +387,22 @@ namespace GxPT
         {
             List<JObject> result = new List<JObject>();
             result.Add(RevealToolsDef());
-            if (revealed == null) return result;
+            IList<JObject> defs = FunctionDefsForNames(workdir, revealed);
+            for (int i = 0; i < defs.Count; i++) result.Add(defs[i]);
+            return result;
+        }
 
-            List<string> fns = new List<string>(revealed);
+        // The concrete function defs for `names` usable on a turn with this working directory — the
+        // same defs (and the same by-name ordering) ExposedFunctionDefs emits, WITHOUT the leading
+        // reveal_tools def. Used to freeze a sub-agent's tool set at dispatch time (A11: an
+        // allowlisted child skips progressive disclosure and is handed its defs whole), so a child's
+        // exposure can't shift with later registry churn.
+        public IList<JObject> FunctionDefsForNames(string workdir, IEnumerable<string> names)
+        {
+            List<JObject> result = new List<JObject>();
+            if (names == null) return result;
+
+            List<string> fns = new List<string>(names);
             fns.Sort(StringComparer.Ordinal);
             lock (_lock)
             {

--- a/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
+++ b/GxPT/Services/Mcp/TranscriptContinuationPrompt.cs
@@ -23,6 +23,18 @@ namespace GxPT
         // if the UI is unavailable (e.g. the tab is closing) so the turn still ends cleanly.
         public bool Ask(int iterationsSoFar)
         {
+            return AskCore(iterationsSoFar, false);
+        }
+
+        // Doom-loop variant: same blocking flow, doom-loop wording on the panel ("repeating tool
+        // calls detected" instead of "limit reached").
+        public bool AskDoomLoop(int iterationsSoFar)
+        {
+            return AskCore(iterationsSoFar, true);
+        }
+
+        private bool AskCore(int iterationsSoFar, bool doomLoop)
+        {
             if (_uiMarshal == null || _getPanel == null) return false;
 
             bool[] result = { false };
@@ -38,7 +50,7 @@ namespace GxPT
                         {
                             ToolApprovalPanel panel = _getPanel();
                             if (panel == null) { done.Set(); return; }
-                            panel.ShowContinuation(iterationsSoFar, delegate(bool cont)
+                            panel.ShowContinuation(iterationsSoFar, doomLoop, delegate(bool cont)
                             {
                                 result[0] = cont;
                                 done.Set();

--- a/servers/FilesMcpServer/FilesTools.cs
+++ b/servers/FilesMcpServer/FilesTools.cs
@@ -49,7 +49,7 @@ namespace FilesMcpServer
             // subdirectory, every read/write/list/search is hard-confined to it (D2 enforcement). Absent a
             // current dir the sandbox falls back to the workspace root, exactly as before.
 
-            server.AddTool("read", "Read the UTF-8 text contents of a file under the workspace root. "
+            server.AddTool("read", "Read the UTF-8 text contents of a file under the current directory. "
                 + "Optionally read a line range (1-based, inclusive) and/or prefix each line with its number. "
                 + "Reads larger than the size cap are TRUNCATED rather than failing: the result is then a JSON "
                 + "object {content, truncated:true, next_start_line?, next_offset}. To continue a truncated "
@@ -57,7 +57,7 @@ namespace FilesMcpServer
                 + "only next_offset is returned (a single line longer than the cap), pass just offset. Loop "
                 + "until a read comes back as plain (non-truncated) text.",
                 SchemaBuilder.Object()
-                    .Str("path", true, "Path relative to the workspace root")
+                    .Str("path", true, "Path relative to the current directory (the workspace root until you cd)")
                     .Int("start_line", false, "First line to return (1-based, inclusive)")
                     .Int("end_line", false, "Last line to return (1-based, inclusive)")
                     .Bool("line_numbers", false, "Prefix each returned line with its 1-based line number")
@@ -68,33 +68,33 @@ namespace FilesMcpServer
                 ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return WithCwd(config, ctx, delegate(PathSandbox sb) { return Read(sb, ctx); }); });
 
-            server.AddTool("list", "List entries of a directory under the workspace root.",
+            server.AddTool("list", "List entries of a directory under the current directory.",
                 SchemaBuilder.Object()
-                    .Str("path", true, "Directory path relative to the workspace root")
+                    .Str("path", true, "Directory path relative to the current directory (the workspace root until you cd)")
                     .Bool("recursive", false, "Recurse into subdirectories (bounded depth)")
                     .Build(),
                 ToolAnnotations.ReadOnly(),
                 delegate(ToolCallContext ctx) { return WithCwd(config, ctx, delegate(PathSandbox sb) { return List(sb, ctx); }); });
 
-            server.AddTool("write", "Create or overwrite a text file under the workspace root.",
+            server.AddTool("write", "Create or overwrite a text file under the current directory.",
                 SchemaBuilder.Object()
-                    .Str("path", true, "Path relative to the workspace root")
+                    .Str("path", true, "Path relative to the current directory (the workspace root until you cd)")
                     .Str("content", true, "UTF-8 text content to write")
                     .Bool("create_dirs", false, "Create missing parent directories")
                     .Build(),
                 ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return WithCwd(config, ctx, delegate(PathSandbox sb) { return Write(sb, ctx); }); });
 
-            server.AddTool("delete", "Delete a file or an empty directory under the workspace root.",
-                SchemaBuilder.Object().Str("path", true, "Path relative to the workspace root").Build(),
+            server.AddTool("delete", "Delete a file or an empty directory under the current directory.",
+                SchemaBuilder.Object().Str("path", true, "Path relative to the current directory (the workspace root until you cd)").Build(),
                 ToolAnnotations.Destructive(),
                 delegate(ToolCallContext ctx) { return WithCwd(config, ctx, delegate(PathSandbox sb) { return Delete(sb, ctx); }); });
 
-            server.AddTool("edit", "Replace an exact text span in a file under the workspace root. "
+            server.AddTool("edit", "Replace an exact text span in a file under the current directory. "
                 + "Prefer this over write for large files: it is targeted and never rewrites the whole file. "
                 + "old_string must match exactly and be unique unless replace_all is set.",
                 SchemaBuilder.Object()
-                    .Str("path", true, "Path relative to the workspace root")
+                    .Str("path", true, "Path relative to the current directory (the workspace root until you cd)")
                     .Str("old_string", true, "Exact text to find (must be unique unless replace_all is set)")
                     .Str("new_string", true, "Replacement text")
                     .Bool("replace_all", false, "Replace every occurrence instead of requiring a unique match")
@@ -102,13 +102,13 @@ namespace FilesMcpServer
                 ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return WithCwd(config, ctx, delegate(PathSandbox sb) { return Edit(sb, ctx); }); });
 
-            server.AddTool("search", "Search file contents for a string or regex under the workspace root, "
+            server.AddTool("search", "Search file contents for a string or regex under the current directory, "
                 + "returning matching {path, line, text}. Recursive, skips binary files. Line-oriented by "
                 + "default (each line is matched with its terminator stripped, so a pattern cannot match a "
                 + "newline or span lines); set multiline to match across line boundaries (grep -U style).",
                 SchemaBuilder.Object()
                     .Str("query", true, "Text or regex to search for")
-                    .Str("path", false, "Directory (or file) to search under; defaults to the workspace root")
+                    .Str("path", false, "Directory (or file) to search under, relative to the current directory; defaults to the current directory")
                     .Bool("regex", false, "Treat query as a .NET regular expression (default: literal substring)")
                     .Bool("ignore_case", false, "Case-insensitive match")
                     .Str("glob", false, "Only search files whose name matches this wildcard (e.g. *.cs)")
@@ -148,7 +148,7 @@ namespace FilesMcpServer
             CallToolResult err = ResolvePath(sandbox, ctx, out full);
             if (err != null) return err;
 
-            if (!File.Exists(full)) return ToolResults.Error("file not found");
+            if (!File.Exists(full)) return ToolResults.Error("file not found: " + full);
 
             bool lineNumbers = BoolArg(ctx, "line_numbers", false);
 
@@ -493,7 +493,7 @@ namespace FilesMcpServer
             CallToolResult err = ResolvePath(sandbox, ctx, out full);
             if (err != null) return err;
 
-            if (!Directory.Exists(full)) return ToolResults.Error("directory not found");
+            if (!Directory.Exists(full)) return ToolResults.Error("directory not found: " + full);
 
             bool recursive = BoolArg(ctx, "recursive", false);
 
@@ -551,7 +551,7 @@ namespace FilesMcpServer
             CallToolResult err = ResolvePath(sandbox, ctx, out full);
             if (err != null) return err;
 
-            if (Directory.Exists(full)) return ToolResults.Error("path is a directory");
+            if (Directory.Exists(full)) return ToolResults.Error("path is a directory: " + full);
 
             string content = ctx.Arguments.Value<string>("content");
             if (content == null) return ToolResults.Error("content is required");
@@ -560,7 +560,8 @@ namespace FilesMcpServer
             string parent = Path.GetDirectoryName(full);
             if (!Directory.Exists(parent))
             {
-                if (!createDirs) return ToolResults.Error("parent directory does not exist (set create_dirs to create it)");
+                if (!createDirs) return ToolResults.Error("parent directory does not exist: " + parent
+                    + " (set create_dirs to create it)");
                 Directory.CreateDirectory(parent);
             }
 
@@ -568,7 +569,19 @@ namespace FilesMcpServer
 
             JObject result = new JObject();
             result["path"] = sandbox.ToRelative(full);
+            // The resolved target, absolute, so a mis-framed path (workspace-root-relative passed
+            // while cd'd) is visible in the very result that "succeeded" instead of much later.
+            result["absolute_path"] = full;
             result["bytesWritten"] = bytesWritten;
+            // The doubling signature: the path's leading segments re-state the current directory's
+            // own tail (cwd ...\x\y with path "x/y/..."), which nests a copy of the tree under
+            // itself. Warn rather than reject — a genuinely intended nested write stays possible.
+            string restated = PathFrames.RestatedRootTail(sandbox.Root, ctx.Arguments.Value<string>("path"));
+            if (restated != null)
+                result["warning"] = "the path's leading '" + restated + "' re-states the current directory's "
+                    + "own tail, so this wrote INSIDE the current directory (see absolute_path). If you meant "
+                    + "the workspace-root-relative location, cd with no argument to return to the workspace "
+                    + "root and re-issue the write.";
             return ToolResults.Json(result);
         }
 
@@ -605,8 +618,8 @@ namespace FilesMcpServer
             CallToolResult err = ResolvePath(sandbox, ctx, out full);
             if (err != null) return err;
 
-            if (Directory.Exists(full)) return ToolResults.Error("path is a directory");
-            if (!File.Exists(full)) return ToolResults.Error("file not found");
+            if (Directory.Exists(full)) return ToolResults.Error("path is a directory: " + full);
+            if (!File.Exists(full)) return ToolResults.Error("file not found: " + full);
 
             string oldString = ctx.Arguments.Value<string>("old_string");
             if (string.IsNullOrEmpty(oldString)) return ToolResults.Error("old_string is required");
@@ -748,7 +761,7 @@ namespace FilesMcpServer
                 catch (SandboxException ex) { return ToolResults.Error(ex.Message); }
             }
             if (!Directory.Exists(root) && !File.Exists(root))
-                return ToolResults.Error("path not found");
+                return ToolResults.Error("path not found: " + root);
 
             bool useRegex = BoolArg(ctx, "regex", false);
             bool ignoreCase = BoolArg(ctx, "ignore_case", false);
@@ -934,7 +947,7 @@ namespace FilesMcpServer
             }
             else
             {
-                return ToolResults.Error("path not found");
+                return ToolResults.Error("path not found: " + full);
             }
 
             JObject result = new JObject();
@@ -947,6 +960,9 @@ namespace FilesMcpServer
         // Resolve this call's effective path sandbox (rooted at the host current dir, re-validated
         // against GXPT_WORKDIR) and invoke the handler with it. A current dir outside the anchor, or one
         // that no longer exists, is rejected as an isError result rather than silently widening the root.
+        // A FAILED call made while cd'd below the anchor additionally gets a frame-orientation note (the
+        // model's most common mistake there is a workspace-root-relative path, which resolves nowhere or
+        // to a nested duplicate) — see AppendFrameHint.
         private static CallToolResult WithCwd(FilesConfig config, ToolCallContext ctx, Func<PathSandbox, CallToolResult> op)
         {
             string root;
@@ -954,7 +970,47 @@ namespace FilesMcpServer
             string err;
             if (!CwdScope.TryResolve(ctx, config.WorkDir, "workspace root", out root, out sandbox, out err))
                 return ToolResults.Error(err);
-            return op(sandbox);
+            CallToolResult result = op(sandbox);
+            try { AppendFrameHint(config, ctx, root, result); }
+            catch { }
+            return result;
+        }
+
+        // On an error result produced while the call's sandbox was re-rooted below the anchor (the model
+        // has cd'd), fold an orientation note into the result's text: which directory paths resolve
+        // against, and — when the failing `path` argument DOES exist taken from the workspace root — a
+        // targeted "did you mean" with the root-frame location. This is the antidote to the observed
+        // doom loop where a model kept re-issuing root-relative paths from inside a subfolder, reading
+        // each bare "not found" as the file being gone rather than the frame being wrong.
+        private static void AppendFrameHint(FilesConfig config, ToolCallContext ctx, string root, CallToolResult result)
+        {
+            if (result == null || !result.IsError) return;
+            if (result.Content == null || result.Content.Count == 0) return;
+            PathSandbox anchor = new PathSandbox(config.WorkDir, "workspace root");
+            if (string.Equals(root, anchor.Root, StringComparison.OrdinalIgnoreCase)) return; // one frame only
+
+            string cwdRel = anchor.ToRelative(root).Replace('\\', '/');
+            StringBuilder note = new StringBuilder();
+            note.Append("\n[note: paths resolve relative to the current directory '").Append(cwdRel)
+                .Append("' (set by cd), not the workspace root.");
+            string rel = ctx.Arguments != null ? ctx.Arguments.Value<string>("path") : null;
+            if (!string.IsNullOrEmpty(rel))
+            {
+                try
+                {
+                    string fromAnchor = anchor.Resolve(rel);
+                    if (File.Exists(fromAnchor) || Directory.Exists(fromAnchor))
+                        note.Append(" '").Append(rel).Append("' does exist relative to the workspace root (")
+                            .Append(fromAnchor).Append("); cd with no argument to return to the workspace ")
+                            .Append("root, or re-state the path relative to the current directory.");
+                }
+                catch (SandboxException) { }
+            }
+            note.Append("]");
+
+            string text;
+            if (result.Content[0] != null && result.Content[0].TryGetText(out text))
+                result.Content[0] = Mcp35.Core.Protocol.ContentBlock.FromText(text + note.ToString());
         }
 
         private static CallToolResult ResolvePath(PathSandbox sandbox, ToolCallContext ctx, out string full)

--- a/servers/FilesMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/FilesMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("fde32af9-71c6-4b14-8521-285bd2b36ab9")]
 
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]

--- a/servers/GitMcpServer/GitTools.cs
+++ b/servers/GitMcpServer/GitTools.cs
@@ -38,8 +38,9 @@ namespace GitMcpServer
         private const int OutputCap = 100000; // chars; trims runaway diffs/logs
 
         private const string CwdHelp =
-            "Run git in this subdirectory of the workspace (e.g. a worktree created with the worktree "
-            + "tool), relative to the workspace root. Defaults to the workspace root.";
+            "Run git in this subdirectory (e.g. a worktree created with the worktree tool), relative "
+            + "to the current directory (the workspace root until you cd) — it selects a deeper "
+            + "directory beneath it, never above. Defaults to the current directory.";
 
         public static void Register(McpServer server, GitConfig config)
         {
@@ -143,10 +144,10 @@ namespace GitMcpServer
                 ToolAnnotations.Write(),
                 delegate(ToolCallContext ctx) { return Branch(config, runner, sandbox, ctx); });
 
-            server.AddTool("worktree", "Manage linked working trees (git worktree): list, add, remove, or prune. Added worktrees live in a subdirectory of the workspace root; by convention place them under .worktrees/ (e.g. .worktrees/feat).",
+            server.AddTool("worktree", "Manage linked working trees (git worktree): list, add, remove, or prune. Added worktrees are carved out under the CURRENT directory — cd to the workspace root before managing worktrees, and by convention place them under .worktrees/ (e.g. .worktrees/feat).",
                 SchemaBuilder.Object()
                     .Str("action", false, "list | add | remove | prune (default: list)")
-                    .Str("path", false, "Worktree directory, relative to the workspace root (required for add/remove). Prefer .worktrees/<name> (e.g. .worktrees/feat) to keep worktrees in one tidy, dotfile-hidden location.")
+                    .Str("path", false, "Worktree directory, relative to the current directory (required for add/remove) — cd to the workspace root first so the path is workspace-root-relative. Prefer .worktrees/<name> (e.g. .worktrees/feat) to keep worktrees in one tidy, dotfile-hidden location.")
                     .Str("ref", false, "Commit/branch to check out in the new worktree (action=add)")
                     .Str("branch", false, "Create a new branch with this name in the new worktree (action=add, git worktree add -b)")
                     .Bool("force", false, "Force the operation (action=add/remove)")
@@ -478,6 +479,18 @@ namespace GitMcpServer
             full = null;
             string rel = ctx.Arguments.Value<string>("path");
             if (string.IsNullOrEmpty(rel)) return ToolResults.Error("path is required for this worktree action");
+            // The doubling signature: the path's leading segments re-state the current directory's own
+            // tail (cwd ...\.worktrees\x with path ".worktrees/x/..."), i.e. a workspace-root-relative
+            // path issued while cd'd into that very folder. Resolved, it would carve a worktree INSIDE
+            // the existing one (....\.worktrees\x\.worktrees\x) — the observed doom-loop disaster that
+            // created doubled trees on disk. Unlike a plain file write, this is never intended: reject
+            // with the fix instead of creating it.
+            string restated = PathFrames.RestatedRootTail(sandbox.Root, rel);
+            if (restated != null)
+                return ToolResults.Error("path '" + rel + "' begins by re-stating the current directory's own "
+                    + "tail ('" + restated + "'), so it would nest a worktree inside the current directory. "
+                    + "Paths resolve relative to the current directory — cd with no argument to return to the "
+                    + "workspace root first, then re-issue this worktree action.");
             try { full = sandbox.Resolve(rel); }
             catch (SandboxException ex) { return ToolResults.Error(ex.Message); }
             return null;
@@ -707,7 +720,9 @@ namespace GitMcpServer
             string full;
             try { full = currentSandbox.Resolve(rel); }
             catch (SandboxException ex) { return ToolResults.Error(ex.Message); }
-            if (!Directory.Exists(full)) return ToolResults.Error("cwd not found: " + rel);
+            if (!Directory.Exists(full))
+                return ToolResults.Error("cwd not found: " + rel + " (resolves to " + full
+                    + "; cwd is taken relative to the current directory, not the workspace root)");
             workDir = full;
             return null;
         }

--- a/servers/GitMcpServer/Properties/AssemblyInfo.cs
+++ b/servers/GitMcpServer/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("96b66f73-25a8-4b45-994b-d9efafcdf4f7")]
 
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyFileVersion("0.3.0.0")]

--- a/src/Gxpt.Mcp.Conventions/CwdScope.cs
+++ b/src/Gxpt.Mcp.Conventions/CwdScope.cs
@@ -70,7 +70,15 @@ namespace Gxpt.Mcp.Conventions
             }
 
             workDir = full;
-            sandbox = new PathSandbox(full, lbl);
+            // Label the re-rooted sandbox honestly: an escape error after a cd must say the path
+            // escaped the CURRENT DIRECTORY, not the workspace root — with the old label a model
+            // that cd'd into a subfolder was told its path "escapes the workspace root" when it was
+            // actually confined to the subfolder, reinforcing exactly the wrong frame.
+            string relDisp = anchor.ToRelative(full);
+            string cwdLabel = string.IsNullOrEmpty(relDisp)
+                ? "current directory"
+                : "current directory ('" + relDisp.Replace('\\', '/') + "', set by cd)";
+            sandbox = new PathSandbox(full, cwdLabel);
             return true;
         }
 

--- a/src/Gxpt.Mcp.Conventions/Gxpt.Mcp.Conventions.csproj
+++ b/src/Gxpt.Mcp.Conventions/Gxpt.Mcp.Conventions.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="GxptMeta.cs" />
     <Compile Include="CwdScope.cs" />
+    <Compile Include="PathFrames.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Gxpt.Mcp.Conventions/PathFrames.cs
+++ b/src/Gxpt.Mcp.Conventions/PathFrames.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+
+namespace Gxpt.Mcp.Conventions
+{
+    /// <summary>
+    /// Heuristic for the one recurring path-frame mistake GxPT's <c>cd</c> model invites: a
+    /// workspace-ROOT-relative path passed while the conversation has cd'd into a subfolder, where
+    /// every path argument actually resolves relative to the CURRENT directory. The signature is a
+    /// path whose leading segments re-state the current directory's own trailing segments (current
+    /// dir <c>...\.worktrees\x</c> with path <c>".worktrees/x/src/f.cs"</c>): resolved, it nests a
+    /// copy of the tree under itself (<c>...\.worktrees\x\.worktrees\x\src\f.cs</c>) — observed in
+    /// the wild as an agent doom loop that created doubled directory trees via <c>create_dirs</c>
+    /// and reported "successful" writes into them.
+    /// </summary>
+    public static class PathFrames
+    {
+        /// <summary>
+        /// When <paramref name="rel"/>'s leading segments re-state the trailing segments of
+        /// <paramref name="root"/>, returns that repeated prefix in forward-slash notation (e.g.
+        /// <c>".worktrees/x"</c>); otherwise null. A FULL multi-segment re-statement counts too —
+        /// <c>".worktrees/x"</c> issued from <c>...\.worktrees\x</c> is exactly the observed
+        /// worktree-doubling disaster. Only single-segment paths are exempt (a file named like its
+        /// parent directory is an ordinary name collision, not the doubling signature).
+        /// </summary>
+        public static string RestatedRootTail(string root, string rel)
+        {
+            if (string.IsNullOrEmpty(root) || string.IsNullOrEmpty(rel)) return null;
+            string[] segs = rel.Split(new char[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segs.Length < 2) return null;
+            string rootTrim = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            // Longest candidate first, so ".worktrees/x/f.cs" against ...\.worktrees\x reports the
+            // full ".worktrees/x" rather than stopping at a shorter accidental suffix match.
+            for (int n = segs.Length; n >= 1; n--)
+            {
+                string tail = string.Empty;
+                for (int i = 0; i < n; i++) tail += Path.DirectorySeparatorChar + segs[i];
+                if (rootTrim.EndsWith(tail, StringComparison.OrdinalIgnoreCase))
+                    return string.Join("/", segs, 0, n);
+            }
+            return null;
+        }
+    }
+}

--- a/src/Gxpt.Mcp.Conventions/Properties/AssemblyInfo.cs
+++ b/src/Gxpt.Mcp.Conventions/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a1b2c3d4-0001-4e5f-8a6b-7c8d9e0f1a2b")]
 
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyFileVersion("0.3.0.0")]

--- a/tests/FilesMcpServer.Tests/PathFrameHintTests.cs
+++ b/tests/FilesMcpServer.Tests/PathFrameHintTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using Gxpt.Mcp.Conventions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FilesMcpServer.Tests
+{
+    // Path-frame observability (doom-loop fixes): errors carry the RESOLVED absolute path, failures
+    // while cd'd get a frame-orientation note (with a targeted "did you mean" when the path exists
+    // at the workspace root), and a write whose path re-states the cwd's own tail — the doubling
+    // signature — warns in its result.
+    public class PathFrameHintTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _sub;
+
+        public PathFrameHintTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "filesframe_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+            _sub = Path.Combine(_root, "sub");
+            Directory.CreateDirectory(_sub);
+            File.WriteAllText(Path.Combine(_root, "root.txt"), "ROOT");
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, true); } catch { }
+        }
+
+        private static string ToolsCallCwd(int id, string name, JObject args, string cwd)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (args != null) p["arguments"] = args;
+            if (cwd != null)
+            {
+                JObject meta = new JObject();
+                meta[GxptMeta.CwdKey] = cwd;
+                p["_meta"] = meta;
+            }
+            return Harness.Request(id, "tools/call", p);
+        }
+
+        [Fact]
+        public void Read_error_includes_the_resolved_absolute_path()
+        {
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "read", Harness.Args("path", "missing.txt")));
+            Assert.True(Harness.IsError(msgs[0]));
+            Assert.Contains(Path.Combine(_root, "missing.txt"), Harness.Text(msgs[0]));
+        }
+
+        [Fact]
+        public void Failed_read_while_cdd_gets_the_frame_note_and_did_you_mean()
+        {
+            // The doom-loop shape: cd'd into sub, the model asks for a root file by its root-relative
+            // name. The error must say where the path actually resolved, that paths are cwd-relative,
+            // and that the file DOES exist at the workspace root.
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, ToolsCallCwd(1, "read", Harness.Args("path", "root.txt"), _sub));
+            Assert.True(Harness.IsError(msgs[0]));
+            string text = Harness.Text(msgs[0]);
+            Assert.Contains(Path.Combine(_sub, "root.txt"), text);           // where it resolved
+            Assert.Contains("current directory 'sub'", text);                // which frame applies
+            Assert.Contains("does exist relative to the workspace root", text); // targeted correction
+        }
+
+        [Fact]
+        public void Failed_read_at_the_root_gets_no_frame_note()
+        {
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, Harness.ToolsCall(1, "read", Harness.Args("path", "missing.txt")));
+            Assert.DoesNotContain("[note:", Harness.Text(msgs[0])); // one frame only - nothing to explain
+        }
+
+        [Fact]
+        public void Write_that_restates_the_cwd_tail_warns_and_reports_the_absolute_path()
+        {
+            // cd'd into sub, writing "sub/x.txt": resolves to sub\sub\x.txt - the doubled tree. The
+            // write still succeeds (a genuinely intended nested write stays possible) but the result
+            // carries the warning and the absolute path, so the mistake is visible immediately.
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, ToolsCallCwd(1, "write",
+                Harness.Args("path", "sub/x.txt", "content", "hi", "create_dirs", true), _sub));
+            Assert.False(Harness.IsError(msgs[0]));
+            string text = Harness.Text(msgs[0]);
+            Assert.Contains("warning", text);
+            Assert.Contains("re-states the current directory", text);
+            string doubled = Path.Combine(Path.Combine(_sub, "sub"), "x.txt");
+            Assert.Contains(doubled.Replace("\\", "\\\\"), text); // absolute_path in the JSON mirror
+            Assert.True(File.Exists(doubled));
+        }
+
+        [Fact]
+        public void Ordinary_write_carries_no_warning()
+        {
+            var server = Harness.NewFilesServer(_root);
+            var msgs = Harness.Exchange(server, ToolsCallCwd(1, "write",
+                Harness.Args("path", "y.txt", "content", "hi"), _sub));
+            Assert.False(Harness.IsError(msgs[0]));
+            Assert.DoesNotContain("warning", Harness.Text(msgs[0]));
+            Assert.True(File.Exists(Path.Combine(_sub, "y.txt")));
+        }
+    }
+}

--- a/tests/GitMcpServer.Tests/WorktreeDoublingTests.cs
+++ b/tests/GitMcpServer.Tests/WorktreeDoublingTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using Gxpt.Mcp.Conventions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GitMcpServer.Tests
+{
+    // The worktree-doubling guard: a worktree path whose leading segments re-state the current
+    // directory's own tail (".worktrees/feat" issued from ...\.worktrees\feat) is a workspace-root-
+    // relative path used while cd'd — resolved, it would carve a worktree INSIDE the existing one
+    // (...\.worktrees\feat\.worktrees\feat, the observed doom-loop disaster that doubled trees on
+    // disk). Reject with the fix instead of creating it.
+    public class WorktreeDoublingTests : IDisposable
+    {
+        private readonly string _dir;
+        private readonly string _work;
+        private readonly string _wt;
+
+        public WorktreeDoublingTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "gitwtdbl_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _work = Path.Combine(_dir, "work");
+            Directory.CreateDirectory(_work);
+            _wt = Path.Combine(Path.Combine(_work, ".worktrees"), "feat");
+            Directory.CreateDirectory(_wt);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        private string ToolsCallCwd(int id, string name, JObject args, string cwd)
+        {
+            JObject p = new JObject();
+            p["name"] = name;
+            if (args != null) p["arguments"] = args;
+            if (cwd != null)
+            {
+                JObject meta = new JObject();
+                meta[GxptMeta.CwdKey] = cwd;
+                p["_meta"] = meta;
+            }
+            return Harness.Request(id, "tools/call", p);
+        }
+
+        [Fact]
+        public void Worktree_add_that_restates_the_cwd_tail_is_rejected()
+        {
+            // git is never invoked: the guard fires before RunGit, so a bogus git path is fine.
+            var server = Harness.NewGitServer(Path.Combine(_dir, "no-such-git"), _work);
+            // cd'd into .worktrees/feat, adding ".worktrees/feat" again - the doubling signature.
+            var msgs = Harness.Exchange(server,
+                ToolsCallCwd(1, "worktree", Harness.Args("action", "add", "path", ".worktrees/feat"), _wt));
+            Assert.True(Harness.IsError(msgs[0]));
+            string text = Harness.Text(msgs[0]);
+            Assert.Contains("re-stating the current directory", text);
+            Assert.Contains("cd with no argument", text);
+        }
+
+        [Fact]
+        public void Worktree_add_from_the_root_is_not_flagged()
+        {
+            // From the workspace root the same path is exactly right; the guard must not fire (the
+            // call then proceeds to git, which fails here because the git exe is bogus - but with a
+            // git error, not the frame rejection).
+            var server = Harness.NewGitServer(Path.Combine(_dir, "no-such-git"), _work);
+            var msgs = Harness.Exchange(server,
+                ToolsCallCwd(1, "worktree", Harness.Args("action", "add", "path", ".worktrees/other"), null));
+            Assert.DoesNotContain("re-stating the current directory", Harness.Text(msgs[0]));
+        }
+    }
+}

--- a/tests/Gxpt.Mcp.Conventions.Tests/PathFramesTests.cs
+++ b/tests/Gxpt.Mcp.Conventions.Tests/PathFramesTests.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using Gxpt.Mcp.Conventions;
+using Xunit;
+
+namespace Gxpt.Mcp.Conventions.Tests
+{
+    // The doubling-signature heuristic: a path whose leading segments re-state the current
+    // directory's own trailing segments (root ...\.worktrees\x with ".worktrees/x/f.cs") is almost
+    // always a workspace-root-relative path issued while cd'd — resolved, it nests a copy of the
+    // tree under itself.
+    public class PathFramesTests
+    {
+        private static string Root(params string[] segs)
+        {
+            string p = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+            foreach (string s in segs) p += Path.DirectorySeparatorChar + s;
+            return p;
+        }
+
+        [Fact]
+        public void Detects_single_segment_restatement()
+        {
+            Assert.Equal("sub", PathFrames.RestatedRootTail(Root("proj", "sub"), "sub/file.txt"));
+        }
+
+        [Fact]
+        public void Detects_multi_segment_restatement_longest_first()
+        {
+            string root = Root("proj", ".worktrees", "feat");
+            Assert.Equal(".worktrees/feat", PathFrames.RestatedRootTail(root, ".worktrees/feat/src/a.cs"));
+        }
+
+        [Fact]
+        public void Accepts_backslash_separators_in_the_path()
+        {
+            string root = Root("proj", ".worktrees", "feat");
+            Assert.Equal(".worktrees/feat", PathFrames.RestatedRootTail(root, ".worktrees\\feat\\a.cs"));
+        }
+
+        [Fact]
+        public void Match_is_case_insensitive()
+        {
+            Assert.Equal("Sub", PathFrames.RestatedRootTail(Root("proj", "sub"), "Sub/file.txt"));
+        }
+
+        [Fact]
+        public void No_match_when_segments_differ()
+        {
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "sub"), "other/file.txt"));
+        }
+
+        [Fact]
+        public void No_match_for_a_single_segment_restatement()
+        {
+            // "sub" alone from ...\sub is an ordinary name collision (a file/dir named like the
+            // cwd), not the doubling signature.
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "sub"), "sub"));
+        }
+
+        [Fact]
+        public void Full_multi_segment_restatement_matches()
+        {
+            // ".worktrees/feat" issued from ...\.worktrees\feat — the exact observed worktree-add
+            // disaster (it would carve ...\.worktrees\feat\.worktrees\feat). No trailing segment
+            // needed for the multi-segment form.
+            string root = Root("proj", ".worktrees", "feat");
+            Assert.Equal(".worktrees/feat", PathFrames.RestatedRootTail(root, ".worktrees/feat"));
+        }
+
+        [Fact]
+        public void No_match_for_single_segment_paths_or_empty_inputs()
+        {
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "sub"), "file.txt"));
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "sub"), null));
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "sub"), ""));
+            Assert.Null(PathFrames.RestatedRootTail(null, "sub/file.txt"));
+        }
+
+        [Fact]
+        public void Partial_segment_names_do_not_match()
+        {
+            // root ends with "subdir"; path starts with "sub" - a segment-boundary check, not a
+            // substring check (the separator prepended to each candidate enforces the boundary).
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "subdir"), "dir/file.txt"));
+            Assert.Null(PathFrames.RestatedRootTail(Root("proj", "subdir"), "sub/file.txt"));
+        }
+    }
+}


### PR DESCRIPTION
Three related fixes for the doom loop where sub-agents were dispatched with
no MCP tools (only the cd host tool) after a mid-turn host rebuild:

1. Defer RebuildMcpHost while any turn is in flight. Rebuilding swaps the
   host AND the McpToolRegistry object out from under the running
   orchestrator; its AgentDispatcher and children keep the old, force-
   emptied registry and never re-bind (only the next user turn reads the
   fresh field), so every sub-agent dispatched after the swap is born
   toolless. The rebuild is now queued and applied from the shared turn-
   finalization tail (HideGenerationBar) once the last turn ends.

2. Narrow SlashRefreshSkillsServer from a full host rebuild to starting/
   stopping just the extensions server (new McpHost.SetBuiltInServerEnabled):
   a skills-enablement flip on a tab switch no longer tears down files/git/
   command/web for every workdir, and even the narrow flip is deferred while
   a turn is in flight.

3. Freeze sub-agent tool defs at dispatch (completes design A11): the child
   orchestrator now carries FrozenToolDefs, snapshotted concrete defs from
   the registry (new McpToolRegistry.FunctionDefsForNames), instead of
   re-deriving its exposure from the live registry every loop iteration -
   so registry churn during a long parent turn can no longer strip a
   running child's tools. Per A11 the frozen list has no reveal_tools and
   no names manifest (nothing to discover).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M1HgnXJgwNGyfguLSKFUGX