### PR TITLE
Persist conversation current directory and advertise per request

### DIFF
--- a/GxPT.Tests/CurrentDirPersistenceTests.cs
+++ b/GxPT.Tests/CurrentDirPersistenceTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using GxPT;
+using Xunit;
+
+namespace GxPT.Tests
+{
+    // Persistence of the conversation's current directory (host `cd`) - the 2026-07-31 amendment to
+    // the host-cd/worktree design: stored anchor-relative so the file cannot express an escape,
+    // restored with validation, so a reopened conversation resumes where its transcript's cd echoes
+    // say it is. Real temp directories because RevalidateCurrentDir checks existence on disk.
+    public sealed class CurrentDirPersistenceTests : IDisposable
+    {
+        private readonly string _anchor;
+        private readonly string _sub;      // <anchor>/src
+        private readonly string _deep;     // <anchor>/src/app
+
+        public CurrentDirPersistenceTests()
+        {
+            _anchor = Path.Combine(Path.GetTempPath(), "curdir_" + Guid.NewGuid().ToString("N"));
+            _sub = Path.Combine(_anchor, "src");
+            _deep = Path.Combine(_sub, "app");
+            Directory.CreateDirectory(_deep);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_anchor, true); } catch { }
+        }
+
+        private Conversation WorkspaceConvo()
+        {
+            var convo = new Conversation(null);
+            convo.Name = "W";
+            convo.WorkingDir = _anchor;
+            convo.History.Add(new ChatMessage("user", "hi"));
+            return convo;
+        }
+
+        private static string QuotedJsonPath(string path)
+        {
+            return "\"" + path.Replace("\\", "\\\\") + "\"";
+        }
+
+        [Fact]
+        public void CurrentDir_round_trips_via_anchor_relative_form()
+        {
+            var convo = WorkspaceConvo();
+            convo.CurrentDir = _deep;
+
+            string json = ConversationStore.ToJson(convo);
+            // Stored relative to the anchor with forward slashes, never absolute.
+            Assert.Contains("\"CurrentDir\":\"src/app\"", json);
+
+            var reload = ConversationStore.LoadFromJson(null, json);
+            Assert.Equal(Path.GetFullPath(_deep), reload.CurrentDir);
+        }
+
+        [Fact]
+        public void CurrentDir_at_anchor_is_omitted()
+        {
+            var convo = WorkspaceConvo(); // CurrentDir null = at the anchor
+            Assert.DoesNotContain("CurrentDir", ConversationStore.ToJson(convo));
+        }
+
+        [Fact]
+        public void CurrentDir_without_workspace_is_omitted()
+        {
+            var convo = new Conversation(null);
+            convo.Name = "N";
+            convo.CurrentDir = _sub; // no WorkingDir: nothing to be relative to
+            convo.History.Add(new ChatMessage("user", "hi"));
+            Assert.DoesNotContain("CurrentDir", ConversationStore.ToJson(convo));
+        }
+
+        [Fact]
+        public void CurrentDir_outside_anchor_is_never_persisted()
+        {
+            // An out-of-anchor runtime value is an upstream bug: serialize drops it rather than
+            // writing an escape into the file format.
+            var convo = WorkspaceConvo();
+            convo.CurrentDir = Path.GetTempPath();
+            Assert.DoesNotContain("CurrentDir", ConversationStore.ToJson(convo));
+        }
+
+        [Fact]
+        public void Load_legacy_file_without_current_dir_is_null()
+        {
+            var convo = ConversationStore.LoadFromJson(null, "{\"Name\":\"C\",\"Messages\":[]}");
+            Assert.Null(convo.CurrentDir);
+        }
+
+        [Fact]
+        public void Load_escaping_stored_value_falls_back_to_null()
+        {
+            // Hand-edited/corrupt file: a relative escape must never survive the load.
+            string json = "{\"Name\":\"C\",\"WorkingDir\":" + QuotedJsonPath(_anchor)
+                + ",\"CurrentDir\":\"../evil\",\"Messages\":[]}";
+            Assert.Null(ConversationStore.LoadFromJson(null, json).CurrentDir);
+        }
+
+        [Fact]
+        public void Load_absolute_stored_value_falls_back_to_null()
+        {
+            // The persisted form is anchor-relative by contract; an absolute path (even one inside
+            // the anchor) is rejected outright, mirroring PathSandbox.
+            string json = "{\"Name\":\"C\",\"WorkingDir\":" + QuotedJsonPath(_anchor)
+                + ",\"CurrentDir\":" + QuotedJsonPath(_sub) + ",\"Messages\":[]}";
+            Assert.Null(ConversationStore.LoadFromJson(null, json).CurrentDir);
+        }
+
+        [Fact]
+        public void Load_dot_stored_value_normalizes_to_null()
+        {
+            // "." resolves to the anchor itself, whose canonical representation is null.
+            string json = "{\"Name\":\"C\",\"WorkingDir\":" + QuotedJsonPath(_anchor)
+                + ",\"CurrentDir\":\".\",\"Messages\":[]}";
+            Assert.Null(ConversationStore.LoadFromJson(null, json).CurrentDir);
+        }
+
+        [Fact]
+        public void Revalidate_accepts_live_subdir()
+        {
+            Assert.Equal(Path.GetFullPath(_sub), ConversationStore.RevalidateCurrentDir(_anchor, _sub));
+        }
+
+        [Fact]
+        public void Revalidate_normalizes_anchor_itself_to_null()
+        {
+            // "At the anchor" is represented as null, never as a path.
+            Assert.Null(ConversationStore.RevalidateCurrentDir(_anchor, _anchor));
+        }
+
+        [Fact]
+        public void Revalidate_rejects_missing_directory()
+        {
+            // Deleted while the app was closed (e.g. a pruned worktree): fall back to the anchor.
+            Assert.Null(ConversationStore.RevalidateCurrentDir(_anchor, Path.Combine(_anchor, "gone")));
+        }
+
+        [Fact]
+        public void Revalidate_rejects_out_of_anchor_directory()
+        {
+            // Exists, but outside the anchor: rejected regardless.
+            Assert.Null(ConversationStore.RevalidateCurrentDir(_anchor, Path.GetTempPath()));
+        }
+
+        [Fact]
+        public void Revalidate_without_workspace_is_null()
+        {
+            Assert.Null(ConversationStore.RevalidateCurrentDir(null, _sub));
+        }
+    }
+}

