### PR TITLE
Add support for pwd command in tool record building

### DIFF
--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -5422,6 +5422,9 @@ namespace GxPT
                         : "Changed directory to " + rel;
                     return true;
                 }
+                // pwd takes no arguments, so unlike cd the label can't name the directory —
+                // that's in the tool result, which records don't show (call, not result).
+                case "pwd": header = "Checked current directory"; return true;
                 case "open_skill":
                 {
                     // Post-flight (completed) record label, so past tense like the other records.


### PR DESCRIPTION
## Summary
Added handling for the `pwd` (print working directory) command in the tool record building logic to properly label this command type in records.

## Key Changes
- Added a new case for the `pwd` command in `TryBuildToolRecord` method
- Set the header label to "Checked current directory" for pwd records
- Added explanatory comment clarifying why pwd records don't include directory information in the label (unlike cd records), since the directory is in the tool result which records don't display

## Implementation Details
The `pwd` command is treated similarly to other shell commands in record building, but with a key difference: while `cd` can include the target directory in its label, `pwd` cannot because the actual directory information is stored in the tool result (not the record label itself). The label simply indicates that the current directory was checked.

https://claude.ai/code/session_016s5EjM94boTL1jqH6kotCW