### PR TITLE
Fix Licenses folder path to include Resources directory

### DIFF
--- a/GxPT/Forms/AboutForm.cs
+++ b/GxPT/Forms/AboutForm.cs
@@ -122,7 +122,7 @@ namespace GxPT
 
         private void link3rdPartyLicenses_MouseClick(object sender, MouseEventArgs e)
         {
-            string path = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Licenses");
+            string path = System.IO.Path.Combine(System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources"), "Licenses");
             try
             {
                 if (System.IO.Directory.Exists(path))


### PR DESCRIPTION
## Summary
Updated the path resolution for the 3rd party licenses folder to correctly reference the "Licenses" directory within the "Resources" subdirectory.

## Key Changes
- Modified `link3rdPartyLicenses_MouseClick` method in `AboutForm.cs` to construct the path using nested `Path.Combine` calls
- Changed from: `AppDomain.CurrentDomain.BaseDirectory/Licenses`
- Changed to: `AppDomain.CurrentDomain.BaseDirectory/Resources/Licenses`

## Details
The licenses folder is now correctly located under the Resources subdirectory rather than directly in the base directory. This aligns the code with the actual project structure and ensures the About dialog can properly locate and display third-party license information.

https://claude.ai/code/session_01FAu3b925EbDt7MxpCZVVFL