--- a/GxPT.Tests/Mcp/HostCdTests.cs
+++ b/GxPT.Tests/Mcp/HostCdTests.cs
@@ -8,8 +8,9 @@ using Xunit;
 namespace GxPT.Tests.Mcp
 {
     // The host `cd` meta-tool and the per-call current-directory injection: cd moves the conversation's
-    // current dir within the workspace anchor (re-validated, transient), and every subsequent
-    // workdir-scoped call carries that dir out-of-band as params._meta["gxpt.cwd"].
+    // current dir within the workspace anchor (re-validated; persisted with the conversation via the
+    // host's CurrentDirChanged mirror), and every subsequent workdir-scoped call carries that dir
+    // out-of-band as params._meta["gxpt.cwd"].
     public class HostCdTests : IDisposable
     {
         private readonly string _anchor;

--- a/GxPT.Tests/Mcp/PathOrientationTests.cs
+++ b/GxPT.Tests/Mcp/PathOrientationTests.cs
@@ -145,6 +145,30 @@ namespace GxPT.Tests.Mcp
         }
 
         [Fact]
+        public void Pwd_renders_an_out_of_anchor_current_dir_as_the_root_not_a_leaked_path()
+        {
+            // Defense-in-depth: all setters keep CurrentDir within the anchor, but if one ever slipped,
+            // pwd must not print the foreign absolute path labeled "relative to the workspace root"
+            // (ToRelative's raw fallback). AnchorRelDisplay clamps it to ".", matching the tail block.
+            RegistryFakeTransport ft;
+            var reg = RegistryWith(out ft, "files", new ToolDef("read"));
+            var streamer = new ScriptedStreamer();
+            streamer.Turns.Add(Chunks.OneToolCall("c1", "pwd", "{}"));
+            streamer.Turns.Add(Chunks.Text("done"));
+
+            var orch = Orch(streamer, reg, _anchor);
+            string outside = Path.Combine(Path.GetTempPath(), "pathorient_outside_" + Guid.NewGuid().ToString("N"));
+            orch.CurrentDir = outside; // out-of-anchor (an upstream-bug state)
+
+            var ui = new RecordingUi();
+            orch.RunTurn(new List<ChatMessage>(), "go", ui);
+
+            // The relative field is clamped to ".", never the foreign path presented as relative.
+            Assert.Contains("Current directory: `.`", ui.ToolResults[0]);
+            Assert.DoesNotContain("`" + outside + "`", ui.ToolResults[0]);
+        }
+
+        [Fact]
         public void Pwd_is_exposed_alongside_cd()
         {
             RegistryFakeTransport ft;

--- a/GxPT.Tests/OrchestratorEphemeralTailTests.cs
+++ b/GxPT.Tests/OrchestratorEphemeralTailTests.cs
@@ -1,32 +1,37 @@
+using System.IO;
 using GxPT;
 using Xunit;
 
 namespace GxPT.Tests
 {
-    // Covers the <agents> section added to the orchestrator's ephemeral context tail (phase 3): it sits
-    // after <skills> and before <available_tools>, and is omitted when empty.
+    // Covers the orchestrator's ephemeral context tail sections: <current_directory> (host `cd`
+    // awareness, 2026-07-31 design amendment) leads, then <memory>, <skills>, <agents>,
+    // <available_tools>; each is omitted when empty.
     public sealed class OrchestratorEphemeralTailTests
     {
         [Fact]
-        public void AgentsSection_OrderedAfterSkills_BeforeTools()
+        public void Sections_Ordered_CwdFirst_ThenMemorySkillsAgentsTools()
         {
-            string tail = McpChatOrchestrator.BuildEphemeralContextText("mem", "sk", "ag", "tools");
+            string tail = McpChatOrchestrator.BuildEphemeralContextText("cwd", "mem", "sk", "ag", "tools");
 
+            int cd = tail.IndexOf("<current_directory>");
             int mem = tail.IndexOf("<memory>");
             int sk = tail.IndexOf("<skills>");
             int ag = tail.IndexOf("<agents>");
             int tl = tail.IndexOf("<available_tools>");
 
-            Assert.True(mem >= 0 && sk >= 0 && ag >= 0 && tl >= 0);
-            Assert.True(mem < sk && sk < ag && ag < tl);
+            Assert.True(cd >= 0 && mem >= 0 && sk >= 0 && ag >= 0 && tl >= 0);
+            Assert.True(cd < mem && mem < sk && sk < ag && ag < tl);
+            Assert.Contains("<current_directory>\ncwd\n</current_directory>", tail);
             Assert.Contains("<agents>\nag\n</agents>", tail);
         }
 
         [Fact]
-        public void AgentsSection_OmittedWhenEmpty()
+        public void EmptySections_Omitted()
         {
-            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, null, "tools");
+            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, null, null, "tools");
 
+            Assert.DoesNotContain("<current_directory>", tail);
             Assert.DoesNotContain("<agents>", tail);
             Assert.Contains("<available_tools>", tail);
         }
@@ -34,15 +39,70 @@ namespace GxPT.Tests
         [Fact]
         public void OnlyAgents_StillProducesTail()
         {
-            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, "ag", null);
+            string tail = McpChatOrchestrator.BuildEphemeralContextText(null, null, null, "ag", null);
 
             Assert.Contains("<agents>\nag\n</agents>", tail);
         }
 
         [Fact]
+        public void OnlyCwd_StillProducesTail()
+        {
+            // A workspace turn with no memory/skills/agents/tools still gets a tail: the
+            // current-directory line must ride every workspace request to stay authoritative.
+            string tail = McpChatOrchestrator.BuildEphemeralContextText("cwd", null, null, null, null);
+
+            Assert.Contains("<current_directory>\ncwd\n</current_directory>", tail);
+        }
+
+        [Fact]
         public void AllEmpty_ReturnsNull()
         {
-            Assert.Null(McpChatOrchestrator.BuildEphemeralContextText(null, null, null, null));
+            Assert.Null(McpChatOrchestrator.BuildEphemeralContextText(null, null, null, null, null));
+        }
+
+        // ---- the <current_directory> block's text (CurrentDirContextBlock) ----
+
+        [Fact]
+        public void CurrentDirBlock_NullWithoutWorkspace()
+        {
+            // No workspace: `cd` doesn't exist there, so no line at all.
+            Assert.Null(McpChatOrchestrator.CurrentDirContextBlock(null, null));
+            Assert.Null(McpChatOrchestrator.CurrentDirContextBlock("", "anything"));
+        }
+
+        [Fact]
+        public void CurrentDirBlock_AtAnchor_SaysWorkspaceRoot()
+        {
+            // Present even at the anchor: its job is to correct a model whose transcript claims a
+            // subdir the host no longer honors, and that is exactly the at-anchor case.
+            string anchor = Path.Combine(Path.GetTempPath(), "ws");
+            string block = McpChatOrchestrator.CurrentDirContextBlock(anchor, null);
+
+            Assert.Contains("current working directory is the workspace root", block);
+            Assert.Contains("authoritative", block);
+        }
+
+        [Fact]
+        public void CurrentDirBlock_Scoped_ShowsAnchorRelativePath()
+        {
+            string anchor = Path.Combine(Path.GetTempPath(), "ws");
+            string sub = Path.Combine(anchor, Path.Combine("src", "app"));
+            string block = McpChatOrchestrator.CurrentDirContextBlock(anchor, sub);
+
+            Assert.Contains("`src/app` (relative to the workspace root)", block);
+        }
+
+        [Fact]
+        public void CurrentDirBlock_OutOfAnchorValue_FallsBackToRootWording()
+        {
+            // An out-of-anchor current dir is an upstream bug; the block never echoes the path
+            // (the servers reject the injected dir anyway) and falls back to the floor wording.
+            string anchor = Path.Combine(Path.GetTempPath(), "ws");
+            string outside = Path.Combine(Path.GetTempPath(), "elsewhere");
+            string block = McpChatOrchestrator.CurrentDirContextBlock(anchor, outside);
+
+            Assert.Contains("the workspace root", block);
+            Assert.DoesNotContain("elsewhere", block);
         }
     }
 }

--- a/GxPT/Controls/WorkspaceContextStrip.cs
+++ b/GxPT/Controls/WorkspaceContextStrip.cs
@@ -37,7 +37,6 @@ namespace GxPT
         private readonly Label _text;
         private readonly FlowLayoutPanel _links;
         private readonly LinkLabel _change;
-        private readonly LinkLabel _returnRoot;
         private readonly LinkLabel _clear;
         private readonly LinkLabel _dismiss;
         private readonly ToolTip _openTip;
@@ -61,9 +60,6 @@ namespace GxPT
         public event EventHandler ChangeRequested;
         public event EventHandler ClearRequested;
         public event EventHandler DismissRequested;
-        // Raised when the user clicks "Return to root" to bring the conversation's current directory
-        // back to the workspace anchor (it may have been scoped into a subdir by the model via `cd`).
-        public event EventHandler ReturnToAnchorRequested;
 
         public WorkspaceContextStrip()
         {
@@ -72,8 +68,6 @@ namespace GxPT
             this.Padding = new Padding(8, 0, 8, 0);
 
             _change = MakeLink("Set workspace...", delegate { Raise(ChangeRequested); });
-            _returnRoot = MakeLink("Return to root", delegate { Raise(ReturnToAnchorRequested); });
-            _returnRoot.Visible = false; // shown only while scoped into a subdir
             _clear = MakeLink("Clear", delegate { Raise(ClearRequested); });
             _dismiss = MakeLink("Dismiss", delegate { Raise(DismissRequested); });
 
@@ -88,7 +82,6 @@ namespace GxPT
             _links.Margin = new Padding(0);
             _links.Anchor = AnchorStyles.Right;
             _links.Controls.Add(_change);
-            _links.Controls.Add(_returnRoot);
             _links.Controls.Add(_clear);
             _links.Controls.Add(_dismiss);
 
@@ -179,7 +172,6 @@ namespace GxPT
 
             // Changing (or clearing) the workspace resets the current directory to the new anchor.
             _currentRel = null;
-            _returnRoot.Visible = false;
 
             if (has)
             {
@@ -211,9 +203,10 @@ namespace GxPT
         }
 
         // Reflect the conversation's current directory (host `cd`), given relative to the workspace
-        // anchor ("." or null = at the anchor). When scoped into a subdir, the path text shows
-        // "Workspace: <dir> ▸ <subdir>" and a "Return to root" link appears; at the anchor it shows just
-        // the workspace. No-op when no workspace is set.
+        // anchor ("." or null = at the anchor). A read-only indicator: when scoped into a subdir the
+        // path text shows "Workspace: <dir> ▸ <subdir>"; at the anchor it shows just the workspace.
+        // No-op when no workspace is set. (The model moves the current dir via `cd`; there is no
+        // user-facing control here.)
         public void SetCurrentDir(string anchorRelative)
         {
             bool scoped = !string.IsNullOrEmpty(anchorRelative)
@@ -223,7 +216,6 @@ namespace GxPT
                 _text.Text = scoped
                     ? ("Workspace:  " + _dir + "   ▸ " + _currentRel)
                     : ("Workspace:  " + _dir);
-            _returnRoot.Visible = scoped;
         }
 
         // Apply (true) or clear (false) the hover affordance while the pointer is over the path: the

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -152,22 +152,22 @@ namespace GxPT
         // (Deserialize routes through PathSandbox.Resolve, which also rejects absolute/drive-form
         // input from a hand-edited file), and the stored subpath survives the anchor being re-picked
         // at a moved location. Both directions fail SOFT to null ("at the anchor"): a current dir is
-        // a convenience worth dropping, never worth failing a conversation save/load over.
+        // a convenience worth dropping, never worth failing a conversation save/load over. Serialize
+        // and Revalidate share PathSandbox.RelativeSubdirOrNull for the containment + at-anchor test,
+        // so save, load, and the model-facing tail (CurrentDirContextBlock) can't drift on that rule.
 
         // Runtime absolute -> persisted anchor-relative. Null when at the anchor, when there is no
         // workspace, or when the value does not sit inside the anchor (a bug upstream - never
         // persist an escape).
         internal static string SerializeCurrentDir(string workingDir, string currentDirAbs)
         {
-            if (string.IsNullOrEmpty(workingDir) || string.IsNullOrEmpty(currentDirAbs)) return null;
+            if (string.IsNullOrEmpty(workingDir)) return null;
             try
             {
-                var sb = new PathSandbox(workingDir, "workspace root");
-                string full = Path.GetFullPath(currentDirAbs);
-                if (!sb.IsWithin(full)) return null;
-                string rel = sb.ToRelative(full);
-                if (string.IsNullOrEmpty(rel)) return null; // the anchor itself -> omitted
-                return rel.Replace('\\', '/');
+                string ignored;
+                string rel = new PathSandbox(workingDir, "workspace root")
+                    .RelativeSubdirOrNull(currentDirAbs, out ignored);
+                return rel == null ? null : rel.Replace('\\', '/');
             }
             catch { return null; }
         }
@@ -191,21 +191,20 @@ namespace GxPT
 
         // Adoption-time revalidation of a restored current dir (MainForm.ApplyLoadedWorkingDir):
         // returns the canonicalized absolute path when it is still a live subdirectory of the anchor
-        // - within the anchor (containment re-checked here, not just trusted from
-        // DeserializeCurrentDir; the layers never assume another is the only defense, see
-        // mcp-architecture.md sec.9), not the anchor itself, and still EXISTING on disk (a worktree
-        // pruned or a subdir deleted while the app was closed) - else null ("start at the anchor").
+        // - within the anchor and not the anchor itself (containment re-checked here via the shared
+        // RelativeSubdirOrNull, not just trusted from DeserializeCurrentDir; the layers never assume
+        // another is the only defense, see mcp-architecture.md sec.9), and still EXISTING on disk (a
+        // worktree pruned or a subdir deleted while the app was closed) - else null ("start at the
+        // anchor").
         internal static string RevalidateCurrentDir(string workingDir, string currentDirAbs)
         {
-            if (string.IsNullOrEmpty(workingDir) || string.IsNullOrEmpty(currentDirAbs)) return null;
+            if (string.IsNullOrEmpty(workingDir)) return null;
             try
             {
-                var sb = new PathSandbox(workingDir, "workspace root");
-                string full = Path.GetFullPath(currentDirAbs);
-                if (!sb.IsWithin(full)) return null;
-                if (string.Equals(full, sb.Root, StringComparison.OrdinalIgnoreCase)) return null;
-                if (!Directory.Exists(full)) return null;
-                return full;
+                string full;
+                string rel = new PathSandbox(workingDir, "workspace root")
+                    .RelativeSubdirOrNull(currentDirAbs, out full);
+                return (rel != null && Directory.Exists(full)) ? full : null;
             }
             catch { return null; }
         }

--- a/GxPT/Data/ConversationStore.cs
+++ b/GxPT/Data/ConversationStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Mcp35.Core.Security;
 using Newtonsoft.Json;
 
 namespace GxPT
@@ -106,6 +107,11 @@ namespace GxPT
                 Name = convo.Name,
                 SelectedModel = convo.SelectedModel,
                 WorkingDir = convo.WorkingDir,
+                // Current directory (host `cd`): stored anchor-RELATIVE with '/' separators, omitted
+                // at the anchor. Relative keeps "current is within the anchor" structural in the file
+                // format itself; an out-of-anchor runtime value (a bug upstream) serializes as null
+                // rather than persisting an escape.
+                CurrentDir = SerializeCurrentDir(convo.WorkingDir, convo.CurrentDir),
                 WorkspaceStripDismissed = convo.WorkspaceStripDismissed,
                 ContinuedFromCompaction = convo.ContinuedFromCompaction,
                 Zdr = convo.Zdr,
@@ -136,6 +142,72 @@ namespace GxPT
                 Messages = convo.History.Select(m => ToMessageDto(m)).ToList()
             };
             return JsonConvert.SerializeObject(dto, _jsonSettings);
+        }
+
+        // ---- current-directory (host `cd`) persistence ----
+        //
+        // The on-disk form of Conversation.CurrentDir is the path RELATIVE to the workspace anchor
+        // (forward slashes), omitted entirely at the anchor. The pair (WorkingDir, CurrentDir) then
+        // stays coherent as a unit: the file cannot express a current dir outside its own anchor
+        // (Deserialize routes through PathSandbox.Resolve, which also rejects absolute/drive-form
+        // input from a hand-edited file), and the stored subpath survives the anchor being re-picked
+        // at a moved location. Both directions fail SOFT to null ("at the anchor"): a current dir is
+        // a convenience worth dropping, never worth failing a conversation save/load over.
+
+        // Runtime absolute -> persisted anchor-relative. Null when at the anchor, when there is no
+        // workspace, or when the value does not sit inside the anchor (a bug upstream - never
+        // persist an escape).
+        internal static string SerializeCurrentDir(string workingDir, string currentDirAbs)
+        {
+            if (string.IsNullOrEmpty(workingDir) || string.IsNullOrEmpty(currentDirAbs)) return null;
+            try
+            {
+                var sb = new PathSandbox(workingDir, "workspace root");
+                string full = Path.GetFullPath(currentDirAbs);
+                if (!sb.IsWithin(full)) return null;
+                string rel = sb.ToRelative(full);
+                if (string.IsNullOrEmpty(rel)) return null; // the anchor itself -> omitted
+                return rel.Replace('\\', '/');
+            }
+            catch { return null; }
+        }
+
+        // Persisted anchor-relative -> runtime absolute. Null when absent, when there is no
+        // workspace, or when the stored value is malformed or escapes the anchor
+        // (PathSandbox.Resolve throws on those).
+        internal static string DeserializeCurrentDir(string workingDir, string currentDirRel)
+        {
+            if (string.IsNullOrEmpty(workingDir) || string.IsNullOrEmpty(currentDirRel)) return null;
+            try
+            {
+                var sb = new PathSandbox(workingDir, "workspace root");
+                string full = sb.Resolve(currentDirRel.Replace('/', Path.DirectorySeparatorChar));
+                full = full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                // "." (or an equivalent) resolves to the anchor itself: normalize to null.
+                return string.Equals(full, sb.Root, StringComparison.OrdinalIgnoreCase) ? null : full;
+            }
+            catch { return null; }
+        }
+
+        // Adoption-time revalidation of a restored current dir (MainForm.ApplyLoadedWorkingDir):
+        // returns the canonicalized absolute path when it is still a live subdirectory of the anchor
+        // - within the anchor (containment re-checked here, not just trusted from
+        // DeserializeCurrentDir; the layers never assume another is the only defense, see
+        // mcp-architecture.md sec.9), not the anchor itself, and still EXISTING on disk (a worktree
+        // pruned or a subdir deleted while the app was closed) - else null ("start at the anchor").
+        internal static string RevalidateCurrentDir(string workingDir, string currentDirAbs)
+        {
+            if (string.IsNullOrEmpty(workingDir) || string.IsNullOrEmpty(currentDirAbs)) return null;
+            try
+            {
+                var sb = new PathSandbox(workingDir, "workspace root");
+                string full = Path.GetFullPath(currentDirAbs);
+                if (!sb.IsWithin(full)) return null;
+                if (string.Equals(full, sb.Root, StringComparison.OrdinalIgnoreCase)) return null;
+                if (!Directory.Exists(full)) return null;
+                return full;
+            }
+            catch { return null; }
         }
 
         private static MessageDto ToMessageDto(ChatMessage m)
@@ -192,6 +264,10 @@ namespace GxPT
                 Name = dto.Name ?? "New Conversation",
                 SelectedModel = dto.SelectedModel,
                 WorkingDir = dto.WorkingDir,
+                // Absent in older files -> null (start at the anchor). Structural validation only
+                // (containment via PathSandbox); the folder's EXISTENCE is checked at adoption time
+                // (MainForm.ApplyLoadedWorkingDir), the moment the workspace is actually bound.
+                CurrentDir = DeserializeCurrentDir(dto.WorkingDir, dto.CurrentDir),
                 WorkspaceStripDismissed = dto.WorkspaceStripDismissed,
                 ContinuedFromCompaction = dto.ContinuedFromCompaction,
                 Zdr = dto.Zdr,
@@ -380,6 +456,9 @@ namespace GxPT
             public string Name { get; set; }
             public string SelectedModel { get; set; }
             public string WorkingDir { get; set; }
+            // The current directory (host `cd`) relative to WorkingDir, '/'-separated; absent at the
+            // anchor and in files from before this field existed. See SerializeCurrentDir.
+            public string CurrentDir { get; set; }
             public bool WorkspaceStripDismissed { get; set; }
             public bool ContinuedFromCompaction { get; set; }
             public bool Zdr { get; set; }

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -913,7 +913,6 @@ namespace GxPT
                 strip.ChangeRequested += delegate { SetWorkingFolderForContext(ctxRef); };
                 strip.ClearRequested += delegate { ClearWorkingFolderForContext(ctxRef); };
                 strip.DismissRequested += delegate { DismissWorkspaceStripForContext(ctxRef); };
-                strip.ReturnToAnchorRequested += delegate { ReturnToAnchorForContext(ctxRef); };
                 // Dock order: the strip is Top, the approval panel is Bottom, and the transcript is
                 // Fill. WinForms lays out docked controls by REVERSE z-order, so the Fill transcript
                 // must be the frontmost child for it to fill the area *between* the Top strip and the
@@ -1403,32 +1402,6 @@ namespace GxPT
             PersistWorkingDir(ctx);
             if (ctx.WorkspaceStrip != null) ctx.WorkspaceStrip.SetWorkingDir(null);
             SyncMcpWorkingDirFromActiveTab();
-        }
-
-        // "Return to root": bring the conversation's current directory back to the workspace anchor. The
-        // model may have scoped into a subdir via `cd`; this is the user's one-click way out. Clears the
-        // tab field AND the persisted conversation value (the current dir is saved with the conversation,
-        // so leaving it would resurrect the subdir on reopen after the user explicitly left it), then
-        // refreshes the strip. The next turn seeds the orchestrator from the cleared value, and its
-        // ephemeral current-directory line tells the model about the move - the click itself leaves no
-        // transcript trace.
-        private void ReturnToAnchorForContext(TabManager.ChatTabContext ctx)
-        {
-            if (ctx == null) return;
-            ctx.CurrentDir = null;
-            if (ctx.Conversation != null)
-            {
-                ctx.Conversation.CurrentDir = null;
-                // Same save gating as PersistWorkingDir: never write a blank, never-sent conversation
-                // to disk over a strip click.
-                try
-                {
-                    if (!ctx.NoSaveUntilUserSend && ctx.Conversation.History.Count > 0)
-                        ConversationStore.Save(ctx.Conversation);
-                }
-                catch { }
-            }
-            UpdateCurrentDirStrip(ctx);
         }
 
         // Refresh a tab's workspace strip to reflect its current directory (host `cd`), shown relative to
@@ -3766,13 +3739,21 @@ namespace GxPT
                     orch.CurrentDir = ctx.CurrentDir;
                     {
                         TabManager.ChatTabContext cdCtx = ctx;
-                        // The turn's conversation, not cdCtx.Conversation: a last-tab recycle swaps
-                        // the latter mid-flight while this turn keeps running detached (#141).
+                        // The turn's conversation, snapshotted: a last-tab recycle swaps cdCtx.Conversation
+                        // mid-flight while this turn keeps running detached (#141).
                         Conversation cdConvo = convo;
                         orch.CurrentDirChanged = delegate(string newCurrent)
                         {
-                            cdCtx.CurrentDir = newCurrent;
+                            // Always mirror onto the turn's own conversation - the detached turn still
+                            // operates in cdConvo's workspace and persists it on finalize.
                             if (cdConvo != null) cdConvo.CurrentDir = newCurrent;
+                            // But only touch the live tab + strip while it STILL hosts this turn's
+                            // conversation. After a recycle the same ctx object holds a fresh conversation;
+                            // stamping the old workspace's dir onto it would strand the tab (a later send
+                            // seeds orch.CurrentDir from it, or PersistWorkingDir copies it onto a brand-new
+                            // conversation). The render timer and approval resolver guard the same way.
+                            if (!ReferenceEquals(cdCtx.Conversation, cdConvo)) return;
+                            cdCtx.CurrentDir = newCurrent;
                             try
                             {
                                 if (!IsDisposed)

--- a/GxPT/Forms/MainForm.cs
+++ b/GxPT/Forms/MainForm.cs
@@ -1406,13 +1406,28 @@ namespace GxPT
         }
 
         // "Return to root": bring the conversation's current directory back to the workspace anchor. The
-        // model may have scoped into a subdir via `cd`; this is the user's one-click way out. Transient
-        // (CurrentDir is never persisted), so it just clears the field and refreshes the strip — the next
-        // turn seeds the orchestrator from this cleared value.
+        // model may have scoped into a subdir via `cd`; this is the user's one-click way out. Clears the
+        // tab field AND the persisted conversation value (the current dir is saved with the conversation,
+        // so leaving it would resurrect the subdir on reopen after the user explicitly left it), then
+        // refreshes the strip. The next turn seeds the orchestrator from the cleared value, and its
+        // ephemeral current-directory line tells the model about the move - the click itself leaves no
+        // transcript trace.
         private void ReturnToAnchorForContext(TabManager.ChatTabContext ctx)
         {
             if (ctx == null) return;
             ctx.CurrentDir = null;
+            if (ctx.Conversation != null)
+            {
+                ctx.Conversation.CurrentDir = null;
+                // Same save gating as PersistWorkingDir: never write a blank, never-sent conversation
+                // to disk over a strip click.
+                try
+                {
+                    if (!ctx.NoSaveUntilUserSend && ctx.Conversation.History.Count > 0)
+                        ConversationStore.Save(ctx.Conversation);
+                }
+                catch { }
+            }
             UpdateCurrentDirStrip(ctx);
         }
 
@@ -1446,7 +1461,7 @@ namespace GxPT
             // Working folder: drop the tab's folder and return the strip to its "no folder" state, shown
             // like a brand-new tab (the fresh conversation isn't dismissed).
             ctx.WorkingDir = null;
-            ctx.CurrentDir = null; // transient; never carries into the recycled conversation
+            ctx.CurrentDir = null; // the fresh conversation starts at its own (unset) anchor
             if (ctx.WorkspaceStrip != null)
             {
                 ctx.WorkspaceStrip.SetWorkingDir(null);
@@ -1500,12 +1515,13 @@ namespace GxPT
             try { SelectTab(ctx.Page); } catch { }
         }
 
-        // After a conversation is loaded into a tab, adopt its persisted working folder onto the tab
-        // context + strip and (re)bind the MCP host to it.
+        // After a conversation is loaded into a tab, adopt its persisted working folder AND current
+        // directory (host `cd`) onto the tab context + strip and (re)bind the MCP host to it.
         private void ApplyLoadedWorkingDir(TabManager.ChatTabContext ctx)
         {
             if (ctx == null) return;
             ctx.WorkingDir = (ctx.Conversation != null) ? ctx.Conversation.WorkingDir : null;
+            ctx.CurrentDir = AdoptPersistedCurrentDir(ctx);
             if (!string.IsNullOrEmpty(ctx.WorkingDir)) RecentWorkDirs.Add(ctx.WorkingDir);
             if (ctx.WorkspaceStrip != null)
             {
@@ -1515,7 +1531,26 @@ namespace GxPT
                                  ctx.Conversation.WorkspaceStripDismissed;
                 ctx.WorkspaceStrip.Visible = !dismissed;
             }
+            // After SetWorkingDir, which resets the strip's current-dir state to "at the anchor".
+            UpdateCurrentDirStrip(ctx);
             SyncMcpWorkingDirFromActiveTab();
+        }
+
+        // The persisted current directory (host `cd`) for a tab's just-loaded conversation,
+        // revalidated at adoption (ConversationStore.RevalidateCurrentDir: still within the anchor
+        // and still EXISTS - a worktree pruned or a subdir deleted while the app was closed falls
+        // back to the anchor). A failed revalidation also drops the stale value from the
+        // conversation so a later save doesn't resurrect it. The orchestrator's ephemeral
+        // current-directory line shows the model where it actually is either way, so a fallback is
+        // visible to the agent, never silent.
+        private static string AdoptPersistedCurrentDir(TabManager.ChatTabContext ctx)
+        {
+            Conversation convo = ctx.Conversation;
+            if (convo == null) return null;
+            string cur = ConversationStore.RevalidateCurrentDir(ctx.WorkingDir, convo.CurrentDir);
+            if (cur == null && !string.IsNullOrEmpty(convo.CurrentDir))
+                convo.CurrentDir = null; // invalid/stale: fall back to the anchor and drop the value
+            return cur;
         }
 
         // Mirror the tab's working folder onto its persisted conversation and save, so it re-opens
@@ -1526,6 +1561,11 @@ namespace GxPT
             // Always hold the folder in memory; the first user send persists the conversation (with this
             // folder) like any other blank tab.
             ctx.Conversation.WorkingDir = ctx.WorkingDir;
+            // The current directory (host `cd`) travels with its anchor. Every caller arrives with the
+            // tab value already reset (a new, cleared, or freshly-opened anchor has no subdir scoping),
+            // so this mirror keeps the conversation from re-persisting a current dir the tab no longer
+            // has.
+            ctx.Conversation.CurrentDir = ctx.CurrentDir;
             // Don't write a blank, never-sent conversation to disk just because a workspace folder was
             // set - that littered the history sidebar with empty "New Conversation" entries (and created
             // invisible empty files on the strip path, which doesn't refresh the sidebar). A conversation
@@ -3717,15 +3757,22 @@ namespace GxPT
                     // the prompt's workspace block stays absent and a scratch-sandbox note is used instead.
                     orch.ScratchWorkingDir = string.IsNullOrEmpty(ctx.WorkingDir) ? scratchDir : null;
                     // Seed the conversation's current directory (host `cd`), carried across the turn's
-                    // calls and subsequent turns. Transient: ctx.CurrentDir starts null (reset to the
-                    // anchor on conversation load). When `cd` moves it, persist back to the context and
+                    // calls and subsequent turns. ctx.CurrentDir arrives restored from disk on a
+                    // reopened conversation (ApplyLoadedWorkingDir validated it), or as whatever the
+                    // previous turn left. When `cd` moves it, mirror it onto the tab context AND the
+                    // turn's conversation - the persisted field rides the turn's normal saves, so the
+                    // host state and the transcript's cd echo persist (or are lost) together - then
                     // refresh the workspace strip on the UI thread.
                     orch.CurrentDir = ctx.CurrentDir;
                     {
                         TabManager.ChatTabContext cdCtx = ctx;
+                        // The turn's conversation, not cdCtx.Conversation: a last-tab recycle swaps
+                        // the latter mid-flight while this turn keeps running detached (#141).
+                        Conversation cdConvo = convo;
                         orch.CurrentDirChanged = delegate(string newCurrent)
                         {
                             cdCtx.CurrentDir = newCurrent;
+                            if (cdConvo != null) cdConvo.CurrentDir = newCurrent;
                             try
                             {
                                 if (!IsDisposed)

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -71,7 +71,7 @@ namespace GxPT
             // echoes in the saved transcript claim this location, so the host must keep honoring it on
             // reopen or the model computes paths against a directory that was silently reset. The user's
             // consented boundary is unchanged by restoring: current only ever NARROWS within the anchor,
-            // the strip shows it with a one-click Return to root, and the ephemeral tail tells the model
+            // the strip shows it as a read-only indicator, and the ephemeral tail tells the model
             // whenever the host and transcript do diverge. The MCP server set is still pooled per
             // WorkingDir (the anchor); this rides each call as out-of-band metadata.
             public string CurrentDir;

--- a/GxPT/Managers/TabManager.cs
+++ b/GxPT/Managers/TabManager.cs
@@ -65,9 +65,14 @@ namespace GxPT
             // null = no workspace (those tools won't connect for this tab).
             public string WorkingDir;
             // The conversation's CURRENT directory (host `cd`): a subdirectory at or below WorkingDir the
-            // model has scoped into, or null to mean the anchor itself. Transient (in memory only) and
-            // reset to the anchor on conversation load, by design — you reopen at the consented boundary,
-            // never at some subdir the model wandered into. The MCP server set is still pooled per
+            // model has scoped into, or null to mean the anchor itself. Persisted with the conversation
+            // (anchor-relative; see ConversationStore) and restored on load after validation
+            // (ApplyLoadedWorkingDir: within-anchor + still exists, else back to the anchor) - the cd
+            // echoes in the saved transcript claim this location, so the host must keep honoring it on
+            // reopen or the model computes paths against a directory that was silently reset. The user's
+            // consented boundary is unchanged by restoring: current only ever NARROWS within the anchor,
+            // the strip shows it with a one-click Return to root, and the ephemeral tail tells the model
+            // whenever the host and transcript do diverge. The MCP server set is still pooled per
             // WorkingDir (the anchor); this rides each call as out-of-band metadata.
             public string CurrentDir;
             // The per-tab workspace strip docked above this tab's transcript (set by MainForm).

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -35,6 +35,16 @@ namespace GxPT
         // MCP working folder for this conversation (GXPT_WORKDIR sandbox root); null = none. Persisted
         // so the conversation re-opens with the same folder.
         public string WorkingDir { get; set; }
+        // The conversation's current directory (host `cd`): an absolute path at or below WorkingDir
+        // that the model has scoped into, or null when at the anchor. Runtime mirror of the tab's
+        // CurrentDir, persisted (anchor-relative on disk - see ConversationStore) so a reopened
+        // conversation resumes where its transcript says it is: the cd tool's success echo lives in
+        // the saved history, so restoring the host state keeps the model's belief and the host's
+        // enforcement in agreement instead of silently resetting one of them. Validated on load
+        // (within-anchor structurally in FromDto; existence at adoption in ApplyLoadedWorkingDir,
+        // which falls back to the anchor) and cleared by the same actions that clear the tab state
+        // (Set/Clear Working Folder, the strip's Return to root).
+        public string CurrentDir { get; set; }
         // Whether the user dismissed the (unset) workspace strip for this conversation; persisted so
         // the strip stays hidden on reopen until they set a folder.
         public bool WorkspaceStripDismissed { get; set; }

--- a/GxPT/Models/Conversation.cs
+++ b/GxPT/Models/Conversation.cs
@@ -42,8 +42,7 @@ namespace GxPT
         // the saved history, so restoring the host state keeps the model's belief and the host's
         // enforcement in agreement instead of silently resetting one of them. Validated on load
         // (within-anchor structurally in FromDto; existence at adoption in ApplyLoadedWorkingDir,
-        // which falls back to the anchor) and cleared by the same actions that clear the tab state
-        // (Set/Clear Working Folder, the strip's Return to root).
+        // which falls back to the anchor) and cleared when the anchor moves (Set/Clear Working Folder).
         public string CurrentDir { get; set; }
         // Whether the user dismissed the (unset) workspace strip for this conversation; persisted so
         // the strip stays hidden on reopen until they set a folder.

--- a/GxPT/Services/Agents/AgentDispatcher.cs
+++ b/GxPT/Services/Agents/AgentDispatcher.cs
@@ -396,6 +396,8 @@ namespace GxPT
             McpChatOrchestrator child = new McpChatOrchestrator(_streamer, _registry, _approval, model,
                                                                 _log, maxIter, _callTimeoutMs);
             child.WorkingDir = _workingDir;
+            // CurrentDir deliberately not inherited: a child runs at the anchor, and its own ephemeral
+            // current-directory line says so - the parent's `cd` scoping is per-conversation state.
             // A "Stop N agents" click trips GroupCancellation (cancels the fan-out, not the turn); when the
             // host hasn't set one, fall back to the parent turn's handle so a plain Stop still cancels.
             child.Cancellation = GroupCancellation != null ? GroupCancellation : Cancellation;

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -113,7 +113,10 @@ namespace GxPT
         // message right after the agent prompt (only when a workspace is set). Kept separate from
         // AgentSystemPrompt because the path is dynamic; absent entirely when there is no workspace,
         // so a workspace-less turn leaves no trace of one in context. Tells the model where it is
-        // running so questions about "the project/code/files" go to disk before the web.
+        // running so questions about "the project/code/files" go to disk before the web. Deliberately
+        // shows only the ANCHOR: it lives in the cached head (Zone A), so it must stay byte-identical
+        // while the workspace does - the volatile current directory (host `cd`) rides the ephemeral
+        // tail instead (CurrentDirContextBlock).
         internal static string WorkspaceSystemMessage(string workingDir)
         {
             if (string.IsNullOrEmpty(workingDir)) return null;
@@ -327,9 +330,12 @@ namespace GxPT
         // that the model has scoped into. Absolute path; null means "the anchor itself" (the default and
         // the floor). The host injects it into every workdir-scoped tool call out-of-band (params._meta,
         // GxptMeta.CwdKey) so files/git/command/msbuild operate there without the model being able to widen
-        // the root. Seeded from the conversation context at turn start and reset to the anchor on
-        // conversation load (it is transient, never persisted). Mutated only by the `cd` host tool, which
-        // re-validates it within the anchor. See the host-cd/worktree design.
+        // the root. Seeded from the conversation context at turn start; on a reopened conversation that
+        // context arrives restored (validated) from the saved conversation, so the host keeps honoring
+        // what the transcript's cd echoes already claim. Advertised back to the model every request via
+        // the ephemeral tail's current-directory line (CurrentDirContextBlock), which stays authoritative
+        // when the two do diverge (user reset, failed restore). Mutated only by the `cd` host tool, which
+        // re-validates it within the anchor. See the host-cd/worktree design and its 2026-07-31 amendment.
         public string CurrentDir { get; set; }
 
         // Notifies the host when `cd` moves the current directory, so it can store the new value on the
@@ -533,11 +539,12 @@ namespace GxPT
                 //   Zone B - the persisted history (append-only). Cache breakpoint #2 rides the
                 //            newest message, so each loop iteration / turn reads the previous
                 //            request's prefix from cache and extends it incrementally.
-                //   Zone C - one ephemeral user-role tail message holding the volatile INVENTORY that may
-                //            change between requests (memory, the skills/agents lists, the MCP tool-name
-                //            list). The static how-to framing for these lives in Zone A; only the lists
-                //            are here. Placed AFTER the breakpoints so its churn never invalidates the
-                //            cached transcript. Never persisted; rebuilt every request.
+                //   Zone C - one ephemeral user-role tail message holding the volatile STATE that may
+                //            change between requests (the current directory, memory, the skills/agents
+                //            lists, the MCP tool-name list). The static how-to framing for these lives
+                //            in Zone A; only the values are here. Placed AFTER the breakpoints so its
+                //            churn never invalidates the cached transcript. Never persisted; rebuilt
+                //            every request.
                 List<ChatMessage> requestMessages = BuildStableHead(SkillsActive, AgentsActive);
                 int headCount = requestMessages.Count;
 
@@ -551,14 +558,17 @@ namespace GxPT
                 // The tail inventory lists are gated on the SAME signal as their head framing and host
                 // tools (SkillsActive/AgentsActive), so a feature's framing, its tools, and its list always
                 // appear together. Each provider is called at most once per iteration (the head framing
-                // takes the bool, not another provider call).
+                // takes the bool, not another provider call). The current-directory line is rebuilt per
+                // iteration too: a mid-turn cd updates CurrentDir, and the next iteration's tail must
+                // already reflect it.
+                string cwdBlock = CurrentDirContextBlock(WorkingDir, CurrentDir);
                 string memoryBlock = MemorySystemMessageProvider != null
                     ? MemorySystemMessageProvider() : null;
                 string skillsBlock = SkillsActive && SkillsManifestSystemMessageProvider != null
                     ? SkillsManifestSystemMessageProvider() : null;
                 string agentsBlock = AgentsActive && AgentsManifestSystemMessageProvider != null
                     ? AgentsManifestSystemMessageProvider() : null;
-                string ephemeralTail = BuildEphemeralContextText(memoryBlock, skillsBlock, agentsBlock, manifest);
+                string ephemeralTail = BuildEphemeralContextText(cwdBlock, memoryBlock, skillsBlock, agentsBlock, manifest);
                 if (!string.IsNullOrEmpty(ephemeralTail))
                     requestMessages.Add(new ChatMessage("user", ephemeralTail));
 
@@ -1002,23 +1012,28 @@ namespace GxPT
         }
 
         // Zone C: the ephemeral context tail - one user-role message holding everything that may
-        // change between requests (memory index, skills manifest, MCP names manifest). User role
-        // because Anthropic (via OpenRouter) hoists in-array system messages to the top-level system
-        // parameter, which would put this back in front of the cached history; as a trailing user
-        // message it merges into the same user turn as any preceding tool results ([tool_result...,
-        // text] is the order Anthropic requires). Returns null when every block is empty, so a turn
-        // without memory/skills/agents/tools leaves no trace. Never persisted; the UI never renders it.
-        internal static string BuildEphemeralContextText(string memory, string skills, string agents, string toolManifest)
+        // change between requests (current directory, memory index, skills manifest, MCP names
+        // manifest). User role because Anthropic (via OpenRouter) hoists in-array system messages to
+        // the top-level system parameter, which would put this back in front of the cached history;
+        // as a trailing user message it merges into the same user turn as any preceding tool results
+        // ([tool_result..., text] is the order Anthropic requires). Returns null when every block is
+        // empty, so a workspace-less turn without memory/skills/agents/tools leaves no trace. Never
+        // persisted; the UI never renders it.
+        internal static string BuildEphemeralContextText(string currentDir, string memory, string skills, string agents, string toolManifest)
         {
+            bool hasCwd = !string.IsNullOrEmpty(currentDir);
             bool hasMemory = !string.IsNullOrEmpty(memory);
             bool hasSkills = !string.IsNullOrEmpty(skills);
             bool hasAgents = !string.IsNullOrEmpty(agents);
             bool hasManifest = !string.IsNullOrEmpty(toolManifest);
-            if (!hasMemory && !hasSkills && !hasAgents && !hasManifest) return null;
+            if (!hasCwd && !hasMemory && !hasSkills && !hasAgents && !hasManifest) return null;
 
             StringBuilder sb = new StringBuilder();
             sb.Append("[Ephemeral context appended by the host application for this request. ");
             sb.Append("It is not part of the user's message.]");
+            // Orientation before inventory: where the conversation is, then what it has.
+            if (hasCwd)
+                sb.Append("\n\n<current_directory>\n").Append(currentDir).Append("\n</current_directory>");
             if (hasMemory)
                 sb.Append("\n\n<memory>\n").Append(memory).Append("\n</memory>");
             if (hasSkills)
@@ -1028,6 +1043,43 @@ namespace GxPT
             if (hasManifest)
                 sb.Append("\n\n<available_tools>\n").Append(toolManifest).Append("\n</available_tools>");
             return sb.ToString();
+        }
+
+        // The <current_directory> block's text: the host's authoritative current dir (host `cd`) for
+        // this request, shown anchor-relative. Present on EVERY workspace turn - including at the
+        // anchor - because its job is to correct a model whose transcript says it cd'd somewhere the
+        // host no longer honors: a reopened conversation whose restored dir failed validation, or the
+        // user clicking the strip's Return to root (which leaves no transcript trace). Omitting the
+        // at-anchor case would leave exactly those models uncorrected, resolving subdir-relative
+        // paths against the anchor (the pre-`pwd` path doom loop, host-induced). Null without a
+        // workspace (`cd` doesn't exist there). Rides Zone C rather than the cached head: `cd` moves
+        // it mid-turn, and the tail is rebuilt each request after the cache breakpoints, so it
+        // changes freely without re-billing the transcript (design addendum A6).
+        internal static string CurrentDirContextBlock(string workingDir, string currentDir)
+        {
+            if (string.IsNullOrEmpty(workingDir)) return null;
+            string where = null;
+            if (!string.IsNullOrEmpty(currentDir))
+            {
+                try
+                {
+                    PathSandbox sb = new PathSandbox(workingDir, "workspace root");
+                    string full = Path.GetFullPath(currentDir);
+                    if (sb.IsWithin(full))
+                    {
+                        string rel = sb.ToRelative(full);
+                        if (!string.IsNullOrEmpty(rel))
+                            where = "`" + rel.Replace('\\', '/') + "` (relative to the workspace root)";
+                    }
+                }
+                catch (Exception) { where = null; }
+            }
+            if (where == null) where = "the workspace root";
+            return "The conversation's current working directory is " + where + ". File, git, and "
+                + "command path arguments resolve against it. This value is authoritative: if an "
+                + "earlier cd in the conversation says otherwise, the host has since moved or reset "
+                + "the directory (e.g. the user returned to the workspace root, or a directory "
+                + "restored on reopen no longer existed).";
         }
 
         private static bool IsEmptyText(string s)

--- a/GxPT/Services/Mcp/McpChatOrchestrator.cs
+++ b/GxPT/Services/Mcp/McpChatOrchestrator.cs
@@ -334,7 +334,7 @@ namespace GxPT
         // context arrives restored (validated) from the saved conversation, so the host keeps honoring
         // what the transcript's cd echoes already claim. Advertised back to the model every request via
         // the ephemeral tail's current-directory line (CurrentDirContextBlock), which stays authoritative
-        // when the two do diverge (user reset, failed restore). Mutated only by the `cd` host tool, which
+        // when the two do diverge (a workspace change, failed restore). Mutated only by the `cd` host tool, which
         // re-validates it within the anchor. See the host-cd/worktree design and its 2026-07-31 amendment.
         public string CurrentDir { get; set; }
 
@@ -1049,37 +1049,31 @@ namespace GxPT
         // this request, shown anchor-relative. Present on EVERY workspace turn - including at the
         // anchor - because its job is to correct a model whose transcript says it cd'd somewhere the
         // host no longer honors: a reopened conversation whose restored dir failed validation, or the
-        // user clicking the strip's Return to root (which leaves no transcript trace). Omitting the
-        // at-anchor case would leave exactly those models uncorrected, resolving subdir-relative
-        // paths against the anchor (the pre-`pwd` path doom loop, host-induced). Null without a
-        // workspace (`cd` doesn't exist there). Rides Zone C rather than the cached head: `cd` moves
-        // it mid-turn, and the tail is rebuilt each request after the cache breakpoints, so it
-        // changes freely without re-billing the transcript (design addendum A6).
+        // user changing the workspace folder (which resets the current dir with no transcript trace).
+        // Omitting the at-anchor case would leave exactly those models uncorrected, resolving
+        // subdir-relative paths against the anchor (the pre-`pwd` path doom loop, host-induced). Null
+        // without a workspace (`cd` doesn't exist there). Shares PathSandbox.RelativeSubdirOrNull with
+        // the persistence path so the tail and the stored value agree on containment. Rides Zone C
+        // rather than the cached head: `cd` moves it mid-turn, and the tail is rebuilt each request
+        // after the cache breakpoints, so it changes freely without re-billing the transcript (A6).
         internal static string CurrentDirContextBlock(string workingDir, string currentDir)
         {
             if (string.IsNullOrEmpty(workingDir)) return null;
-            string where = null;
-            if (!string.IsNullOrEmpty(currentDir))
+            string where = "the workspace root";
+            try
             {
-                try
-                {
-                    PathSandbox sb = new PathSandbox(workingDir, "workspace root");
-                    string full = Path.GetFullPath(currentDir);
-                    if (sb.IsWithin(full))
-                    {
-                        string rel = sb.ToRelative(full);
-                        if (!string.IsNullOrEmpty(rel))
-                            where = "`" + rel.Replace('\\', '/') + "` (relative to the workspace root)";
-                    }
-                }
-                catch (Exception) { where = null; }
+                string ignored;
+                string rel = new PathSandbox(workingDir, "workspace root")
+                    .RelativeSubdirOrNull(currentDir, out ignored);
+                if (rel != null)
+                    where = "`" + rel.Replace('\\', '/') + "` (relative to the workspace root)";
             }
-            if (where == null) where = "the workspace root";
+            catch (Exception) { where = "the workspace root"; }
             return "The conversation's current working directory is " + where + ". File, git, and "
                 + "command path arguments resolve against it. This value is authoritative: if an "
                 + "earlier cd in the conversation says otherwise, the host has since moved or reset "
-                + "the directory (e.g. the user returned to the workspace root, or a directory "
-                + "restored on reopen no longer existed).";
+                + "the directory (e.g. the workspace folder was changed, or a directory restored on "
+                + "reopen no longer existed).";
         }
 
         private static bool IsEmptyText(string s)
@@ -1513,11 +1507,24 @@ namespace GxPT
             }
             PathSandbox anchorSb = new PathSandbox(anchor, "workspace root");
             string cur = !string.IsNullOrEmpty(CurrentDir) ? CurrentDir : anchorSb.Root;
-            string relDisp = anchorSb.ToRelative(cur);
-            if (string.IsNullOrEmpty(relDisp)) relDisp = ".";
-            relDisp = relDisp.Replace('\\', '/');
+            // AnchorRelDisplay renders an out-of-anchor cur (a bug: all setters validate) as "." rather
+            // than leaking it labeled "relative to the workspace root" - the same guard the tail uses.
+            string relDisp = AnchorRelDisplay(anchorSb, cur);
             return "Current directory: `" + relDisp + "` (relative to the workspace root; absolute: "
                 + cur + "). Workspace root: " + anchorSb.Root + ".";
+        }
+
+        // The workspace-root-relative display form of an absolute path within the anchor: "." at the
+        // anchor itself, else the relative path with forward slashes. The single spelling shared by
+        // pwd, cd's success echo, and cd's not-found error, so those model-facing messages never
+        // describe the same location two ways. Routes through RelativeSubdirOrNull, so an empty or
+        // (defensively) out-of-anchor `abs` renders "." instead of a mislabeled absolute path - all
+        // callers pass a within-anchor path, so that arm is belt-and-suspenders.
+        private static string AnchorRelDisplay(PathSandbox sb, string abs)
+        {
+            string ignored;
+            string rel = sb.RelativeSubdirOrNull(abs, out ignored);
+            return rel != null ? rel.Replace('\\', '/') : ".";
         }
 
         // Builds an OpenAI-format function def (mirrors McpToolRegistry.FunctionDef, which is private).
@@ -1586,10 +1593,9 @@ namespace GxPT
                 if (!Directory.Exists(full))
                 {
                     isError = true;
-                    string curDisp = anchorSb.ToRelative(baseDir);
-                    if (string.IsNullOrEmpty(curDisp)) curDisp = ".";
+                    string curDisp = AnchorRelDisplay(anchorSb, baseDir);
                     return "[cd: directory not found: " + rel + " (resolves to " + full
-                        + "; the current directory is `" + curDisp.Replace('\\', '/') + "`).]";
+                        + "; the current directory is `" + curDisp + "`).]";
                 }
                 target = full;
             }
@@ -1599,9 +1605,7 @@ namespace GxPT
             Action<string> cb = CurrentDirChanged;
             if (cb != null) { try { cb(CurrentDir); } catch { } }
 
-            string relDisp = anchorSb.ToRelative(target);
-            if (string.IsNullOrEmpty(relDisp)) relDisp = ".";
-            relDisp = relDisp.Replace('\\', '/');
+            string relDisp = AnchorRelDisplay(anchorSb, target);
             return "Current directory is now `" + relDisp + "` (relative to the workspace root; absolute: "
                 + target + "). File, git, and command operations now run there, and their path arguments "
                 + "resolve relative to it.";

--- a/docs/superpowers/specs/2026-06-26-host-cd-worktree-design.md
+++ b/docs/superpowers/specs/2026-06-26-host-cd-worktree-design.md
@@ -143,7 +143,9 @@ concurrency burden beyond the shared-folder case the system already handles.
 - **Current** — the conversation's effective working directory. Transient: held in
   memory per conversation, **not persisted**, and **reset to the anchor on conversation
   load** (you reopen at the consented boundary, never at some subdir the model wandered
-  into). Starts equal to the anchor.
+  into). Starts equal to the anchor. *(Superseded by the 2026-07-31 amendment: `current`
+  is now persisted anchor-relative and restored with validation — the transcript's cd
+  echoes persist, so the host state must too.)*
 
 `cd` mutates **current** only.
 
@@ -265,7 +267,9 @@ model-facing `cwd` once `cd` exists or keep it for one-off sub-scoping. The ship
   (same class as `PathSandbox` today; do it at both host clamp and server re-check).
 - Race: `cd` changes current while a call is in flight → each call carries its own
   `__cwd` snapshot; no shared mutable server state to corrupt.
-- Conversation reload → current resets to anchor (not restored).
+- Conversation reload → current resets to anchor (not restored). *(Superseded by the
+  2026-07-31 amendment: restored after validation; falls back to the anchor only when
+  the stored dir is invalid or gone, and the ephemeral tail tells the model either way.)*
 
 ## Testing strategy
 
@@ -491,3 +495,68 @@ Beyond the body's list:
   is ignored/overwritten by the host (A4).
 - Scratch: `cd` tool absent on scratch turns; `command` still honors `__cwd` (A5).
 - Default: absent `__cwd` falls back to the anchor on every scoped server (A2).
+
+---
+
+## Amendment (2026-07-31): persist `current` and advertise it per request
+
+Two decisions above are revised in light of shipped experience. **This section wins on
+conflict** with the body and the 2026-06-26 addenda.
+
+### What went wrong
+
+The body made `current` transient — "reset to the anchor on conversation load" (§Design,
+§Edge cases) — reasoning that you reopen at the consented boundary. But the model's
+belief about `current` lives in the *persisted transcript*: the `cd` tool's success echo
+("Current directory is now `src/foo` …") is saved with the history. On reopen the host
+silently reset its half of the state while the transcript kept claiming the subdir, so
+the model resolved subdir-relative paths against the anchor — a host-*induced* variant of
+the path doom loop `pwd` was added to cure. The same divergence occurred mid-session when
+the user clicked the strip's **Return to root**, which moves `current` without leaving
+any transcript trace. Separately, addendum A6's requirement that the per-request context
+show `current` ("or the model computes paths against the wrong dir") was only half
+shipped: the workspace block stayed anchor-only in the cached head, and nothing carried
+`current` at all.
+
+### Revision 1 — `current` is persisted and restored (supersedes reset-on-load)
+
+- `Conversation.CurrentDir` mirrors the tab's current dir and rides every normal
+  conversation save. On disk it is stored **anchor-relative** ('/'-separated,
+  omitted at the anchor), so a conversation file cannot express a current dir outside
+  its own anchor and the subpath survives the anchor being re-picked at a moved
+  location (`ConversationStore.SerializeCurrentDir` / `DeserializeCurrentDir`).
+- Because the mirror is written when `cd` fires and saved when the turn finalizes, the
+  host state and the transcript's cd echo **persist or are lost together** — the two
+  can no longer diverge through a save/load cycle.
+- Restore validates twice: structurally on deserialize (containment via
+  `PathSandbox.Resolve`; malformed/escaping values → null), then at adoption
+  (`MainForm.ApplyLoadedWorkingDir`): containment re-checked + the directory must still
+  **exist**, else fall back to the anchor and drop the stored value. The load-time
+  fallback is deliberate and differs from the mid-session rule (§Edge cases: in-flight
+  stale `__cwd` still errors, never silently falls back) — at load there is no in-flight
+  operation to mis-target, and Revision 2 makes the fallback visible to the model.
+- Consent is unchanged: `current` only ever narrows within the consented anchor, the
+  strip shows the restored subdir immediately with one-click Return to root, and **Set
+  Working Folder** still resets it (re-consent). Return to root now also clears the
+  persisted value (and saves), so an explicit user reset can never resurrect on reopen.
+
+### Revision 2 — A6 completed: `current` rides the ephemeral tail every request
+
+The per-request tail (Zone C, rebuilt after the cache breakpoints) now carries a
+`<current_directory>` block (`McpChatOrchestrator.CurrentDirContextBlock`) on **every
+workspace turn, including at the anchor**, stating the host's authoritative current dir
+anchor-relative. Always-on is the point: the block exists to correct a model whose
+transcript says otherwise (failed restore, user Return-to-root), and those are exactly
+the turns an "only when scoped" block would omit. The workspace block in the cached head
+(Zone A) deliberately keeps showing only the anchor — it must stay byte-identical while
+the workspace does; the volatile half lives in the tail, completing A6 without the
+cache-bust it warned about. Sub-agent children do not inherit `current` (they run at the
+anchor) and their own tails say so.
+
+### Testing
+
+- Store: relative round-trip, at-anchor omission, legacy files → null, malformed /
+  escaping / absolute stored values → null (never a load failure).
+- Tail: `<current_directory>` present at anchor and when scoped, correct
+  anchor-relative rendering, absent without a workspace, ordered before `<memory>`.
+- Adoption: within-anchor + existence enforced; fallback clears the stored value.

--- a/docs/superpowers/specs/2026-06-26-host-cd-worktree-design.md
+++ b/docs/superpowers/specs/2026-06-26-host-cd-worktree-design.md
@@ -235,7 +235,8 @@ A host tool (e.g. `cd`) the model can call:
 
 - Surface the current directory on the workspace strip (distinct from the anchor) so
   the user can see when a conversation is scoped into a subdir, with a one-click return
-  to the anchor.
+  to the anchor. *(Superseded by the 2026-07-31 amendment: the indicator ships, but the
+  one-click return was removed — the model returns to the anchor with a bare `cd`.)*
 - Sandbox-rejection errors should be `cd`-aware: *"you are in `<current>`; `cd` to the
   workspace root to reach `<path>`"* — otherwise a model that scoped deep then asks for
   an anchor-level file gets an opaque "escapes the workspace root."
@@ -536,9 +537,11 @@ shipped: the workspace block stayed anchor-only in the cached head, and nothing 
   stale `__cwd` still errors, never silently falls back) — at load there is no in-flight
   operation to mis-target, and Revision 2 makes the fallback visible to the model.
 - Consent is unchanged: `current` only ever narrows within the consented anchor, the
-  strip shows the restored subdir immediately with one-click Return to root, and **Set
-  Working Folder** still resets it (re-consent). Return to root now also clears the
-  persisted value (and saves), so an explicit user reset can never resurrect on reopen.
+  strip shows the restored subdir as a read-only indicator, and **Set Working Folder**
+  still resets it to the new anchor (re-consent). *(The earlier one-click "Return to
+  root" strip affordance was removed — scope creep that also carried a mid-turn-save
+  race; the model still returns to the anchor with a bare `cd`, and changing the
+  workspace folder resets `current`.)*
 
 ### Revision 2 — A6 completed: `current` rides the ephemeral tail every request
 
@@ -546,8 +549,9 @@ The per-request tail (Zone C, rebuilt after the cache breakpoints) now carries a
 `<current_directory>` block (`McpChatOrchestrator.CurrentDirContextBlock`) on **every
 workspace turn, including at the anchor**, stating the host's authoritative current dir
 anchor-relative. Always-on is the point: the block exists to correct a model whose
-transcript says otherwise (failed restore, user Return-to-root), and those are exactly
-the turns an "only when scoped" block would omit. The workspace block in the cached head
+transcript says otherwise (a failed restore that fell back to the anchor, or a workspace
+change that reset `current`), and those are exactly the turns an "only when scoped" block
+would omit. The workspace block in the cached head
 (Zone A) deliberately keeps showing only the anchor — it must stay byte-identical while
 the workspace does; the volatile half lives in the tail, completing A6 without the
 cache-bust it warned about. Sub-agent children do not inherit `current` (they run at the

--- a/src/Mcp35.Core/Properties/AssemblyInfo.cs
+++ b/src/Mcp35.Core/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("667ac466-f30b-4cdb-bec9-7a139a709aa9")]
 
-[assembly: AssemblyVersion("0.1.2.0")]
-[assembly: AssemblyFileVersion("0.1.2.0")]
+[assembly: AssemblyVersion("0.1.3.0")]
+[assembly: AssemblyFileVersion("0.1.3.0")]

--- a/src/Mcp35.Core/Security/PathSandbox.cs
+++ b/src/Mcp35.Core/Security/PathSandbox.cs
@@ -84,5 +84,33 @@ namespace Mcp35.Core.Security
                 return string.Empty;
             return full;
         }
+
+        /// <summary>
+        /// The root-relative path of <paramref name="path"/> when it canonicalizes to a directory
+        /// STRICTLY BELOW the root — within it, but not the root itself. Returns null when
+        /// <paramref name="path"/> is null/empty, is the root itself (the "at anchor" case), escapes
+        /// the root, or cannot be canonicalized. On a non-null return, <paramref name="canonical"/>
+        /// carries the canonical absolute form so callers that also stat or store it don't
+        /// re-canonicalize. The returned relative path uses the platform separator (like
+        /// <see cref="ToRelative"/>); callers that persist or display it normalize to '/'.
+        /// <para>
+        /// One primitive for "is this a real subdir of the root, and what is it called" so the host's
+        /// serialize / revalidate / display-to-model paths cannot drift on the containment rule or the
+        /// at-anchor predicate (they once spelled the latter two different ways).
+        /// </para>
+        /// </summary>
+        public string RelativeSubdirOrNull(string path, out string canonical)
+        {
+            canonical = null;
+            if (string.IsNullOrEmpty(path)) return null;
+            string full;
+            try { full = Path.GetFullPath(path); }
+            catch { return null; }
+            if (!IsWithin(full)) return null;
+            string rel = ToRelative(full);
+            if (string.IsNullOrEmpty(rel)) return null; // the root itself
+            canonical = full;
+            return rel;
+        }
     }
 }

--- a/tests/Mcp35.Core.Tests/Security/PathSandboxTests.cs
+++ b/tests/Mcp35.Core.Tests/Security/PathSandboxTests.cs
@@ -140,5 +140,69 @@ namespace Mcp35.Core.Tests.Security
             Assert.Equal(Path.Combine("sub", "a.txt"), sandbox.ToRelative(full));
             Assert.Equal(string.Empty, sandbox.ToRelative(sandbox.Root));
         }
+
+        // ---- RelativeSubdirOrNull: the shared "is this a real subdir, and what is it called"
+        // primitive the host's current-dir serialize / revalidate / display paths route through. ----
+
+        [Fact]
+        public void RelativeSubdirOrNull_returns_relative_and_canonical_for_a_subdir()
+        {
+            var sandbox = new PathSandbox(_root);
+            string abs = Path.Combine(_root, Path.Combine("sub", "app"));
+            string canonical;
+            string rel = sandbox.RelativeSubdirOrNull(abs, out canonical);
+
+            Assert.Equal(Path.Combine("sub", "app"), rel);
+            Assert.Equal(Path.GetFullPath(abs), canonical);
+        }
+
+        [Fact]
+        public void RelativeSubdirOrNull_collapses_interior_dotdot_within_root()
+        {
+            var sandbox = new PathSandbox(_root);
+            string abs = Path.Combine(_root, Path.Combine("sub", "..", "app"));
+            string canonical;
+            string rel = sandbox.RelativeSubdirOrNull(abs, out canonical);
+
+            Assert.Equal("app", rel);
+            Assert.Equal(Path.Combine(_root, "app"), canonical);
+        }
+
+        [Fact]
+        public void RelativeSubdirOrNull_returns_null_at_the_root_itself()
+        {
+            var sandbox = new PathSandbox(_root);
+            string canonical;
+            Assert.Null(sandbox.RelativeSubdirOrNull(_root, out canonical));
+            Assert.Null(canonical);
+            // A trailing separator still resolves to the root, so still "at anchor" -> null.
+            Assert.Null(sandbox.RelativeSubdirOrNull(_root + Path.DirectorySeparatorChar, out canonical));
+            Assert.Null(canonical);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void RelativeSubdirOrNull_returns_null_for_empty_input(string abs)
+        {
+            var sandbox = new PathSandbox(_root);
+            string canonical;
+            Assert.Null(sandbox.RelativeSubdirOrNull(abs, out canonical));
+            Assert.Null(canonical);
+        }
+
+        [Fact]
+        public void RelativeSubdirOrNull_returns_null_for_an_out_of_root_path()
+        {
+            var sandbox = new PathSandbox(_root);
+            string canonical;
+            // A sibling that shares the root's prefix must NOT read as within (the boundary check).
+            Assert.Null(sandbox.RelativeSubdirOrNull(_root + "-evil", out canonical));
+            Assert.Null(canonical);
+            // And an interior path that escapes via '..'.
+            string escape = Path.Combine(_root, Path.Combine("sub", "..", "..", "outside"));
+            Assert.Null(sandbox.RelativeSubdirOrNull(escape, out canonical));
+            Assert.Null(canonical);
+        }
     }
 }


### PR DESCRIPTION
## Summary

This change implements persistence of the conversation's current directory (host `cd` state) and ensures it is advertised to the model on every request. Previously, the current directory was transient and reset to the workspace anchor on conversation load, causing divergence between the model's persisted transcript (which recorded `cd` commands) and the host's runtime state. This led to path resolution errors when reopening conversations.

## Key Changes

- **Persist current directory**: `Conversation.CurrentDir` is now saved with the conversation in anchor-relative form (forward-slash separated), making it impossible to express paths outside the workspace root. Stored as null when at the anchor.

- **Validate on restore**: Added `ConversationStore.RevalidateCurrentDir()` to validate restored directories at load time—checking both containment within the anchor and existence on disk. Falls back to the anchor if the directory was deleted or moved while the app was closed.

- **Advertise per request**: Implemented `McpChatOrchestrator.CurrentDirContextBlock()` to generate a `<current_directory>` section in the ephemeral context tail, sent with every workspace-scoped request. This ensures the model always knows the authoritative current directory, even when it diverges from what the transcript claims.

- **Serialization helpers**: Added `ConversationStore.SerializeCurrentDir()` and `DeserializeCurrentDir()` to handle anchor-relative conversion, with soft failures (null) rather than throwing on malformed input.

- **Shared containment primitive**: Extended `PathSandbox` with `RelativeSubdirOrNull()` to provide a single source of truth for "is this a real subdirectory" checks across serialize, revalidate, and display paths.

- **UI updates**: Removed the "Return to root" button from the workspace strip (scope creep that also had a mid-turn-save race). Users can still return to the anchor with a bare `cd` command. Updated `MainForm.ApplyLoadedWorkingDir()` to adopt and revalidate the persisted current directory.

- **Test coverage**: Added comprehensive `CurrentDirPersistenceTests` covering round-trip serialization, validation, escape prevention, and edge cases. Updated `OrchestratorEphemeralTailTests` to verify the new `<current_directory>` block ordering and content.

## Implementation Details

- The on-disk format uses forward slashes and is relative to the workspace anchor, ensuring portability when the anchor is re-picked at a new location.
- Both serialization and revalidation use `PathSandbox.RelativeSubdirOrNull()` to prevent drift on the containment rule and at-anchor predicate.
- The ephemeral tail's current-directory line is rebuilt on every iteration so mid-turn `cd` commands are reflected in the next request.
- Out-of-anchor runtime values (upstream bugs) are silently dropped during serialization rather than persisting an escape.
- Restore-time validation is deliberately soft (falls back to anchor) since there is no in-flight operation to mis-target, and the ephemeral tail makes the fallback visible to the model.

This completes the 2026-07-31 amendment to the host-cd/worktree design, ensuring the host state and transcript's `cd` echoes persist or are lost together.

https://claude.ai/code/session_01DaG7sxRLJgrz1SUQdWVjr9